### PR TITLE
Remove Zookeeper relevant logic from KafkaRoller

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
@@ -56,12 +56,12 @@ class KafkaQuorumCheck {
     }
 
     /**
-     * Returns id of the quorum leader.
+     * Returns id of the active controller/quorum leader.
      **/
     Future<Integer> quorumLeaderId() {
-        LOGGER.debugCr(reconciliation, "Determining the controller quorum leader id");
+        LOGGER.debugCr(reconciliation, "Determining the active controller");
         return describeMetadataQuorum().map(QuorumInfo::leaderId).recover(error -> {
-            LOGGER.warnCr(reconciliation, "Error determining the controller quorum leader id", error);
+            LOGGER.warnCr(reconciliation, "Error determining the active controller", error);
             return Future.failedFuture(error);
         });
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -34,17 +34,12 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -461,7 +456,7 @@ public class KafkaRoller {
                 LOGGER.debugCr(reconciliation, "Pod {} can be rolled now", nodeRef);
                 restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS, restartContext);
             } else if (restartContext.needsRestart || restartContext.needsReconfig) {
-                if (deferController(nodeRef, restartContext)) {
+                if (isController && deferController(nodeRef, restartContext)) {
                     LOGGER.debugCr(reconciliation, "Pod {} is the active controller and there are other pods to verify first.", nodeRef);
                     throw new ForceableProblem("Pod " + nodeRef.podName() + " is the active controller and there are other pods to verify first");
                 } else if (!canRoll(nodeRef.nodeId(), isController, isBroker, 60, TimeUnit.SECONDS, false, restartContext)) {
@@ -940,7 +935,7 @@ public class KafkaRoller {
     }
     
     /**
-     * Return true if the given {@code nodeId} is the controller or the active controller in KRaft case and there are other brokers we might yet have to consider.
+     * Return true if the given {@code nodeId} is the active controller and there are other controllers we might yet have to consider.
      * This ensures that the active controller is restarted/reconfigured last.
      */
     private boolean deferController(NodeRef nodeRef, RestartContext restartContext) throws Exception {
@@ -955,76 +950,17 @@ public class KafkaRoller {
     }
 
     /**
-     * Completes the returned future <strong>on the context thread</strong> with the id of the controller of the cluster
-     * or the active controller when running in KRaft mode.
+     * Completes the returned future <strong>on the context thread</strong> with the id of the active controller.
      * This will be -1 if there is not currently a controller.
      *
      * @return A future which completes the node id of the controller of the cluster, or -1 if there is not currently a controller.
      */
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // seems to be completely spurious
     int controller(NodeRef nodeRef, long timeout, TimeUnit unit, RestartContext restartContext) throws Exception {
-        int id;
-        if (nodeRef.controller()) {
-            id = await(restartContext.quorumCheck.quorumLeaderId(), timeout, unit,
-                    t -> new UnforceableProblem("An error while trying to determine the quorum leader id", t));
-            LOGGER.debugCr(reconciliation, "KRaft active controller is {}", id);
-        } else {
-            // TODO Either this is a KRaft broker or ZooKeeper broker. Since KafkaRoller does not know if this is KRaft mode or
-            //      not continue with describeCluster. In KRaft mode this returns a random broker and will mean this broker is deferred.
-            //      In future this can be improved by telling KafkaRoller whether the cluster is in KRaft mode or not.
-            //      This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9373.
-            // Use admin client connected directly to this broker here, then any exception or timeout trying to connect to
-            // the current node will be caught and handled from this method, rather than appearing elsewhere.
-            try (Admin ac = adminClient(Set.of(nodeRef), false)) {
-                Node controllerNode = null;
-
-                try {
-                    DescribeClusterResult describeClusterResult = ac.describeCluster();
-                    KafkaFuture<Node> controller = describeClusterResult.controller();
-                    controllerNode = controller.get(timeout, unit);
-                    restartContext.clearConnectionError();
-                } catch (ExecutionException | TimeoutException e) {
-                    maybeTcpProbe(nodeRef, e, restartContext);
-                }
-
-                id = controllerNode == null || Node.noNode().equals(controllerNode) ? -1 : controllerNode.id();
-                LOGGER.debugCr(reconciliation, "Controller is {} (only relevant for Zookeeper mode)", id);
-            }
-        }
+        int id = await(restartContext.quorumCheck.quorumLeaderId(), timeout, unit,
+                t -> new UnforceableProblem("An error while trying to determine the quorum leader id", t));
+        LOGGER.debugCr(reconciliation, "Active controller is {}", id);
         return id;
-    }
-
-    /**
-     * If we've already had trouble connecting to this broker try to probe whether the connection is
-     * open on the broker; if it's not then maybe throw a ForceableProblem to immediately force a restart.
-     * This is an optimization for brokers which don't seem to be running.
-     */
-    private void maybeTcpProbe(NodeRef nodeRef, Exception executionException, RestartContext restartContext) throws Exception {
-        if (restartContext.connectionError() + nodes.size() * 120_000L >= System.currentTimeMillis()) {
-            try {
-                LOGGER.debugCr(reconciliation, "Probing TCP port due to previous problems connecting to pod {}", nodeRef);
-                // do a tcp connect and close (with a short connect timeout)
-                tcpProbe(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), nodeRef.podName()), KafkaCluster.REPLICATION_PORT);
-            } catch (IOException connectionException) {
-                throw new ForceableProblem("Unable to connect to " + nodeRef.podName() + ":" + KafkaCluster.REPLICATION_PORT, executionException.getCause(), true);
-            }
-            throw executionException;
-        } else {
-            restartContext.noteConnectionError();
-            throw new ForceableProblem("Error while trying to determine the cluster controller from pod " + nodeRef.podName(), executionException.getCause());
-        }
-    }
-
-    /**
-     * Tries to open and close a TCP connection to the given host and port.
-     * @param hostname The host
-     * @param port The port
-     * @throws IOException if anything went wrong.
-     */
-    /*test*/ void tcpProbe(String hostname, int port) throws IOException {
-        try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(hostname, port), 5_000);
-        }
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -27,13 +27,10 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.DescribeMetadataQuorumResult;
 import org.apache.kafka.clients.admin.QuorumInfo;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.Node;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -42,7 +39,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,7 +65,6 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -119,92 +114,37 @@ public class KafkaRollerTest {
     @Test
     public void testRollWithNoController(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, -1);
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(REPLICAS, 0, 0), -1);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 1, 2, 3, 4));
     }
 
-    @Test
-    public void testRollTcpProbe(VertxTestContext testContext) {
-        PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        AdminClientProvider mock = givenControllerFutureFailsWithTimeout();
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(KafkaRollerTest.REPLICAS), podOps,
-                noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(true),
-                true, mock, mockKafkaAgentClientProvider(), true, null, -1);
-        List<String> expectedTcpProbes = List.of(
-                "c-kafka-0.c-kafka-brokers.ns.svc.cluster.local:9091",
-                "c-kafka-1.c-kafka-brokers.ns.svc.cluster.local:9091",
-                "c-kafka-2.c-kafka-brokers.ns.svc.cluster.local:9091",
-                "c-kafka-3.c-kafka-brokers.ns.svc.cluster.local:9091",
-                "c-kafka-4.c-kafka-brokers.ns.svc.cluster.local:9091"
-        );
-        doSuccessfulRollingRestart(testContext, kafkaRoller,
-                asList(0, 1, 2, 3, 4),
-                asList(0, 1, 2, 3, 4), () -> {
-                    assertEquals(kafkaRoller.tcpProbes, expectedTcpProbes);
-                });
-    }
-
-    private static AdminClientProvider givenControllerFutureFailsWithTimeout() {
-        KafkaFutureImpl<Node> controllerFuture = new KafkaFutureImpl<>();
-        controllerFuture.completeExceptionally(new TimeoutException("fail"));
-        DescribeClusterResult mockResult = mock(DescribeClusterResult.class);
-        when(mockResult.controller()).thenReturn(controllerFuture);
-        Admin admin = mock(Admin.class);
-        when(admin.describeCluster()).thenReturn(mockResult);
-        AdminClientProvider mock = mock(AdminClientProvider.class);
-        when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
-        return mock;
-    }
-
-    private static KafkaAgentClientProvider mockKafkaAgentClientProvider() {
-        return mock(KafkaAgentClientProvider.class);
-    }
-
 
     @Test
-    public void testRollWithPod2AsController(VertxTestContext testContext) {
+    public void testRollWithPod2AsActiveController(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 2);
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(0, 0, REPLICAS), 2);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 1, 3, 4, 2));
     }
 
     @Test
-    public void testRollUnreadyPodFirst(VertxTestContext testContext) {
-        AtomicBoolean podUnready = new AtomicBoolean(true);
-        PodOperator podOps = mockPodOps(podId -> {
-            if (podId == 1 && podUnready.getAndSet(false)) {
-                return failedFuture(new TimeoutException("fail"));
-            } else {
-                return succeededFuture();
-            }
-        });
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 2);
-        doSuccessfulRollingRestart(testContext, kafkaRoller,
-                asList(0, 1, 2, 3, 4),
-                asList(1, 0, 3, 4, 2));
-    }
-
-    @Test
-    public void testRollWithAControllerChange(VertxTestContext testContext) {
+    public void testRollWithControllerAndBrokers(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 0, 1);
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(3, 0, 3), 3);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
-                asList(0, 1, 2, 3, 4),
-                asList(2, 3, 4, 0, 1));
+                asList(0, 1, 2, 3, 4, 5),
+                asList(4, 5, 3, 0, 1, 2));
     }
 
     @Test
-    public void pod0NotReadyAfterRolling(VertxTestContext testContext) throws InterruptedException {
+    public void pod0NotReadyAfterRollingBroker(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId ->
-            podId == 0 ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
+                podId == 0 ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
         );
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 2);
-        // What does/did the ZK algo do?
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(REPLICAS, 0, 0), -1);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.FatalProblem.class, "Error while waiting for restarted pod c-kafka-0 to become ready",
@@ -217,14 +157,14 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId ->
                 podId == 1 ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
         );
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 2);
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(REPLICAS, 0, 0), -1);
         // On the first reconciliation we expect it to abort when it gets to pod 1
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.FatalProblem.class, "Error while waiting for restarted pod c-kafka-1 to become ready",
                 asList(1));
         // On the next reconciliation only pod 2 (controller) would need rolling, and we expect it to fail in the same way
-        kafkaRoller = rollerWithControllers(podOps, 2);
+        kafkaRoller = rollerWithActiveController(podOps, addPodNames(REPLICAS, 0, 0), -1);
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(2, 3, 4),
@@ -237,14 +177,14 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId ->
                 podId == 3 ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
         );
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 2);
-        // On the first reconciliation we expect it to abort when it gets to pod 3 (but not 2, which is controller)
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(REPLICAS, 0, 0), -1);
+        // On the first reconciliation we expect it to abort when it gets to pod 3
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.FatalProblem.class, "Error while waiting for restarted pod c-kafka-3 to become ready",
                 asList(3));
-        // On the next reconciliation only pods 2 (controller) and 4 would need rolling, and we expect it to fail in the same way
-        kafkaRoller = rollerWithControllers(podOps, 2);
+        // On the next reconciliation, we expect it to fail in the same way
+        kafkaRoller = rollerWithActiveController(podOps, addPodNames(REPLICAS, 0, 0), -1);
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 4),
@@ -253,18 +193,18 @@ public class KafkaRollerTest {
     }
 
     @Test
-    public void controllerNotReadyAfterRolling(VertxTestContext testContext) throws InterruptedException {
+    public void activeControllerNotReadyAfterRolling(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId ->
                 podId == 2 ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
         );
-        TestingKafkaRoller kafkaRoller = rollerWithControllers(podOps, 2);
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(0, 0, REPLICAS), 2);
         // On the first reconciliation we expect it to fail when rolling the controller (i.e. as rolling all the rest)
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.FatalProblem.class, "Error while waiting for restarted pod c-kafka-2 to become ready",
                 asList(0, 1, 3, 4, 2));
         // On the next reconciliation only pod 2 would need rolling, and we expect it to fail in the same way
-        kafkaRoller = rollerWithControllers(podOps, 2);
+        kafkaRoller = rollerWithActiveController(podOps, addPodNames(0, REPLICAS, 0), 2);
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(2),
@@ -272,17 +212,27 @@ public class KafkaRollerTest {
                 singletonList(2));
     }
 
-    public Set<NodeRef> addPodNames(int replicas) {
-        Set<NodeRef> podNames = new LinkedHashSet<>(replicas);
-
-        for (int podId = 0; podId < replicas; podId++) {
-            podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), podId), podId, null, false, true));
-        }
-
-        return podNames;
+    @Test
+    public void activeControllerNotReadyAfterRollingCombined(VertxTestContext testContext) throws InterruptedException {
+        PodOperator podOps = mockPodOps(podId ->
+                podId == 2 ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
+        );
+        TestingKafkaRoller kafkaRoller = rollerWithActiveController(podOps, addPodNames(0, REPLICAS, 0), 2);
+        // On the first reconciliation we expect it to fail when rolling the controller (i.e. as rolling all the rest)
+        doFailingRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                KafkaRoller.FatalProblem.class, "Error while waiting for restarted pod c-kafka-2 to become ready",
+                asList(0, 1, 3, 4, 2));
+        // On the next reconciliation only pod 2 would need rolling, and we expect it to fail in the same way
+        kafkaRoller = rollerWithActiveController(podOps, addPodNames(0, REPLICAS, 0), 2);
+        clearRestarted();
+        doFailingRollingRestart(testContext, kafkaRoller,
+                singletonList(2),
+                KafkaRoller.FatalProblem.class, "Error while waiting for restarted pod c-kafka-2 to become ready",
+                singletonList(2));
     }
 
-    public Set<NodeRef> addKraftPodNames(int brokerReplicas, int combinedReplicas, int controllerReplicas) {
+    public Set<NodeRef> addPodNames(int brokerReplicas, int combinedReplicas, int controllerReplicas) {
         Set<NodeRef> podNames = new LinkedHashSet<>(brokerReplicas);
         for (int brokerId = 0; brokerId < brokerReplicas; brokerId++) {
             podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), brokerId), brokerId, "broker", false, true));
@@ -301,16 +251,16 @@ public class KafkaRollerTest {
     public Set<NodeRef> addDisconnectedPodNames(int replicas) {
         Set<NodeRef> podNames = new LinkedHashSet<>(replicas);
 
-        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 10), 10, null, false, true));
-        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 200), 200, null, false, true));
-        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 30), 30, null, false, true));
-        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 400), 400, null, false, true));
-        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 500), 500, null, false, true));
+        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 10), 10, null, true, true));
+        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 200), 200, null, true, true));
+        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 30), 30, null, true, true));
+        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 400), 400, null, true, true));
+        podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 500), 500, null, true, true));
         return podNames;
     }
 
     @Test
-    public void testRollWithDisconnectedPodNames(VertxTestContext testContext) {
+    public void testRollWithDisconnectedBrokerPodNames(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addDisconnectedPodNames(REPLICAS), podOps,
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
@@ -326,77 +276,133 @@ public class KafkaRollerTest {
 
 
     @Test
-    public void testRollHandlesErrorWhenOpeningAdminClient(VertxTestContext testContext) {
+    public void testRollHandlesErrorWhenOpeningBrokerAdminClient(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
-            bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
-            null, noException(), noException(), noException(),
-            brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
+                null, noException(), noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged),
-        // because we never find the controller we get ascending order
+        // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
-                asList(0, 1, 3, 4, 2));
+                asList(0, 1, 2, 3, 4));
     }
 
     @Test
-    public void testRollHandlesErrorWhenGettingControllerFromNonController(VertxTestContext testContext) {
-        int controller = 2;
-        int nonController = 1;
+    public void testRollHandlesErrorWhenOpeningCombinedAdminClient(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
+                bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
+                null, noException(), noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+        // The algorithm should carry on rolling the pods (errors are logged),
+        // because we force restart the node if we can't create an admin client
+        doSuccessfulRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                asList(0, 1, 2, 3, 4));
+    }
+
+    @Test
+    public void testHandlesErrorWhenOpenControllerAdminClient(VertxTestContext testContext) {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
+                bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
+                null, noException(), noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 4);
+        // The algorithm should carry on rolling the pods (errors are logged),
+        // because we force restart the node if we can't create an admin client
+        doSuccessfulRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                asList(0, 1, 2, 3, 4));
+    }
+
+    @Test
+    public void testRollHandlesErrorWhenGettingActiveControllerFromController(VertxTestContext testContext) {
+        int activeController = 2;
+        int nonActiveController = 1;
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
                 noException(), null,
-            podId -> podId == nonController ? new RuntimeException("Test Exception") : null, noException(), noException(),
-            brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
-        // The algorithm should carry on rolling the pods (errors are logged),
-        // because we never find the controller we get ascending order
+                podId -> podId == nonActiveController ? new RuntimeException("Test Exception") : null, noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
-                asList(0, 3, 4, nonController, controller));
+                asList(0, 3, 4, 1, 2));
     }
 
     @Test
-    public void testRollHandlesErrorWhenGettingControllerFromController(VertxTestContext testContext) {
-        int controller = 2;
+    public void testRollHandlesErrorWhenGettingActiveControllerFromActiveController(VertxTestContext testContext) {
+        int activeController = 2;
+        int nonActiveController = 1;
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
-            noException(), null,
-            podId -> podId == controller ? new RuntimeException("Test Exception") : null, noException(), noException(),
-            brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
-        // The algorithm should carry on rolling the pods (errors are logged),
-        // because we never find the controller we get ascending order
-        doSuccessfulRollingRestart(testContext, kafkaRoller,
-                asList(0, 1, 2, 3, 4),
-                asList(0, 1, 3, 4, controller));
-    }
-
-    @Test
-    public void testRollHandlesErrorWhenClosingAdminClient(VertxTestContext testContext) {
-        PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
-            noException(),
-            new RuntimeException("Test Exception"), noException(), noException(), noException(),
-            brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
-        // The algorithm should carry on rolling the pods (errors are logged),
-        // because we did the controller we controller last order
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
+                noException(), null,
+                podId -> podId == activeController ? new RuntimeException("Test Exception") : null, noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 1, 3, 4, 2));
     }
 
     @Test
-    public void testNonControllerNotInitiallyRollable(VertxTestContext testContext) {
+    public void testRollHandlesErrorWhenClosingBrokerAdminClient(VertxTestContext testContext) {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(),
+                new RuntimeException("Test Exception"), noException(), noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+        // The algorithm should carry on rolling the pods (errors are logged)
+        doSuccessfulRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                asList(0, 1, 2, 3, 4));
+    }
+
+    @Test
+    public void testRollHandlesErrorWhenClosingControllerAdminClient(VertxTestContext testContext) {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
+                noException(),
+                new RuntimeException("Test Exception"), noException(), noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 3);
+        // The algorithm should carry on rolling the pods (errors are logged),
+        // because we did the active controller last order
+        doSuccessfulRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                asList(0, 1, 2, 4, 3));
+    }
+
+    @Test
+    public void testBrokerNotInitiallyRollable(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         AtomicInteger count = new AtomicInteger(3);
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId ->
-                    brokerId == 1 ? succeededFuture(count.getAndDecrement() == 0)
-                            : succeededFuture(true),
+                brokerId ->
+                        brokerId == 1 ? succeededFuture(count.getAndDecrement() == 0)
+                                : succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+        doSuccessfulRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                asList(0, 2, 3, 4, 1));
+    }
+
+    @Test
+    public void testCombinedNotInitiallyRollable(VertxTestContext testContext) {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        // we expect canRoll to be called twice for each combined node
+        AtomicInteger count = new AtomicInteger(5);
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                combinedId ->
+                        combinedId == 1 ? succeededFuture(count.getAndDecrement() < 0) : succeededFuture(true),
                 false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -406,60 +412,79 @@ public class KafkaRollerTest {
     @Test
     public void testControllerNotInitiallyRollable(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        AtomicInteger count = new AtomicInteger(2);
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        AtomicInteger count = new AtomicInteger(3);
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId -> {
-                if (brokerId == 2) {
-                    boolean b = count.getAndDecrement() == 0;
-                    LOGGER.info("Can broker {} be rolled now ? {}", brokerId, b);
-                    return succeededFuture(b);
-                } else {
-                    return succeededFuture(true);
-                }
-            },
+                controllerId ->
+                        (controllerId == 1) ? succeededFuture(count.getAndDecrement() == 0) : succeededFuture(true),
                 false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
-                asList(0, 1, 3, 4, 2));
+                asList(0, 3, 4, 1, 2));
     }
 
     @Test
-    public void testNonControllerNeverRollable(VertxTestContext testContext) throws InterruptedException {
+    public void testBrokerNeverRollable(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId ->
-                    brokerId == 1 ? succeededFuture(false)
-                            : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                brokerId ->
+                        brokerId == 1 ? succeededFuture(false)
+                                : succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
-                // Controller last, broker 1 never restarted
-                asList(0, 3, 4, 2));
-        // TODO assert subsequent rolls
-        kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+                // broker 1 never restarted
+                asList(0, 2, 3, 4));
+        kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId -> succeededFuture(brokerId != 1),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                brokerId -> succeededFuture(brokerId != 1),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(1),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
-                // Controller last, broker 1 never restarted
+                // broker 1 never restarted
+                emptyList());
+    }
+
+    @Test
+    public void testCombinedNeverRollable(VertxTestContext testContext) throws InterruptedException {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId ->
+                        brokerId == 1 ? succeededFuture(false)
+                                : succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+        doFailingRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
+                // broker 1 never restarted
+                asList(0, 2, 3, 4));
+
+        kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> succeededFuture(brokerId != 1),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+        clearRestarted();
+        doFailingRollingRestart(testContext, kafkaRoller,
+                singletonList(1),
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
+                // broker 1 never restarted
                 emptyList());
     }
 
     @Test
     public void testControllerNeverRollable(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId ->
-                    brokerId == 2 ? succeededFuture(false)
-                            : succeededFuture(true),
+                brokerId ->
+                        brokerId == 2 ? succeededFuture(false)
+                                : succeededFuture(true),
                 false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -467,10 +492,10 @@ public class KafkaRollerTest {
                 // We expect all non-controller pods to be rolled
                 asList(0, 1, 3, 4));
         clearRestarted();
-        kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
-            podOps,
+        kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0),
+                podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId -> succeededFuture(brokerId != 2),
+                brokerId -> succeededFuture(brokerId != 2),
                 false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(2),
@@ -480,26 +505,39 @@ public class KafkaRollerTest {
     }
 
     @Test
-    public void testRollHandlesErrorWhenGettingConfigFromNonController(VertxTestContext testContext) {
+    public void testRollHandlesErrorWhenGettingBrokerConfig(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-            brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
-                asList(0, 3, 4, 1, 2));
+                asList(0, 2, 3, 4, 1));
+    }
+
+    @Test
+    public void testRollHandlesErrorWhenGettingCombinedConfig(VertxTestContext testContext) {
+        PodOperator podOps = mockPodOps(podId -> succeededFuture());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
+                noException(), null,
+                noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
+                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+        // The algorithm should carry on rolling the pods
+        doSuccessfulRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4),
+                asList(0, 2, 3, 4, 1));
     }
 
     @Test
     public void testRollHandlesErrorWhenGettingConfigFromController(VertxTestContext testContext) {
         int controller = 2;
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
-            noException(), null,
-            noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-            brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
+                noException(), null,
+                noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
+                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -509,30 +547,30 @@ public class KafkaRollerTest {
     @Test
     public void testRollHandlesErrorWhenAlteringConfig(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), podId -> new KafkaRoller.ForceableProblem("could not get alter exception"), noException(),
-            brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulConfigUpdate(testContext, kafkaRoller,
-                asList(0, 1, 3, 4, 2));
+                asList(0, 1, 2, 3, 4));
     }
 
     @Test
     public void testSuccessfulAlteringConfigNotRoll(VertxTestContext testContext) {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS), podOps,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), noException(), noException(),
-            brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should not carry on rolling the pods
         doSuccessfulConfigUpdate(testContext, kafkaRoller,
                 emptyList());
     }
 
     @Test
-    public void testSuccessfulRollingKRaftControllers(VertxTestContext testContext) {
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 3, 3),
+    public void testSuccessfulRollingControllers(VertxTestContext testContext) {
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 3, 3),
                 mockPodOps(podId -> succeededFuture()), noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -541,8 +579,8 @@ public class KafkaRollerTest {
     }
 
     @Test
-    public void testKRaftControllerNoQuorum(VertxTestContext testContext) throws InterruptedException {
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 3),
+    public void testControllerNoQuorum(VertxTestContext testContext) throws InterruptedException {
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, 3),
                 mockPodOps(podId -> succeededFuture()), noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(false), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(testContext, kafkaRoller,
@@ -554,20 +592,20 @@ public class KafkaRollerTest {
     @Test
     public void testControllerAndOneMoreNeverRollable(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
-            podOps,
-            noException(), null, noException(), noException(), noException(),
-            brokerId -> brokerId == 2 || brokerId == 3 ? succeededFuture(false) : succeededFuture(true),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS),
+                podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> brokerId == 2 || brokerId == 3 ? succeededFuture(false) : succeededFuture(true),
                 false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
-            asList(0, 1, 2, 3, 4),
-            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is the active controller and there are other pods to verify first",
-            // We expect all non-controller pods to be rolled
-            asList(0, 1, 4));
+                asList(0, 1, 2, 3, 4),
+                KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is the active controller and there are other pods to verify first",
+                // We expect all non-controller pods to be rolled
+                asList(0, 1, 4));
     }
 
     @Test
-     public void testBrokerInRecoveryState(VertxTestContext testContext) throws InterruptedException {
+    public void testBrokerInRecoveryState(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId ->
                 (podId == 0) ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
         );
@@ -577,20 +615,20 @@ public class KafkaRollerTest {
         recoveryState.put("remainingSegmentsToRecover", 100);
         BrokerState brokerstate = new BrokerState(2, recoveryState);
 
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 0, 3),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, 1);
+                false, null, null, false, brokerstate, 3);
 
         doFailingRollingRestart(testContext, kafkaRoller,
-                asList(0, 1, 2, 3, 4),
+                asList(0, 1, 2, 3, 4, 5),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-0 is not ready because the Kafka node is performing log recovery. There are 10 logs and 100 segments left to recover.",
-                asList(2, 3, 4, 1));
+                asList(4, 5, 3, 1, 2));
     }
 
     @Test
-    public void testBrokerInRecoveryStateForKRaftController(VertxTestContext testContext) throws InterruptedException {
+    public void testControllerInRecoveryState(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId ->
                 (podId == 0) ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
         );
@@ -600,7 +638,7 @@ public class KafkaRollerTest {
         recoveryState.put("remainingSegmentsToRecover", 100);
         BrokerState brokerstate = new BrokerState(2, recoveryState);
 
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 3),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, 3),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
@@ -613,6 +651,30 @@ public class KafkaRollerTest {
     }
 
     @Test
+    public void testCombinedInRecoveryState(VertxTestContext testContext) throws InterruptedException {
+        PodOperator podOps = mockPodOps(podId ->
+                (podId == 4) ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
+        );
+
+        Map<String, Object> recoveryState = new HashMap<>();
+        recoveryState.put("remainingLogsToRecover", 10);
+        recoveryState.put("remainingSegmentsToRecover", 100);
+        BrokerState brokerstate = new BrokerState(2, recoveryState);
+
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 0),
+                podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> succeededFuture(true),
+                false, null, null, false, brokerstate, 3);
+
+        // It rolls brokers if only successfully rolled controllers
+        doFailingRollingRestart(testContext, kafkaRoller,
+                asList(0, 1, 2, 3, 4, 5),
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-4 is not ready because the Kafka node is performing log recovery. There are 10 logs and 100 segments left to recover.",
+                asList(5, 3));
+    }
+
+    @Test
     public void testBrokerInRunningState(VertxTestContext testContext) throws InterruptedException {
         PodOperator podOps = mockPodOps(podId ->
                 (podId == 0) ? failedFuture(new TimeoutException("Timeout")) : succeededFuture()
@@ -620,11 +682,11 @@ public class KafkaRollerTest {
 
         BrokerState brokerstate = new BrokerState(3, null);
 
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, 1);
+                false, null, null, false, brokerstate, -1);
 
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -640,7 +702,7 @@ public class KafkaRollerTest {
 
         BrokerState brokerstate = new BrokerState(-1, null);
 
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
@@ -658,7 +720,7 @@ public class KafkaRollerTest {
                 (podId == 0) ? failedFuture(new KubernetesClientException("Failed")) : succeededFuture()
         );
 
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
@@ -671,8 +733,8 @@ public class KafkaRollerTest {
     }
 
     @Test
-    public void testRollWithKRaftNodes(VertxTestContext testContext) {
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(3, 3, 3),
+    public void testRollWithAllRoles(VertxTestContext testContext) {
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3),
                 mockPodOps(podId -> succeededFuture()), noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 6);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -681,7 +743,7 @@ public class KafkaRollerTest {
     }
 
     @Test
-    public void testRollUnreadyPodFirstKRaftNodes(VertxTestContext testContext) {
+    public void testRollUnreadyPodFirstAllRoles(VertxTestContext testContext) {
         AtomicBoolean pod1Unready = new AtomicBoolean(true);
         AtomicBoolean pod4Unready = new AtomicBoolean(true);
         AtomicBoolean pod7Unready = new AtomicBoolean(true);
@@ -700,7 +762,7 @@ public class KafkaRollerTest {
             }
             return succeededFuture();
         });
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(3, 3, 3),
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3),
                 podOps, noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -708,15 +770,15 @@ public class KafkaRollerTest {
                 asList(7, 4, 3, 5, 6, 8, 1, 0, 2)); //Rolls in order: unready controllers, ready controllers, unready brokers, ready brokers
     }
 
-    private TestingKafkaRoller rollerWithControllers(PodOperator podOps, int... controllers) {
-        return new TestingKafkaRoller(addPodNames(KafkaRollerTest.REPLICAS), podOps,
+    private TestingKafkaRoller rollerWithActiveController(PodOperator podOps, Set<NodeRef> nodes, int activeController) {
+        return new TestingKafkaRoller(nodes, podOps,
                 noException(), null, noException(), noException(), noException(),
-            brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controllers);
+                brokerId -> succeededFuture(true),
+                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
     }
 
     private void doSuccessfulConfigUpdate(VertxTestContext testContext, TestingKafkaRoller kafkaRoller,
-                                            List<Integer> expected) {
+                                          List<Integer> expected) {
         Checkpoint async = testContext.checkpoint();
         kafkaRoller.rollingRestart(pod -> RestartReasons.empty())
                 .onComplete(testContext.succeeding(v -> {
@@ -727,8 +789,8 @@ public class KafkaRollerTest {
     }
 
     private void doSuccessfulRollingRestart(VertxTestContext testContext, TestingKafkaRoller kafkaRoller,
-                                    Collection<Integer> podsToRestart,
-                                    List<Integer> expected) {
+                                            Collection<Integer> podsToRestart,
+                                            List<Integer> expected) {
         doSuccessfulRollingRestart(testContext, kafkaRoller, podsToRestart, expected, null);
     }
 
@@ -736,21 +798,22 @@ public class KafkaRollerTest {
                                             Collection<Integer> podsToRestart,
                                             List<Integer> expected, Runnable onCompletion) {
         Checkpoint async = testContext.checkpoint();
-        kafkaRoller.rollingRestart(pod -> {
-            if (podsToRestart.contains(podName2Number(pod.getMetadata().getName()))) {
-                return RestartReasons.of(RestartReason.MANUAL_ROLLING_UPDATE);
-            } else {
-                return RestartReasons.empty();
-            }
-        })
-            .onComplete(testContext.succeeding(v -> {
-                testContext.verify(() -> assertThat(restarted(), is(expected)));
-                assertNoUnclosedAdminClient(testContext, kafkaRoller);
-                if (onCompletion != null) {
-                    onCompletion.run();
-                }
-                async.flag();
-            }));
+        kafkaRoller
+                .rollingRestart(pod -> {
+                    if (podsToRestart.contains(podName2Number(pod.getMetadata().getName()))) {
+                        return RestartReasons.of(RestartReason.MANUAL_ROLLING_UPDATE);
+                    } else {
+                        return RestartReasons.empty();
+                    }
+                })
+                .onComplete(testContext.succeeding(v -> {
+                    testContext.verify(() -> assertThat(restarted(), is(expected)));
+                    assertNoUnclosedAdminClient(testContext, kafkaRoller);
+                    if (onCompletion != null) {
+                        onCompletion.run();
+                    }
+                    async.flag();
+                }));
     }
 
     private void assertNoUnclosedAdminClient(VertxTestContext testContext, TestingKafkaRoller kafkaRoller) {
@@ -762,28 +825,29 @@ public class KafkaRollerTest {
     }
 
     private void doFailingRollingRestart(VertxTestContext testContext, TestingKafkaRoller kafkaRoller,
-                                 Collection<Integer> podsToRestart,
-                                 Class<? extends Throwable> exception, String message,
-                                 List<Integer> expectedRestart) throws InterruptedException {
+                                         Collection<Integer> podsToRestart,
+                                         Class<? extends Throwable> exception, String message,
+                                         List<Integer> expectedRestart) throws InterruptedException {
         CountDownLatch async = new CountDownLatch(1);
-        kafkaRoller.rollingRestart(pod -> {
-            if (podsToRestart.contains(podName2Number(pod.getMetadata().getName()))) {
-                return RestartReasons.of(RestartReason.MANUAL_ROLLING_UPDATE);
-            } else {
-                return RestartReasons.empty();
-            }
-        })
-            .onComplete(testContext.failing(e -> testContext.verify(() -> {
-                try {
-                    assertThat(e.getClass() + " is not a subclass of " + exception.getName(), e, instanceOf(exception));
-                    assertThat("The exception message was not as expected", e.getMessage(), is(message));
-                    assertThat("The restarted pods were not as expected", restarted(), is(expectedRestart));
-                    assertNoUnclosedAdminClient(testContext, kafkaRoller);
-                    testContext.completeNow();
-                } finally {
-                    async.countDown();
-                }
-            })));
+        kafkaRoller
+                .rollingRestart(pod -> {
+                    if (podsToRestart.contains(podName2Number(pod.getMetadata().getName()))) {
+                        return RestartReasons.of(RestartReason.MANUAL_ROLLING_UPDATE);
+                    } else {
+                        return RestartReasons.empty();
+                    }
+                })
+                .onComplete(testContext.failing(e -> testContext.verify(() -> {
+                    try {
+                        assertThat(e.getClass() + " is not a subclass of " + exception.getName(), e, instanceOf(exception));
+                        assertThat("The exception message was not as expected", e.getMessage(), is(message));
+                        assertThat("The restarted pods were not as expected", restarted(), is(expectedRestart));
+                        assertNoUnclosedAdminClient(testContext, kafkaRoller);
+                        testContext.completeNow();
+                    } finally {
+                        async.countDown();
+                    }
+                })));
         async.await();
     }
 
@@ -801,8 +865,8 @@ public class KafkaRollerTest {
         when(podOps.get(any(), any())).thenAnswer(
                 invocation -> new PodBuilder()
                         .withNewMetadata()
-                            .withNamespace(invocation.getArgument(0))
-                            .withName(invocation.getArgument(1))
+                        .withNamespace(invocation.getArgument(0))
+                        .withName(invocation.getArgument(1))
                         .endMetadata()
                         .build()
         );
@@ -839,8 +903,7 @@ public class KafkaRollerTest {
         private final Function<Integer, ForceableProblem> getConfigsException;
         private final boolean delegateControllerCall;
         private final boolean delegateAdminClientCall;
-        private final int[] controllers;
-        private final List<String> tcpProbes = new ArrayList<>();
+        private final int activeController;
         private final BrokerState brokerState;
 
         @SuppressWarnings("checkstyle:ParameterNumber")
@@ -855,7 +918,7 @@ public class KafkaRollerTest {
                                    boolean delegateControllerCall,
                                    AdminClientProvider adminClientProvider,
                                    KafkaAgentClientProvider kafkaAgentClientProvider,
-                                   boolean delegateAdminClientCall, BrokerState brokerState, int... controllers) {
+                                   boolean delegateAdminClientCall, BrokerState brokerState, int activeController) {
             super(
                     new Reconciliation("test", "Kafka", stsNamespace(), clusterName()),
                     KafkaRollerTest.vertx,
@@ -874,7 +937,7 @@ public class KafkaRollerTest {
                     mock(KubernetesRestartEventPublisher.class));
             this.delegateControllerCall = delegateControllerCall;
             this.delegateAdminClientCall = delegateAdminClientCall;
-            this.controllers = controllers;
+            this.activeController = activeController;
             this.controllerCall = 0;
             Objects.requireNonNull(acOpenException);
             this.acOpenException = acOpenException;
@@ -968,14 +1031,8 @@ public class KafkaRollerTest {
             if (throwable != null) {
                 throw new ForceableProblem("An error while trying to determine the cluster controller from pod " + nodeRef.podName(), throwable);
             } else {
-                int index;
-                if (controllerCall < controllers.length) {
-                    index = controllerCall;
-                } else {
-                    index = controllers.length - 1;
-                }
                 controllerCall++;
-                return controllers[index];
+                return activeController;
             }
         }
 
@@ -1005,13 +1062,5 @@ public class KafkaRollerTest {
             restarted.add(pod.getMetadata().getName());
             return succeededFuture();
         }
-
-        @Override
-        protected void tcpProbe(String hostname, int port) throws IOException {
-            tcpProbes.add(hostname + ":" + port);
-            throw new IOException("mock probe failure");
-        }
     }
-
-    // TODO Error when finding the next broker
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -266,7 +265,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 30);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 30);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we never find the controller we get ascending order
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -282,7 +281,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -297,7 +296,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -312,7 +311,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(node -> node.nodeId()).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 4);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 4);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -329,7 +328,7 @@ public class KafkaRollerTest {
                 noException(), null,
                 podId -> podId == nonActiveController ? new RuntimeException("Test Exception") : null, noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 3, 4, 1, 2));
@@ -344,7 +343,7 @@ public class KafkaRollerTest {
                 noException(), null,
                 podId -> podId == activeController ? new RuntimeException("Test Exception") : null, noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 1, 3, 4, 2));
@@ -357,7 +356,7 @@ public class KafkaRollerTest {
                 noException(),
                 new RuntimeException("Test Exception"), noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged)
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -371,7 +370,7 @@ public class KafkaRollerTest {
                 noException(),
                 new RuntimeException("Test Exception"), noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 3);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 3);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we did the active controller last order
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -388,7 +387,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 1 ? succeededFuture(count.getAndDecrement() == 0)
                                 : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 2, 3, 4, 1));
@@ -403,7 +402,7 @@ public class KafkaRollerTest {
                 noException(), null, noException(), noException(), noException(),
                 combinedId ->
                         combinedId == 1 ? succeededFuture(count.getAndDecrement() < 0) : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 3, 4, 1, 2));
@@ -417,7 +416,7 @@ public class KafkaRollerTest {
                 noException(), null, noException(), noException(), noException(),
                 controllerId ->
                         (controllerId == 1) ? succeededFuture(count.getAndDecrement() == 0) : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 3, 4, 1, 2));
@@ -431,7 +430,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 1 ? succeededFuture(false)
                                 : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
@@ -440,7 +439,7 @@ public class KafkaRollerTest {
         kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(brokerId != 1),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(1),
@@ -457,7 +456,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 1 ? succeededFuture(false)
                                 : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
@@ -467,7 +466,7 @@ public class KafkaRollerTest {
         kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(brokerId != 1),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(1),
@@ -485,22 +484,21 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 2 ? succeededFuture(false)
                                 : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
-                // We expect all non-controller pods to be rolled
+                // We expect all non-active controller pods to be rolled
                 asList(0, 1, 3, 4));
         clearRestarted();
         kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0),
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(brokerId != 2),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(2),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
-                // We expect all non-controller pods to be rolled
                 emptyList());
     }
 
@@ -510,7 +508,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -523,7 +521,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
                 noException(), null,
                 noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -537,7 +535,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
                 noException(), null,
                 noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -550,7 +548,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), podId -> new KafkaRoller.ForceableProblem("could not get alter exception"), noException(),
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulConfigUpdate(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4));
@@ -562,7 +560,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), noException(), noException(),
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should not carry on rolling the pods
         doSuccessfulConfigUpdate(testContext, kafkaRoller,
                 emptyList());
@@ -572,7 +570,7 @@ public class KafkaRollerTest {
     public void testSuccessfulRollingControllers(VertxTestContext testContext) {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 3, 3),
                 mockPodOps(podId -> succeededFuture()), noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5),
                 asList(0, 1, 2, 3, 4, 5));
@@ -582,7 +580,7 @@ public class KafkaRollerTest {
     public void testControllerNoQuorum(VertxTestContext testContext) throws InterruptedException {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, 3),
                 mockPodOps(podId -> succeededFuture()), noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(false), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(false), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-0 cannot be updated right now.",
@@ -596,7 +594,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> brokerId == 2 || brokerId == 3 ? succeededFuture(false) : succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is the active controller and there are other pods to verify first",
@@ -619,7 +617,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, 3);
+                null, null, false, brokerstate, 3);
 
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5),
@@ -642,7 +640,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, -1);
+                null, null, false, brokerstate, -1);
 
         doFailingRollingRestart(testContext, kafkaRoller,
                 List.of(0, 1, 2),
@@ -665,7 +663,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, 3);
+                null, null, false, brokerstate, 3);
 
         // It rolls brokers if only successfully rolled controllers
         doFailingRollingRestart(testContext, kafkaRoller,
@@ -686,7 +684,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, -1);
+                null, null, false, brokerstate, -1);
 
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -706,7 +704,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, brokerstate, 1);
+                null, null, false, brokerstate, 1);
 
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0),
@@ -724,7 +722,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, null, null, false, null, 1);
+                null, null, false, null, 1);
 
         doFailingRollingRestart(testContext, kafkaRoller,
                 List.of(),
@@ -736,7 +734,7 @@ public class KafkaRollerTest {
     public void testRollWithAllRoles(VertxTestContext testContext) {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3),
                 mockPodOps(podId -> succeededFuture()), noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 6);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 6);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8),
                 asList(3, 4, 5, 7, 8, 6, 0, 1, 2));
@@ -764,7 +762,7 @@ public class KafkaRollerTest {
         });
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3),
                 podOps, noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
+                brokerId -> succeededFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8), // brokers, combined, controllers
                 asList(7, 4, 3, 5, 6, 8, 1, 0, 2)); //Rolls in order: unready controllers, ready controllers, unready brokers, ready brokers
@@ -774,7 +772,7 @@ public class KafkaRollerTest {
         return new TestingKafkaRoller(nodes, podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
-                false, new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
     }
 
     private void doSuccessfulConfigUpdate(VertxTestContext testContext, TestingKafkaRoller kafkaRoller,
@@ -901,7 +899,6 @@ public class KafkaRollerTest {
         private final Function<Integer, Throwable> controllerException;
         private final Function<Integer, ForceableProblem> alterConfigsException;
         private final Function<Integer, ForceableProblem> getConfigsException;
-        private final boolean delegateControllerCall;
         private final boolean delegateAdminClientCall;
         private final int activeController;
         private final BrokerState brokerState;
@@ -915,7 +912,6 @@ public class KafkaRollerTest {
                                    Function<Integer, ForceableProblem> alterConfigsException,
                                    Function<Integer, ForceableProblem> getConfigsException,
                                    Function<Integer, Future<Boolean>> canRollFn,
-                                   boolean delegateControllerCall,
                                    AdminClientProvider adminClientProvider,
                                    KafkaAgentClientProvider kafkaAgentClientProvider,
                                    boolean delegateAdminClientCall, BrokerState brokerState, int activeController) {
@@ -935,7 +931,6 @@ public class KafkaRollerTest {
                     KafkaVersionTestUtils.getLatestVersion(),
                     true,
                     mock(KubernetesRestartEventPublisher.class));
-            this.delegateControllerCall = delegateControllerCall;
             this.delegateAdminClientCall = delegateAdminClientCall;
             this.activeController = activeController;
             this.controllerCall = 0;
@@ -1019,20 +1014,21 @@ public class KafkaRollerTest {
                 Future<Boolean> canRollController(int nodeId) {
                     return canRollFn.apply(nodeId);
                 }
+
+                @Override
+                Future<Integer> quorumLeaderId() {
+                    return succeededFuture(activeController);
+                }
             };
         }
 
         @Override
-        int controller(NodeRef nodeRef, long timeout, TimeUnit unit, RestartContext restartContext) throws Exception {
-            if (delegateControllerCall) {
-                return super.controller(nodeRef, timeout, unit, restartContext);
-            }
+        boolean deferController(NodeRef nodeRef, RestartContext restartContext) throws Exception {
             Throwable throwable = controllerException.apply(nodeRef.nodeId());
             if (throwable != null) {
                 throw new ForceableProblem("An error while trying to determine the cluster controller from pod " + nodeRef.podName(), throwable);
             } else {
-                controllerCall++;
-                return activeController;
+                return super.deferController(nodeRef, restartContext);
             }
         }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description
Remove the controller check that was only relevant for Zookeeper based brokers. With KRaft, we don't need this check. We only need to check if a controller node that is being considered to be restarted is the active controller or not. 
This also results in removing the tcp probe logic, as this was only relevant for Zookeeper based brokers. 

Refactor unit tests to remove any Zookeeper relevant tests and ensure all KRaft tests cases are covered. 

Closes #9373 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

