### PR TITLE
Added development doc about the Operators Catalog release

### DIFF
--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -127,17 +127,18 @@ Any CVEs in our code or in the Java dependencies require new patch (or minor) re
 In order to make the Strimzi operator available in the [OperatorHub.io](https://operatorhub.io/) catalog, you need to build a bundle containing the Strimzi operator metadata together with its Custom Resource Definitions.
 The metadata are described through a `ClusterServiceVersion` (CSV) resource declared by using a corresponding YAML file.
 
-The bundle for the OperatorHub.io is available in the https://github.com/k8s-operatorhub/community-operators/tree/main/operators/strimzi-kafka-operator GitHub repo.
+The bundle for the OperatorHub.io is available in the [Community-Operators](https://github.com/k8s-operatorhub/community-operators/tree/main/operators/strimzi-kafka-operator) GitHub repo.
 
-In order provide the bundle for a new release, you can start looking at a previous one, create a folder for the new release, but making the following changes:
+In order provide the bundle for a new release, you can use the previous one as a base.  
+Create a folder for the new release by copying the previous one and make the following changes:
 
-* change the `metadata/annotations.yaml` in order to add a channel related to the new release (i.e. `strimzi-0.45.x`) alongside the stable one.
-* copy the CRDs and the Cluster Roles YAML to the `manifests` folder by taking them from the `packaging/install/cluster-operator` folder (within the Strimzi repo).
+* if releasing a new minor or major version (rather than fix), change the `metadata/annotations.yaml` to update the second channel listed next to `operators.operatorframework.io.bundle.channels.v1` to the new release version range (e.g. `strimzi-0.45.x`).
+* copy the CRDs and the Cluster Roles YAML to the `manifests` folder by taking them from the `install/cluster-operator` folder (within the Strimzi repo).
 * take the `strimzi-cluster-operator.v<VERSION>.clusterserviceversion.yaml` CSV file (by using the new release as `<VERSION>`) in order to update the following:
-  * `metadata.annotations.alm-examples-metadata` section by using the examples from the `packaging/examples` folder (within the Strimzi repo).
+  * `metadata.annotations.alm-examples-metadata` section by using the examples from the `examples` folder (within the Strimzi repo).
   * `containerImage` field with the new operator image (using the SHA).
   * `name` field by setting the new version in the operator name.
-  * `customresourcedefinitions.owned` section with the CRDs descriptions.
+  * `customresourcedefinitions.owned` section with the CRDs descriptions, from the `install/cluster-operator` folder (within the Strimzi repo).
   * `description` section with all the Strimzi operator information already used for the release on GitHub.
   * `install.spec.permissions` section by using the Cluster Role files from the `packaging/install/cluster-operator` (within the Strimzi repo).
   * `deployments` section by using the Strimzi Cluster Operator Deployment YAML from the `packaging/install/cluster-operator` (within the Strimzi repo) but using the SHAs for the images.
@@ -149,7 +150,7 @@ After making all these changes, you can double-check the validity of the CSV by 
 
 ### Testing the bundle
 
-When the operator manifests and metadata files are ready, it is useful to test the operator bundle on an actual Kubernetes and OpenShift cluster.
+When the operator manifests and metadata files are ready, you should test the operator bundle on an actual Kubernetes and OpenShift cluster.
 If you are using Kubernetes, then you first need to install the Operator Lifecycle Manager (OLM) on it:
 
 ```shell

--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -140,8 +140,8 @@ Create a folder for the new release by copying the previous one and make the fol
   * `name` field by setting the new version in the operator name.
   * `customresourcedefinitions.owned` section with the CRDs descriptions, from the `install/cluster-operator` folder (within the Strimzi repo).
   * `description` section with all the Strimzi operator information already used for the release on GitHub.
-  * `install.spec.permissions` section by using the Cluster Role files from the `packaging/install/cluster-operator` (within the Strimzi repo).
-  * `deployments` section by using the Strimzi Cluster Operator Deployment YAML from the `packaging/install/cluster-operator` (within the Strimzi repo) but using the SHAs for the images.
+  * `install.spec.permissions` section by using the Cluster Role files from the `install/cluster-operator` (within the Strimzi repo).
+  * `deployments` section by using the Strimzi Cluster Operator Deployment YAML from the `install/cluster-operator` (within the Strimzi repo) but using the SHAs for the images.
   * `relatedImages` section with the same images as the step before.
   * `replaces` field by setting the old version that this new one is going to replace.
   * `version` field with the new release.

--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -121,3 +121,36 @@ After the manual approval, the image will be also pushed under the tag without s
 
 This process should be used only for CVEs in the base images.
 Any CVEs in our code or in the Java dependencies require new patch (or minor) release.
+
+## Operators Catalog
+
+In order to make the Strimzi operator available in the [OperatorHub.io](https://operatorhub.io/) catalog, you need to build a bundle containing the Strimzi operator metadata together with its Custom Resource Definitions.
+The metadata are described through a `ClusterServiceVersion` (CSV) resource declared by using a corresponding YAML file.
+
+The bundle for the OperatorHub.io is available in the https://github.com/k8s-operatorhub/community-operators/tree/main/operators/strimzi-kafka-operator GitHub repo.
+
+In order provide the bundle for a new release, you can start looking at a previous one, create a folder for the new release, but making the following changes:
+
+* change the `metadata/annotations.yaml` in order to add a channel related to the new release (i.e. `strimzi-0.45.x`) alongside the stable one.
+* copy the CRDs and the Cluster Roles YAML to the `manifests` folder by taking them from the `packaging/install/cluster-operator` folder (within the Strimzi repo).
+* take the `strimzi-cluster-operator.v<VERSION>.clusterserviceversion.yaml` CSV file (by using the new release as `<VERSION>`) in order to update the following:
+  * `metadata.annotations.alm-examples-metadata` section by using the examples from the `packaging/examples` folder (within the Strimzi repo).
+  * `containerImage` field with the new operator image (using the SHA).
+  * `name` field by setting the new version in the operator name.
+  * `customresourcedefinitions.owned` section with the CRDs descriptions.
+  * `description` section with all the Strimzi operator information already used for the release on GitHub.
+  * `install.spec.permissions` section by using the Cluster Role files from the `packaging/install/cluster-operator` (within the Strimzi repo).
+  * `deployments` section by using the Strimzi Cluster Operator Deployment YAML from the `packaging/install/cluster-operator` (within the Strimzi repo) but using the SHAs for the images.
+  * `relatedImages` section with the same images as the step before.
+  * `replaces` field by setting the old version that this new one is going to replace.
+  * `version` field with the new release.
+
+After making all these changes, you can double-check the validity of the CSV by copy/paste its content into the [OperatorHub.io preview](https://operatorhub.io/preview) tool.
+Finally, open a PR against the `k8s-operatorhub/community-operators` repository.
+The PR will run some sanity checks which could need some fixes in case of errors.
+After being reviewed by maintainers and merged, the Strimzi operator will be available in the OperatorHub.io website.
+
+*Note*
+The operator should be made available in the OpenShift Operator Catalog as well.
+The bundle for the OpenShift Operator Catalog is available in the https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/strimzi-kafka-operator GitHub repo.
+Just follow the same steps as above for building the bundle.

--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -330,10 +330,12 @@ There is no need to create an `OperatorGroup` and `Subscription` manually.
 
 You can now deploy a Kafka cluster by using the installed operator and running some smoke tests.
 
-Finally, uninstall the operator by deleting the `Subscription`:
+Finally, uninstall the operator by deleting the `Subscription` and the corresponding `ClusterServiceVersion`:
 
 ```shell
+CSV=$(kubectl get subscription strimzi-subscription -n kafka -o json | jq -r '.status.installedCSV')
 kubectl delete subscription strimzi-subscription -n kafka
+kubectl delete csv $CSV -n kafka
 ```
 
 ### Publishing to OperatorHub.io and OpenShift Operator Catalog

--- a/development-docs/RELEASE.md
+++ b/development-docs/RELEASE.md
@@ -146,11 +146,202 @@ In order provide the bundle for a new release, you can start looking at a previo
   * `version` field with the new release.
 
 After making all these changes, you can double-check the validity of the CSV by copy/paste its content into the [OperatorHub.io preview](https://operatorhub.io/preview) tool.
-Finally, open a PR against the `k8s-operatorhub/community-operators` repository.
+
+### Testing the bundle
+
+When the operator manifests and metadata files are ready, it is useful to test the operator bundle on an actual Kubernetes and OpenShift cluster.
+If you are using Kubernetes, then you first need to install the Operator Lifecycle Manager (OLM) on it:
+
+```shell
+curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.31.0/install.sh | bash -s v0.31.0
+```
+
+The above step is not necessary if you are using OpenShift, because it has the OLM out-of-box.
+
+In this section, the following steps show how to:
+
+* create the operator bundle image and put it into a catalog image.
+* publish the catalog on the cluster.
+* install the operator from the catalog itself.
+
+Prerequisites:
+
+* [opm](https://github.com/operator-framework/operator-registry/releases) tool.
+* docker, podman or buildah (the following steps will use docker as an example)
+
+*Note*
+For further details about the following steps, you can also refer to the official [Operator Lifecycle Manager documentation](https://olm.operatorframework.io/docs/tasks/).
+
+#### Create the operator bundle image
+
+In this step, you are going to create a container image containing the bundle with the operator manifests and metadata. 
+Inside the bundle directory (i.e. `operators/strimzi-kafka-operator/0.45.0`), export the following environment variables to specify the operator version and the container registry and user used to push the bundle and catalog images:
+
+``shell
+export OPERATOR_VERSION=0.45.0
+export DOCKER_REGISTRY=quay.io
+export DOCKER_USER=ppatierno
+``
+
+Run the following command in order to generate a `bundle.Dockerfile` representing the operator bundle image.
+
+```shell
+opm alpha bundle generate --directory ./manifests/ --package strimzi-kafka-operator --channels stable,strimzi-0.45.x --default stable
+```
+
+*Note*
+The channels are the same as the ones specified in the `metadata/annotations.yaml` file.
+
+The generated Dockerfile will look like the following:
+
+```dockerfile
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=strimzi-kafka-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable,strimzi-0.45.x
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/
+```
+
+Run the following command to build the operator bundle image and push it to a repository:
+
+```shell
+docker build -t $DOCKER_REGISTRY/$DOCKER_USER/strimzi-kafka-operator-bundle:$OPERATOR_VERSION -f bundle.Dockerfile .
+docker push $DOCKER_REGISTRY/$DOCKER_USER/strimzi-kafka-operator-bundle:$OPERATOR_VERSION
+```
+
+You can also run some validations to ensure that your bundle is valid and in the correct format.:
+
+```shell
+opm alpha bundle validate --tag $DOCKER_REGISTRY/$DOCKER_USER/strimzi-kafka-operator-bundle:$OPERATOR_VERSION --image-builder docker
+```
+
+#### Create the catalog image
+
+In this step, you are going to create a catalog and put the operator bundle into it.
+Inside the bundle directory (i.e. `operators/strimzi-kafka-operator/0.45.0`), create a folder for the catalog:
+
+```shell
+mkdir -p strimzi-catalog
+```
+
+Run the following command in order to generate a `strimzi-catalog.Dockerfile` representing the catalog image.
+
+```shell
+opm generate dockerfile strimzi-catalog
+```
+
+Initialize the catalog:
+
+```shell
+opm init strimzi-kafka-operator --default-channel=stable --output yaml > strimzi-catalog/index.yaml
+```
+
+Add the bundle to the catalog (repeat for each operator version/bundle you want to add in order to be able to test operator upgrades):
+
+```shell
+opm render $DOCKER_REGISTRY/$DOCKER_USER/strimzi-kafka-operator-bundle:$OPERATOR_VERSION --output=yaml >> strimzi-catalog/index.yaml
+```
+
+Edit the `index.yaml` to add the bundle to a channel (i.e. using the stable one):
+
+```shell
+cat << EOF >> strimzi-catalog/index.yaml
+---
+schema: olm.channel
+package: strimzi-kafka-operator
+name: stable
+entries:
+  - name: strimzi-cluster-operator.v0.45.0
+EOF
+```
+
+Build and push the catalog image:
+
+```shell
+docker build -f strimzi-catalog.Dockerfile -t $DOCKER_REGISTRY/$DOCKER_USER/olm-catalog:latest .
+docker push $DOCKER_REGISTRY/$DOCKER_USER/olm-catalog:latest
+```
+
+### Make the catalog available on cluster
+
+Create a `CatalogSource` resource to make the catalog available on the cluster:
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: strimzi-catalog
+  namespace: olm # use openshift-marketplace if running on OpenShift
+spec:
+  sourceType: grpc
+  image: quay.io/ppatierno/olm-catalog:latest # use the correct image
+  displayName: Strimzi Catalog
+EOF
+```
+
+You can now list the operator as part of the "Strimzi Catalog" catalog and not the "Community Operators" catalog (coming from OLM):
+
+```shell
+kubectl get packagemanifest -n olm | grep strimzi-kafka-operator
+```
+
+### Install the operator
+
+Create a `kafka` namespace where the operator will be installed.
+On Kubernetes, you can install the operator by creating an `OperatorGroup` and a `Subscription`:
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: strimzi-group
+  namespace: kafka
+EOF
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: strimzi-subscription
+  namespace: kafka
+spec:
+  channel: stable
+  name: strimzi-kafka-operator
+  source: strimzi-catalog
+  sourceNamespace: olm
+  installPlanApproval: Automatic
+EOF
+```
+
+When the `Subscription` is created the OLM will use the "Strimzi Catalog" to install the operator from there.
+
+On OpenShift, after the `CatalogSource` creation, you can use the web interface and install the operator from the Operator Catalog page.
+There is no need to create an `OperatorGroup` and `Subscription` manually.
+
+You can now deploy a Kafka cluster by using the installed operator and running some smoke tests.
+
+Finally, uninstall the operator by deleting the `Subscription`:
+
+```shell
+kubectl delete subscription strimzi-subscription -n kafka
+```
+
+### Publishing to OperatorHub.io and OpenShift Operator Catalog
+
+When the bundle was successfully tested, you can finally open a PR against the `k8s-operatorhub/community-operators` repository.
 The PR will run some sanity checks which could need some fixes in case of errors.
 After being reviewed by maintainers and merged, the Strimzi operator will be available in the OperatorHub.io website.
 
-*Note*
 The operator should be made available in the OpenShift Operator Catalog as well.
 The bundle for the OpenShift Operator Catalog is available in the https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/strimzi-kafka-operator GitHub repo.
-Just follow the same steps as above for building the bundle.
+Just follow the same steps as for OperatorHub.io for building the bundle.


### PR DESCRIPTION
This PR adds some development documentation about how to make the Strimzi operator available within the OperatorHub.io (as well as the OpenShift Operators Catalog).