### PR TITLE
Removed controller logging in ZK mode

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/KafkaCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaCluster.properties
@@ -10,9 +10,6 @@ log4j.logger.kafka.request.logger=WARN, CONSOLE
 log4j.logger.kafka.network.Processor=OFF
 log4j.logger.kafka.server.KafkaApis=OFF
 log4j.logger.kafka.network.RequestChannel$=WARN
-# ZK mode controller
-log4j.logger.kafka.controller=TRACE
-# KRaft mode controller
 log4j.logger.org.apache.kafka.controller=INFO
 log4j.logger.kafka.log.LogCleaner=INFO
 log4j.logger.state.change.logger=INFO


### PR DESCRIPTION
Trivial PR to remove the Kafka controller (default) logging for the ZooKeeper mode which is now not supported anymore.