### PR TITLE
[system test] [perf] Add to TO scalability tests also printing the table

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
@@ -163,6 +163,7 @@ public interface PerformanceConstants {
     String TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE = "bobStreamingUseCase";
     String TOPIC_OPERATOR_ALICE_BULK_USE_CASE = "aliceBulkUseCase";
     String USER_OPERATOR_ALICE_BULK_USE_CASE = "aliceBulkUseCase";
+    String GENERAL_SCALABILITY_USE_CASE = "scalabilityUseCase";
     String GENERAL_CAPACITY_USE_CASE = "capacityUseCase";
     String TOPIC_OPERATOR_FIXED_SIZE_OF_EVENTS_USE_CASE = "fixedSizeOfEventsUseCase";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
@@ -87,6 +87,7 @@ public interface PerformanceConstants {
     String TOPIC_OPERATOR_OUT_SUCCESSFUL_KAFKA_TOPICS_CREATED = "OUT: Successful KafkaTopics Created";
     String TOPIC_OPERATOR_OUT_SUCCESSFUL_KAFKA_TOPICS_CREATED_AND_MODIFIED_AND_DELETED = "OUT: Successful KafkaTopics Created and Modified and Deleted (ms)";
     String TOPIC_OPERATOR_OUT_UPDATE_TIME = "OUT: Update Time (ms)";
+    String TOPIC_OPERATOR_OUT_RECONCILIATION_INTERVAL = "OUT: Reconciliation interval (ms)";
 
     // --------------------------------------------------------------------------------
     // ------------------------------ USER OPERATOR -----------------------------------

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorScalabilityPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorScalabilityPerformance.java
@@ -9,8 +9,11 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
+import io.strimzi.systemtest.performance.report.TopicOperatorPerformanceReporter;
+import io.strimzi.systemtest.performance.report.parser.TopicOperatorMetricsParser;
 import io.strimzi.systemtest.performance.utils.TopicOperatorPerformanceUtils;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -19,9 +22,13 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAccessor;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +39,11 @@ import static io.strimzi.systemtest.TestTags.SCALABILITY;
 @Tag(PERFORMANCE)
 @Tag(SCALABILITY)
 public class TopicOperatorScalabilityPerformance extends AbstractST {
+
+    protected static final TemporalAccessor ACTUAL_TIME = LocalDateTime.now();
+    protected static final String REPORT_DIRECTORY = "topic-operator";
+
+    protected TopicOperatorPerformanceReporter topicOperatorPerformanceReporter = new TopicOperatorPerformanceReporter();
 
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorScalabilityPerformance.class);
 
@@ -68,6 +80,12 @@ public class TopicOperatorScalabilityPerformance extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_IN_PROCESS_TYPE, "TOPIC-CONCURRENT");
 
                 performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_OUT_SUCCESSFUL_KAFKA_TOPICS_CREATED_AND_MODIFIED_AND_DELETED, reconciliationTimeMs);
+
+                try {
+                    this.topicOperatorPerformanceReporter.logPerformanceData(this.suiteTestStorage, performanceAttributes, REPORT_DIRECTORY + "/" + PerformanceConstants.GENERAL_SCALABILITY_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         });
     }
@@ -135,5 +153,12 @@ public class TopicOperatorScalabilityPerformance extends AbstractST {
                     .endSpec()
                 .build()
         );
+    }
+
+    @AfterAll
+    void tearDown() {
+        TopicOperatorPerformanceUtils.stopExecutor();
+        // show tables with metrics
+        TopicOperatorMetricsParser.main(new String[]{PerformanceConstants.TOPIC_OPERATOR_PARSER});
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorScalabilityPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorScalabilityPerformance.java
@@ -79,7 +79,7 @@ public class TopicOperatorScalabilityPerformance extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_IN_MAX_BATCH_LINGER_MS, maxBatchLingerMs);
                 performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_IN_PROCESS_TYPE, "TOPIC-CONCURRENT");
 
-                performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_OUT_SUCCESSFUL_KAFKA_TOPICS_CREATED_AND_MODIFIED_AND_DELETED, reconciliationTimeMs);
+                performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_OUT_RECONCILIATION_INTERVAL, reconciliationTimeMs);
 
                 try {
                     this.topicOperatorPerformanceReporter.logPerformanceData(this.suiteTestStorage, performanceAttributes, REPORT_DIRECTORY + "/" + PerformanceConstants.GENERAL_SCALABILITY_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

Currently, we did not print/log and save the results from the scalability tests. This PR adds this:
```java
Use Case: scalabilityUseCase
+------------+--------------------+-------------------------+----------------------+----------------------+---------------------------+------------------+-----------------------------------+
| Experiment | IN: MAX QUEUE SIZE | IN: MAX BATCH SIZE (ms) | IN: NUMBER OF TOPICS | IN: NUMBER OF EVENTS | IN: MAX BATCH LINGER (ms) | IN: PROCESS TYPE | OUT: Reconciliation interval (ms) |
| 1          | 2147483647         | 100                     | 25                   | 75                   | 100                       | TOPIC-CONCURRENT | 9156                              |
| 2          | 2147483647         | 100                     | 2                    | 8                    | 100                       | TOPIC-CONCURRENT | 6147                              |
| 3          | 2147483647         | 100                     | 250                  | 750                  | 100                       | TOPIC-CONCURRENT | 24730                             |
| 4          | 2147483647         | 100                     | 125                  | 375                  | 100                       | TOPIC-CONCURRENT | 26827                             |
+------------+--------------------+-------------------------+----------------------+----------------------+---------------------------+------------------+-----------------------------------+
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass