### PR TITLE
Fix deprecated GitHub actions/cache plugin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,7 +59,7 @@ jobs:
 
     # Setup Maven cache
     - name: Cache local Maven repository
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR tries to fix the deprecated GitHub actions/cache plugin the CodeQL pipeline seems to be complaining about. Stranglely, it seems to link to an article about deprecation of v1 and v2 versions while we use version v4. But in any case updating the version seems to help.