### PR TITLE
[ST] Use correct variable types for metrics, fix wrong logging

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -90,20 +90,20 @@ public class MetricsUtils {
         assertThat(values.isEmpty(), is(true));
     }
 
-    public static void assertCoMetricResourceState(String namespaceName, String kind, String name, BaseMetricsCollector collector, int value, String reason) {
+    public static void assertCoMetricResourceState(String namespaceName, String kind, String name, BaseMetricsCollector collector, double value, String reason) {
         assertMetricResourceState(namespaceName, kind, name, collector, value, reason);
     }
 
-    public static void assertMetricResourceState(String namespaceName, String kind, String name, BaseMetricsCollector collector, int value, String reason) {
+    public static void assertMetricResourceState(String namespaceName, String kind, String name, BaseMetricsCollector collector, double value, String reason) {
         String metric = "strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",reason=\"" + reason + ".*\",resource_namespace=\"" + namespaceName + "\",}";
         assertMetricValue(collector, metric, value);
     }
 
-    public static void assertCoMetricResources(String namespaceName, String kind, BaseMetricsCollector collector, int value) {
+    public static void assertCoMetricResources(String namespaceName, String kind, BaseMetricsCollector collector, double value) {
         assertMetricResources(namespaceName, kind, collector, value);
     }
 
-    public static void assertMetricResources(String namespaceName, String kind, BaseMetricsCollector collector, int value) {
+    public static void assertMetricResources(String namespaceName, String kind, BaseMetricsCollector collector, double value) {
         assertMetricValue(collector, getResourceMetricPattern(namespaceName, kind), value);
     }
 
@@ -155,28 +155,28 @@ public class MetricsUtils {
         }
     }
 
-    public static void assertMetricValue(BaseMetricsCollector collector, String metric, int expectedValue) {
+    public static void assertMetricValue(BaseMetricsCollector collector, String metric, double expectedValue) {
         List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).sum();
-        assertThat(String.format("metric '%s' actual value %s is different than expected %s", metric, actualValue, expectedValue), actualValue, is((double) expectedValue));
+        assertThat(String.format("metric '%s' actual value %s is different than expected %s", metric, actualValue, expectedValue), actualValue, is(expectedValue));
     }
 
-    public static void assertMetricValueCount(BaseMetricsCollector collector, String metric, long expectedValue) {
+    public static void assertMetricValueCount(BaseMetricsCollector collector, String metric, double expectedValue) {
         List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).count();
-        assertThat(String.format("metric '%s' actual value %s is different than expected %s", actualValue, expectedValue, metric), actualValue, is((double) expectedValue));
+        assertThat(String.format("metric '%s' actual value %s is different than expected %s", actualValue, expectedValue, metric), actualValue, is(expectedValue));
     }
 
-    public static void assertMetricCountHigherThan(BaseMetricsCollector collector, String metric, long expectedValue) {
+    public static void assertMetricCountHigherThan(BaseMetricsCollector collector, String metric, double expectedValue) {
         List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).count();
-        assertThat(String.format("metric '%s' actual value %s not is higher than expected %s", metric, actualValue, expectedValue), actualValue > expectedValue);
+        assertThat(String.format("metric '%s' actual value %s is not higher than expected %s", metric, actualValue, expectedValue), actualValue > expectedValue);
     }
 
-    public static void assertMetricValueHigherThan(BaseMetricsCollector collector, String metric, int expectedValue) {
+    public static void assertMetricValueHigherThanOrEqualTo(BaseMetricsCollector collector, String metric, double expectedValue) {
         List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).sum();
-        assertThat(String.format("metric '%s' actual value %s is different than expected %s", metric, actualValue, expectedValue), actualValue > expectedValue);
+        assertThat(String.format("metric '%s' actual value %s is not higher than or equal to %s", metric, actualValue, expectedValue), actualValue > expectedValue);
     }
 
     public static void assertContainsMetric(List<Metric> metrics, String metricName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -176,7 +176,7 @@ public class MetricsUtils {
     public static void assertMetricValueHigherThanOrEqualTo(BaseMetricsCollector collector, String metric, double expectedValue) {
         List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).sum();
-        assertThat(String.format("metric '%s' actual value %s is not higher than or equal to %s", metric, actualValue, expectedValue), actualValue > expectedValue);
+        assertThat(String.format("metric '%s' actual value %s is not higher than or equal to %s", metric, actualValue, expectedValue), actualValue >= expectedValue);
     }
 
     public static void assertContainsMetric(List<Metric> metrics, String metricName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -100,7 +100,7 @@ import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricReso
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResources;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValue;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueCount;
-import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueHigherThan;
+import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueHigherThanOrEqualTo;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueNotNull;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueNullOrZero;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.getExporterRunScript;
@@ -172,9 +172,9 @@ public class MetricsST extends AbstractST {
         }
     )
     void testKafkaMetrics() {
-        assertMetricValueCount(kafkaCollector, "kafka_server_replicamanager_leadercount", 3);
+        assertMetricValueCount(kafkaCollector, "kafka_server_replicamanager_leadercount", 3.0);
         assertMetricCountHigherThan(kafkaCollector, "kafka_server_replicamanager_partitioncount", 2);
-        assertMetricValue(kafkaCollector, "kafka_server_replicamanager_underreplicatedpartitions", 0);
+        assertMetricValue(kafkaCollector, "kafka_server_replicamanager_underreplicatedpartitions", 0.0);
     }
 
     @ParallelTest
@@ -215,21 +215,21 @@ public class MetricsST extends AbstractST {
 
         kafkaConnectCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
 
-        assertMetricValueHigherThan(kafkaConnectCollector, "kafka_connect_node_request_total\\{clientid=\".*\"}", 0);
-        assertMetricValueHigherThan(kafkaConnectCollector, "kafka_connect_node_response_total\\{clientid=\".*\".*}", 0);
-        assertMetricValueHigherThan(kafkaConnectCollector, "kafka_connect_network_io_total\\{clientid=\".*\".*}", 0);
+        assertMetricValueHigherThanOrEqualTo(kafkaConnectCollector, "kafka_connect_node_request_total\\{clientid=\".*\"}", 0.0);
+        assertMetricValueHigherThanOrEqualTo(kafkaConnectCollector, "kafka_connect_node_response_total\\{clientid=\".*\".*}", 0.0);
+        assertMetricValueHigherThanOrEqualTo(kafkaConnectCollector, "kafka_connect_network_io_total\\{clientid=\".*\".*}", 0.0);
 
         // Check CO metrics and look for KafkaConnect and KafkaConnector
         clusterOperatorCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
-        assertCoMetricResources(namespaceFirst, KafkaConnect.RESOURCE_KIND, clusterOperatorCollector, 1);
+        assertCoMetricResources(namespaceFirst, KafkaConnect.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaConnect.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceState(namespaceFirst, KafkaConnect.RESOURCE_KIND, kafkaClusterFirstName, clusterOperatorCollector, 1, "none");
+        assertCoMetricResourceState(namespaceFirst, KafkaConnect.RESOURCE_KIND, kafkaClusterFirstName, clusterOperatorCollector, 1.0, "none");
 
-        assertCoMetricResources(namespaceFirst, KafkaConnector.RESOURCE_KIND, clusterOperatorCollector, 1);
+        assertCoMetricResources(namespaceFirst, KafkaConnector.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaConnector.RESOURCE_KIND, clusterOperatorCollector);
 
-        assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 1);
-        assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(namespaceSecond, StrimziPodSet.RESOURCE_KIND), 0);
+        assertMetricValueHigherThanOrEqualTo(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 1.0);
+        assertMetricValueHigherThanOrEqualTo(clusterOperatorCollector, getResourceMetricPattern(namespaceSecond, StrimziPodSet.RESOURCE_KIND), 0.0);
     }
 
     @IsolatedTest
@@ -340,23 +340,23 @@ public class MetricsST extends AbstractST {
     )
     void testClusterOperatorMetrics() {
         // Expected PodSet counts per component
-        int podSetCount = 2;
+        double podSetCount = 2.0;
 
         assertCoMetricResourceNotNull(clusterOperatorCollector, "strimzi_reconciliations_periodical_total", Kafka.RESOURCE_KIND);
         assertCoMetricResourceNotNull(clusterOperatorCollector, "strimzi_reconciliations_duration_seconds_bucket", Kafka.RESOURCE_KIND);
         assertCoMetricResourceNotNull(clusterOperatorCollector, "strimzi_reconciliations_successful_total", Kafka.RESOURCE_KIND);
 
-        assertCoMetricResources(namespaceFirst, Kafka.RESOURCE_KIND, clusterOperatorCollector, 1);
-        assertCoMetricResources(namespaceSecond, Kafka.RESOURCE_KIND, clusterOperatorCollector, 1);
-        assertCoMetricResourceState(namespaceFirst, Kafka.RESOURCE_KIND, kafkaClusterFirstName, clusterOperatorCollector, 1, "none");
-        assertCoMetricResourceState(namespaceSecond, Kafka.RESOURCE_KIND, kafkaClusterSecondName, clusterOperatorCollector, 1, "none");
+        assertCoMetricResources(namespaceFirst, Kafka.RESOURCE_KIND, clusterOperatorCollector, 1.0);
+        assertCoMetricResources(namespaceSecond, Kafka.RESOURCE_KIND, clusterOperatorCollector, 1.0);
+        assertCoMetricResourceState(namespaceFirst, Kafka.RESOURCE_KIND, kafkaClusterFirstName, clusterOperatorCollector, 1.0, "none");
+        assertCoMetricResourceState(namespaceSecond, Kafka.RESOURCE_KIND, kafkaClusterSecondName, clusterOperatorCollector, 1.0, "none");
 
         assertCoMetricResourcesNullOrZero(namespaceFirst, KafkaRebalance.RESOURCE_KIND, clusterOperatorCollector);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaRebalance.RESOURCE_KIND, clusterOperatorCollector);
         assertCoMetricResourceStateNotExists(kafkaClusterFirstName, KafkaRebalance.RESOURCE_KIND, namespaceFirst, clusterOperatorCollector);
 
         // check StrimziPodSet metrics in CO
-        assertMetricCountHigherThan(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 0);
+        assertMetricCountHigherThan(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 0.0);
         assertCoMetricResources(namespaceSecond, StrimziPodSet.RESOURCE_KIND, clusterOperatorCollector, podSetCount);
 
         assertCoMetricResourceNotNull(clusterOperatorCollector, "strimzi_reconciliations_duration_seconds_bucket", StrimziPodSet.RESOURCE_KIND);
@@ -390,7 +390,7 @@ public class MetricsST extends AbstractST {
         assertMetricResourceNotNull(userOperatorCollector, "strimzi_reconciliations_periodical_total", KafkaUser.RESOURCE_KIND);
         assertMetricResourceNotNull(userOperatorCollector, "strimzi_reconciliations_total", KafkaUser.RESOURCE_KIND);
 
-        assertMetricResources(namespaceFirst, KafkaUser.RESOURCE_KIND, userOperatorCollector, 2);
+        assertMetricResources(namespaceFirst, KafkaUser.RESOURCE_KIND, userOperatorCollector, 2.0);
     }
 
     @ParallelTest
@@ -422,15 +422,15 @@ public class MetricsST extends AbstractST {
             .withComponent(KafkaMirrorMaker2MetricsComponent.create(mm2ClusterName))
             .build();
 
-        assertMetricValue(kmm2Collector, "kafka_connect_worker_connector_count", 3);
-        assertMetricValue(kmm2Collector, "kafka_connect_worker_task_count", 2);
+        assertMetricValue(kmm2Collector, "kafka_connect_worker_connector_count", 3.0);
+        assertMetricValueHigherThanOrEqualTo(kmm2Collector, "kafka_connect_worker_task_count", 2.0);
 
         // Check CO metrics and look for KafkaBridge
         clusterOperatorCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
-        assertCoMetricResources(namespaceFirst, KafkaMirrorMaker2.RESOURCE_KIND, clusterOperatorCollector, 1);
+        assertCoMetricResources(namespaceFirst, KafkaMirrorMaker2.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaMirrorMaker2.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceState(namespaceFirst, KafkaMirrorMaker2.RESOURCE_KIND, mm2ClusterName, clusterOperatorCollector, 1, "none");
-        assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 1);
+        assertCoMetricResourceState(namespaceFirst, KafkaMirrorMaker2.RESOURCE_KIND, mm2ClusterName, clusterOperatorCollector, 1.0, "none");
+        assertMetricValueHigherThanOrEqualTo(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 1.0);
     }
 
     @ParallelTest
@@ -495,9 +495,9 @@ public class MetricsST extends AbstractST {
 
         // Check CO metrics and look for KafkaBridge
         clusterOperatorCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
-        assertCoMetricResources(namespaceFirst, KafkaBridge.RESOURCE_KIND, clusterOperatorCollector, 1);
+        assertCoMetricResources(namespaceFirst, KafkaBridge.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaBridge.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceState(namespaceFirst, KafkaBridge.RESOURCE_KIND, bridgeClusterName, clusterOperatorCollector, 1, "none");
+        assertCoMetricResourceState(namespaceFirst, KafkaBridge.RESOURCE_KIND, bridgeClusterName, clusterOperatorCollector, 1.0, "none");
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -56,7 +56,7 @@ import static io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils.hasTopicInC
 import static io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils.hasTopicInKafka;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResourceNotNull;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResourcesHigherThanOrEqualTo;
-import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueHigherThan;
+import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueHigherThanOrEqualTo;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -376,7 +376,7 @@ public class TopicST extends AbstractST {
         KafkaTopicUtils.waitForKafkaTopicReady(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName());
 
         assertKafkaTopicStatus(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), Ready, True, ++expectedObservedGeneration);
-        assertMetricValueHigherThan(toMetricsCollector, "strimzi_reconciliations_failed_total\\{kind=\"" + KafkaTopic.RESOURCE_KIND + "\",.*}", 3);
+        assertMetricValueHigherThanOrEqualTo(toMetricsCollector, "strimzi_reconciliations_failed_total\\{kind=\"" + KafkaTopic.RESOURCE_KIND + "\",.*}", 3);
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This simple PR changes the variable types for the methods that are asserting some metric values -> from `long` or `int` to `double`. Also, it fixes wrong log message for comparing if the actual value is higher than the expected value (also changing the method to be "higher than or equal to", as we were hitting some race conditions).

### Checklist

- [x] Make sure all tests pass

