### PR TITLE
[ST] Fix issue with specified Bridge image when running tests with Helm installation type and add info about configuring images into TESTING.md

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -535,3 +535,41 @@ To run performance tests in Jenkins, execute them as standard system tests e.g.,
 ```
 @strimzi-ci run tests --profile=performance --testcase=TopicOperatorScalabilityPerformance`
 ```
+## Running tests with custom images
+
+Running STs with custom images for operator, Kafka, and other components is possible using few ways.
+
+### Bundle installation (using YAML files)
+
+In case that you want to run tests with Bundle installation type (which is the default), you can do two things:
+
+1. Update the `packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml` file for everything related to the Cluster Operator.
+   In case that you have also custom image for DrainCleaner, you should update `packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml` 
+   (currently we are picking everything from the `kubernetes` part, even if you are running on OCP for example). In both you can update each of the images you
+   have built. This is useful in case that you built just operator image, you can change only the references of operator image (and you can again pick where you need it to be changed).
+2. Set `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` which will change all the images inside `packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml`
+   to reflect your configuration. This is useful for example in pipelines or if you are building everything. Keep in mind that Bridge image will be kept for the latest released Bridge
+   available in our official Quay.io Strimzi repository. These envs are not changing the DrainCleaner file! That's because, again, you are not building DrainCleaner image in this repository.
+
+**IMPORTANT**: In case that you want to use your own custom Bridge image, you need to configure the `BRIDGE_IMAGE` environment variable!
+Changes to `packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml` will not be reflected.
+That's because currently, the default value of `BRIDGE_IMAGE` is `latest-released`, preventing the rewrite of the image by the `DOCKER_*` environment variables
+and using the officially released Bridge image in case that this environment variable is not specified.
+
+### Helm installation
+
+Similarly to Bundle installation type, you can do two things:
+
+1. Update the `packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml` where you can configure each image separately. 
+   In STs we are configuring `defaultImageRegistry`, `defaultImageRepository`, and `defaultImageTag` to point on official images from Strimzi.
+   So the values are `quay.io`, `strimzi`, `latest`. **Do not update these fields, as they will be overwritten to these defaults.**
+2. Set `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` which will change `defaultImageRegistry`, `defaultImageRepository`, and `defaultImageTag`.
+   Again, this applies to **all of the images** but the Bridge image, which defaults to the official image supported by Strimzi.
+
+**IMPORTANT**: Same as for Bundle installation, in case that you want to use custom Bridge image, please use `BRIDGE_IMAGE` environment variable.
+Changes to the `values.yaml` will not be reflected and will be overwritten by the official Bridge image supported by Strimzi.
+
+### OLM installation
+
+For custom images inside OLM and running the tests with OLM installation please refer to [Testing Cluster Operator deployment via OLM section](#testing-cluster-operator-deployment-via-olm)
+and to environment variables with `OLM_` prefix.

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
@@ -78,8 +78,8 @@ public class HelmResource implements SpecificResourceType {
             // in case that the image has correct value, we can configure the values
             if (matcher.matches()) {
                 bridgeRegistry = Optional.ofNullable(matcher.group("registry")).orElse(bridgeRegistry);
-                bridgeRepository = Optional.ofNullable(matcher.group("repository")).orElse(bridgeRepository);
-                bridgeName = Optional.ofNullable(matcher.group("name")).orElse(bridgeName);
+                bridgeRepository = Optional.ofNullable(matcher.group("org")).orElse(bridgeRepository);
+                bridgeName = Optional.ofNullable(matcher.group("image")).orElse(bridgeName);
                 bridgeTag = Optional.ofNullable(matcher.group("tag")).orElse(bridgeTag);
             }
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -66,8 +66,8 @@ public class StUtils {
 
     public static final Pattern IMAGE_PATTERN_FULL_PATH = Pattern.compile(
         "^(?:(?<registry>[a-zA-Z0-9.-]+(?::\\d+)?)/)?" +              // Group for registry (and port)
-        "(?<repository>[a-z0-9][a-z0-9._-]*(?:/[a-z0-9._-]+)*)/" +    // Full repository path
-        "(?<name>[a-zA-Z0-9._-]+)" +                                  // Name of the image
+        "(?<org>[a-z0-9][a-z0-9._-]*(?:/[a-z0-9._-]+)*)/" +           // Full repository path (org)
+        "(?<image>[a-zA-Z0-9._-]+)" +                                 // Name of the image
         "(?::(?<tag>[a-zA-Z0-9._-]+))?$"                              // Tag of the image
     );
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -64,7 +64,13 @@ public class StUtils {
 
     private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile("([^-|^_]*?)(?<kafka>[-|_]kafka[-|_])(?<version>.*)$");
 
-    private static final Pattern IMAGE_PATTERN_FULL_PATH = Pattern.compile("^(?<registry>[^/]*)/(?<org>[^/]*)/(?<image>[^:]*):(?<tag>.*)$");
+    public static final Pattern IMAGE_PATTERN_FULL_PATH = Pattern.compile(
+        "^(?:(?<registry>[^/:]+(?:\\.[^/:]+)*(:\\d+)?)/)?" +     // Group for registry (and port)
+            "(?<repository>.+?)" +                               // Full repository path
+            "(?:/(?<name>[^/:]+))?" +                            // Name of the image
+            "(?::(?<tag>[^:]+))?$"                               // Tag of the image
+    );
+
     private static final Pattern IMAGE_PATTERN = Pattern.compile("^(?<org>[^/]*)/(?<image>[^:]*):(?<tag>.*)$");
 
     private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -65,10 +65,10 @@ public class StUtils {
     private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile("([^-|^_]*?)(?<kafka>[-|_]kafka[-|_])(?<version>.*)$");
 
     public static final Pattern IMAGE_PATTERN_FULL_PATH = Pattern.compile(
-        "^(?:(?<registry>[^/:]+(?:\\.[^/:]+)*(:\\d+)?)/)?" +     // Group for registry (and port)
-            "(?<repository>.+?)" +                               // Full repository path
-            "(?:/(?<name>[^/:]+))?" +                            // Name of the image
-            "(?::(?<tag>[^:]+))?$"                               // Tag of the image
+        "^(?:(?<registry>[a-zA-Z0-9.-]+(?::\\d+)?)/)?" +              // Group for registry (and port)
+        "(?<repository>[a-z0-9][a-z0-9._-]*(?:/[a-z0-9._-]+)*)/" +    // Full repository path
+        "(?<name>[a-zA-Z0-9._-]+)" +                                  // Name of the image
+        "(?::(?<tag>[a-zA-Z0-9._-]+))?$"                              // Tag of the image
     );
 
     private static final Pattern IMAGE_PATTERN = Pattern.compile("^(?<org>[^/]*)/(?<image>[^:]*):(?<tag>.*)$");


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement

### Description

This PR updates the whole regex pattern for the "full image" we have in `StUtils` for quite a long time -> in order to take the full "repository" name correctly (in case that there are multiple namespaces etc.).
Additionally, this fixes issue with Bridge image, which was wrongly parsed/used when running the tests with Helm installation type and `BRIDGE_IMAGE` set.

NOTE: If you want to run the tests with Helm installation type and custom Bridge image, you will need to set the `BRIDGE_IMAGE` env variable. Nothing else is needed.

Finally, this PR adds info about what should be configured where when running tests with different installation types and with different custom images.

Resolves #11066 
 
### Checklist

- [x] Make sure all tests pass

