### PR TITLE
docs: fix missing escape characters

### DIFF
--- a/documentation/modules/operators/con-configuring-cluster-operator.adoc
+++ b/documentation/modules/operators/con-configuring-cluster-operator.adoc
@@ -79,7 +79,7 @@ A pod disruption budget with the `maxUnavailable` value set to zero prevents Kub
 +
 Set this environment variable to `false` to disable pod disruption budget generation. You might do this, for example, if you want to manage the pod disruption budgets yourself, or if you have a development environment where availability is not important.
 
-`STRIMZI_LABELS_EXCLUSION_PATTERN`:: Optional, default regex pattern is `(^app.kubernetes.io/(?!part-of).*|^kustomize.toolkit.fluxcd.io.*)`.
+`STRIMZI_LABELS_EXCLUSION_PATTERN`:: Optional, default regex pattern is `(\^app.kubernetes.io/(?!part-of).\*|^kustomize.toolkit.fluxcd.io.*)`.
 The regex exclusion pattern used to filter labels propagation from the main custom resource to its subresources.
 The labels exclusion filter is not applied to labels in template sections such as `spec.kafka.template.pod.metadata.labels`.
 +


### PR DESCRIPTION
**Documentation**

### Description

This PR addresses an issue in the **configuring-cluster-operator** section of the documentation.  

The formatting is broken due to missing escape characters, as seen in the following link:  
[STRIMZI_LABELS_EXCLUSION_PATTERN](https://strimzi.io/docs/operators/latest/deploying#:~:text=is%20not%20important.-,STRIMZI_LABELS_EXCLUSION_PATTERN,-Optional%2C%20default%20regex)  

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

