### PR TITLE
Update KindContainer to 1.4.9 and to Kube 1.32

### DIFF
--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -95,6 +95,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube3/MockKube3.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube3/MockKube3.java
@@ -25,6 +25,7 @@ import io.strimzi.test.mockkube3.controllers.MockDeletionController;
 import io.strimzi.test.mockkube3.controllers.MockDeploymentController;
 import io.strimzi.test.mockkube3.controllers.MockPodController;
 import io.strimzi.test.mockkube3.controllers.MockServiceController;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +40,8 @@ import java.util.concurrent.TimeUnit;
  * running controllers.
  */
 public class MockKube3 {
+    private final static String ETCD_IMAGE = "registry.k8s.io/etcd:3.5.17-0";
+
     private final ApiServerContainer<?> apiServer;
     private final List<AbstractMockController> controllers = new ArrayList<>();
     private final List<String> crds = new ArrayList<>();
@@ -53,7 +56,7 @@ public class MockKube3 {
      * Constructs the Kubernetes Mock Kube Server
      */
     public MockKube3() {
-        this.apiServer = new ApiServerContainer<>();
+        this.apiServer = new ApiServerContainer<>().withEtcdImage(DockerImageName.parse(ETCD_IMAGE));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,9 @@
         <valid4j.version>1.1</valid4j.version>
         <javax.json.version>1.1.4</javax.json.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
-        <kindcontainer.version>1.4.8</kindcontainer.version>
+        <kindcontainer.version>1.4.9</kindcontainer.version>
+        <testcontainer.version>1.20.1</testcontainer.version>
+        <docker-java.version>3.4.0</docker-java.version>
         <junit4.version>4.13.2</junit4.version>
         <skodjob.test-frame.version>0.8.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.3.0</skodjob-doc.version>
@@ -833,6 +835,23 @@
                 <artifactId>test-docs-generator-maven-plugin</artifactId>
                 <version>${skodjob-doc.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <!-- TestContainer dependency is needed at compile time by MockKube -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>toxiproxy</artifactId>
+                <version>${testcontainer.version}</version>
+            </dependency>
+            <!-- Needed to align Java Docker API version between different TestContainer implementations -->
+            <dependency>
+                <groupId> com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${docker-java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the KindContainer to 1.4.9 which uses Kubernetes 1.32. I also had to update the Etcd version used to improve the stability of the tests.

### Checklist

- [x] Make sure all tests pass