### PR TITLE
[ST] Change the way how we assert values in logs from Pods

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
@@ -29,7 +29,6 @@ import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,6 +38,7 @@ import java.util.Collections;
 
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
@@ -133,7 +133,7 @@ public class QuotasST extends AbstractST {
 
         String belowLimitLog = String.format("below the limit of %s", minAvailableBytes);
 
-        assertThat("Kafka log doesn't contain '" + belowLimitLog + "' log", kafkaLog, CoreMatchers.containsString(belowLimitLog));
+        assertThat("Kafka log doesn't contain '" + belowLimitLog + "' log", kafkaLog.contains(belowLimitLog), is(true));
 
         LOGGER.info("Sending messages with user that is specified in list of excluded principals, we should be able to send the messages without problem");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfST.java
@@ -116,8 +116,8 @@ public class DynamicConfST extends AbstractST {
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(Environment.TEST_SUITE_NAMESPACE, testStorage.getClusterName())) {
             String kafkaConfiguration = kubeClient().getConfigMap(Environment.TEST_SUITE_NAMESPACE, cmName).getData().get("server.config");
-            assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=1"));
-            assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=1"));
+            assertThat("Kafka configuration CM doesn't contain 'offsets.topic.replication.factor=1'", kafkaConfiguration.contains("offsets.topic.replication.factor=1"), is(true));
+            assertThat("Kafka configuration CM doesn't contain 'transaction.state.log.replication.factor=1'", kafkaConfiguration.contains("transaction.state.log.replication.factor=1"), is(true));
         }
 
         String kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(Environment.TEST_SUITE_NAMESPACE, scraperPodName, KafkaResources.plainBootstrapAddress(testStorage.getClusterName()), podNum);
@@ -135,9 +135,9 @@ public class DynamicConfST extends AbstractST {
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(Environment.TEST_SUITE_NAMESPACE, testStorage.getClusterName())) {
             String kafkaConfiguration = kubeClient().getConfigMap(Environment.TEST_SUITE_NAMESPACE, cmName).getData().get("server.config");
-            assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=1"));
-            assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=1"));
-            assertThat(kafkaConfiguration, containsString("unclean.leader.election.enable=true"));
+            assertThat("Kafka configuration CM doesn't contain 'offsets.topic.replication.factor=1'", kafkaConfiguration.contains("offsets.topic.replication.factor=1"), is(true));
+            assertThat("Kafka configuration CM doesn't contain 'transaction.state.log.replication.factor=1'", kafkaConfiguration.contains("transaction.state.log.replication.factor=1"), is(true));
+            assertThat("Kafka configuration CM doesn't contain 'unclean.leader.election.enable=true'", kafkaConfiguration.contains("unclean.leader.election.enable=true"), is(true));
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -75,7 +75,6 @@ import static io.strimzi.systemtest.TestTags.MIRROR_MAKER2;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -445,7 +444,7 @@ class LogSettingST extends AbstractST {
 
         LOGGER.info("Checking logs in CruiseControl - make sure no DEBUG is found there");
         String logOut = StUtils.getLogFromPodByTime(Environment.TEST_SUITE_NAMESPACE, cruiseControlPodName, TestConstants.CRUISE_CONTROL_CONTAINER_NAME, "20s");
-        assertThat(logOut.toUpperCase(Locale.ENGLISH), not(containsString(debugText)));
+        assertThat(String.format("CC log contains '%s' and it shouldn't", debugText), logOut.toUpperCase(Locale.ENGLISH).contains(debugText), is(false));
 
         InlineLogging logging = new InlineLogging();
         logging.setLoggers(Collections.singletonMap("rootLogger.level", debugText.strip()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -79,7 +79,6 @@ import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -563,8 +562,8 @@ class MirrorMaker2ST extends AbstractST {
         String header1 = "key: header_key_one, value: header_value_one";
         String header2 = "key: header_key_two, value: header_value_two";
         String log = StUtils.getLogFromPodByTime(testStorage.getNamespaceName(), kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(testStorage.getConsumerName()).get(0).getMetadata().getName(), "", testStorage.getMessageCount() + "s");
-        assertThat(log, containsString(header1));
-        assertThat(log, containsString(header2));
+        assertThat(String.format("Consumer's log doesn't contain header: %s", header1), log.contains(header1), is(true));
+        assertThat(String.format("Consumer's log doesn't contain header: %s", header2), log.contains(header2), is(true));
     }
 
     /*

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/LeaderElectionST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/LeaderElectionST.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -89,7 +88,7 @@ public class LeaderElectionST extends AbstractST {
         String logFromNewLeader = StUtils.getLogFromPodByTime(clusterOperator.getDeploymentNamespace(), currentLeaderPodName, clusterOperator.getClusterOperatorName(), "300s");
 
         LOGGER.info("Checking if the new leader is elected");
-        assertThat("Log doesn't contains mention about election of the new leader", logFromNewLeader, containsString(LEADER_MESSAGE));
+        assertThat("Log doesn't contains mention about election of the new leader", logFromNewLeader.contains(LEADER_MESSAGE), is(true));
         assertThat("Old and current leaders are same", oldLeaderPodName, not(equalTo(currentLeaderPodName)));
     }
 
@@ -111,8 +110,7 @@ public class LeaderElectionST extends AbstractST {
 
         // Assert that the Lease does not exist
         assertThat("Lease for CO exists", notExistingLease, is(nullValue()));
-
-        assertThat("Log contains message about leader election", logFromCoPod, not(containsString(LEADER_MESSAGE)));
+        assertThat("Log contains message about leader election", logFromCoPod.contains(LEADER_MESSAGE), is(false));
     }
 
     void checkDeploymentFiles() throws Exception {
@@ -126,10 +124,10 @@ public class LeaderElectionST extends AbstractST {
 
         String clusterOperatorDep = Files.readString(Paths.get(pathToDepFile));
 
-        assertThat(clusterOperatorDep, containsString("STRIMZI_LEADER_ELECTION_ENABLED"));
-        assertThat(clusterOperatorDep, containsString("STRIMZI_LEADER_ELECTION_LEASE_NAME"));
-        assertThat(clusterOperatorDep, containsString("STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE"));
-        assertThat(clusterOperatorDep, containsString("STRIMZI_LEADER_ELECTION_IDENTITY"));
+        assertThat("Cluster Operator's Deployment doesn't contain 'STRIMZI_LEADER_ELECTION_ENABLED' env variable", clusterOperatorDep.contains("STRIMZI_LEADER_ELECTION_ENABLED"), is(true));
+        assertThat("Cluster Operator's Deployment doesn't contain 'STRIMZI_LEADER_ELECTION_LEASE_NAME' env variable", clusterOperatorDep.contains("STRIMZI_LEADER_ELECTION_LEASE_NAME"), is(true));
+        assertThat("Cluster Operator's Deployment doesn't contain 'STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE' env variable", clusterOperatorDep.contains("STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE"), is(true));
+        assertThat("Cluster Operator's Deployment doesn't contain 'STRIMZI_LEADER_ELECTION_IDENTITY' env variable", clusterOperatorDep.contains("STRIMZI_LEADER_ELECTION_IDENTITY"), is(true));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -465,7 +465,7 @@ public class TopicST extends AbstractST {
         // Checking TO logs
         String tOPodName = cmdKubeClient(testStorage.getNamespaceName()).listResourcesByLabel("pod", Labels.STRIMZI_NAME_LABEL + "=" + testStorage.getClusterName() + "-entity-operator").get(0);
         String tOlogs = kubeClient(testStorage.getNamespaceName()).logsInSpecificNamespace(testStorage.getNamespaceName(), tOPodName, "topic-operator");
-        assertThat(tOlogs, not(containsString(String.format("Created topic '%s'", testStorage.getTargetTopicName()))));
+        assertThat("TO's log contains information about created topic", tOlogs.contains(String.format("Created topic '%s'", testStorage.getTargetTopicName())), is(false));
 
         //Deleting topic
         cmdKubeClient(testStorage.getNamespaceName()).deleteByName("kafkatopic", testStorage.getTargetTopicName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -160,9 +160,10 @@ public class OauthAbstractST extends AbstractST {
      */
     protected final void verifyOauthConfiguration(final String componentLogs) {
         for (Map.Entry<String, Object> configField : COMPONENT_FIELDS_TO_VERIFY.entrySet()) {
-            assertThat(componentLogs, CoreMatchers.containsString(configField.getKey() + ": " + configField.getValue()));
+            String expectedKeyValue = configField.getKey() + ": " + configField.getValue();
+            assertThat(String.format("Component's log doesn't contain expected key/value: %s", expectedKeyValue), componentLogs.contains(expectedKeyValue), CoreMatchers.is(true));
         }
-        assertThat(componentLogs, CoreMatchers.containsString("Successfully logged in"));
+        assertThat("Component's log doesn't contain 'Successfully logged in' sentence", componentLogs.contains("Successfully logged in"), CoreMatchers.is(true));
     }
 
     /**
@@ -172,9 +173,10 @@ public class OauthAbstractST extends AbstractST {
      */
     protected final void verifyOauthListenerConfiguration(final String kafkaLogs) {
         for (Map.Entry<String, Object> configField : LISTENER_FIELDS_TO_VERIFY.entrySet()) {
-            assertThat(kafkaLogs, CoreMatchers.containsString(configField.getKey() + ": " + configField.getValue()));
+            String expectedKeyValue = configField.getKey() + ": " + configField.getValue();
+            assertThat(String.format("Kafka's log doesn't contain expected key/value: %s", expectedKeyValue), kafkaLogs.contains(expectedKeyValue), CoreMatchers.is(true));
         }
-        assertThat(kafkaLogs, CoreMatchers.containsString("Successfully logged in"));
+        assertThat("Kafka's log doesn't contain 'Successfully logged in' sentence", kafkaLogs.contains("Successfully logged in"), CoreMatchers.is(true));
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
@@ -31,7 +31,6 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
@@ -42,6 +41,7 @@ import static io.strimzi.systemtest.TestTags.CONNECT;
 import static io.strimzi.systemtest.TestTags.OAUTH;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(OAUTH)
@@ -126,11 +126,16 @@ public class OauthScopeST extends OauthAbstractST {
         String kafkaConnectPodName = kubeClient().listPodsByPrefixInName(Environment.TEST_SUITE_NAMESPACE, StrimziPodSetResource.getBrokerComponentName(oauthClusterName)).get(0).getMetadata().getName();
 
         String kafkaLog = kubeClient().logsInSpecificNamespace(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName);
-        assertThat(kafkaLog, CoreMatchers.containsString("Access token expires at"));
-        assertThat(kafkaLog, CoreMatchers.containsString("Evaluating path: $[*][?]"));
-        assertThat(kafkaLog, CoreMatchers.containsString("Evaluating path: @['scope']"));
-        assertThat(kafkaLog, CoreMatchers.containsString("User validated"));
-        assertThat(kafkaLog, CoreMatchers.containsString("Set validated token on callback"));
+        assertThat("Kafka's log doesn't contain information about expiration of the access token",
+            kafkaLog.contains("Access token expires at"), is(true));
+        assertThat("Kafka's log doesn't contain information about evaluating path",
+            kafkaLog.contains("Evaluating path: $[*][?]"), is(true));
+        assertThat("Kafka's log doesn't contain information about evaluating path for scope",
+            kafkaLog.contains("Evaluating path: @['scope']"), is(true));
+        assertThat("Kafka's log doesn't contain information about user validation",
+            kafkaLog.contains("User validated"), is(true));
+        assertThat("Kafka's log doesn't contain information about setting validated token on callback",
+            kafkaLog.contains("Set validated token on callback"), is(true));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

In some tests we have asserts for logs containing specific values. In case that a test fails on this kind of assert, the whole log of the particular Pod is printed as "actual value" - which makes debugging and reading through the test logs a bit too difficult.

This PR changes the way how we are asserting these things - only on places where we are checking logs/Deployments/ConfigMaps that are anyway stored by LogCollector.

### Checklist

- [x] Make sure all tests pass
