### PR TITLE
feat(examples,metrics,kube-state-metrics): extend configmap and prome…

### DIFF
--- a/packaging/examples/metrics/kube-state-metrics/configmap.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/configmap.yaml
@@ -14,7 +14,7 @@ data:
           metricNamePrefix: strimzi_kafka_topic
           metrics:
             - name: resource_info
-              help: "The current state of a Strimzi kafka topic resource"
+              help: "The current state of a Strimzi kafka topic resource."
               each:
                 type: Info
                 info:
@@ -22,10 +22,10 @@ data:
                     name: [ metadata, name ]
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
-                partitions: [ spec, partitions ]
-                replicas: [ spec, replicas ]
                 ready: [ status, conditions, "[type=Ready]", status ]
                 deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                partitions: [ spec, partitions ]
+                replicas: [ spec, replicas ]
                 generation: [ status, observedGeneration ]
                 topicId: [ status, topicId ]
                 topicName: [ status, topicName ]
@@ -36,7 +36,7 @@ data:
           metricNamePrefix: strimzi_kafka_user
           metrics:
             - name: resource_info
-              help: "The current state of a Strimzi kafka user resource"
+              help: "The current state of a Strimzi kafka user resource."
               each:
                 type: Info
                 info:
@@ -49,3 +49,90 @@ data:
                 secret: [ status, secret ]
                 generation: [ status, observedGeneration ]
                 username: [ status, username ]
+        - groupVersionKind:
+            group: kafka.strimzi.io
+            version: v1beta2
+            kind: Kafka
+          metricNamePrefix: strimzi_kafka
+          metrics:
+            - name: resource_info
+              help: "The current state of a Strimzi kafka resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                kafka_version: [ status, kafkaVersion ]
+                kafka_metadata_state: [ status, kafkaMetadataState ]
+                kafka_metadata_version: [ status, kafkaMetadataVersion ]
+                cluster_id: [ status, clusterId ]
+                operator_last_successful_version: [ status, operatorLastSuccessfulVersion ]
+                generation: [ status, observedGeneration ]
+        - groupVersionKind:
+            group: kafka.strimzi.io
+            version: v1beta2
+            kind: KafkaNodePool
+          metricNamePrefix: strimzi_kafka_node_pool
+          metrics:
+            - name: resource_info
+              help: "The current state of a Strimzi kafka node pool resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                # KafkaNodePool is not having a ready status as this is implemented via Kafka resource
+                # ready: [ status, conditions, "[type=Ready]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                node_ids: [ status, nodeIds ]
+                roles: [ status, roles ]
+                replicas: [ status, replicas ]
+                cluster_id: [ status, clusterId ]
+                generation: [ status, observedGeneration ]
+        - groupVersionKind:
+            group: core.strimzi.io
+            version: v1beta2
+            kind: StrimziPodSet
+          metricNamePrefix: strimzi_pod_set
+          metrics:
+            - name: resource_info
+              help: "The current state of a Strimzi pod set resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                # TODO do we want to have that? If not please make a suggestion to remove it
+                # deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                currentPods: [ status, currentPods ]
+                pods: [ status, pods ]
+                readyPods: [ status, readyPods ]
+                generation: [ status, observedGeneration ]
+        - groupVersionKind:
+            group: kafka.strimzi.io
+            version: v1beta2
+            kind: KafkaRebalance
+          metricNamePrefix: strimzi_kafka_rebalance
+          metrics:
+            - name: resource_info
+              help: "The current state of a Strimzi kafka rebalance resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                proposal_ready: [ status, conditions, "[type=ProposalReady]", status ]
+                rebalancing: [ status, conditions, "[type=Rebalancing]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                template: [ metadata, annotations, "strimzi.io/rebalance-template" ]

--- a/packaging/examples/metrics/kube-state-metrics/configmap.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/configmap.yaml
@@ -110,8 +110,7 @@ data:
                     name: [ metadata, name ]
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
-                # TODO do we want to have that? If not please make a suggestion to remove it
-                # deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 currentPods: [ status, currentPods ]
                 pods: [ status, pods ]
                 readyPods: [ status, readyPods ]

--- a/packaging/examples/metrics/kube-state-metrics/configmap.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/configmap.yaml
@@ -14,7 +14,7 @@ data:
           metricNamePrefix: strimzi_kafka_topic
           metrics:
             - name: resource_info
-              help: "The current state of a Strimzi kafka topic resource."
+              help: "The current state of a Strimzi Kafka topic resource."
               each:
                 type: Info
                 info:
@@ -36,7 +36,7 @@ data:
           metricNamePrefix: strimzi_kafka_user
           metrics:
             - name: resource_info
-              help: "The current state of a Strimzi kafka user resource."
+              help: "The current state of a Strimzi Kafka user resource."
               each:
                 type: Info
                 info:
@@ -56,7 +56,7 @@ data:
           metricNamePrefix: strimzi_kafka
           metrics:
             - name: resource_info
-              help: "The current state of a Strimzi kafka resource."
+              help: "The current state of a Strimzi Kafka resource."
               each:
                 type: Info
                 info:
@@ -79,7 +79,7 @@ data:
           metricNamePrefix: strimzi_kafka_node_pool
           metrics:
             - name: resource_info
-              help: "The current state of a Strimzi kafka node pool resource."
+              help: "The current state of a Strimzi Kafka node pool resource."
               each:
                 type: Info
                 info:

--- a/packaging/examples/metrics/kube-state-metrics/prometheus-rules.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/prometheus-rules.yaml
@@ -7,27 +7,6 @@ spec:
   groups:
     - name: strimzi-kube-state-metrics
       rules:
-        - alert: KafkaUserDeprecated
-          expr: strimzi_kafka_user_resource_info{deprecated="Warning"}
-          for: 15m
-          labels:
-            severity: warning
-          annotations:
-            message: "Strimzi KafkaUser {{ $labels.username }} has a deprecated configuration"
-        - alert: KafkaUserNotReady
-          expr: strimzi_kafka_user_resource_info{ready!="True"}
-          for: 15m
-          labels:
-            severity: warning
-          annotations:
-            message: "Strimzi KafkaUser {{ $labels.username }} is not ready"
-        - alert: KafkaTopicDeprecated
-          expr: strimzi_kafka_topic_resource_info{deprecated="Warning"}
-          for: 15m
-          labels:
-            severity: warning
-          annotations:
-            message: "Strimzi KafkaTopic {{ $labels.topicName }} has a deprecated configuration"
         - alert: KafkaTopicNotReady
           expr: strimzi_kafka_topic_resource_info{ready!="True"}
           for: 15m
@@ -35,3 +14,82 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaTopic {{ $labels.topicName }} is not ready"
+        - alert: KafkaTopicDeprecated
+          expr: strimzi_kafka_topic_resource_info{deprecated="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaTopic {{ $labels.topicName }} contains a deprecated configuration"
+        - alert: KafkaUserNotReady
+          expr: strimzi_kafka_user_resource_info{ready!="True"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaUser {{ $labels.username }} is not ready"
+        - alert: KafkaUserDeprecated
+          expr: strimzi_kafka_user_resource_info{deprecated="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaUser {{ $labels.username }} contains a deprecated configuration"
+        - alert: KafkaNotReady
+          expr: strimzi_kafka_resource_info{ready!="True"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi Kafka {{ $labels.name }} using {{ $labels.kafka_version }} is not ready"
+        - alert: KafkaDeprecated
+          expr: strimzi_kafka_resource_info{deprecated="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi Kafka {{ $labels.name }} contains a deprecated configuration"
+        # KafkaNodePool is not having a ready status as this is implemented via Kafka resource
+        # - alert: KafkaNodePoolNotReady
+        #   expr: strimzi_kafka_node_pool_resource_info{ready!="True"}
+        #   for: 15m
+        #   labels:
+        #     severity: warning
+        #   annotations:
+        #     message: {{ printf "'Strimzi KafkaNodePool {{`{{ $labels.name }}`}} using {{`{{ $labels.kafka_version }}`}} is not ready'"}}
+        - alert: KafkaNodePoolDeprecated
+          expr: strimzi_kafka_node_pool_resource_info{deprecated="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaNodePool {{ $labels.name }} contains a deprecated configuration"
+        # StrimziPodSet is not having any further information as it is an internal resource and doesn't get operated by the user
+        - alert: KafkaRebalanceNotReady
+          expr: strimzi_kafka_rebalance_resource_info{ready!="True",template!="true"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaRebalance {{ $labels.name }} is not ready"
+        - alert: KafkaRebalanceProposalPending
+          expr: strimzi_kafka_rebalance_resource_info{ready="True",template!="true",proposal_ready="True"}
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaRebalance {{ $labels.name }} is in proposal pending state and waits for approval for more than 1h."
+        - alert: KafkaRebalanceRebalancing
+          expr: strimzi_kafka_rebalance_resource_info{ready="True",template!="true",rebalancing="True"}
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            message: "Strimzi KafkaRebalance {{ $labels.name }} is taking longer than 1h."
+        - alert: KafkaRebalanceDeprecated
+          expr: strimzi_kafka_rebalance_resource_info{deprecated="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaRebalance {{ $labels.name }} contains a deprecated configuration"

--- a/packaging/examples/metrics/kube-state-metrics/prometheus-rules.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/prometheus-rules.yaml
@@ -50,13 +50,6 @@ spec:
           annotations:
             message: "Strimzi Kafka {{ $labels.name }} contains a deprecated configuration"
         # KafkaNodePool is not having a ready status as this is implemented via Kafka resource
-        # - alert: KafkaNodePoolNotReady
-        #   expr: strimzi_kafka_node_pool_resource_info{ready!="True"}
-        #   for: 15m
-        #   labels:
-        #     severity: warning
-        #   annotations:
-        #     message: {{ printf "'Strimzi KafkaNodePool {{`{{ $labels.name }}`}} using {{`{{ $labels.kafka_version }}`}} is not ready'"}}
         - alert: KafkaNodePoolDeprecated
           expr: strimzi_kafka_node_pool_resource_info{deprecated="Warning"}
           for: 15m


### PR DESCRIPTION
…theusrules

In order to implement https://github.com/strimzi/proposals/blob/main/087-monitoring-of-custom-resources.md the configmap and prometheus-rules are extended for 'Kafka', 'KafkaNodePool', 'StrimziPodSet' and 'KafkaRebalance' resources.

Part of #10276

### Type of change

- Enhancement / new feature

### Description

See commit message

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

