### PR TITLE
Fix Mirror Maker 2 connector reconciliation race condition

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
@@ -14,7 +14,9 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +47,17 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
         this.connectors = connectors;
     }
 
+    /**
+     * Synchronized method for adding a connector to the status. It adds the connector and sorts the list to make sure
+     * that when the status is not changing all the time and triggering reconciliations in a loop.
+     *
+     * @param connector The connector status
+     */
+    public synchronized void addConnector(Map<String, Object> connector) {
+        this.connectors.add(connector);
+        this.connectors.sort(new ConnectorsComparatorByName());
+    }
+
     @Description("List of MirrorMaker 2 connector auto restart statuses")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<AutoRestartStatus> getAutoRestartStatuses() {
@@ -53,5 +66,31 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
 
     public void setAutoRestartStatuses(List<AutoRestartStatus> autoRestartStatuses) {
         this.autoRestartStatuses = autoRestartStatuses;
+    }
+
+    /**
+     * Synchronized method for adding an auto-restart to the status. It adds the connector and sorts the list to make sure
+     * that when the status is not changing all the time and triggering reconciliations in a loop.
+     *
+     * @param status    The Auto-restart status
+     */
+    public synchronized void addAutoRestartStatus(AutoRestartStatus status) {
+        this.autoRestartStatuses.add(status);
+        this.autoRestartStatuses.sort(Comparator.comparing(AutoRestartStatus::getConnectorName));
+    }
+
+    /**
+     * This comparator compares two maps where connectors' configurations are stored.
+     * The comparison is done by using only one property - 'name'
+     */
+    private static class ConnectorsComparatorByName implements Comparator<Map<String, Object>>, Serializable {
+        private static final long serialVersionUID = 1L;
+        
+        @Override
+        public int compare(Map<String, Object> m1, Map<String, Object> m2) {
+            String name1 = m1.get("name") == null ? "" : m1.get("name").toString();
+            String name2 = m2.get("name") == null ? "" : m2.get("name").toString();
+            return name1.compareTo(name2);
+        }
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Sometimes, during the reconciliation of the MM2 connectors, we run into a race condition when the connectors are reconciled and we try to add the status to multiple connectors at the same time:

```
java.util.ConcurrentModificationException: null
        at java.util.ArrayList.sort(ArrayList.java:1723) ~[?:?]
        at io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator.lambda$createOrUpdateMirrorMaker2Connector$25(KafkaMirrorMaker2AssemblyOperator.java:292) ~[io.strimzi.cluster-operator-0.46.0-SNAPSHOT.jar:0.46.0-SNAPSHOT]
        at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:310) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:88) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:43) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.vertx.core.Promise.complete(Promise.java:66) ~[io.vertx.vertx-core-4.5.13.jar:4.5.13]
        at io.strimzi.operator.cluster.operator.VertxUtil.lambda$completableFutureToVertxFuture$3(VertxUtil.java:212) ~[io.strimzi.cluster-operator-0.46.0-SNAPSHOT.jar:0.46.0-SNAPSHOT]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
        at java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:614) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:844) ~[?:?]
        at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

This PR works around it by using synchronized methods to add the connector status and sort them. That seems to help to avid the race condition.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally