### PR TITLE
[ST] Fix creation of CollectorElement based on installation type

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -212,9 +212,9 @@ public class SetupClusterOperator {
         if (Environment.isOlmInstall()) {
             runOlmInstallation();
         } else if (Environment.isHelmInstall()) {
-            helmInstallation();
+            runHelmInstallation();
         } else {
-            bundleInstallation();
+            runBundleInstallation();
         }
         return this;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -209,9 +209,23 @@ public class SetupClusterOperator {
      */
     @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
     public SetupClusterOperator runInstallation() {
-        LOGGER.info("Cluster Operator installation configuration:\n{}", this::prettyPrint);
-        LOGGER.debug("Cluster Operator installation configuration:\n{}", this::toString);
+        if (Environment.isOlmInstall()) {
+            runOlmInstallation();
+        } else if (Environment.isHelmInstall()) {
+            helmInstallation();
+        } else {
+            bundleInstallation();
+        }
+        return this;
+    }
 
+    /**
+     * Method used for configuring the {@link #testClassName} and {@link #testMethodName}.
+     * These two are then used for {@link CollectorElement} during the Namespace creation.
+     * It is important to have these specified for correct collection of logs from various Namespaces
+     * by {@link io.strimzi.systemtest.logs.TestLogCollector}.
+     */
+    private void configureTestClassAndMethodNames() {
         this.testClassName = this.extensionContext.getRequiredTestClass() != null ? this.extensionContext.getRequiredTestClass().getName() : "";
 
         try {
@@ -223,31 +237,25 @@ public class SetupClusterOperator {
             // getRequiredTestMethod() is not present, in @BeforeAll scope so we're avoiding PreconditionViolationException exception
             this.testMethodName = "";
         }
-
-        if (Environment.isOlmInstall()) {
-            runOlmInstallation();
-        } else if (Environment.isHelmInstall()) {
-            helmInstallation();
-        } else {
-            bundleInstallation();
-        }
-        return this;
     }
 
     public SetupClusterOperator runBundleInstallation() {
         LOGGER.info("Cluster Operator installation configuration:\n{}", this::toString);
+        configureTestClassAndMethodNames();
         bundleInstallation();
         return this;
     }
 
     public SetupClusterOperator runOlmInstallation() {
         LOGGER.info("Cluster Operator installation configuration:\n{}", this::toString);
+        configureTestClassAndMethodNames();
         olmInstallation();
         return this;
     }
 
     public SetupClusterOperator runHelmInstallation() {
         LOGGER.info("Cluster Operator installation configuration:\n{}", this::toString);
+        configureTestClassAndMethodNames();
         helmInstallation();
         return this;
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In most of our STs classes, we are using the `runInstallation` method, that - based on the `CLUSTER_OPERATOR_INSTALL_TYPE` env variable - installs the Cluster Operator using specified installation method.
Inside of this method, the `testClass` and `testMethod` variables are assigned to correct values, which are then used for `CollectorElement` -> this one is used during the Namespace creations, as it is added to stack and, if the test fails, based on this `CollectorElement` are the logs collected.

As mentioned, this works for the `runInstallation` method, but we have other methods like `runBundleInstallation`, which are missing this step, so the CollectorElement is filled with `null`s and empty Strings, because the correct values are never assigned to the two variables. So in case that the test fails, nothing is really collected from the Namespaces.

This PR fixes this issue by adding the assignment of the values in each of the install methods, and removes it from the `runInstallation` method.
It also removes some of the "this is config of CO" log messages, as we are anyway printing the config in each of the installation methods again.

This resolves issue with LogCollector not collecting logs from the all created Namespaces by the test.

### Checklist

- [x] Make sure all tests pass

