### PR TITLE
Deprecate the `type: opa` authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 * The storage overrides for configuring per-broker storage class are not supported anymore.
   If you are using the storage overrides, you should instead use multiple KafkaNodePool resources with a different storage class each.
   For more details about migrating from storage overrides, please follow the [documentation](https://strimzi.io/docs/operators/0.45.0/full/deploying.html#con-config-storage-zookeeper-str).
+* The Open Policy Agent authorization (`type: opa`) has been deprecated and will be removed in the future.
+  To use the Open Policy Agent authorizer, you can use the `type: custom` authorization.
 * Removed the `statefulset.kubernetes.io/pod-name` label from pods and external listeners Kubernetes Services.
   * If you have any custom setup leveraging such label, please use the `strimzi.io/pod-name` one instead.
 * The `secrets` list for mounting additional Kubernetes Secrets in `type: custom` authentication was deprecated and will be removed in the future.

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
@@ -21,6 +21,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "type")
+@SuppressWarnings("deprecation") // OPA Authorization is deprecated
 @JsonSubTypes({
     @JsonSubTypes.Type(name = KafkaAuthorizationSimple.TYPE_SIMPLE, value = KafkaAuthorizationSimple.class),
     @JsonSubTypes.Type(name = KafkaAuthorizationOpa.TYPE_OPA, value = KafkaAuthorizationOpa.class),
@@ -37,8 +38,10 @@ public abstract class KafkaAuthorization implements UnknownPropertyPreserving {
             "Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. " +
             "`simple` authorization type uses Kafka's built-in authorizer for authorization. " +
             "`keycloak` authorization type uses Keycloak Authorization Services for authorization. " +
-            "`opa` authorization type uses Open Policy Agent based authorization." +
-            "`custom` authorization type uses user-provided implementation for authorization.")
+            "`opa` authorization type uses Open Policy Agent based authorization. " +
+            "`custom` authorization type uses user-provided implementation for authorization. " +
+            "As of Strimzi 0.46.0, `opa` type is deprecated and will be removed in the future. " +
+            "Please use `custom` type instead.")
     public abstract String getType();
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.kafka;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -30,6 +31,8 @@ import java.util.List;
     "tlsTrustedCertificates", "superUsers", "enableMetrics"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
+@DeprecatedType(replacedWithType = KafkaAuthorizationCustom.class)
 public class KafkaAuthorizationOpa extends KafkaAuthorization {
     public static final String TYPE_OPA = "opa";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -627,6 +627,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param superUsers        Super-users list who have all the rights on the cluster
      * @param authorization     The authorization configuration from the Kafka CR
      */
+    @SuppressWarnings("deprecation") // OPA Authorization is deprecated
     private void configureAuthorization(String clusterName, List<String> superUsers, KafkaAuthorization authorization) {
         if (authorization instanceof KafkaAuthorizationSimple simpleAuthz) {
             configureSimpleAuthorization(simpleAuthz, superUsers);
@@ -660,6 +661,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param authorization     OPA authorization configuration
      * @param superUsers        Super-users list who have all the rights on the cluster
      */
+    @SuppressWarnings("deprecation") // OPA Authorization is deprecated
     private void configureOpaAuthorization(KafkaAuthorizationOpa authorization, List<String> superUsers) {
         writer.println("authorizer.class.name=" + KafkaAuthorizationOpa.AUTHORIZER_CLASS_NAME);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1345,7 +1345,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return List of non-data volumes used by the Kafka pods
      */
-    @SuppressWarnings("deprecation") // Secrets in custom authentication are deprecated
+    @SuppressWarnings("deprecation") // OPA authorization and Secrets in custom authentication are deprecated
     private List<Volume> getNonDataVolumes(boolean isOpenShift, NodeRef node, PodTemplate templatePod) {
         List<Volume> volumeList = new ArrayList<>();
 
@@ -1438,7 +1438,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of volume mounts
      */
-    @SuppressWarnings("deprecation") // Secrets in custom authentication are deprecated
+    @SuppressWarnings("deprecation") // OPA Authorization and Secrets in custom authentication are deprecated
     private List<VolumeMount> getVolumeMounts(Storage storage, ContainerTemplate containerTemplate, boolean isBroker) {
         List<VolumeMount> volumeMountList = new ArrayList<>(VolumeUtils.createVolumeMounts(storage, false));
         volumeMountList.add(VolumeUtils.createTempDirVolumeMount());
@@ -1602,6 +1602,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of environment variables
      */
+    @SuppressWarnings("deprecation") // OPA Authorization is deprecated
     private  List<EnvVar> getEnvVars(KafkaPool pool) {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(metrics.isEnabled())));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -303,6 +303,7 @@ public class EntityUserOperatorTest {
         assertThat(binding.getRoleRef().getName(), is("my-cluster-entity-operator"));
     }
 
+    @SuppressWarnings("deprecation") // OPA Authorization is deprecated
     @ParallelTest
     public void testAclsAdminApiSupported() {
         testAclsAdminApiSupported(new KafkaAuthorizationSimple());

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaAuthorizationOpa.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaAuthorizationOpa.adoc
@@ -5,7 +5,10 @@ and configure OPA properties as required.
 Strimzi uses the Open Policy Agent plugin for Kafka authorization as the authorizer.
 For more information about the format of the input data and policy examples, see {OPAAuthorizer}.
 
-.Example Open Policy Agent authorizer configuration
+The `type: opa` authorization is now deprecated and will be removed in the future.
+If you want to use the Open Policy Agent authorizer, you should use the `type: custom` authorization.
+
+.Example Open Policy Agent authorizer configuration using the `type: custom` API
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}
@@ -17,15 +20,19 @@ spec:
   kafka:
     # ...
     authorization:
-      type: opa
-      url: http://opa:8181/v1/data/kafka/allow
-      allowOnError: false
-      initialCacheCapacity: 1000
-      maximumCacheSize: 10000
-      expireAfterMs: 60000
+      type: custom
+      authorizerClass: org.openpolicyagent.kafka.OpaAuthorizer
       superUsers:
         - CN=user-1
         - user-2
         - CN=user-3
+    config:
+      # OPA authorization options
+      opa.authorizer.url: http://opa:8181/v1/data/kafka/allow
+      opa.authorizer.cache.expire.after.seconds: 60
+      opa.authorizer.allow.on.error: false
+      opa.authorizer.cache.initial.capacity: 1000
+      opa.authorizer.cache.maximum.size: 10000
     # ...
 ----
+

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -747,6 +747,9 @@ It must have the value `simple` for the type `KafkaAuthorizationSimple`.
 [id='type-KafkaAuthorizationOpa-{context}']
 = `KafkaAuthorizationOpa` schema reference
 
+*The type `KafkaAuthorizationOpa` has been deprecated.*
+Please use xref:type-KafkaAuthorizationCustom-{context}[`KafkaAuthorizationCustom`] instead.
+
 Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 
 xref:type-KafkaAuthorizationOpa-schema-{context}[Full list of `KafkaAuthorizationOpa` schema properties]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -763,7 +763,7 @@ spec:
                             - opa
                             - keycloak
                             - custom
-                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
+                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.46.0, `opa` type is deprecated and will be removed in the future. Please use `custom` type instead."
                         url:
                           type: string
                           example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -762,7 +762,7 @@ spec:
                         - opa
                         - keycloak
                         - custom
-                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
+                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.46.0, `opa` type is deprecated and will be removed in the future. Please use `custom` type instead."
                       url:
                         type: string
                         example: http://opa:8181/v1/data/kafka/authz/allow


### PR DESCRIPTION
### Type of change

- Task

### Description

As approved in the proposal [SP#097](https://github.com/strimzi/proposals/pull/150), this PR deprecates the `type: opa` authorization. It also updates the docs and CHANGELOG.md. The warnings in the conditions and in the log are automatically issued by the existing operator code:

```yaml
    - lastTransitionTime: "2025-02-27T19:45:54.818334178Z"
      message: In resource Kafka(myproject/my-cluster) in API version kafka.strimzi.io/v1beta2
        the object authorization at path spec.kafka.authorization has been deprecated.
        This object has been replaced with KafkaAuthorizationCustom.
      reason: DeprecatedObjects
      status: "True"
      type: Warning
```

and

```
2025-02-27 20:45:55 WARN  StatusUtils:131 - Reconciliation #71(timer) Kafka(myproject/my-cluster): In resource Kafka(myproject/my-cluster) in API version kafka.strimzi.io/v1beta2 the object authorization at path spec.kafka.authorization has been deprecated. This object has been replaced with KafkaAuthorizationCustom.
```

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md