### PR TITLE
[ST] Annotate the Pod resources instead of the StrimziPodSet resource for starting a rolling restart in KafkaRollerST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.test.TestUtils;
@@ -336,5 +337,11 @@ public class PodUtils {
             .listPodsByPrefixInName(testStorage.getEoDeploymentName()));
 
         return kafkaClusterPods;
+    }
+
+    public static void annotatePod(String namespaceName, String podName, String annotationKey, String annotationValue) {
+        LOGGER.info("Annotating Pod: {}/{} with annotation {}={}", namespaceName, podName, annotationKey, annotationValue);
+        ResourceManager.cmdKubeClient().namespace(namespaceName)
+                .execInCurrentNamespace("annotate", "pod", podName, annotationKey + "=" + annotationValue);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -42,7 +42,6 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -149,7 +148,10 @@ public class KafkaRollerST extends AbstractST {
 
         // try to perform rolling update while scale down is being prevented.
         Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
-        StrimziPodSetUtils.annotateStrimziPodSet(testStorage.getNamespaceName(), testStorage.getBrokerComponentName(), Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
+        // We annotate the Pod resources instead of the StrimziPodSet resource for starting a rolling restart
+        for (String podName : kafkaPods.keySet()) {
+            PodUtils.annotatePod(testStorage.getNamespaceName(), podName, Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true");
+        }
         kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), scaledUpBrokerReplicaCount, kafkaPods);
 
         LOGGER.info("Remove Topic, thereby remove all partitions located on broker to be scaled down");


### PR DESCRIPTION
In KafkaRollerST the testKafkaDoesNotRollsWhenTopicIsUnderReplicated case is flaky. In unlucky conditions it is possible that the StrimziPodSet has been annotated and the cluster operator simply removes this annotation without doing anything, which causes test failure.

### Type of change

Test flakiness fix

### Description

In KafkaRollerST the testKafkaDoesNotRollsWhenTopicIsUnderReplicated case is flaky. In unlucky conditions it is possible that the StrimziPodSet has been annotated and the cluster operator simply removes this annotation without doing anything, which causes test failure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally