### PR TITLE
Add support for volumeAttributesClassName on persistent storage

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -26,7 +26,7 @@ import java.util.Map;
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
-@JsonPropertyOrder({"id", "type", "size", "kraftMetadata", "class", "selector", "deleteClaim", "overrides"})
+@JsonPropertyOrder({"id", "type", "size", "kraftMetadata", "class", "volumeAttributesClass", "selector", "deleteClaim", "overrides"})
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -36,6 +36,7 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
     private Map<String, String> selector;
     private boolean deleteClaim;
     private List<PersistentClaimStorageOverride> overrides;
+    private String volumeAttributesClass;
 
     @Description("Must be `" + TYPE_PERSISTENT_CLAIM + "`")
     @Override
@@ -124,5 +125,14 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
 
     public void setOverrides(List<PersistentClaimStorageOverride> overrides) {
         this.overrides = overrides;
+    }
+
+    @Description("Specifies `VolumeAttributeClass` name for dynamic volume allocation.")
+    public String getVolumeAttributesClass() {
+        return this.volumeAttributesClass;
+    }
+
+    public void setVolumeAttributesClass(String volumeAttributesClass) {
+        this.volumeAttributesClass = volumeAttributesClass;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
@@ -114,6 +114,7 @@ public class PersistentVolumeClaimUtils {
                         .withRequests(requests)
                     .endResources()
                     .withStorageClassName(storage.getStorageClass())
+                    .withVolumeAttributesClassName(storage.getVolumeAttributesClass())
                     .withSelector(storageSelector)
                     .withVolumeMode("Filesystem")
                 .endSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -56,6 +56,7 @@ public class PersistentVolumeClaimUtilsTest {
             .build();
     private final static PersistentClaimStorage PERSISTENT_CLAIM_STORAGE = new PersistentClaimStorageBuilder()
             .withStorageClass("my-storage-class")
+            .withVolumeAttributesClass("my-volume-attributes-class")
             .withSize("100Gi")
             .build();
     private final static Set<NodeRef> SINGLE_NODE = Set.of(new NodeRef(NAME + "-" + 0, 0, null, false, true));
@@ -106,6 +107,7 @@ public class PersistentVolumeClaimUtilsTest {
         assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
         assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
         assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+        assertThat(pvcs.get(0).getSpec().getVolumeAttributesClassName(), is("my-volume-attributes-class"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -38,6 +38,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diff.volumeAttributesClassChanged(), is(false));
         assertThat(diff.issuesDetected(), is(false));
 
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod2, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -45,6 +46,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diff.volumeAttributesClassChanged(), is(false));
         assertThat(diff.issuesDetected(), is(true));
     }
 
@@ -56,11 +58,13 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).volumeAttributesClassChanged(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).volumeAttributesClassChanged(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(true));
     }
 
@@ -96,16 +100,19 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).volumeAttributesClassChanged(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).volumeAttributesClassChanged(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).volumeAttributesClassChanged(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
     }
 
@@ -132,6 +139,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).volumeAttributesClassChanged(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
     }
 
@@ -362,5 +370,49 @@ public class StorageDiffTest {
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod3, Set.of(0, 1, 2), Set.of(0, 1, 2));
         assertThat(diff.isDuplicateVolumeIds(), is(true));
         assertThat(diff.issuesDetected(), is(true));
+    }
+
+    @ParallelTest
+    public void testVolumeAttributesChanges() {
+        Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
+        Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").withVolumeAttributesClass("vac-example").build();
+        Storage persistent3 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").withVolumeAttributesClass("vac-example-2").build();
+
+        StorageDiff diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.volumeAttributesClassChanged(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.volumeAttributesClassChanged(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.volumeAttributesClassChanged(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
+
+        Storage jbod = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withId(0).withVolumeAttributesClass("vac-example-1").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withId(1).withVolumeAttributesClass("vac-example-2").build()
+        ).build();
+        Storage jbod2 = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withId(0).build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withId(1).withVolumeAttributesClass("vac-example-2").build()
+        ).build();
+        Storage jbod3 = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withId(0).withVolumeAttributesClass("vac-example-2").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withId(1).withVolumeAttributesClass("vac-example-2").build()
+        ).build();
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.volumeAttributesClassChanged(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod2, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.volumeAttributesClassChanged(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod3, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.volumeAttributesClassChanged(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
     }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -671,6 +671,9 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |class
 |string
 |The storage class to use for dynamic volume allocation.
+|volumeAttributesClass
+|string
+|Specifies `VolumeAttributeClass` name for dynamic volume allocation.
 |selector
 |map
 |Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -599,6 +599,9 @@ spec:
                             - persistent-claim
                             - jbod
                           description: "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'."
+                        volumeAttributesClass:
+                          type: string
+                          description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                         volumes:
                           type: array
                           items:
@@ -649,6 +652,9 @@ spec:
                                   - ephemeral
                                   - persistent-claim
                                 description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                              volumeAttributesClass:
+                                type: string
+                                description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                             required:
                               - type
                           description: List of volumes as Storage objects representing the JBOD disks array.
@@ -2348,6 +2354,9 @@ spec:
                             - ephemeral
                             - persistent-claim
                           description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                        volumeAttributesClass:
+                          type: string
+                          description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                       required:
                         - type
                       description: Storage configuration (disk). Cannot be updated.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -111,6 +111,9 @@ spec:
                         - persistent-claim
                         - jbod
                       description: "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'."
+                    volumeAttributesClass:
+                      type: string
+                      description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                     volumes:
                       type: array
                       items:
@@ -161,6 +164,9 @@ spec:
                               - ephemeral
                               - persistent-claim
                             description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                          volumeAttributesClass:
+                            type: string
+                            description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                         required:
                           - type
                       description: List of volumes as Storage objects representing the JBOD disks array.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -598,6 +598,9 @@ spec:
                         - persistent-claim
                         - jbod
                         description: "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'."
+                      volumeAttributesClass:
+                        type: string
+                        description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                       volumes:
                         type: array
                         items:
@@ -648,6 +651,9 @@ spec:
                               - ephemeral
                               - persistent-claim
                               description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                            volumeAttributesClass:
+                              type: string
+                              description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                           required:
                           - type
                         description: List of volumes as Storage objects representing the JBOD disks array.
@@ -2347,6 +2353,9 @@ spec:
                         - ephemeral
                         - persistent-claim
                         description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                      volumeAttributesClass:
+                        type: string
+                        description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                     required:
                     - type
                     description: Storage configuration (disk). Cannot be updated.

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -110,6 +110,9 @@ spec:
                     - persistent-claim
                     - jbod
                     description: "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'."
+                  volumeAttributesClass:
+                    type: string
+                    description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                   volumes:
                     type: array
                     items:
@@ -160,6 +163,9 @@ spec:
                           - ephemeral
                           - persistent-claim
                           description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                        volumeAttributesClass:
+                          type: string
+                          description: Specifies `VolumeAttributeClass` name for dynamic volume allocation.
                       required:
                       - type
                     description: List of volumes as Storage objects representing the JBOD disks array.


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Currently, it is not possible to set the volumeAttributesClassName in the generated PVC using the persistent storage type. This enables that feature by adding a volumeAttributesClass field to the persistent storage that maps to the PVC.

Changes to the StorageDiff was required because it fails when a field is changed other than size and a few others.

Fixes #10462

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

