### PR TITLE
Adopt new Kafka Connect health check endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Dependency updates (Vert.x 4.5.12, Netty 4.1.117.Final)
 * Moved Kafka Connect configuration to the ConfigMap created by the operator.
 * Update Kafka Exporter to [1.9.0](https://github.com/danielqsj/kafka_exporter/releases/tag/v1.9.0)
+* Adopted new Kafka Connect health check endpoint (see [proposal 89](https://github.com/strimzi/proposals/blob/main/089-adopt-connect-health-endpoint.md)).
 
 ### Major changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -591,8 +591,8 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                 getEnvVars(),
                 getContainerPortList(),
                 getVolumeMounts(),
-                ProbeUtils.httpProbe(livenessProbeOptions, "/", REST_API_PORT_NAME),
-                ProbeUtils.httpProbe(readinessProbeOptions, "/", REST_API_PORT_NAME),
+                ProbeUtils.httpProbe(livenessProbeOptions, "/health", REST_API_PORT_NAME),
+                ProbeUtils.httpProbe(readinessProbeOptions, "/health", REST_API_PORT_NAME),
                 imagePullPolicy
         );
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Trivial change required to adopt the new Kafka Connect health check endpoint.

Should close #10751.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md


