### PR TITLE
Replaced openssl with Java security to add key/cert into keystore

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -6,6 +6,7 @@ package io.strimzi.certs;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -95,9 +96,10 @@ public interface CertManager {
      * @param alias key and certificate alias in the keystore
      * @param keyStoreFile path to the file related to the keystore
      * @param keyStorePassword password for protecting the keystore
+     * @throws GeneralSecurityException if something goes wrong when creating the keystore
      * @throws IOException If an input or output file could not be read/written.
      */
-    void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException;
+    void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws GeneralSecurityException, IOException;
 
     /**
      * Remove entries with provided aliases from the truststore

--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -6,10 +6,10 @@ package io.strimzi.certs;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -96,10 +96,14 @@ public interface CertManager {
      * @param alias key and certificate alias in the keystore
      * @param keyStoreFile path to the file related to the keystore
      * @param keyStorePassword password for protecting the keystore
-     * @throws GeneralSecurityException if something goes wrong when creating the keystore
      * @throws IOException If an input or output file could not be read/written.
+     * @throws CertificateException if any problems reading the certificate file in X509 format
+     * @throws KeyStoreException if any problems with reading/writing the keystore
+     * @throws NoSuchAlgorithmException if specified algorithm for keystore is not supported
+     * @throws InvalidKeySpecException if any problems while getting the private key
      */
-    void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws GeneralSecurityException, IOException;
+    void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException, InvalidKeySpecException;
 
     /**
      * Remove entries with provided aliases from the truststore

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -7,6 +7,7 @@ package io.strimzi.certs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.crypto.spec.PBEParameterSpec;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -21,12 +22,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -34,6 +41,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -372,18 +380,60 @@ public class OpenSslCertManager implements CertManager {
     }
 
     @Override
-    public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException {
-        new OpensslArgs("openssl", "pkcs12")
-                .opt("-export")
-                .optArg("-in", certFile)
-                .optArg("-inkey", keyFile)
-                .optArg("-name", alias)
-                .optArg("-out", keyStoreFile)
-                .optArg("-passout", "pass:" + keyStorePassword)
-                .optArg("-certpbe", "aes-128-cbc")
-                .optArg("-keypbe", "aes-128-cbc")
-                .optArg("-macalg", "sha256")
-                .exec();
+    public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws GeneralSecurityException, IOException {
+        // Preconditions
+        Objects.requireNonNull(keyFile);
+        Objects.requireNonNull(certFile);
+        Objects.requireNonNull(alias);
+        Objects.requireNonNull(keyStoreFile);
+        Objects.requireNonNull(keyStorePassword);
+
+        FileInputStream isKeyStore = null;
+        try {
+
+            // check if the keystore file is empty or not, for loading its content eventually
+            // the KeyStore class is able to create an empty store if the input stream is null
+            if (keyStoreFile.length() > 0) {
+                isKeyStore = new FileInputStream(keyStoreFile);
+            }
+
+            // load the private key
+            try (FileInputStream isKey = new FileInputStream(keyFile)) {
+                byte[] keyBytes = isKey.readAllBytes();
+                String strippedPrivateKey = new String(keyBytes, StandardCharsets.US_ASCII)
+                        .replace("-----BEGIN PRIVATE KEY-----", "")
+                        .replaceAll(System.lineSeparator(), "")
+                        .replace("-----END PRIVATE KEY-----", "");
+                byte[] decodedKey = Base64.getDecoder().decode(strippedPrivateKey);
+                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKey);
+                final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                final PrivateKey key = keyFactory.generatePrivate(keySpec);
+
+                // load the certificate
+                try (FileInputStream isCertificate = new FileInputStream(certFile)) {
+                    CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+                    X509Certificate certificate = (X509Certificate) certFactory.generateCertificate(isCertificate);
+
+                    KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                    keyStore.load(isKeyStore, keyStorePassword.toCharArray());
+
+                    byte[] salt = new byte[20];
+                    new SecureRandom().nextBytes(salt);
+                    // going to store the private key as encrypted by using AES-128-CBC with a key derived from the keystore password itself
+                    keyStore.setEntry(alias, new KeyStore.PrivateKeyEntry(key, new Certificate[]{certificate}),
+                            new KeyStore.PasswordProtection(keyStorePassword.toCharArray(), "PBEWithHmacSHA256AndAES_128", new PBEParameterSpec(salt, 2048)));
+
+                    try (FileOutputStream osKeyStore = new FileOutputStream(keyStoreFile)) {
+                        keyStore.store(osKeyStore, keyStorePassword.toCharArray());
+                    }
+                }
+            }
+
+        } finally {
+            if (isKeyStore != null) {
+                isKeyStore.close();
+            }
+        }
     }
 
     @Override

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -77,6 +77,8 @@ public class OpenSslCertManager implements CertManager {
     private static final Logger LOGGER = LogManager.getLogger(OpenSslCertManager.class);
     private final Clock clock;
 
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     /**
      * Constructs the OpenSslCertManager with the system time
      */
@@ -420,7 +422,7 @@ public class OpenSslCertManager implements CertManager {
                     keyStore.load(isKeyStore, keyStorePassword.toCharArray());
 
                     byte[] salt = new byte[20];
-                    new SecureRandom().nextBytes(salt);
+                    RANDOM.nextBytes(salt);
                     // going to store the private key as encrypted by using AES-128-CBC with a key derived from the keystore password itself
                     keyStore.setEntry(alias, new KeyStore.PrivateKeyEntry(key, new Certificate[]{certificate}),
                             new KeyStore.PasswordProtection(keyStorePassword.toCharArray(), "PBEWithHmacSHA256AndAES_128", new PBEParameterSpec(salt, 2048)));

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.crypto.spec.PBEParameterSpec;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -23,7 +23,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -34,6 +33,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Clock;
 import java.time.Instant;
@@ -381,7 +381,8 @@ public class OpenSslCertManager implements CertManager {
     }
 
     @Override
-    public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws GeneralSecurityException, IOException {
+    public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException, InvalidKeySpecException {
         // Preconditions
         Objects.requireNonNull(keyFile);
         Objects.requireNonNull(certFile);

--- a/development-docs/systemtests/labels/connect.md
+++ b/development-docs/systemtests/labels/connect.md
@@ -11,8 +11,8 @@ maintaining data consistency and availability in a streaming ecosystem.
 <!-- generated part -->
 **Tests:**
 - [testConnectLogSetting](../io.strimzi.systemtest.log.LogSettingST.md)
-- [testBuildFailsWithWrongChecksumOfArtifact](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testScaleConnectWithoutConnectorToZero](../io.strimzi.systemtest.connect.ConnectST.md)
+- [testBuildFailsWithWrongChecksumOfArtifact](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testBuildWithJarTgzAndZip](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testKafkaConnectWithPlainAndScramShaAuthentication](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testKafkaConnectScaleUpScaleDown](../io.strimzi.systemtest.connect.ConnectST.md)
@@ -32,8 +32,8 @@ maintaining data consistency and availability in a streaming ecosystem.
 - [testKafkaConnectAndConnectorMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)
 - [testKafkaConnectWithScramShaAuthenticationRolledAfterPasswordChanged](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testJvmAndResources](../io.strimzi.systemtest.connect.ConnectST.md)
-- [testBuildOtherPluginTypeWithAndWithoutFileName](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testSecretsWithKafkaConnectWithTlsAndScramShaAuthentication](../io.strimzi.systemtest.connect.ConnectST.md)
+- [testBuildOtherPluginTypeWithAndWithoutFileName](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testConnectScramShaAuthWithWeirdUserName](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testBuildPluginUsingMavenCoordinatesArtifacts](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testUpdateConnectWithAnotherPlugin](../io.strimzi.systemtest.connect.ConnectBuilderST.md)

--- a/development-docs/systemtests/labels/connect.md
+++ b/development-docs/systemtests/labels/connect.md
@@ -11,8 +11,8 @@ maintaining data consistency and availability in a streaming ecosystem.
 <!-- generated part -->
 **Tests:**
 - [testConnectLogSetting](../io.strimzi.systemtest.log.LogSettingST.md)
-- [testScaleConnectWithoutConnectorToZero](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testBuildFailsWithWrongChecksumOfArtifact](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
+- [testScaleConnectWithoutConnectorToZero](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testBuildWithJarTgzAndZip](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testKafkaConnectWithPlainAndScramShaAuthentication](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testKafkaConnectScaleUpScaleDown](../io.strimzi.systemtest.connect.ConnectST.md)
@@ -32,8 +32,8 @@ maintaining data consistency and availability in a streaming ecosystem.
 - [testKafkaConnectAndConnectorMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)
 - [testKafkaConnectWithScramShaAuthenticationRolledAfterPasswordChanged](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testJvmAndResources](../io.strimzi.systemtest.connect.ConnectST.md)
-- [testSecretsWithKafkaConnectWithTlsAndScramShaAuthentication](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testBuildOtherPluginTypeWithAndWithoutFileName](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
+- [testSecretsWithKafkaConnectWithTlsAndScramShaAuthentication](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testConnectScramShaAuthWithWeirdUserName](../io.strimzi.systemtest.connect.ConnectST.md)
 - [testBuildPluginUsingMavenCoordinatesArtifacts](../io.strimzi.systemtest.connect.ConnectBuilderST.md)
 - [testUpdateConnectWithAnotherPlugin](../io.strimzi.systemtest.connect.ConnectBuilderST.md)


### PR DESCRIPTION
This PR is going to replace the usage of OpenSSL tooling for adding a key/cert pair to the keystore with Java security framework.
While running tests I compared what we get by using openssl and what we get with Java.
I was able to tune the algorithm being used to encrypt the private key when it's stored, in order to have AES-128-CBC with 2048 iterations (which are the parameters with current openssl tooling vs the default Java which uses AES-256-CBC and 10000 iterations instead).

```shell
PKCS7 Data
Shrouded Keybag: PBES2, PBKDF2, AES-128-CBC, Iteration 2048, PRF hmacWithSHA256
Bag Attributes
    friendlyName: ca
    localKeyID: 54 69 6D 65 20 31 37 34 31 30 38 38 31 39 35 36 32 39 
Key Attributes: <No Attributes>
```

The only difference is about the HMAC used for the keystore integrity.
The openssl tool uses 2048 iterations and salt length 8 bytes.

```shell
MAC: sha256, Iteration 2048
MAC length: 32, salt length: 8
```

Java defaults to use 10000 iterations and salt length 10 bytes.

```shell
MAC: sha256, Iteration 10000
MAC length: 32, salt length: 20
```

I couldn't find any way to tune them both. Java doesn't expose anything to do so. It's only possible to tune the iterations but by setting a global Java properties like this:

```shell
System.setProperty("keystore.pkcs12.macIterationCount", "2048");
```

Tbh I am not keen to have such addition because it would be a global setting on the JVM.
So compared to openssl with have more secure HMAC which should not be a problem (the opposite I would say).