### PR TITLE
Remove broker failure detection from Cruise Control configuration

### DIFF
--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -25,7 +25,6 @@ ssl.keystore.password=$CERTS_STORE_PASSWORD
 ssl.truststore.type=PKCS12
 ssl.truststore.location=/tmp/cruise-control/replication.truststore.p12
 ssl.truststore.password=$CERTS_STORE_PASSWORD
-kafka.broker.failure.detection.enable=true
 capacity.config.file=/opt/cruise-control/custom-config/capacity.json
 ${CRUISE_CONTROL_CONFIGURATION}
 EOF


### PR DESCRIPTION
This trivial PR removes the `kafka.broker.failure.detection.enable=true` configuration within the Cruise Control script.
This setting is within the forbidden list but also it should not be enabled by default. Maybe it was added there by mistake? (Yes it was me, a few years back).