### PR TITLE
[ST] Add Service to LogCollector's list of resources to collect

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
@@ -137,6 +137,7 @@ public class TestLogCollector {
             TestConstants.SECRET.toLowerCase(Locale.ROOT),
             TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),
             TestConstants.CONFIG_MAP.toLowerCase(Locale.ROOT),
+            TestConstants.SERVICE.toLowerCase(Locale.ROOT),
             Kafka.RESOURCE_SINGULAR,
             KafkaNodePool.RESOURCE_SINGULAR,
             KafkaConnect.RESOURCE_SINGULAR,


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This trivial PR adds `Service` to list of resources that should be collected when test fails by LogCollector.

### Checklist

- [x] Make sure all tests pass
