### PR TITLE
[ST] Correct names in loggers for KAO ST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/access/SetupAccessOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/access/SetupAccessOperator.java
@@ -15,7 +15,6 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.DeploymentTypes;
 import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.draincleaner.SetupDrainCleaner;
 import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -28,7 +27,7 @@ import java.util.List;
 public class SetupAccessOperator {
 
     public static final String PATH_TO_KAO_CONFIG = TestUtils.USER_PATH + "/../packaging/install/access-operator/";
-    private static final Logger LOGGER = LogManager.getLogger(SetupDrainCleaner.class);
+    private static final Logger LOGGER = LogManager.getLogger(SetupAccessOperator.class);
 
     /**
      * Method for installing Kafka Access Operator into the specified Namespace.

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/AccessOperatorST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/AccessOperatorST.java
@@ -46,7 +46,7 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
  */
 @Tag(REGRESSION)
 public class AccessOperatorST extends AbstractST {
-    private static final Logger LOGGER = LogManager.getLogger(DrainCleanerST.class);
+    private static final Logger LOGGER = LogManager.getLogger(AccessOperatorST.class);
 
     @IsolatedTest
     @TestDoc(


### PR DESCRIPTION
### Type of change

- Fix

### Description

This small PR fixes typos (more like copy-paste errors) in the `SetupAccessOperator` and `AccessOperatorST` classes where I used wrong names of the classes.

### Checklist

- [ ] Make sure all tests pass

