### PR TITLE
[ST] Use `AutoOffsetResetStrategy` in clients instead of `OffsetResetStrategy`

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/clientproperties/ConsumerProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/clientproperties/ConsumerProperties.java
@@ -6,7 +6,7 @@ package io.strimzi.systemtest.kafkaclients.clientproperties;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -46,12 +46,9 @@ public class ConsumerProperties extends AbstractKafkaClientProperties<ConsumerPr
             return this;
         }
 
-        // OffsetResetStrategy is deprecated and should be replaced by using AutoOffsetResetStrategy
-        // Tracked by issue https://github.com/strimzi/strimzi-kafka-operator/issues/11201
-        @SuppressWarnings("deprecation")
-        public ConsumerPropertiesBuilder withAutoOffsetResetConfig(OffsetResetStrategy offsetResetConfig) {
+        public ConsumerPropertiesBuilder withAutoOffsetResetConfig(AutoOffsetResetStrategy autoOffsetResetStrategy) {
 
-            this.properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetResetConfig.name().toLowerCase(Locale.ENGLISH));
+            this.properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetResetStrategy.name().toLowerCase(Locale.ENGLISH));
             return this;
         }
 
@@ -72,7 +69,7 @@ public class ConsumerProperties extends AbstractKafkaClientProperties<ConsumerPr
     }
 
     @Override
-    @SuppressWarnings({"unchecked", "deprecation"}) // OffsetResetStrategy is deprecated
+    @SuppressWarnings({"unchecked"})
     public ConsumerProperties.ConsumerPropertiesBuilder toBuilder(ConsumerProperties clientProperties) {
         ConsumerPropertiesBuilder builder = new ConsumerProperties.ConsumerPropertiesBuilder();
 
@@ -90,7 +87,7 @@ public class ConsumerProperties extends AbstractKafkaClientProperties<ConsumerPr
         }
 
         builder.withClientIdConfig(clientProperties.getProperties().getProperty(ConsumerConfig.CLIENT_ID_CONFIG));
-        builder.withAutoOffsetResetConfig(OffsetResetStrategy.valueOf(clientProperties.getProperties().getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ENGLISH)));
+        builder.withAutoOffsetResetConfig(AutoOffsetResetStrategy.fromString(clientProperties.getProperties().getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ENGLISH)));
         builder.withSharedProperties();
 
         return builder;

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
@@ -13,7 +13,7 @@ import io.strimzi.test.WaitException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -68,9 +68,6 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
             .withClientIdConfig("producer-" + RANDOM.nextInt(Integer.MAX_VALUE));
     }
 
-    // OffsetResetStrategy is deprecated and should be replaced by using AutoOffsetResetStrategy
-    // Tracked by issue https://github.com/strimzi/strimzi-kafka-operator/issues/11201
-    @SuppressWarnings("deprecation")
     private ConsumerProperties.ConsumerPropertiesBuilder getConsumerProperties() {
         return new ConsumerProperties.ConsumerPropertiesBuilder()
             .withNamespaceName(namespaceName)
@@ -79,7 +76,7 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
             .withKeyDeserializerConfig(StringDeserializer.class)
             .withValueDeserializerConfig(StringDeserializer.class)
             .withClientIdConfig("consumer-" + RANDOM.nextInt(Integer.MAX_VALUE))
-            .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
+            .withAutoOffsetResetConfig(AutoOffsetResetStrategy.EARLIEST)
             .withGroupIdConfig(consumerGroup);
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR changes usage of `OffsetResetStrategy` - now deprecated - to `AutoOffsetResetStrategy`, which is not deprecated.

Fixes #11201 

### Checklist

- [ ] Make sure all tests pass

