### PR TITLE
Fix Javadoc warnings in kafka-init module

### DIFF
--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriterConfig.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriterConfig.java
@@ -43,6 +43,8 @@ public class InitWriterConfig {
     private final Map<String, Object> map;
 
     /**
+     * Returns set of keys obtained from the {@link #CONFIG_VALUES} map.
+     *
      * @return Set of configuration key/names
      */
     public static Set<String> keyNames() {
@@ -79,34 +81,45 @@ public class InitWriterConfig {
     }
 
     /**
-     * @return Kubernetes cluster node name from which getting the rack related label
+     * Returns name of Kubernetes cluster node from which getting the rack related label
+     *
+     * @return Kubernetes cluster node name from {@link #NODE_NAME}
      */
     public String getNodeName() {
         return get(NODE_NAME);
     }
 
     /**
-     * @return the Kubernetes cluster node label to use as topology key for rack definition
+     * Returns the Kubernetes cluster node label to use as topology key for rack definition
+     *
+     * @return rack topology key from {@link #RACK_TOPOLOGY_KEY}
      */
     public String getRackTopologyKey() {
         return get(RACK_TOPOLOGY_KEY);
     }
 
     /**
-     * @return folder where the rackid file is written
+     * Returns folder where the rackid file is written, taken from the {@link #INIT_FOLDER}.
+     *
+     * @return init folder where the rackid file is written.
      */
     public String getInitFolder() {
         return get(INIT_FOLDER);
     }
 
     /**
-     * @return Return whether external address should be acquired
+     * Returns boolean value that determines if the external address should be acquired or not.
+     * Taken from {@link #EXTERNAL_ADDRESS}.
+     *
+     * @return boolean value determining if the external address should be acquired
      */
     public boolean isExternalAddress() {
         return get(EXTERNAL_ADDRESS);
     }
 
     /**
+     * Returns type of the external address, taken from the {@link #EXTERNAL_ADDRESS_TYPE}.
+     *
      * @return The address type which should be preferred in the selection
      */
     public String getAddressType() {

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
@@ -16,6 +16,14 @@ public class Main {
     private static final Logger LOGGER = LogManager.getLogger(Main.class);
 
     /**
+     * Default constructor for the Main class.
+     * The constructor is intentionally left empty.
+     */
+    public Main() {
+        // No initialization required
+    }
+
+    /**
      * The main method
      *
      * @param args  Array with arguments form the command line


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This small PR fixes multiple Javadoc warnings in the `kafka-init` module.

### Checklist

- [ ] Make sure all tests pass

