### PR TITLE
Specify tagSuffix by version for the strimzi helm chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -6,19 +6,19 @@
 {{/* Generate the kafka image map */}}
 {{- define "strimzi.kafka.image.map" }}
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: {{ template "strimzi.image" (merge . (dict "key" "kafkaExporter" "tagSuffix" "-kafka-4.0.0")) }}
+              value: {{ template "strimzi.image" (merge . (dict "key" "kafkaExporter" "version" "4.0.0" "defaultTagSuffix" "-kafka-4.0.0")) }}
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: {{ template "strimzi.image" (merge . (dict "key" "cruiseControl" "tagSuffix" "-kafka-4.0.0")) }}
+              value: {{ template "strimzi.image" (merge . (dict "key" "cruiseControl" "version" "4.0.0" "defaultTagSuffix" "-kafka-4.0.0")) }}
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.9.0")) }}
-                4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.0.0")) }}
+                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "version" "3.9.0" "defaultTagSuffix" "-kafka-3.9.0")) }}
+                4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "version" "4.0.0" "defaultTagSuffix" "-kafka-4.0.0")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.9.0")) }}
-                4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.0.0")) }}
+                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "version" "3.9.0" "defaultTagSuffix" "-kafka-3.9.0")) }}
+                4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "version" "4.0.0" "defaultTagSuffix" "-kafka-4.0.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.9.0")) }}
-                4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.0.0")) }}
+                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "version" "3.9.0" "defaultTagSuffix" "-kafka-3.9.0")) }}
+                4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "version" "4.0.0" "defaultTagSuffix" "-kafka-4.0.0")) }}
 {{- end -}}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
@@ -147,13 +147,16 @@ tests:
           repository: test-repo
           name: kafka-test
           tagPrefix: test-tag
+          tagSuffix: # these versions need to be updated to align with the compatible kafka version of the current release
+            "3.9.0": -test-suffix
+            "4.0.0": -test-suffix
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[5].name
           value: STRIMZI_KAFKA_IMAGES
       - matchRegex:
           path: spec.template.spec.containers[0].env[5].value
-          pattern: '[0-9]+\.[0-9]+\.[0-9]+=test.registry.com/test-repo/kafka-test:test-tag-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+=test.registry.com/test-repo/kafka-test:test-tag-test-suffix'
 
   - it: should set IMAGE_PULL_SECRETS literally if provided as string
     set:

--- a/packaging/helm-charts/kafka-version-tpl.sh
+++ b/packaging/helm-charts/kafka-version-tpl.sh
@@ -15,20 +15,20 @@ get_default_kafka_version
 get_kafka_does_not_support
 
 # Set the default images
-kafka_exporter_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"tagSuffix\" \"-kafka-${default_kafka_version}\")) }}"
+kafka_exporter_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"version\" \"${default_kafka_version}\" \"defaultTagSuffix\" \"-kafka-${default_kafka_version}\")) }}"
 
 for version in "${versions[@]}"
 do
-    kafka_exporter_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"tagSuffix\" \"-kafka-${version}\")) }}"
-    cruise_control_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"cruiseControl\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+    kafka_exporter_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"version\" \"${version}\" \"defaultTagSuffix\" \"-kafka-${version}\")) }}"
+    cruise_control_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"cruiseControl\" \"version\" \"${version}\" \"defaultTagSuffix\" \"-kafka-${version}\")) }}"
     kafka_versions="${kafka_versions}
-${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafka\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafka\" \"version\" \"${version}\" \"defaultTagSuffix\" \"-kafka-${version}\")) }}"
     kafka_connect_versions="${kafka_connect_versions}
-${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaConnect\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaConnect\" \"version\" \"${version}\" \"defaultTagSuffix\" \"-kafka-${version}\")) }}"
     kafka_exporter_versions="${kafka_exporter_versions}
-${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"version\" \"${version}\" \"defaultTagSuffix\" \"-kafka-${version}\")) }}"
     kafka_mirror_maker_2_versions="${kafka_mirror_maker_2_versions}
-${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaMirrorMaker2\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaMirrorMaker2\" \"version\" \"${version}\" \"defaultTagSuffix\" \"-kafka-${version}\")) }}"
 done
 
 kafka_versions=$(echo "$kafka_versions" | sed 's/^/                /g')


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The current helm chart allows us to override the default tagPrefix for kafka, kafkaConnect, kafkaExporter, kafkaMirrorMaker2, and cruiseControl but doesn't allow for overriding the tagSuffix. At our company, we build a docker image on top of `quay.io/strimzi/kafka:x.xx.x-kafka-x.x.x` and use a different naming convention for the tagSuffix than `-kafka-x.x.x` in our own artifactory.

This PR makes it so we can optionally customize a tagSuffix according to the supported version of kafka. If a tagSuffix isn't defined, it will default to the normal `-kafka-x.x.x` behaviour.
eg.
```yaml
kafka:
  image:
    registry: ""
    repository: ""
    name: kafka
    tagPrefix: ""
    tagSuffix:
      3.9.0: "-foo"
      4.0.0: "-bar"
```
The values.yaml above will template to:
```yaml
- name: STRIMZI_KAFKA_IMAGES
              value: |                 
                3.9.0=quay.io/strimzi/kafka:latest-foo
                4.0.0=quay.io/strimzi/kafka:latest-bar
```

One issue I found when changing the tests was I had to specify the current supported versions. The tests were version agnostic and we lose that with the way I currently wrote the test. I'm open to any suggestions on this. I can also update the PR to update documentation and update the changelog if this is a change the maintainers are interested in!

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Update CHANGELOG.md

