### PR TITLE
Remove preferIPv4Stack option and let it use JVM defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Adopted new Kafka Connect health check endpoint (see [proposal 89](https://github.com/strimzi/proposals/blob/main/089-adopt-connect-health-endpoint.md)).
 * Update standalone User Operator to handle Cluster CA cert Secret being missing when TLS is not needed.
 * Strimzi Drain Cleaner updated to 1.3.0 (included in the Strimzi installation files)
+* Implicit IPv4 preference when enabling JMX has been removed, and will now use JVM defaults.
+  This will make the cluster boot up correctly in IPv6 only environments, where IPv4 preference will break it due to lack of IPv4 addresses.
 
 ### Major changes, deprecations and removals
 

--- a/docker-images/kafka-based/kafka/scripts/set_kafka_jmx_options.sh
+++ b/docker-images/kafka-based/kafka/scripts/set_kafka_jmx_options.sh
@@ -6,7 +6,7 @@ JMX_USERNAME="$2"
 JMX_PASSWORD="$3"
 
 if [ "$JMX_ENABLED" = "true" ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$(hostname -I | awk '{print $1}') -Djava.net.preferIPv4Stack=true"
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$(hostname -I | awk '{print $1}')"
 
   if [ -n "$JMX_USERNAME" ]; then
     mkdir -p /tmp/jmx/

--- a/systemtest/scripts/run_tests.sh
+++ b/systemtest/scripts/run_tests.sh
@@ -21,7 +21,6 @@ function run_test() {
       -pl systemtest \
       -am \
       -P"${PROFILE}" \
-      -Djava.net.preferIPv4Stack=true \
       -DfailIfNoTests=false \
       -Djansi.force=true \
       -Dstyle.color=always \


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

Bugfix?

### Description

_Please describe your pull request_

Turns out that when setting the `jmxOptions`, `java.net.preferIPv4Stack` option is also set to `true` implicitly.

This will break IPv6 only settings since there are no IPv4 IPs available in the system.

Please see the Slack thread for more details:
https://cloud-native.slack.com/archives/CMH3Q3SNP/p1741634709885909

Opening this PR as a check to see if there will be any issues with regression tests.

#### NOTE

Verified that JMX will work fine with IPv6. It does depend on the tool knowing to use `[ipv6]:port` syntax instead of `ip:port`.

Verified this with Datadog's Kafka integration, and metrics is getting ingested.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

