### PR TITLE
Mount OAuth related client configuration via volume within Kafka Bridge

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -88,6 +88,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
     protected static final String ENV_VAR_KAFKA_BRIDGE_METRICS_ENABLED = "KAFKA_BRIDGE_METRICS_ENABLED";
     protected static final String ENV_VAR_KAFKA_BRIDGE_TRUSTED_CERTS = "KAFKA_BRIDGE_TRUSTED_CERTS";
     protected static final String OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/strimzi/oauth-certs/";
+    protected static final String OAUTH_SECRETS_BASE_VOLUME_MOUNT = "/opt/strimzi/oauth/";
 
     protected static final String CO_ENV_VAR_CUSTOM_BRIDGE_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS";
     protected static final String INIT_VOLUME_MOUNT = "/opt/strimzi/init";
@@ -284,7 +285,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
             volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
         }
 
-        AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift);
+        AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift, "", true);
 
         TemplateUtils.addAdditionalVolumes(templatePod, volumeList);
 
@@ -305,7 +306,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
             volumeMountList.add(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT));
         }
 
-        AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT, "oauth-certs");
+        AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT, "oauth-certs", "", true, OAUTH_SECRETS_BASE_VOLUME_MOUNT);
 
         TemplateUtils.addAdditionalVolumeMounts(volumeMountList, templateContainer);
 
@@ -403,6 +404,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_BRIDGE_TRUSTED_CERTS, CertUtils.trustedCertsEnvVar(tls.getTrustedCertificates())));
         }
 
+        // This is still needed to generate oauth truststore certificates in PKCS12 format
         AuthenticationUtils.configureClientAuthenticationEnvVars(authentication, varList, name -> ENV_VAR_PREFIX + name);
 
         // Add shared environment variables used for all containers

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
@@ -21,6 +21,9 @@ import io.strimzi.operator.common.Reconciliation;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.stream.Collectors;
+
+import static io.strimzi.operator.cluster.model.KafkaBridgeCluster.OAUTH_SECRETS_BASE_VOLUME_MOUNT;
 
 /**
  * This class is used to generate the bridge configuration template. The template is later passed using a ConfigMap to
@@ -32,10 +35,9 @@ public class KafkaBridgeConfigurationBuilder {
 
     // placeholders expanded through config providers inside the bridge node
     private static final String PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR = "${strimzienv:CERTS_STORE_PASSWORD}";
-    private static final String PLACEHOLDER_SASL_USERNAME_CONFIG_PROVIDER_ENV_VAR = "${strimzienv:KAFKA_BRIDGE_SASL_USERNAME}";
     private static final String PASSWORD_VOLUME_MOUNT = "/opt/strimzi/bridge-password/";
     // the SASL password file template includes: <volume_mount>/<secret_name>/<password_file>
-    private static final String PLACEHOLDER_SASL_PASSWORD_FILE_TEMPLATE_CONFIG_PROVIDER_DIR = "${strimzidir:%s%s:%s}";
+    private static final String PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR = "${strimzidir:%s%s:%s}";
 
     private final Reconciliation reconciliation;
     private final StringWriter stringWriter = new StringWriter();
@@ -147,8 +149,8 @@ public class KafkaBridgeConfigurationBuilder {
 
                 if (authentication instanceof KafkaClientAuthenticationPlain passwordAuth) {
                     saslMechanism = "PLAIN";
-                    String passwordFilePath = String.format(PLACEHOLDER_SASL_PASSWORD_FILE_TEMPLATE_CONFIG_PROVIDER_DIR, PASSWORD_VOLUME_MOUNT, passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword());
-                    jaasConfig.append("org.apache.kafka.common.security.plain.PlainLoginModule required username=" + PLACEHOLDER_SASL_USERNAME_CONFIG_PROVIDER_ENV_VAR + " password=" + passwordFilePath + ";");
+                    String passwordFilePath = String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, PASSWORD_VOLUME_MOUNT, passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword());
+                    jaasConfig.append("org.apache.kafka.common.security.plain.PlainLoginModule required username=" + passwordAuth.getUsername() + " password=" + passwordFilePath + ";");
                 } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
 
                     if (scramAuth.getType().equals(KafkaClientAuthenticationScramSha256.TYPE_SCRAM_SHA_256)) {
@@ -157,26 +159,38 @@ public class KafkaBridgeConfigurationBuilder {
                         saslMechanism = "SCRAM-SHA-512";
                     }
 
-                    String passwordFilePath = String.format(PLACEHOLDER_SASL_PASSWORD_FILE_TEMPLATE_CONFIG_PROVIDER_DIR, PASSWORD_VOLUME_MOUNT, scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword());
-                    jaasConfig.append("org.apache.kafka.common.security.scram.ScramLoginModule required username=" + PLACEHOLDER_SASL_USERNAME_CONFIG_PROVIDER_ENV_VAR + " password=" + passwordFilePath + ";");
+                    String passwordFilePath = String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, PASSWORD_VOLUME_MOUNT, scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword());
+                    jaasConfig.append("org.apache.kafka.common.security.scram.ScramLoginModule required username=" + scramAuth.getUsername() + " password=" + passwordFilePath + ";");
                 } else if (authentication instanceof KafkaClientAuthenticationOAuth oauth) {
                     saslMechanism = "OAUTHBEARER";
-                    jaasConfig.append("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${strimzienv:KAFKA_BRIDGE_OAUTH_CONFIG}");
+                    String oauthConfig = AuthenticationUtils.oauthJaasOptions(oauth).entrySet().stream()
+                            .map(e -> e.getKey() + "=\"" + e.getValue() + "\"")
+                            .collect(Collectors.joining(" "));
+
+                    if (!oauthConfig.isEmpty()) {
+                        jaasConfig.append("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " + oauthConfig);
+                    } else {
+                        jaasConfig.append("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required");
+                    }
 
                     if (oauth.getClientSecret() != null) {
-                        jaasConfig.append(" oauth.client.secret=${strimzienv:KAFKA_BRIDGE_OAUTH_CLIENT_SECRET}");
+                        jaasConfig.append(" oauth.client.secret=" + String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, OAUTH_SECRETS_BASE_VOLUME_MOUNT, oauth.getClientSecret().getSecretName(), oauth.getClientSecret().getKey()));
                     }
 
                     if (oauth.getRefreshToken() != null) {
-                        jaasConfig.append(" oauth.refresh.token=${strimzienv:KAFKA_BRIDGE_OAUTH_REFRESH_TOKEN}");
+                        jaasConfig.append(" oauth.refresh.token=" + String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, OAUTH_SECRETS_BASE_VOLUME_MOUNT, oauth.getRefreshToken().getSecretName(), oauth.getRefreshToken().getKey()));
                     }
 
                     if (oauth.getAccessToken() != null) {
-                        jaasConfig.append(" oauth.access.token=${strimzienv:KAFKA_BRIDGE_OAUTH_ACCESS_TOKEN}");
+                        jaasConfig.append(" oauth.access.token=" + String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, OAUTH_SECRETS_BASE_VOLUME_MOUNT, oauth.getAccessToken().getSecretName(), oauth.getAccessToken().getKey()));
                     }
 
                     if (oauth.getPasswordSecret() != null) {
-                        jaasConfig.append(" oauth.password.grant.password=${strimzienv:KAFKA_BRIDGE_OAUTH_PASSWORD_GRANT_PASSWORD}");
+                        jaasConfig.append(" oauth.password.grant.password=" + String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, OAUTH_SECRETS_BASE_VOLUME_MOUNT, oauth.getPasswordSecret().getSecretName(), oauth.getPasswordSecret().getPassword()));
+                    }
+
+                    if (oauth.getClientAssertion() != null) {
+                        jaasConfig.append(" oauth.client.assertion=" + String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, OAUTH_SECRETS_BASE_VOLUME_MOUNT, oauth.getClientAssertion().getSecretName(), oauth.getClientAssertion().getKey()));
                     }
 
                     if (oauth.getTlsTrustedCertificates() != null && !oauth.getTlsTrustedCertificates().isEmpty()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
@@ -158,6 +158,7 @@ public class KafkaBridgeConfigurationBuilderTest {
     public void testSaslMechanism() {
         // test plain authentication
         KafkaClientAuthenticationPlain authPlain = new KafkaClientAuthenticationPlainBuilder()
+                .withUsername("user1")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -171,7 +172,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=PLAIN",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_BRIDGE_SASL_USERNAME} password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=user1 password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};"
         ));
 
         // test plain authentication but with TLS as well (server authentication only, encryption)
@@ -190,7 +191,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_SSL",
                 "kafka.sasl.mechanism=PLAIN",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_BRIDGE_SASL_USERNAME} password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};",
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=user1 password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};",
                 "kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12",
                 "kafka.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
                 "kafka.ssl.truststore.type=PKCS12"
@@ -198,6 +199,7 @@ public class KafkaBridgeConfigurationBuilderTest {
 
         // test scram-sha-256 authentication
         KafkaClientAuthenticationScramSha256 authScramSha256 = new KafkaClientAuthenticationScramSha256Builder()
+                .withUsername("user1")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -211,11 +213,12 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=SCRAM-SHA-256",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_BRIDGE_SASL_USERNAME} password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=user1 password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};"
         ));
 
         // test scram-sha-512 authentication
         KafkaClientAuthenticationScramSha512 authScramSha512 = new KafkaClientAuthenticationScramSha512Builder()
+                .withUsername("user1")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -229,7 +232,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=SCRAM-SHA-512",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_BRIDGE_SASL_USERNAME} password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=user1 password=${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key};"
         ));
 
         // test oauth authentication
@@ -266,13 +269,17 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=OAUTHBEARER",
-                "kafka.sasl.jaas.config=" +
-                        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${strimzienv:KAFKA_BRIDGE_OAUTH_CONFIG}" +
-                        " oauth.client.secret=${strimzienv:KAFKA_BRIDGE_OAUTH_CLIENT_SECRET}" +
-                        " oauth.refresh.token=${strimzienv:KAFKA_BRIDGE_OAUTH_REFRESH_TOKEN}" +
-                        " oauth.access.token=${strimzienv:KAFKA_BRIDGE_OAUTH_ACCESS_TOKEN}" +
-                        " oauth.password.grant.password=${strimzienv:KAFKA_BRIDGE_OAUTH_PASSWORD_GRANT_PASSWORD}" +
-                        " oauth.ssl.truststore.location=\"/tmp/strimzi/oauth.truststore.p12\" oauth.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD} oauth.ssl.truststore.type=\"PKCS12\";",
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " +
+                        "oauth.client.id=\"oauth-client-id\" " +
+                        "oauth.password.grant.username=\"oauth-username\" " +
+                        "oauth.token.endpoint.uri=\"http://token-endpoint-uri\" " +
+                        "oauth.client.secret=${strimzidir:/opt/strimzi/oauth/my-client-secret-secret:my-client-secret-key} " +
+                        "oauth.refresh.token=${strimzidir:/opt/strimzi/oauth/my-refresh-token-secret:my-refresh-token-key} " +
+                        "oauth.access.token=${strimzidir:/opt/strimzi/oauth/my-access-token-secret:my-access-token-key} " +
+                        "oauth.password.grant.password=${strimzidir:/opt/strimzi/oauth/my-password-secret-secret:my-password-key} " +
+                        "oauth.ssl.truststore.location=\"/tmp/strimzi/oauth.truststore.p12\" " +
+                        "oauth.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD} " +
+                        "oauth.ssl.truststore.type=\"PKCS12\";",
                 "kafka.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
         ));
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Mount OAuth related secrets and use them for configurations, rather than exposing as environment variables and using them for configurations. This is consistent with how it's done for MirrorMaker2 (and the same change will be made for KafkaConnect). The environment variables will be eventually removed once we use PEM certificates directly for configurations instead of the script generated PKCS certificates for truststore. 

Resolves #11227 partially. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

