### PR TITLE
docs(logging): log4j2 support updates

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -16,7 +16,7 @@ Kafka Bridge has its own configurable loggers:
 * `rootLogger`
 * `bridge`
 
-You can also log levels for specific operations based on endpoints:
+You can also set log levels for specific operations based on endpoints:
 
 * `createConsumer`
 * `deleteConsumer`

--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -77,7 +77,9 @@ spec:
 Kafka Bridge uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
+You can set log levels using either the `inline` or `external` logging configuration types.
+
+Specify loggers and levels directly in the custom resource for inline configuration:
 
 .Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
@@ -95,6 +97,8 @@ spec:
       logger.send.level: DEBUG
   # ...
 ----
+
+Alternatively, you can reference an external `ConfigMap` containing a complete `log4j2.properties` file that defines your own log4j2 configuration, including loggers, appenders, and layout configuration:
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -69,7 +69,7 @@ spec:
   logging:
     type: inline
     loggers:
-      logger.send.name: "http.openapi.operation.send"
+      logger.send.name: http.openapi.operation.send
       logger.send.level: DEBUG
   # ...
 ----
@@ -93,7 +93,7 @@ spec:
     loggers:
       rootLogger.level: INFO
       # enabling DEBUG for send operation
-      logger.send.name: "http.openapi.operation.send"
+      logger.send.name: http.openapi.operation.send
       logger.send.level: DEBUG
   # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -11,12 +11,36 @@ Configuration options relate to:
 [id='property-kafka-bridge-logging-{context}']
 = Logging
 
-Kafka Bridge has its own configurable loggers:
+Kafka Bridge has its own preconfigured loggers:
 
-* `rootLogger`
-* `bridge`
+[cols="1m,2,1",options="header"]
+|===
+| Logger     | Description                                          | Default Level
 
-You can also set log levels for specific operations based on endpoints:
+| rootLogger | Default logger for all classes                       | INFO
+| bridge     | All classes in the `io.strimzi.kafka.bridge` package | INFO
+| healthy    | Uses `http.openapi.operation.healthy` endpoint       | WARN
+| ready      | Uses `http.openapi.operation.ready` endpoint         | WARN
+|===
+
+You can configure log levels directly for these loggers.
+For example:
+
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaBridge
+spec:
+  # ...
+  logging:
+    type: inline
+    loggers:
+      rootLogger.level: INFO
+      logger.ready.level: DEBUG
+  # ...
+----
+
+You can also specify custom loggers for other operations:
 
 * `createConsumer`
 * `deleteConsumer`
@@ -30,31 +54,25 @@ You can also set log levels for specific operations based on endpoints:
 * `seekToBeginning`
 * `seekToEnd`
 * `seek`
-* `healthy` (default: `WARN`)
-* `ready` (default: `WARN`)
 * `openapi`
 
-The healthy and ready loggers are set to `WARN` by default due to verbosity:
+Each operation maps to an API endpoint,  defined according to the OpenAPI specification, and supports fine-grained logging via `http.openapi.operation.<operation_id>`.
 
-[source,properties]
+For example, to set the logging level for the `send` operation logger:
+
+[source,yaml,subs="+quotes,attributes"]
 ----
-logger.healthy.name = http.openapi.operation.healthy
-logger.healthy.level = WARN
-logger.ready.name = http.openapi.operation.ready
-logger.ready.level = WARN
+apiVersion: {KafkaApiVersion}
+kind: KafkaBridge
+spec:
+  # ...
+  logging:
+    type: inline
+    loggers:
+      logger.send.name: "http.openapi.operation.send"
+      logger.send.level: DEBUG
+  # ...
 ----
-
-The log level of all other operations is set to `INFO` by default.
-
-Each operation has a corresponding API endpoint, defined according to the OpenAPI specification, allowing fine-grained logging of HTTP requests.
-
-Configure each logger by assigning it a name as `http.openapi.operation.<operation_id>`. 
-For example, to set the logging level for the send operation logger:
-
-```
-logger.send.name = http.openapi.operation.send
-logger.send.level = DEBUG
-```
 
 Kafka Bridge uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -57,17 +57,9 @@ logger.ready.level = WARN
 The log level of all other operations is set to `INFO` by default.
 
 Use the `logging` property to configure loggers and logger levels.
+You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
-You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
-If a ConfigMap is used, you set `logging.valueFrom.configMapKeyRef.name` property to the name of the ConfigMap containing the external logging configuration.
-The `logging.valueFrom.configMapKeyRef.name` and `logging.valueFrom.configMapKeyRef.key` properties are mandatory.
-Default logging is used if the `name` or `key` is not set.
-Inside the ConfigMap, the logging configuration is described using `log4j.properties`.
-For more information about log levels, see {ApacheLoggers}.
-
-Here we see examples of `inline` and `external` logging.
-
-.Inline logging
+.Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -78,13 +70,13 @@ spec:
     type: inline
     loggers:
       rootLogger.level: INFO
-      # enabling DEBUG just for send operation
+      # enabling DEBUG for send operation
       logger.send.name: "http.openapi.operation.send"
       logger.send.level: DEBUG
   # ...
 ----
 
-.External logging
+.Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -95,17 +87,11 @@ spec:
     type: external
     valueFrom:
       configMapKeyRef:
+        # name and key are mandatory
         name: customConfigMap
-        key: bridge-logj42.properties
+        key: log4j2.properties
   # ...
 ----
-
-Any available loggers that are not configured have their level set to `OFF`.
-
-If the Kafka Bridge was deployed using the Cluster Operator,
-changes to Kafka Bridge logging levels are applied dynamically.
-
-If you use external logging, a rolling update is triggered when logging appenders are changed.
 
 .Garbage collector (GC)
 

--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -13,8 +13,8 @@ Configuration options relate to:
 
 Kafka Bridge has its own configurable loggers:
 
-* `rootLogger.level`
-* `logger.__<operation-id>__`
+* `rootLogger.*`
+* `logger.<operation_id>`
 
 You can replace `_<operation-id>_` in the `logger.__<operation-id>__` logger to set log levels for specific operations:
 
@@ -37,7 +37,7 @@ You can replace `_<operation-id>_` in the `logger.__<operation-id>__` logger to 
 Each operation is defined according OpenAPI specification, and has a corresponding API endpoint through which the bridge receives requests from HTTP clients.
 You can change the log level on each endpoint to create fine-grained logging information about the incoming and outgoing HTTP requests.
 
-Each logger has to be configured assigning it a `name` as `http.openapi.operation.__<operation-id>__`.
+Each logger has to be configured assigning it a `name` as `http.openapi.operation.<operation_id>`.
 For example, configuring the logging level for the `send` operation logger means defining the following:
 
 ```

--- a/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc
@@ -13,10 +13,10 @@ Configuration options relate to:
 
 Kafka Bridge has its own configurable loggers:
 
-* `rootLogger.*`
-* `logger.<operation_id>`
+* `rootLogger`
+* `bridge`
 
-You can replace `_<operation-id>_` in the `logger.__<operation-id>__` logger to set log levels for specific operations:
+You can also log levels for specific operations based on endpoints:
 
 * `createConsumer`
 * `deleteConsumer`
@@ -30,15 +30,26 @@ You can replace `_<operation-id>_` in the `logger.__<operation-id>__` logger to 
 * `seekToBeginning`
 * `seekToEnd`
 * `seek`
-* `healthy`
-* `ready`
+* `healthy` (default: `WARN`)
+* `ready` (default: `WARN`)
 * `openapi`
 
-Each operation is defined according OpenAPI specification, and has a corresponding API endpoint through which the bridge receives requests from HTTP clients.
-You can change the log level on each endpoint to create fine-grained logging information about the incoming and outgoing HTTP requests.
+The healthy and ready loggers are set to `WARN` by default due to verbosity:
 
-Each logger has to be configured assigning it a `name` as `http.openapi.operation.<operation_id>`.
-For example, configuring the logging level for the `send` operation logger means defining the following:
+[source,properties]
+----
+logger.healthy.name = http.openapi.operation.healthy
+logger.healthy.level = WARN
+logger.ready.name = http.openapi.operation.ready
+logger.ready.level = WARN
+----
+
+The log level of all other operations is set to `INFO` by default.
+
+Each operation has a corresponding API endpoint, defined according to the OpenAPI specification, allowing fine-grained logging of HTTP requests.
+
+Configure each logger by assigning it a name as `http.openapi.operation.<operation_id>`. 
+For example, to set the logging level for the send operation logger:
 
 ```
 logger.send.name = http.openapi.operation.send
@@ -46,17 +57,8 @@ logger.send.level = DEBUG
 ```
 
 Kafka Bridge uses the Apache `log4j2` logger implementation.
-Loggers are defined in the `log4j2.properties` file, which has the following default configuration for `healthy` and `ready` endpoints:
-
-```
-logger.healthy.name = http.openapi.operation.healthy
-logger.healthy.level = WARN
-logger.ready.name = http.openapi.operation.ready
-logger.ready.level = WARN
-```
-The log level of all other operations is set to `INFO` by default.
-
 Use the `logging` property to configure loggers and logger levels.
+
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
 .Example inline logging configuration

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -104,7 +104,9 @@ curl -s http://<connect-cluster-name>-connect-api:8083/admin/loggers/
 Kafka Connect uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
+You can set log levels using either the `inline` or `external` logging configuration types.
+
+Specify loggers and levels directly in the custom resource for inline configuration:
 
 .Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
@@ -121,9 +123,10 @@ spec:
   # ...
 ----
 
-You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
-For example, to configure logging for runtime tasks:
+You can define additional loggers by specifying the full class or package name using `logger.<name>.name`.
+For example, to configure logging for Kafka Connect runtime classes inline:
 
+.Example custom inline loggers
 [source,yaml]
 ----
 # ...
@@ -136,6 +139,8 @@ logger.sinktask.level: DEBUG # <4>
 <2> Sets the logging level for `WorkerSourceTask`.
 <3> Creates a logger for the runtime `WorkerSinkTask` class.
 <4> Sets the logging level for `WorkerSinkTask`.
+
+Alternatively, you can reference an external `ConfigMap` containing a complete `log4j2.properties` file that defines your own log4j2 configuration, including loggers, appenders, and layout configuration:
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -80,9 +80,8 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 = Logging
 Kafka Connect has its own configurable loggers:
 
-* `rootLogger.*`
-* `logger.reflections.name = org.reflections`
-* `logger.reflections.*`
+* `rootLogger`
+* `reflections`
 
 Further loggers are added depending on the Kafka Connect plugins running.
 
@@ -95,6 +94,9 @@ curl -s http://<connect-cluster-name>-connect-api:8083/admin/loggers/
 
 Kafka Connect uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
+
+NOTE: For Strimzi 0.45 and earlier, log4j1 was used for Kafka components. 
+Refer to the Strimzi 0.45 documentation for loggers and logging configuration examples based on log4j1.
 
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -80,8 +80,9 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 = Logging
 Kafka Connect has its own configurable loggers:
 
-* `rootLogger.level`
-* `logger.org.reflections`
+* `rootLogger.*`
+* `logger.reflections.name = org.reflections`
+* `logger.reflections.*`
 
 Further loggers are added depending on the Kafka Connect plugins running.
 
@@ -108,8 +109,10 @@ spec:
     type: inline
     loggers:
       rootLogger.level: INFO
-      logger.org.apache.kafka.connect.runtime.WorkerSourceTask: TRACE
-      logger.org.apache.kafka.connect.runtime.WorkerSinkTask: DEBUG
+      logger.sourcetask.name: org.apache.kafka.connect.runtime.WorkerSourceTask
+      logger.sourcetask.level: TRACE
+      logger.sinktask.name: org.apache.kafka.connect.runtime.WorkerSinkTask
+      logger.sinktask.level: DEBUG
   # ...
 ----
 

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -80,8 +80,7 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 = Logging
 
 WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
-For loggers and logging configuration examples based on log4j1, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
-These examples can also be used with Strimzi 0.46 and Kafka 3.9.x.
+For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
 
 Kafka Connect has its own configurable loggers:
 

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -82,10 +82,15 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
 For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
 
-Kafka Connect has its own configurable loggers:
+Kafka Connect has its own preconfigured loggers:
 
-* `rootLogger`
-* `reflections`
+[cols="1m,2,1",options="header"]
+|===
+| Logger      | Description                                                         | Default Level
+
+| rootLogger  | Default logger for all classes                                      | INFO
+| reflections | Logs classpath scanning and metadata discovery used to find plugins | ERROR
+|===
 
 Further loggers are added depending on the Kafka Connect plugins running.
 
@@ -112,12 +117,25 @@ spec:
     type: inline
     loggers:
       rootLogger.level: INFO
-      logger.sourcetask.name: org.apache.kafka.connect.runtime.WorkerSourceTask
-      logger.sourcetask.level: TRACE
-      logger.sinktask.name: org.apache.kafka.connect.runtime.WorkerSinkTask
-      logger.sinktask.level: DEBUG
+      logger.reflections.level: DEBUG
   # ...
 ----
+
+You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to configure logging for runtime tasks:
+
+[source,yaml]
+----
+# ...
+logger.sourcetask.name: org.apache.kafka.connect.runtime.WorkerSourceTask # <1>
+logger.sourcetask.level: TRACE # <2>
+logger.sinktask.name: org.apache.kafka.connect.runtime.WorkerSinkTask # <3>
+logger.sinktask.level: DEBUG # <4>
+----
+<1> Creates a logger for the runtime `WorkerSourceTask` class.
+<2> Sets the logging level for `WorkerSourceTask`.
+<3> Creates a logger for the runtime `WorkerSinkTask` class.
+<4> Sets the logging level for `WorkerSinkTask`.
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -78,6 +78,11 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 
 [id='property-kafka-connect-logging-{context}']
 = Logging
+
+WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
+For loggers and logging configuration examples based on log4j1, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
+These examples can also be used with Strimzi 0.46 and Kafka 3.9.x.
+
 Kafka Connect has its own configurable loggers:
 
 * `rootLogger`
@@ -94,9 +99,6 @@ curl -s http://<connect-cluster-name>-connect-api:8083/admin/loggers/
 
 Kafka Connect uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
-
-NOTE: For Strimzi 0.45 and earlier, log4j1 was used for Kafka components. 
-Refer to the Strimzi 0.45 documentation for loggers and logging configuration examples based on log4j1.
 
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -80,8 +80,8 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 = Logging
 Kafka Connect has its own configurable loggers:
 
-* `connect.root.logger.level`
-* `log4j.logger.org.reflections`
+* `rootLogger.level`
+* `logger.org.reflections`
 
 Further loggers are added depending on the Kafka Connect plugins running.
 
@@ -92,19 +92,12 @@ Use a curl request to get a complete list of Kafka Connect loggers running from 
 curl -s http://<connect-cluster-name>-connect-api:8083/admin/loggers/
 ----
 
-Kafka Connect uses the Apache `log4j` logger implementation.
-
+Kafka Connect uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
-If a ConfigMap is used, you set `logging.valueFrom.configMapKeyRef.name` property to the name of the ConfigMap containing the external logging configuration. Inside the ConfigMap, the logging configuration is described using `log4j.properties`. Both `logging.valueFrom.configMapKeyRef.name` and `logging.valueFrom.configMapKeyRef.key` properties are mandatory. A ConfigMap using the exact logging configuration specified is created with the custom resource when the Cluster Operator is running, then recreated after each reconciliation. If you do not specify a custom ConfigMap, default logging settings are used. If a specific logger value is not set, upper-level logger settings are inherited for that logger.
-For more information about log levels, see {ApacheLoggers}.
+You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
-Here we see examples of `inline` and `external` logging.
-The `inline` logging specifies the root logger level.
-You can also set log levels for specific classes or loggers by adding them to the loggers property.
-
-.Inline logging
+.Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
@@ -114,15 +107,13 @@ spec:
   logging:
     type: inline
     loggers:
-      connect.root.logger.level: INFO
-      log4j.logger.org.apache.kafka.connect.runtime.WorkerSourceTask: TRACE
-      log4j.logger.org.apache.kafka.connect.runtime.WorkerSinkTask: DEBUG
+      rootLogger.level: INFO
+      logger.org.apache.kafka.connect.runtime.WorkerSourceTask: TRACE
+      logger.org.apache.kafka.connect.runtime.WorkerSinkTask: DEBUG
   # ...
 ----
 
-NOTE: Setting a log level to `DEBUG` may result in a large amount of log output and may have performance implications.
-
-.External logging
+.Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
@@ -133,17 +124,11 @@ spec:
     type: external
     valueFrom:
       configMapKeyRef:
-        name: customConfigMap
-        key: connect-logging.log4j
+        # name and key are mandatory
+        name: customConfigMap 
+        key: log4j2.properties
   # ...
 ----
-
-Any available loggers that are not configured have their level set to `OFF`.
-
-If Kafka Connect was deployed using the Cluster Operator,
-changes to Kafka Connect logging levels are applied dynamically.
-
-If you use external logging, a rolling update is triggered when logging appenders are changed.
 
 .Garbage collector (GC)
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -140,7 +140,9 @@ Kafka has its own preconfigured loggers:
 Kafka uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
+You can set log levels using either the `inline` or `external` logging configuration types.
+
+Specify loggers and levels directly in the custom resource for inline configuration:
 
 .Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
@@ -161,9 +163,10 @@ spec:
   # ...
 ----
 
-You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
-For example, to configure logging for OAuth components:
+You can define additional loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to configure logging for OAuth components inline:
 
+.Example custom inline loggers
 [source,yaml]
 ----
 # ...
@@ -172,6 +175,8 @@ logger.oauth.level: DEBUG # <2>
 ----
 <1> Creates a logger for the `io.strimzi.kafka.oauth` package.
 <2> Sets the logging level for the OAuth package.
+
+Alternatively, you can reference an external `ConfigMap` containing a complete `log4j2.properties` file that defines your own log4j2 configuration, including loggers, appenders, and layout configuration:
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -119,14 +119,23 @@ Be aware that if the configured image is not compatible with Strimzi images, it 
 
 Kafka has its own configurable loggers, which include the following:
 
-* `logger.kafka`
-* `logger.org.apache.kafka`
-* `logger.kafka.request.logger`
-* `logger.kafka.network.RequestChannel$`
-* `logger.org.apache.kafka.controller`
-* `logger.kafka.log.LogCleaner`
-* `logger.state.change.logger`
-* `logger.kafka.authorizer.logger`
+* `rootLogger.*`
+* `logger.kafka.name = kafka`
+* `logger.kafka.*`
+* `logger.orgapachekafka.name = org.apache.kafka`
+* `logger.orgapachekafka.*`
+* `logger.requestlogger.name = kafka.request.logger`
+* `logger.requestlogger.*`
+* `logger.requestchannel.name = kafka.network.RequestChannel$`
+* `logger.requestchannel.*`
+* `logger.controller.name = org.apache.kafka.controller`
+* `logger.controller.*`
+* `logger.logcleaner.name = kafka.log.LogCleaner`
+* `logger.logcleaner.*`
+* `logger.statechange.name = state.change.logger`
+* `logger.statechange.*`
+* `logger.authorizer.name = kafka.authorizer.logger`
+* `logger.authorizer.*`
 
 Kafka uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
@@ -146,10 +155,15 @@ spec:
       type: inline
       loggers:
         rootLogger.level: INFO
-        logger.kafka.coordinator.transaction: TRACE
-        logger.kafka.log.LogCleanerManager: DEBUG
-        logger.kafka.request.logger: DEBUG
-        logger.io.strimzi.kafka.oauth: DEBUG
+        logger.kafka.name: kafka
+        logger.transaction.name: logger.kafka.coordinator.transaction
+        logger.transaction.level: TRACE
+        logger.cleaner.name: logger.kafka.log.LogCleanerManager
+        logger.cleaner.level: DEBUG
+        logger.request.name: logger.kafka.request.logger
+        logger.request.level: DEBUG
+        logger.oauth.name: logger.io.strimzi.kafka.oauth
+        logger.oauth.level: DEBUG
   # ...
 ----
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -117,6 +117,10 @@ Be aware that if the configured image is not compatible with Strimzi images, it 
 [id='property-kafka-logging-{context}']
 = Logging
 
+WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
+For loggers and logging configuration examples based on log4j1, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
+These examples can also be used with Strimzi 0.46 and Kafka 3.9.x.
+
 Kafka has its own configurable loggers, which include the following:
 
 * `rootLogger`
@@ -133,9 +137,6 @@ Kafka has its own configurable loggers, which include the following:
 Kafka uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-NOTE: For Strimzi 0.45 and earlier, log4j1 was used for Kafka components. 
-Refer to the Strimzi 0.45 documentation for loggers and logging configuration examples based on log4j1.
-
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
 .Example inline logging configuration
@@ -151,7 +152,6 @@ spec:
       type: inline
       loggers:
         rootLogger.level: INFO
-        logger.kafka.name: kafka
         logger.transaction.name: logger.kafka.coordinator.transaction
         logger.transaction.level: TRACE
         logger.cleaner.name: logger.kafka.log.LogCleanerManager

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -119,30 +119,21 @@ Be aware that if the configured image is not compatible with Strimzi images, it 
 
 Kafka has its own configurable loggers, which include the following:
 
-* `log4j.logger.kafka`
-* `log4j.logger.org.apache.kafka`
-* `log4j.logger.kafka.request.logger`
-* `log4j.logger.kafka.network.Processor`
-* `log4j.logger.kafka.server.KafkaApis`
-* `log4j.logger.kafka.network.RequestChannel$`
-* `log4j.logger.kafka.controller`
-* `log4j.logger.kafka.log.LogCleaner`
-* `log4j.logger.state.change.logger`
-* `log4j.logger.kafka.authorizer.logger`
+* `logger.kafka`
+* `logger.org.apache.kafka`
+* `logger.kafka.request.logger`
+* `logger.kafka.network.RequestChannel$`
+* `logger.org.apache.kafka.controller`
+* `logger.kafka.log.LogCleaner`
+* `logger.state.change.logger`
+* `logger.kafka.authorizer.logger`
 
-Kafka uses the Apache `log4j` logger implementation.
-
+Kafka uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
-If a ConfigMap is used, you set `logging.valueFrom.configMapKeyRef.name` property to the name of the ConfigMap containing the external logging configuration. Inside the ConfigMap, the logging configuration is described using `log4j.properties`. Both `logging.valueFrom.configMapKeyRef.name` and `logging.valueFrom.configMapKeyRef.key` properties are mandatory. A ConfigMap using the exact logging configuration specified is created with the custom resource when the Cluster Operator is running, then recreated after each reconciliation. If you do not specify a custom ConfigMap, default logging settings are used. If a specific logger value is not set, upper-level logger settings are inherited for that logger.
-For more information about log levels, see {ApacheLoggers}.
+You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
-Here we see examples of `inline` and `external` logging.
-The `inline` logging specifies the root logger level.
-You can also set log levels for specific classes or loggers by adding them to the loggers property.
-
-.Inline logging
+.Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -154,18 +145,15 @@ spec:
     logging:
       type: inline
       loggers:
-        kafka.root.logger.level: INFO
-        log4j.logger.kafka.coordinator.transaction: TRACE
-        log4j.logger.kafka.log.LogCleanerManager: DEBUG
-        log4j.logger.kafka.request.logger: DEBUG
-        log4j.logger.io.strimzi.kafka.oauth: DEBUG
-        log4j.logger.org.openpolicyagents.kafka.OpaAuthorizer: DEBUG
+        rootLogger.level: INFO
+        logger.kafka.coordinator.transaction: TRACE
+        logger.kafka.log.LogCleanerManager: DEBUG
+        logger.kafka.request.logger: DEBUG
+        logger.io.strimzi.kafka.oauth: DEBUG
   # ...
 ----
 
-NOTE: Setting a log level to `DEBUG` may result in a large amount of log output and may have performance implications.
-
-.External logging
+.Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -176,17 +164,11 @@ spec:
     type: external
     valueFrom:
       configMapKeyRef:
+        # name and key are mandatory
         name: customConfigMap
-        key: kafka-log4j.properties
+        key: log4j2.properties
   # ...
 ----
-
-Any available loggers that are not configured have their level set to `OFF`.
-
-If Kafka was deployed using the Cluster Operator,
-changes to Kafka logging levels are applied dynamically.
-
-If you use external logging, a rolling update is triggered when logging appenders are changed.
 
 .Garbage collector (GC)
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -118,8 +118,7 @@ Be aware that if the configured image is not compatible with Strimzi images, it 
 = Logging
 
 WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
-For loggers and logging configuration examples based on log4j1, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
-These examples can also be used with Strimzi 0.46 and Kafka 3.9.x.
+For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
 
 Kafka has its own configurable loggers, which include the following:
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -120,18 +120,22 @@ Be aware that if the configured image is not compatible with Strimzi images, it 
 WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
 For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
 
-Kafka has its own configurable loggers, which include the following:
+Kafka has its own preconfigured loggers:
 
-* `rootLogger`
-* `kafka`
-* `orgapachekafka`
-* `requestlogger`
-* `requestchannel`
-* `requestchannel`
-* `controller`
-* `logcleaner`
-* `statechange`
-* `authorizer`
+[cols="1m,2,1",options="header"]
+|===
+| Logger              | Description                                              | Default Level
+
+| rootLogger          | Default logger for all classes                           | INFO
+| kafka               | Logs Kafka node classes                                  | INFO
+| orgapachekafka      | Logs Kafka library classes                               | INFO
+| requestlogger       | Logs client request details                              | WARN
+| requestchannel      | Logs request handling in the broker                      | WARN
+| controller          | Logs controller activity, such as leadership changes     | INFO
+| logcleaner          | Logs log compaction and cleanup processes                | INFO
+| statechange         | Logs broker and partition state transitions              | INFO
+| authorizer          | Logs access control decisions                            | INFO
+|===
 
 Kafka uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
@@ -151,16 +155,23 @@ spec:
       type: inline
       loggers:
         rootLogger.level: INFO
-        logger.transaction.name: logger.kafka.coordinator.transaction
-        logger.transaction.level: TRACE
-        logger.cleaner.name: logger.kafka.log.LogCleanerManager
-        logger.cleaner.level: DEBUG
-        logger.request.name: logger.kafka.request.logger
-        logger.request.level: DEBUG
-        logger.oauth.name: logger.io.strimzi.kafka.oauth
-        logger.oauth.level: DEBUG
+        logger.kafka.level: DEBUG 
+        logger.logcleaner.level: DEBUG 
+        logger.authorizer.level: TRACE
   # ...
 ----
+
+You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to configure logging for OAuth components:
+
+[source,yaml]
+----
+# ...
+logger.oauth.name: io.strimzi.kafka.oauth # <1>
+logger.oauth.level: DEBUG # <2>
+----
+<1> Creates a logger for the `io.strimzi.kafka.oauth` package.
+<2> Sets the logging level for the OAuth package.
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -119,26 +119,22 @@ Be aware that if the configured image is not compatible with Strimzi images, it 
 
 Kafka has its own configurable loggers, which include the following:
 
-* `rootLogger.*`
-* `logger.kafka.name = kafka`
-* `logger.kafka.*`
-* `logger.orgapachekafka.name = org.apache.kafka`
-* `logger.orgapachekafka.*`
-* `logger.requestlogger.name = kafka.request.logger`
-* `logger.requestlogger.*`
-* `logger.requestchannel.name = kafka.network.RequestChannel$`
-* `logger.requestchannel.*`
-* `logger.controller.name = org.apache.kafka.controller`
-* `logger.controller.*`
-* `logger.logcleaner.name = kafka.log.LogCleaner`
-* `logger.logcleaner.*`
-* `logger.statechange.name = state.change.logger`
-* `logger.statechange.*`
-* `logger.authorizer.name = kafka.authorizer.logger`
-* `logger.authorizer.*`
+* `rootLogger`
+* `kafka`
+* `orgapachekafka`
+* `requestlogger`
+* `requestchannel`
+* `requestchannel`
+* `controller`
+* `logcleaner`
+* `statechange`
+* `authorizer`
 
 Kafka uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
+
+NOTE: For Strimzi 0.45 and earlier, log4j1 was used for Kafka components. 
+Refer to the Strimzi 0.45 documentation for loggers and logging configuration examples based on log4j1.
 
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -313,7 +313,9 @@ Cruise Control has its own preconfigured logger:
 Cruise Control uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
+You can set log levels using either the `inline` or `external` logging configuration types.
+
+Specify loggers and levels directly in the custom resource for inline configuration:
 
 .Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
@@ -331,9 +333,10 @@ spec:
     # ...
 ----
 
-You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
-For example, to add more detailed logging for Cruise Control:
+You can define additional loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to configure more detailed logging for Cruise Control inline:
 
+.Example custom inline loggers
 [source,yaml]
 ----
 # ...
@@ -346,6 +349,8 @@ logger.go.level: DEBUG # <4>
 <2> Sets the logging level for the `Executor` class.
 <3> Creates a logger for the Cruise Control `GoalOptimizer` class.
 <4> Sets the logging level for the `GoalOptimizer` class.
+
+Alternatively, you can reference an external `ConfigMap` containing a complete `log4j2.properties` file that defines your own log4j2 configuration, including loggers, appenders, and layout configuration:
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -306,17 +306,11 @@ Cruise Control has its own configurable logger:
 * `rootLogger.level`
 
 Cruise Control uses the Apache `log4j2` logger implementation.
-
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
-If a ConfigMap is used, you set `logging.valueFrom.configMapKeyRef.name` property to the name of the ConfigMap containing the external logging configuration. Inside the ConfigMap, the logging configuration is described using `log4j.properties`. Both `logging.valueFrom.configMapKeyRef.name` and `logging.valueFrom.configMapKeyRef.key` properties are mandatory. A ConfigMap using the exact logging configuration specified is created with the custom resource when the Cluster Operator is running, then recreated after each reconciliation. If you do not specify a custom ConfigMap, default logging settings are used. If a specific logger value is not set, upper-level logger settings are inherited for that logger.
+You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
-Here we see examples of `inline` and `external` logging.
-The `inline` logging specifies the root logger level.
-You can also set log levels for specific classes or loggers by adding them to the loggers property.
-
-.Inline logging
+.Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -340,9 +334,7 @@ spec:
 <3> Creates a logger for the Cruise Control `GoalOptimizer` class.
 <4> Sets the logging level for the `GoalOptimizer` class.
 
-NOTE: When investigating an issue with Cruise Control, it's usually sufficient to change the `rootLogger` to `DEBUG` to get more detailed logs. However, keep in mind that setting the log level to `DEBUG` may result in a large amount of log output and may have performance implications.
-
-.External logging
+.Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -355,8 +347,9 @@ spec:
       type: external
       valueFrom:
         configMapKeyRef:
+          # name and key are mandatory
           name: customConfigMap
-          key: cruise-control-log4j.properties
+          key: log4j2.properties
     # ...
 ----
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -301,9 +301,14 @@ For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapa
 [id='property-cruise-control-logging-{context}']
 = Logging
 
-Cruise Control has its own configurable logger:
+Cruise Control has its own preconfigured logger:
 
-* `rootLogger`
+[cols="1m,2,1",options="header"]
+|===
+| Logger     | Description                        | Default Level
+
+| rootLogger | Default logger for all classes     | INFO
+|===
 
 Cruise Control uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
@@ -323,11 +328,19 @@ spec:
       type: inline
       loggers:
         rootLogger.level: INFO
-        logger.exec.name: com.linkedin.kafka.cruisecontrol.executor.Executor # <1>
-        logger.exec.level: TRACE # <2>
-        logger.go.name: com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer # <3>
-        logger.go.level: DEBUG # <4>
     # ...
+----
+
+You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to add more detailed logging for Cruise Control:
+
+[source,yaml]
+----
+# ...
+logger.exec.name: com.linkedin.kafka.cruisecontrol.executor.Executor # <1>
+logger.exec.level: TRACE # <2>
+logger.go.name: com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer # <3>
+logger.go.level: DEBUG # <4>
 ----
 <1> Creates a logger for the Cruise Control `Executor` class.
 <2> Sets the logging level for the `Executor` class.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -303,7 +303,7 @@ For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapa
 
 Cruise Control has its own configurable logger:
 
-* `rootLogger.*`
+* `rootLogger`
 
 Cruise Control uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -303,7 +303,7 @@ For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapa
 
 Cruise Control has its own configurable logger:
 
-* `rootLogger.level`
+* `rootLogger.*`
 
 Cruise Control uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
@@ -5,7 +5,7 @@ Configures the Topic Operator.
 
 The Topic Operator has a configurable logger:
 
-* `rootLogger.level`
+* `rootLogger.*`
 
 The Topic Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
@@ -8,18 +8,13 @@ The Topic Operator has a configurable logger:
 * `rootLogger.level`
 
 The Topic Operator uses the Apache `log4j2` logger implementation.
-
-Use the `logging` property in the `entityOperator.topicOperator` field of the Kafka resource `Kafka` resource to configure loggers and logger levels.
+Use the `logging` property to configure loggers and logger levels.
 
 You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
-If a ConfigMap is used, you set `logging.valueFrom.configMapKeyRef.name` property to the name of the ConfigMap containing the external logging configuration. Inside the ConfigMap, the logging configuration is described using `log4j2.properties`. Both `logging.valueFrom.configMapKeyRef.name` and `logging.valueFrom.configMapKeyRef.key` properties are mandatory. A ConfigMap using the exact logging configuration specified is created with the custom resource when the Cluster Operator is running, then recreated after each reconciliation. If you do not specify a custom ConfigMap, default logging settings are used. If a specific logger value is not set, upper-level logger settings are inherited for that logger.
-For more information about log levels, see {ApacheLoggers}.
 
-Here we see examples of `inline` and `external` logging.
-The `inline` logging specifies the root logger level.
-You can also set log levels for specific classes or loggers by adding them to the loggers property.
+You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
-.Inline logging
+.Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -49,10 +44,7 @@ spec:
 <3> Creates a logger for the `TopicOperator` class.
 <4> Sets the logging level for the `TopicOperator` class.
 
-NOTE: When investigating an issue with the operator, it's usually sufficient to change the `rootLogger` to `DEBUG` to get more detailed logs. 
-However, keep in mind that setting the log level to `DEBUG` may result in a large amount of log output and may have performance implications.
-
-.External logging
+.Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -71,8 +63,9 @@ spec:
         type: external
         valueFrom:
           configMapKeyRef:
+            # name and key are mandatory
             name: customConfigMap
-            key: topic-operator-log4j2.properties
+            key: log4j2.properties
   # ...
 ----
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
@@ -3,14 +3,18 @@ Configures the Topic Operator.
 [id='property-topic-operator-logging-{context}']
 = Logging
 
-The Topic Operator has a configurable logger:
+The Topic Operator has its own preconfigured loggers:
 
-* `rootLogger`
+[cols="1m,2,1",options="header"]
+|===
+| Logger     | Description                    | Default Level
+
+| rootLogger | Default logger for all classes | INFO
+| jetty      | Logs HTTP server activity      | INFO
+|===
 
 The Topic Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
-
-You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
 
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
@@ -33,11 +37,20 @@ spec:
         type: inline
         loggers:
           rootLogger.level: INFO
-          logger.top.name: io.strimzi.operator.topic # <1>
-          logger.top.level: DEBUG # <2> 
-          logger.toc.name: io.strimzi.operator.topic.TopicOperator # <3>
-          logger.toc.level: TRACE # <4>
+          logger.jetty.level: WARN
   # ...
+----
+
+You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to add more detailed logging for the Topic Operator:
+
+[source,yaml]
+----
+# ...
+logger.top.name: io.strimzi.operator.topic # <1>
+logger.top.level: DEBUG # <2> 
+logger.toc.name: io.strimzi.operator.topic.TopicOperator # <3>
+logger.toc.level: TRACE # <4>
 ----
 <1> Creates a logger for the `topic` package.
 <2> Sets the logging level for the `topic` package.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
@@ -16,7 +16,9 @@ The Topic Operator has its own preconfigured loggers:
 The Topic Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
+You can set log levels using either the `inline` or `external` logging configuration types.
+
+Specify loggers and levels directly in the custom resource for inline configuration:
 
 .Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
@@ -41,9 +43,10 @@ spec:
   # ...
 ----
 
-You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
-For example, to add more detailed logging for the Topic Operator:
+You can define additional loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to configure more detailed logging for the Topic Operator inline:
 
+.Example custom inline loggers
 [source,yaml]
 ----
 # ...
@@ -56,6 +59,8 @@ logger.toc.level: TRACE # <4>
 <2> Sets the logging level for the `topic` package.
 <3> Creates a logger for the `TopicOperator` class.
 <4> Sets the logging level for the `TopicOperator` class.
+
+Alternatively, you can reference an external `ConfigMap` containing a complete `log4j2.properties` file that defines your own log4j2 configuration, including loggers, appenders, and layout configuration:
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
@@ -5,7 +5,7 @@ Configures the Topic Operator.
 
 The Topic Operator has a configurable logger:
 
-* `rootLogger.*`
+* `rootLogger`
 
 The Topic Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
@@ -5,7 +5,7 @@ Configures the User Operator.
 
 The User Operator has a configurable logger:
 
-* `rootLogger.*`
+* `rootLogger`
 
 The User Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
@@ -3,9 +3,15 @@ Configures the User Operator.
 [id='property-user-operator-logging-{context}']
 = Logging
 
-The User Operator has a configurable logger:
+The User Operator has its own preconfigured loggers:
 
-* `rootLogger`
+[cols="1m,2,1",options="header"]
+|===
+| Logger     | Description                    | Default Level
+
+| rootLogger | Default logger for all classes | INFO
+| jetty      | Logs HTTP server activity      | INFO
+|===
 
 The User Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
@@ -13,7 +19,6 @@ Use the `logging` property to configure loggers and logger levels.
 You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
 .Example inline logging configuration
-[source,yaml,subs="+quotes,attributes"]
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -32,20 +37,25 @@ spec:
         type: inline
         loggers:
           rootLogger.level: INFO
-          logger.uop.name: io.strimzi.operator.user # <1>
-          logger.uop.level: DEBUG # <2> 
-          logger.abstractcache.name: io.strimzi.operator.user.operator.cache.AbstractCache # <3>
-          logger.abstractcache.level: TRACE # <4>
-          logger.jetty.level: DEBUG # <5>
-          
+          logger.jetty.level: WARN  
   # ...
+----
+
+You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to add more detailed logging for the User Operator:
+
+[source,yaml]
+----
+# ...
+logger.uop.name: io.strimzi.operator.user # <1>
+logger.uop.level: DEBUG # <2> 
+logger.abstractcache.name: io.strimzi.operator.user.operator.cache.AbstractCache # <3>
+logger.abstractcache.level: TRACE # <4>     
 ----
 <1> Creates a logger for the `user` package.
 <2> Sets the logging level for the `user` package.
 <3> Creates a logger for the `AbstractCache` class.
-<4> Sets the logging level for the `AbstractCache` class.
-<5> Changes the logging level for the default `jetty` logger. The `jetty` logger is part of the logging configuration provided with Strimzi.
-By default, it is set to `INFO`.  
+<4> Sets the logging level for the `AbstractCache` class. 
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
@@ -8,18 +8,12 @@ The User Operator has a configurable logger:
 * `rootLogger.level`
 
 The User Operator uses the Apache `log4j2` logger implementation.
+Use the `logging` property to configure loggers and logger levels.
 
-Use the `logging` property in the `entityOperator.userOperator` field of the `Kafka` resource to configure loggers and logger levels.
+You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
 
-You can set the log levels by specifying the logger and level directly (inline) or use a custom (external) ConfigMap.
-If a ConfigMap is used, you set `logging.valueFrom.configMapKeyRef.name` property to the name of the ConfigMap containing the external logging configuration. Inside the ConfigMap, the logging configuration is described using `log4j2.properties`. Both `logging.valueFrom.configMapKeyRef.name` and `logging.valueFrom.configMapKeyRef.key` properties are mandatory. A ConfigMap using the exact logging configuration specified is created with the custom resource when the Cluster Operator is running, then recreated after each reconciliation. If you do not specify a custom ConfigMap, default logging settings are used. If a specific logger value is not set, upper-level logger settings are inherited for that logger.
-For more information about log levels, see {ApacheLoggers}.
-
-Here we see examples of `inline` and `external` logging.
-The `inline` logging specifies the `rootLogger.level`.
-You can also set log levels for specific classes or loggers by adding them to the loggers property.
-
-.Inline logging
+.Example inline logging configuration
+[source,yaml,subs="+quotes,attributes"]
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -53,9 +47,7 @@ spec:
 <5> Changes the logging level for the default `jetty` logger. The `jetty` logger is part of the logging configuration provided with Strimzi.
 By default, it is set to `INFO`.  
 
-NOTE: When investigating an issue with the operator, it's usually sufficient to change the `rootLogger` to `DEBUG` to get more detailed logs. However, keep in mind that setting the log level to `DEBUG` may result in a large amount of log output and may have performance implications.
-
-.External logging
+.Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -74,8 +66,9 @@ spec:
         type: external
         valueFrom:
           configMapKeyRef:
+            # name and key are mandatory
             name: customConfigMap
-            key: user-operator-log4j2.properties
+            key: log4j2.properties
    # ...
 ----
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
@@ -5,7 +5,7 @@ Configures the User Operator.
 
 The User Operator has a configurable logger:
 
-* `rootLogger.level`
+* `rootLogger.*`
 
 The User Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpec.adoc
@@ -16,7 +16,9 @@ The User Operator has its own preconfigured loggers:
 The User Operator uses the Apache `log4j2` logger implementation.
 Use the `logging` property to configure loggers and logger levels.
 
-You can set the log levels by specifying the logger and level directly (`inline`) or use a custom (`external`) `ConfigMap` to define logging configurations using the `log4j2.properties` key.
+You can set log levels using either the `inline` or `external` logging configuration types.
+
+Specify loggers and levels directly in the custom resource for inline configuration:
 
 .Example inline logging configuration
 [source,yaml,subs="+quotes,attributes"]
@@ -41,9 +43,10 @@ spec:
   # ...
 ----
 
-You can also define custom loggers by specifying the full class or package name using `logger.<name>.name`. 
-For example, to add more detailed logging for the User Operator:
+You can define additional loggers by specifying the full class or package name using `logger.<name>.name`. 
+For example, to configure more detailed logging for the User Operator inline:
 
+.Example custom inline loggers
 [source,yaml]
 ----
 # ...
@@ -56,6 +59,8 @@ logger.abstractcache.level: TRACE # <4>
 <2> Sets the logging level for the `user` package.
 <3> Creates a logger for the `AbstractCache` class.
 <4> Sets the logging level for the `AbstractCache` class. 
+
+Alternatively, you can reference an external `ConfigMap` containing a complete `log4j2.properties` file that defines your own log4j2 configuration, including loggers, appenders, and layout configuration:
 
 .Example external logging configuration
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -6,6 +6,11 @@
 = Configuring logging levels
 
 [role="_abstract"]
+
+WARNING: Strimzi operators and Kafka components use log4j2 for logging.
+However, Kafka 3.9 and earlier versions rely on log4j1.
+For loggers and logging configuration examples based on log4j1, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. These examples can also be used with Strimzi 0.46 and Kafka 3.9.x.
+
 Configure the logging levels of Kafka components and Strimzi operators through their custom resources.
 You can use either of these options:
 
@@ -17,9 +22,6 @@ Advantages of using a `ConfigMap`:
 * Centralized maintenance
 * Reusable with multiple resources
 * For operators, the flexibility to append logging specifications to add filters
-
-NOTE: Log4j2 is used for logging of Kafka components and Strimzi operators. 
-For Strimzi 0.45 and earlier, log4j1 was used for Kafka components.
 
 Specify a logging `type` in your logging specification:
 

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -19,7 +19,7 @@ Advantages of using a `ConfigMap`:
 * For operators, the flexibility to append logging specifications to add filters
 
 NOTE: Log4j2 is used for logging of Kafka components and Strimzi operators. 
-For versions 0.45 and earlier, log4j1 was used for Kafka components.
+For Strimzi 0.45 and earlier, log4j1 was used for Kafka components.
 
 Specify a logging `type` in your logging specification:
 

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -9,7 +9,7 @@
 
 WARNING: Strimzi operators and Kafka components use log4j2 for logging.
 However, Kafka 3.9 and earlier versions rely on log4j1.
-For loggers and logging configuration examples based on log4j1, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. These examples can also be used with Strimzi 0.46 and Kafka 3.9.x.
+For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^].
 
 Configure the logging levels of Kafka components and Strimzi operators through their custom resources.
 You can use either of these options:

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -35,7 +35,7 @@ For `inline` configuration, use the `loggers` property to set the root logger le
 logging:
   type: inline
   loggers:
-    kafka.root.logger.level: INFO
+    rootLogger.level: INFO
 # ...
 ----
 

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -6,20 +6,29 @@
 = Configuring logging levels
 
 [role="_abstract"]
-Configure logging levels in the custom resources of Kafka components and Strimzi operators.
-You can specify the logging levels directly in the `spec.logging` property of the custom resource.
-Or you can define the logging properties in a ConfigMap that's referenced in the custom resource using the `configMapKeyRef` property.
+Configure the logging levels of Kafka components and Strimzi operators through their custom resources.
+You can use either of these options:
 
-The advantages of using a ConfigMap are that the logging properties are maintained in one place and are accessible to more than one resource.
-You can also reuse the ConfigMap for more than one resource.
-If you are using a ConfigMap to specify loggers for Strimzi Operators, you can also append the logging specification to add filters.
+* Specify logging levels directly in the `spec.logging` property of the custom resource.
+* Define logging properties in a custom `ConfigMap` and reference it using the `configMapKeyRef` property.
 
-You specify a logging `type` in your logging specification:
+Advantages of using a `ConfigMap`:
+
+* Centralized maintenance
+* Reusable with multiple resources
+* For operators, the flexibility to append logging specifications to add filters
+
+NOTE: Log4j2 is used for logging of Kafka components and Strimzi operators. 
+For versions 0.45 and earlier, log4j1 was used for Kafka components.
+
+Specify a logging `type` in your logging specification:
 
 * `inline` when specifying logging levels directly
-* `external` when referencing a ConfigMap
+* `external` when referencing a `ConfigMap`
 
-.Example `inline` logging configuration
+For `inline` configuration, use the `loggers` property to set the root logger level and levels for specific classes or loggers.
+
+.Example inline logging configuration
 [source,shell,subs="+quotes,attributes"]
 ----
 # ...
@@ -30,7 +39,11 @@ logging:
 # ...
 ----
 
-.Example `external` logging configuration
+Use a `ConfigMap` to define logging configurations using the `log4j2.properties` key. 
+Set the logging `name` and `key` properties to reference the `ConfigMap`. 
+Both properties are mandatory. 
+
+.Example external logging configuration
 [source,shell,subs="+quotes,attributes"]
 ----
 # ...
@@ -39,29 +52,32 @@ logging:
   valueFrom:
     configMapKeyRef:
       name: my-config-map
-      key: my-config-map-key
+      key: log4j2.properties
 # ...
 ----
 
-Values for the `name` and `key` of the ConfigMap are mandatory.
-Default logging is used if the `name` or `key` is not set.
+Default logging is used if logging is not specified in the resource using either method.
+Loggers that haven't been explicitly configured inherit settings from their parent loggers. 
+By default, any available loggers that are not configured have their level set to `OFF`.
 
-== Logging options for Kafka components and operators
+When a resource managed by the Cluster Operator is created, a `ConfigMap` with the specified logging configuration is also created. 
+For components managed by the Strimzi operators, changes to logging levels are applied dynamically.
 
-For more information on configuring logging for specific Kafka components or operators, see the following sections.
+WARNING: Setting a log level to `DEBUG` may result in a large amount of log output and may have performance implications.
 
-.Kafka component logging
+== Configurable loggers
 
-* link:{BookURLConfiguring}#property-kafka-logging-reference[Kafka logging^]
-* link:{BookURLConfiguring}#property-kafka-connect-logging-reference[Kafka Connect and MirrorMaker 2 logging^]
-* link:{BookURLConfiguring}#property-kafka-bridge-logging-reference[Kafka Bridge logging^]
-* link:{BookURLConfiguring}#property-cruise-control-logging-reference[Cruise Control logging^]
+The following Kafka components and operators have specific loggers available for configuration:
 
-.Operator logging
+* link:{BookURLConfiguring}#property-kafka-logging-reference[Kafka loggers^]
+* link:{BookURLConfiguring}#property-kafka-connect-logging-reference[Kafka Connect and MirrorMaker 2 loggers^]
+* link:{BookURLConfiguring}#property-kafka-bridge-logging-reference[Kafka Bridge loggers^]
+* link:{BookURLConfiguring}#property-cruise-control-logging-reference[Cruise Control loggers^]
+* xref:ref-operator-cluster-logging-configmap-str[Cluster Operator loggers]
+* link:{BookURLConfiguring}#property-topic-operator-logging-reference[Topic Operator loggers^]
+* link:{BookURLConfiguring}#property-user-operator-logging-reference[User Operator loggers^]
 
-* xref:ref-operator-cluster-logging-configmap-str[Cluster Operator logging]
-* link:{BookURLConfiguring}#property-topic-operator-logging-reference[Topic Operator logging^]
-* link:{BookURLConfiguring}#property-user-operator-logging-reference[User Operator logging^]
+For information about log levels, see {ApacheLoggers}.
 
 //creating a configmap for logging
 include::../../modules/configuring/proc-creating-configmap.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -21,7 +21,7 @@ Advantages of using a `ConfigMap`:
 
 * Centralized maintenance
 * Reusable with multiple resources
-* For operators, the flexibility to append logging specifications to add filters
+* Flexibility to append logging specifications to add filters
 
 Specify a logging `type` in your logging specification:
 
@@ -41,7 +41,7 @@ logging:
 # ...
 ----
 
-Use a `ConfigMap` to define logging configurations using the `log4j2.properties` key. 
+For `external` configuration, use a `ConfigMap` to define logging configurations using a full `log4j2.properties` file. 
 Set the logging `name` and `key` properties to reference the `ConfigMap`. 
 Both properties are mandatory. 
 
@@ -60,12 +60,11 @@ logging:
 
 Default logging is used if logging is not specified in the resource using either method.
 Loggers that haven't been explicitly configured inherit settings from their parent loggers. 
-By default, any available loggers that are not configured have their level set to `OFF`.
 
 When a resource managed by the Cluster Operator is created, a `ConfigMap` with the specified logging configuration is also created. 
 For components managed by the Strimzi operators, changes to logging levels are applied dynamically.
 
-WARNING: Setting a log level to `DEBUG` may result in a large amount of log output and may have performance implications.
+WARNING: Setting a log level to `DEBUG` or `TRACE` may result in a large amount of log output and may have performance implications.
 
 == Configurable loggers
 

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -70,7 +70,7 @@ spec:
     loggers:
       rootLogger.level: INFO
       # Enabling DEBUG just for send operation
-      logger.send.name: "http.openapi.operation.send"
+      logger.send.name: http.openapi.operation.send
       logger.send.level: DEBUG
   # JVM options (optional)
   jvmOptions: # <11>

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -68,7 +68,7 @@ spec:
   logging: # <10>
     type: inline
     loggers:
-      logger.bridge.level: INFO
+      rootLogger.level: INFO
       # Enabling DEBUG just for send operation
       logger.send.name: "http.openapi.operation.send"
       logger.send.level: DEBUG

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -120,7 +120,7 @@ spec:
 By default, the Kafka Bridge connects to Kafka brokers without authentication.
 <8> Consumer configuration options.
 <9> Producer configuration options.
-<10> Specified Kafka Bridge loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` or `log4j2.properties` key in the ConfigMap. For the Kafka Bridge loggers, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<10> Kafka Bridge loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
 <11> JVM configuration options to optimize performance for the Virtual Machine (VM) running the Kafka Bridge.
 <12> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <13> Optional: Container image configuration, which is recommended only in special situations.

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -97,7 +97,7 @@ spec:
   logging: # <12>
     type: inline
     loggers:
-      log4j.rootLogger: INFO
+      rootLogger.level: INFO
   # Readiness probe (optional)
   readinessProbe: # <13>
     initialDelaySeconds: 15
@@ -172,7 +172,7 @@ By default, Kafka Connect connects to Kafka brokers using a plain text connectio
 <9> Build configuration properties for building a container image with connector plugins automatically.
 <10> (Required) Configuration of the container registry where new images are pushed.
 <11> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
-<12> Specified Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` or `log4j2.properties` key in the ConfigMap. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<12> Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
 <13> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <14> Prometheus metrics, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
 <15> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka Connect.

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -97,6 +97,7 @@ spec:
   logging: # <12>
     type: inline
     loggers:
+      # Kafka 4.0+ uses Log4j2
       rootLogger.level: INFO
   # Readiness probe (optional)
   readinessProbe: # <13>

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -131,7 +131,6 @@ spec:
       logging: # <23>
         type: inline
         loggers:
-          # Kafka 4.0+ uses Log4j2
           rootLogger.level: INFO
     userOperator:
       watchedNamespace: my-topic-namespace
@@ -148,7 +147,6 @@ spec:
       logging: # <24>
         type: inline
         loggers:
-          # Kafka 4.0+ uses Log4j2
           rootLogger.level: INFO
   # Kafka Exporter (optional)
   kafkaExporter: # <25>

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -85,6 +85,7 @@ spec:
     logging: # <14>
       type: inline
       loggers:
+        # Kafka 4.0+ uses Log4j2
         rootLogger.level: INFO
     # Readiness probe (optional)
     readinessProbe: # <15>
@@ -130,6 +131,7 @@ spec:
       logging: # <23>
         type: inline
         loggers:
+          # Kafka 4.0+ uses Log4j2
           rootLogger.level: INFO
     userOperator:
       watchedNamespace: my-topic-namespace
@@ -146,6 +148,7 @@ spec:
       logging: # <24>
         type: inline
         loggers:
+          # Kafka 4.0+ uses Log4j2
           rootLogger.level: INFO
   # Kafka Exporter (optional)
   kafkaExporter: # <25>

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -85,7 +85,7 @@ spec:
     logging: # <14>
       type: inline
       loggers:
-        kafka.root.logger.level: INFO
+        rootLogger.level: INFO
     # Readiness probe (optional)
     readinessProbe: # <15>
       initialDelaySeconds: 15

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -167,7 +167,7 @@ spec:
 <11> Kafka metadata version, which can be changed to a supported version by following the upgrade procedure.
 <12> Broker configuration. Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 <13> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<14> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` key in the ConfigMap. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<14> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
 <15> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <16> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka.
 <17> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -169,6 +169,7 @@ spec:
   logging: # <36>
     type: inline
     loggers:
+      # Kafka 4.0+ uses Log4j2
       rootLogger.level: INFO
   # Readiness probe (optional)
   readinessProbe: # <37>

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -169,7 +169,7 @@ spec:
   logging: # <36>
     type: inline
     loggers:
-      connect.root.logger.level: INFO
+      rootLogger.level: INFO
   # Readiness probe (optional)
   readinessProbe: # <37>
     initialDelaySeconds: 15
@@ -247,7 +247,7 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <33> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.
 <34> The Kafka Connect and MirrorMaker 2 version, which will always be the same.
 <35> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<36> Specified Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` or `log4j2.properties` key in the ConfigMap. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<36> Specified Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
 <37> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <38> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <39> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.

--- a/documentation/modules/configuring/con-configuration-points-configmaps.adoc
+++ b/documentation/modules/configuring/con-configuration-points-configmaps.adoc
@@ -2,29 +2,28 @@
 //
 // assembly-config.adoc
 
-[id="configuration-points-configmaps-{context}"]
-= Using ConfigMaps to add configuration 
+[id="configuration-points-config-maps-{context}"]
+= Using ConfigMap resources to add configuration 
 
 [role="_abstract"]
 Add specific configuration to your Strimzi deployment using `ConfigMap` resources.
-ConfigMaps use key-value pairs to store non-confidential data.  
-Configuration data added to ConfigMaps is maintained in one place and can be reused amongst components.
+Config maps use key-value pairs to store non-confidential data.  
+Configuration data added to config maps is maintained in one place and can be reused amongst components.
 
-ConfigMaps can only store the following types of configuration data:
+Config maps can only store the following types of configuration data:
 
 * Logging configuration
 * Metrics configuration
 * External configuration for Kafka Connect connectors
 
-You can't use ConfigMaps for other areas of configuration.
+You can't use config maps for other areas of configuration.
 
-When you configure a component, you can add a reference to a ConfigMap using the `configMapKeyRef` property. 
+When you configure a component, you can add a reference to a `ConfigMap` using the `configMapKeyRef` property. 
 
-For example, you can use `configMapKeyRef` to reference a ConfigMap that provides configuration for logging. 
-You might use a ConfigMap to pass a Log4j configuration file.
-You add the reference to the `logging` configuration. 
+For example, you can use `configMapKeyRef` to reference a `ConfigMap` that provides configuration for logging. 
+You define logging levels using the `log4j2.properties` key in the `ConfigMap` and then reference it in the `logging` configuration of the resource. 
 
-.Example ConfigMap for logging
+.Example reference to a `ConfigMap`
 [source,shell,subs="+quotes,attributes"]
 ----
 # ...
@@ -33,17 +32,17 @@ logging:
   valueFrom:
     configMapKeyRef:
       name: my-config-map
-      key: my-config-map-key
+      key: log4j2.properties
 # ...
 ----
 
-To use a ConfigMap for metrics configuration, you add a reference to the `metricsConfig` configuration of the component in the same way.
+To use a `ConfigMap` for metrics configuration, you add a reference to the `metricsConfig` configuration of the component in the same way.
 
 `template` properties allow data from a `ConfigMap` or `Secret` to be mounted in a pod as environment variables or volumes.
 You can use external configuration data for the connectors used by Kafka Connect.
 The data might be related to an external data source, providing the values needed for the connector to communicate with that data source.
 
-For example, you can use the `configMapKeyRef` property to pass configuration data from a ConfigMap as an environment variable.  
+For example, you can use the `configMapKeyRef` property to pass configuration data from a `ConfigMap` as an environment variable.  
 
 .Example ConfigMap providing environment variable values
 [source,yaml,subs="attributes+"]
@@ -64,19 +63,21 @@ spec:
               key: my-key
 ----
 
-If you are using ConfigMaps that are managed externally, use configuration providers to load the data in the ConfigMaps.  
+If you are using config maps that are managed externally, use configuration providers to load the data in the config maps.  
 
-== Naming custom ConfigMaps 
+== Naming custom config maps 
 
-Strimzi xref:ref-list-of-kafka-cluster-resources-str[creates its own ConfigMaps and other resources] when it is deployed to Kubernetes. 
-The ConfigMaps contain data necessary for running components.  
-The ConfigMaps created by Strimzi must not be edited. 
+Strimzi xref:ref-list-of-kafka-cluster-resources-str[creates its own config maps and other resources] when it is deployed to Kubernetes. 
+The config maps contain data necessary for running components.  
+The config maps created by Strimzi must not be edited. 
 
-Make sure that any custom ConfigMaps you create do not have the same name as these default ConfigMaps. If they have the same name, they will be overwritten. For example, if your ConfigMap has the same name as the ConfigMap for the Kafka cluster, it will be overwritten when there is an update to the Kafka cluster.
+Make sure that any custom config maps you create do not have the same name as these default config maps. 
+If they have the same name, they are overwritten. 
+For example, if the custom `ConfigMap` has the same name as the `ConfigMap` for the Kafka cluster, it is overwritten when there is an update to the Kafka cluster.
 
 [role="_additional-resources"]
 .Additional resources
-* xref:ref-list-of-kafka-cluster-resources-str[List of Kafka cluster resources] (including ConfigMaps)
+* xref:ref-list-of-kafka-cluster-resources-str[List of Kafka cluster resources] (including config maps)
 * xref:external-logging_str[Logging configuration]
 * link:{BookURLConfiguring}#con-common-configuration-prometheus-reference[`metricsConfig`^]
 * link:{BookURLConfiguring}#type-ContainerTemplate-reference[`ContainerTemplate` schema reference^]

--- a/documentation/modules/configuring/proc-creating-configmap.adoc
+++ b/documentation/modules/configuring/proc-creating-configmap.adoc
@@ -23,8 +23,16 @@ apiVersion: v1
 metadata:
   name: logging-configmap
 data:
-  log4j2.properties:
+  log4j2.properties: |
     rootLogger.level="INFO"
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+    rootLogger.level = INFO
+    rootLogger.appenderRefs = console
+    rootLogger.appenderRef.console.ref = STDOUT
+    rootLogger.additivity = false
 ----
 +
 If you are using a properties file, define the logging configuration and specify the file at the command line when creating the `ConfigMap`.

--- a/documentation/modules/configuring/proc-creating-configmap.adoc
+++ b/documentation/modules/configuring/proc-creating-configmap.adoc
@@ -6,25 +6,16 @@
 = Creating a ConfigMap for logging
 
 [role="_abstract"]
-To use a ConfigMap to define logging properties, you create the ConfigMap and then reference it as part of the logging definition in the `spec` of a resource.
+To use a `ConfigMap` to define logging properties, you create and then reference it as part of the logging definition in the `spec` of a resource.
+Place the configuration under `log4j2.properties` 
 
-The ConfigMap must contain the appropriate logging configuration.
-
-* `log4j.properties` for Kafka components and the Kafka Bridge
-* `log4j2.properties` for the Topic Operator and User Operator
-
-The configuration must be placed under these properties.
-
-In this procedure a ConfigMap defines a root logger for a Kafka resource.
+In this procedure a `ConfigMap` defines a root logger for a `Kafka` resource.
 
 .Procedure
 
-. Create the ConfigMap.
+. Create the `ConfigMap` as a YAML file or from a properties file.
 +
-You can create the ConfigMap as a YAML file or from a properties file.
-+
-ConfigMap example with a root logger definition for Kafka:
-+
+.Example ConfigMap for logging
 [source,yaml,subs="+attributes"]
 ----
 kind: ConfigMap
@@ -32,27 +23,27 @@ apiVersion: v1
 metadata:
   name: logging-configmap
 data:
-  log4j.properties:
-    kafka.root.logger.level="INFO"
+  log4j2.properties:
+    rootLogger.level="INFO"
 ----
 +
-If you are using a properties file, specify the file at the command line:
+If you are using a properties file, define the logging configuration and specify the file at the command line when creating the `ConfigMap`.
 +
-[source,shell]
-----
-kubectl create configmap logging-configmap --from-file=log4j.properties
-----
-+
-The properties file defines the logging configuration:
-+
+.Properties file definition
 [source,text]
 ----
 # Define the logger
-kafka.root.logger.level="INFO"
+rootLogger.level="INFO"
 # ...
 ----
++
+.Specifying the properties file
+[source,shell]
+----
+kubectl create configmap logging-configmap --from-file=log4j2.properties
+----
 
-. Define _external_ logging in the `spec` of the resource, setting the `logging.valueFrom.configMapKeyRef.name` to the name of the ConfigMap and `logging.valueFrom.configMapKeyRef.key` to the key in this ConfigMap.
+. Add `external` logging to the `spec` of the `Kafka` resource, specifying the `name` and `key` of the `ConfigMap`:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
@@ -62,13 +53,8 @@ logging:
   valueFrom:
     configMapKeyRef:
       name: logging-configmap
-      key: log4j.properties
+      key: log4j2.properties
 # ...
 ----
 
-. Create or update the resource.
-+
-[source,shell,subs=+quotes]
-----
-kubectl apply -f _<kafka_configuration_file>_
-----
+. Apply the changes to the `Kafka` configuration.

--- a/documentation/modules/configuring/proc-creating-configmap.adoc
+++ b/documentation/modules/configuring/proc-creating-configmap.adoc
@@ -24,7 +24,7 @@ metadata:
   name: logging-configmap
 data:
   log4j2.properties: |
-    rootLogger.level="INFO"
+    rootLogger.level = "INFO"
     appender.console.type = Console
     appender.console.name = STDOUT
     appender.console.layout.type = PatternLayout
@@ -41,7 +41,7 @@ If you are using a properties file, define the logging configuration and specify
 [source,text]
 ----
 # Define the logger
-rootLogger.level="INFO"
+rootLogger.level = "INFO"
 # ...
 ----
 +

--- a/documentation/modules/configuring/proc-creating-logging-filters.adoc
+++ b/documentation/modules/configuring/proc-creating-logging-filters.adoc
@@ -6,19 +6,13 @@
 = Adding logging filters to Strimzi operators
 
 [role="_abstract"]
-If you are using a ConfigMap to configure the (log4j2) logging levels for Strimzi operators,
-you can also define logging filters to limit what's returned in the log.
+Use a `ConfigMap` to configure (log4j2) logging levels for Strimzi operators and define logging filters to limit log returns.
 
-Logging filters are useful when you have a large number of logging messages.
-Suppose you set the log level for the logger as DEBUG (`rootLogger.level="DEBUG"`).
-Logging filters reduce the number of logs returned for the logger at that level, so you can focus on a specific resource.
-When the filter is set, only log messages matching the filter are logged.
+Filters are useful when too many logging messages are being produced. 
+For instance, if `rootLogger.level="DEBUG"`, filters reduce the number of logs to focus on a specific resource by logging only messages matching the filter.
 
-Filters use _markers_ to specify what to include in the log.
-You specify a kind, namespace and name for the marker.
-For example, if a Kafka cluster is failing, you can isolate the logs by specifying the kind as `Kafka`, and use the namespace and name of the failing cluster.
-
-This example shows a marker filter for a Kafka cluster named `my-kafka-cluster`.
+Markers specify what to include in the log using kind, namespace, and resource name values. 
+For example, to isolate the logs of a failing Kafka cluster, set the kind to `Kafka` and use the namespace and name of the cluster.
 
 .Basic logging filter configuration
 [source,yaml,subs="+attributes"]
@@ -29,13 +23,12 @@ appender.console.filter.filter1.onMatch=ACCEPT <2>
 appender.console.filter.filter1.onMismatch=DENY <3>
 appender.console.filter.filter1.marker=Kafka(my-namespace/my-kafka-cluster) <4>
 ----
-<1> The `MarkerFilter` type compares a specified marker for filtering.
-<2> The `onMatch` property accepts the log if the marker matches.
-<3> The `onMismatch` property rejects the log if the marker does not match.
-<4> The marker used for filtering is in the format __KIND(NAMESPACE/NAME-OF-RESOURCE)__.
+<1> The `MarkerFilter` compares a specified marker.
+<2> `onMatch` accepts logs if the marker matches.
+<3> `onMismatch` rejects logs if the marker does not match.
+<4> Marker format: `kind(namespace/resource_name)`.
 
-You can create one or more filters.
-Here, the log is filtered for two Kafka clusters.
+For multiple filters, define each one separately:
 
 .Multiple logging filter configuration
 [source,yaml,subs="+attributes"]
@@ -52,13 +45,11 @@ appender.console.filter.filter2.marker=Kafka(my-namespace/my-kafka-cluster-2)
 
 .Adding filters to the Cluster Operator
 
-To add filters to the Cluster Operator, update its logging ConfigMap YAML file (`install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml`).
+To add filters to the Cluster Operator, update the `ConfigMap` YAML file (`install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml`):
 
 .Procedure
 
-. Update the `050-ConfigMap-strimzi-cluster-operator.yaml` file to add the filter properties to the ConfigMap.
-+
-In this example, the filter properties return logs only for the `my-kafka-cluster` Kafka cluster:
+. Update the `050-ConfigMap-strimzi-cluster-operator.yaml` file to add the filter properties:
 +
 [source,yaml,subs="+attributes"]
 ----
@@ -82,28 +73,18 @@ Alternatively, edit the `ConfigMap` directly:
 kubectl edit configmap strimzi-cluster-operator
 ----
 
-. If you updated the YAML file instead of editing the `ConfigMap` directly, apply the changes by deploying the ConfigMap:
-+
-[source,shell,subs=+quotes]
-----
-kubectl create -f install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
-----
+. If updating the YAML file, apply the changes to the `ConfigMap` configuration.
 
-.Adding filters to the Topic Operator or User Operator
+.Adding filters to the Topic or User Operator
 
-To add filters to the Topic Operator or User Operator, create or edit a logging ConfigMap.
-
-In this procedure a logging ConfigMap is created with filters for the Topic Operator.
-The same approach is used for the User Operator.
+To add filters to the Topic or User Operator, create or edit a logging `ConfigMap`. 
+The same method applies for both operators.
 
 .Procedure
 
-. Create the ConfigMap.
+. Create the `ConfigMap` as a YAML file or from a properties file. 
 +
-You can create the ConfigMap as a YAML file or from a properties file.
-+
-In this example, the filter properties return logs only for the `my-topic` topic:
-+
+.Example filter properties for `my-topic` topic
 [source,yaml,subs="+attributes"]
 ----
 kind: ConfigMap
@@ -119,15 +100,9 @@ data:
     appender.console.filter.filter1.marker=KafkaTopic(my-namespace/my-topic)
 ----
 +
-If you are using a properties file, specify the file at the command line:
+If you are using a properties file, define the logging configuration and specify the file at the command line when creating the `ConfigMap`.
 +
-[source,shell]
-----
-kubectl create configmap logging-configmap --from-file=log4j2.properties
-----
-+
-The properties file defines the logging configuration:
-+
+.Properties file definition
 [source,text]
 ----
 # Define the logger
@@ -139,10 +114,14 @@ appender.console.filter.filter1.onMismatch=DENY
 appender.console.filter.filter1.marker=KafkaTopic(my-namespace/my-topic)
 # ...
 ----
-
-. Define _external_ logging in the `spec` of the resource, setting the `logging.valueFrom.configMapKeyRef.name` to the name of the ConfigMap and `logging.valueFrom.configMapKeyRef.key` to the key in this ConfigMap.
 +
-For the Topic Operator, logging is specified in the `topicOperator` configuration of the `Kafka` resource.
+.Specifying the properties file
+[source,shell]
+----
+kubectl create configmap logging-configmap --from-file=log4j2.properties
+----
+
+. Define `external` logging in the `topicOperator` or `userOperator` configuration of the `Kafka` resource, specifying the `name` and `key` of the ConfigMap:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
@@ -158,12 +137,7 @@ spec:
             key: log4j2.properties
 ----
 
-. Apply the changes by deploying the Cluster Operator:
-
-[source,shell,subs=+quotes]
-----
-create -f install/cluster-operator -n my-cluster-operator-namespace
-----
+. Apply the changes to the `Kafka` configuration.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/configuring/proc-creating-logging-filters.adoc
+++ b/documentation/modules/configuring/proc-creating-logging-filters.adoc
@@ -6,7 +6,7 @@
 = Adding logging filters to Strimzi operators
 
 [role="_abstract"]
-Use a `ConfigMap` to configure (log4j2) logging levels for Strimzi operators and define logging filters to limit log returns.
+Use a `ConfigMap` to configure logging levels in Strimzi operators with Log4j2 and define filters to control log output.
 
 Filters are useful when too many logging messages are being produced. 
 For instance, if `rootLogger.level="DEBUG"`, filters reduce the number of logs to focus on a specific resource by logging only messages matching the filter.
@@ -18,10 +18,18 @@ For example, to isolate the logs of a failing Kafka cluster, set the kind to `Ka
 [source,yaml,subs="+attributes"]
 ----
 rootLogger.level="INFO"
-appender.console.filter.filter1.type=MarkerFilter <1>
-appender.console.filter.filter1.onMatch=ACCEPT <2>
-appender.console.filter.filter1.onMismatch=DENY <3>
-appender.console.filter.filter1.marker=Kafka(my-namespace/my-kafka-cluster) <4>
+rootLogger.appenderRefs = console
+rootLogger.appenderRef.console.ref = STDOUT
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+appender.console.filter.filter1.type = MarkerFilter <1>
+appender.console.filter.filter1.onMatch = ACCEPT <2>
+appender.console.filter.filter1.onMismatch = DENY <3>
+appender.console.filter.filter1.marker = Kafka(my-namespace/my-kafka-cluster) <4>
 ----
 <1> The `MarkerFilter` compares a specified marker.
 <2> `onMatch` accepts logs if the marker matches.
@@ -33,14 +41,19 @@ For multiple filters, define each one separately:
 .Multiple logging filter configuration
 [source,yaml,subs="+attributes"]
 ----
-appender.console.filter.filter1.type=MarkerFilter
-appender.console.filter.filter1.onMatch=ACCEPT
-appender.console.filter.filter1.onMismatch=DENY
-appender.console.filter.filter1.marker=Kafka(my-namespace/my-kafka-cluster-1)
-appender.console.filter.filter2.type=MarkerFilter
-appender.console.filter.filter2.onMatch=ACCEPT
-appender.console.filter.filter2.onMismatch=DENY
-appender.console.filter.filter2.marker=Kafka(my-namespace/my-kafka-cluster-2)
+# ...
+
+appender.console.name = STDOUT
+
+appender.console.filter.filter1.type = MarkerFilter
+appender.console.filter.filter1.onMatch = ACCEPT
+appender.console.filter.filter1.onMismatch = DENY
+appender.console.filter.filter1.marker = Kafka(my-namespace/my-kafka-cluster-1)
+
+appender.console.filter.filter2.type = MarkerFilter
+appender.console.filter.filter2.onMatch = ACCEPT
+appender.console.filter.filter2.onMismatch = DENY
+appender.console.filter.filter2.marker = Kafka(my-namespace/my-kafka-cluster-2)
 ----
 
 .Adding filters to the Cluster Operator
@@ -59,7 +72,15 @@ metadata:
   name: strimzi-cluster-operator
 data:
   log4j2.properties:
-    #...
+    rootLogger.level="INFO"
+    rootLogger.appenderRefs = console
+    rootLogger.appenderRef.console.ref = STDOUT
+
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+    
     appender.console.filter.filter1.type=MarkerFilter
     appender.console.filter.filter1.onMatch=ACCEPT
     appender.console.filter.filter1.onMismatch=DENY
@@ -93,11 +114,19 @@ metadata:
   name: logging-configmap
 data:
   log4j2.properties:
-    rootLogger.level="INFO"
-    appender.console.filter.filter1.type=MarkerFilter
-    appender.console.filter.filter1.onMatch=ACCEPT
-    appender.console.filter.filter1.onMismatch=DENY
-    appender.console.filter.filter1.marker=KafkaTopic(my-namespace/my-topic)
+    rootLogger.level = "INFO"
+    rootLogger.appenderRefs = console
+    rootLogger.appenderRef.console.ref = STDOUT
+
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+    appender.console.filter.filter1.type = MarkerFilter
+    appender.console.filter.filter1.onMatch = ACCEPT
+    appender.console.filter.filter1.onMismatch = DENY
+    appender.console.filter.filter1.marker = KafkaTopic(my-namespace/my-topic)
 ----
 +
 If you are using a properties file, define the logging configuration and specify the file at the command line when creating the `ConfigMap`.
@@ -106,12 +135,19 @@ If you are using a properties file, define the logging configuration and specify
 [source,text]
 ----
 # Define the logger
-rootLogger.level="INFO"
+rootLogger.level = "INFO"
+rootLogger.appenderRefs = console
+rootLogger.appenderRef.console.ref = STDOUT
+# Define the appenders
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 # Set the filters
-appender.console.filter.filter1.type=MarkerFilter
-appender.console.filter.filter1.onMatch=ACCEPT
-appender.console.filter.filter1.onMismatch=DENY
-appender.console.filter.filter1.marker=KafkaTopic(my-namespace/my-topic)
+appender.console.filter.filter1.type = MarkerFilter
+appender.console.filter.filter1.onMatch = ACCEPT
+appender.console.filter.filter1.onMismatch = DENY
+appender.console.filter.filter1.marker = KafkaTopic(my-namespace/my-topic)
 # ...
 ----
 +

--- a/documentation/modules/configuring/proc-creating-logging-filters.adoc
+++ b/documentation/modules/configuring/proc-creating-logging-filters.adoc
@@ -6,7 +6,7 @@
 = Adding logging filters to Strimzi operators
 
 [role="_abstract"]
-Use a `ConfigMap` to configure logging levels in Strimzi operators with Log4j2 and define filters to control log output.
+Add logging filters to Strimzi operators by using a `ConfigMap` that contains a complete `log4j2.properties` file with your custom log4j2 configuration.
 
 Filters are useful when too many logging messages are being produced. 
 For instance, if `rootLogger.level="DEBUG"`, filters reduce the number of logs to focus on a specific resource by logging only messages matching the filter.
@@ -15,7 +15,7 @@ Markers specify what to include in the log using kind, namespace, and resource n
 For example, to isolate the logs of a failing Kafka cluster, set the kind to `Kafka` and use the namespace and name of the cluster.
 
 .Basic logging filter configuration
-[source,yaml,subs="+attributes"]
+[source,properties]
 ----
 rootLogger.level="INFO"
 rootLogger.appenderRefs = console
@@ -39,7 +39,7 @@ appender.console.filter.filter1.marker = Kafka(my-namespace/my-kafka-cluster) <4
 For multiple filters, define each one separately:
 
 .Multiple logging filter configuration
-[source,yaml,subs="+attributes"]
+[source,properties]
 ----
 # ...
 
@@ -71,7 +71,7 @@ apiVersion: v1
 metadata:
   name: strimzi-cluster-operator
 data:
-  log4j2.properties:
+  log4j2.properties: |
     rootLogger.level="INFO"
     rootLogger.appenderRefs = console
     rootLogger.appenderRef.console.ref = STDOUT
@@ -113,7 +113,7 @@ apiVersion: v1
 metadata:
   name: logging-configmap
 data:
-  log4j2.properties:
+  log4j2.properties: |
     rootLogger.level = "INFO"
     rootLogger.appenderRefs = console
     rootLogger.appenderRef.console.ref = STDOUT

--- a/documentation/modules/configuring/proc-creating-logging-filters.adoc
+++ b/documentation/modules/configuring/proc-creating-logging-filters.adoc
@@ -17,7 +17,7 @@ For example, to isolate the logs of a failing Kafka cluster, set the kind to `Ka
 .Basic logging filter configuration
 [source,properties]
 ----
-rootLogger.level="INFO"
+rootLogger.level = "INFO"
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 
@@ -72,7 +72,7 @@ metadata:
   name: strimzi-cluster-operator
 data:
   log4j2.properties: |
-    rootLogger.level="INFO"
+    rootLogger.level = "INFO"
     rootLogger.appenderRefs = console
     rootLogger.appenderRef.console.ref = STDOUT
 

--- a/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
@@ -106,7 +106,7 @@ spec:
 <4> Optimization goals configuration, which can include configuration for default optimization goals (`default.goals`), supported optimization goals (`goals`), and hard goals (`hard.goals`).
 <5> CORS enabled and configured for read-only access to the Cruise Control API.
 <6> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<7> Cruise Control loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` key in the ConfigMap. Cruise Control has a single logger named `rootLogger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<7> Cruise Control loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
 <8> Template customization. Here a pod is scheduled with additional security attributes.
 <9> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <10> Prometheus metrics enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).

--- a/documentation/modules/operators/ref-operator-cluster-logging-configmap.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-logging-configmap.adoc
@@ -29,6 +29,7 @@ With this `ConfigMap`, you can control the following aspects of logging:
 
 Netty is a framework used in Strimzi for network communication.
 The `monitorInterval` setting determines how often in seconds the logging configuration is dynamically reloaded.
+The default is 30 seconds.
 
 If the `ConfigMap` is missing when the Cluster Operator is deployed, the default logging values are used.
 

--- a/documentation/modules/operators/ref-operator-cluster-logging-configmap.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-logging-configmap.adoc
@@ -7,11 +7,10 @@
 
 [role="_abstract"]
 Cluster Operator logging is configured through a `ConfigMap` named `strimzi-cluster-operator`.
-A `ConfigMap` containing logging configuration is created when installing the Cluster Operator.
-This `ConfigMap` is described in the file `install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml`.
-You configure Cluster Operator logging by changing the `data.log4j2.properties` values in this `ConfigMap`.
+This `ConfigMap`, created with default values during installation, is described in the file `install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml`.
+Configure Cluster Operator logging by changing `data.log4j2.properties` values in the file.
 
-To update the logging configuration, you can edit the `050-ConfigMap-strimzi-cluster-operator.yaml` file and then run the following command:
+To update the logging configuration, edit the `050-ConfigMap-strimzi-cluster-operator.yaml` file and then run the following command:
 [source,shell,subs=+quotes]
 kubectl create -f _install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml_
 
@@ -19,14 +18,21 @@ Alternatively, edit the `ConfigMap` directly:
 [source,shell,subs=+quotes]
 kubectl edit configmap strimzi-cluster-operator
 
-With this ConfigMap, you can control various aspects of logging, including the root logger level, log output format, and log levels for different components. 
-The `monitorInterval` setting, determines how often the logging configuration is reloaded. 
-You can also control the logging levels for the Kafka `AdminClient` or Netty.
-Netty is a framework used in Strimzi for network communication, and OkHttp is a library used for making HTTP requests.
-  
+With this `ConfigMap`, you can control the following aspects of logging:
+
+* Root logger level
+* Log output format
+* Log levels for different components
+* Kafka `AdminClient` logging levels
+* Netty logging Levels
+* How often logging configuration is loaded
+
+Netty is a framework used in Strimzi for network communication.
+The `monitorInterval` setting determines how often in seconds the logging configuration is dynamically reloaded.
+
 If the `ConfigMap` is missing when the Cluster Operator is deployed, the default logging values are used.
 
 If the `ConfigMap` is accidentally deleted after the Cluster Operator is deployed, the most recently loaded logging configuration is used.
 Create a new `ConfigMap` to load a new logging configuration.
 
-NOTE: Do not remove the `monitorInterval` option from the `ConfigMap`.
+WARNING: Do not remove the `monitorInterval` option from the `ConfigMap`.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -168,6 +168,7 @@
 :BookURLConfiguring: ./configuring.html
 :BookURLOverview: ./overview.html
 :BookURLBridge: https://strimzi.io/docs/bridge/latest/
+:DocArchive: https://strimzi.io/documentation/archive/
 
 // Link to resource on https://github.com/strimzi/strimzi-kafka-operator
 // Default `main`, specific version overriden when building the docs by `make`


### PR DESCRIPTION
**Documentation**

Updates the logging content to reflect new support and Kafka 4.0 adoption of log4j2
- Removes/updates references to log4j1 and log4j1 logger names
- Updates logging content in the deploying guide 
  - Refreshes logging config overview
- streamlines logging information in API reference guide to remove repetition


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

