### PR TITLE
[DOC] clarifies configuration of jmxOptions and Prometheus Exporter

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions.adoc
@@ -59,7 +59,7 @@ spec:
     # ...
 ----
 
-NOTE: The `jmxOptions` configuration enables direct access to Java Management Extensions (JMX) metrics from Kafka components. 
+NOTE: The `jmxOptions` configuration enables direct access to Java Management Extensions (JMX) from Kafka components. 
 It is not required for the Prometheus JMX Exporter, which collects and converts JMX metrics to Prometheus metrics without direct JMX access.
 
 [role="_additional-resources"]

--- a/documentation/api/io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions.adoc
@@ -59,6 +59,9 @@ spec:
     # ...
 ----
 
+NOTE: The `jmxOptions` configuration enables direct access to Java Management Extensions (JMX) metrics from Kafka components. 
+It is not required for the Prometheus JMX Exporter, which collects and converts JMX metrics to Prometheus metrics without direct JMX access.
+
 [role="_additional-resources"]
 .Additional resources
 

--- a/documentation/assemblies/metrics/assembly-metrics-config-files.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics-config-files.adoc
@@ -63,6 +63,10 @@ metrics
 <14> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for MirrorMaker 2.
 <15> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for OAuth 2.0.
 
+NOTE: The Prometheus JMX Exporter collects Java Management Extensions (JMX) metrics from Kafka components and converts them into Prometheus metrics.
+You do not require `jmxOptions` configuration in the custom resource of the component for the Prometheus JMX Exporter to function.
+`jmxOptions` is only required if you need direct access to JMX metrics from Kafka components.
+
 //Example Prometheus metrics files
 include::../../modules/metrics/ref-prometheus-metrics-config.adoc[leveloffset=+1]
 //Example Prometheus alert rules

--- a/documentation/assemblies/metrics/assembly-metrics-config-files.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics-config-files.adoc
@@ -63,9 +63,9 @@ metrics
 <14> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for MirrorMaker 2.
 <15> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for OAuth 2.0.
 
-NOTE: The Prometheus JMX Exporter collects Java Management Extensions (JMX) metrics from Kafka components and converts them into Prometheus metrics.
+NOTE: The Prometheus JMX Exporter collects Java Management Extensions (JMX) from Kafka components and converts them into Prometheus metrics.
 You do not require `jmxOptions` configuration in the custom resource of the component for the Prometheus JMX Exporter to function.
-`jmxOptions` is only required if you need direct access to JMX metrics from Kafka components.
+`jmxOptions` is only required if you need direct access to JMX from Kafka components.
 
 //Example Prometheus metrics files
 include::../../modules/metrics/ref-prometheus-metrics-config.adoc[leveloffset=+1]


### PR DESCRIPTION
Documentation

You do not require `jmxOptions` configuration in the custom resource of a component for the Prometheus JMX Exporter to function.
This update adds a couple of notes to the docs for clarification.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

