### PR TITLE
Cherry-pick update Fabric8 Kubernetes Client to 7.1.0 to 0.45.x release branch

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -897,6 +897,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -1043,6 +1045,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -1065,6 +1069,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -2433,6 +2439,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -2597,6 +2605,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -2619,6 +2629,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -3551,6 +3563,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -3718,6 +3732,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -3814,6 +3830,8 @@ spec:
                                 type: object
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                             limits:
                               additionalProperties:
@@ -3965,6 +3983,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -3987,6 +4007,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -5096,6 +5118,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -5183,6 +5207,8 @@ spec:
                             type: object
                             properties:
                               name:
+                                type: string
+                              request:
                                 type: string
                         limits:
                           additionalProperties:
@@ -5384,6 +5410,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -5406,6 +5434,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -6501,6 +6531,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -6590,6 +6622,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -6612,6 +6646,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -7342,6 +7378,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -7488,6 +7526,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -7510,6 +7550,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -289,6 +289,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -573,6 +575,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -595,6 +599,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:
@@ -1586,6 +1592,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -1608,6 +1616,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:
@@ -2547,6 +2557,8 @@ spec:
                             type: object
                             properties:
                               name:
+                                type: string
+                              request:
                                 type: string
                         limits:
                           additionalProperties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -542,6 +542,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -738,6 +740,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -760,6 +764,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -346,6 +346,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -562,6 +564,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -584,6 +588,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -506,6 +506,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -790,6 +792,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -812,6 +816,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:
@@ -1803,6 +1809,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -1825,6 +1833,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -185,6 +185,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -300,6 +302,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -322,6 +326,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -896,6 +896,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -1042,6 +1044,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -1064,6 +1068,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -2432,6 +2438,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -2596,6 +2604,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -2618,6 +2628,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -3550,6 +3562,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                           limits:
                             additionalProperties:
                               anyOf:
@@ -3717,6 +3731,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                           limits:
                             additionalProperties:
                               anyOf:
@@ -3813,6 +3829,8 @@ spec:
                               type: object
                               properties:
                                 name:
+                                  type: string
+                                request:
                                   type: string
                           limits:
                             additionalProperties:
@@ -3964,6 +3982,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -3986,6 +4006,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -5095,6 +5117,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                           limits:
                             additionalProperties:
                               anyOf:
@@ -5182,6 +5206,8 @@ spec:
                           type: object
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                       limits:
                         additionalProperties:
@@ -5383,6 +5409,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -5405,6 +5433,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -6500,6 +6530,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -6589,6 +6621,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -6611,6 +6645,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -7341,6 +7377,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -7487,6 +7525,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -7509,6 +7549,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -288,6 +288,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -572,6 +574,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -594,6 +598,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:
@@ -1585,6 +1591,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -1607,6 +1615,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:
@@ -2546,6 +2556,8 @@ spec:
                           type: object
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                       limits:
                         additionalProperties:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -541,6 +541,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -737,6 +739,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -759,6 +763,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -345,6 +345,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -561,6 +563,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -583,6 +587,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -505,6 +505,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -789,6 +791,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -811,6 +815,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:
@@ -1802,6 +1808,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -1824,6 +1832,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -184,6 +184,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -299,6 +301,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -321,6 +325,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.13.4</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.13.4</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.13.4</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.1.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.1.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.1.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.16.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.16.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
Trivial PR to cherry-pick the bump of Vert.x and Netty from PR https://github.com/strimzi/strimzi-kafka-operator/pull/11102 to the 0.45 release branch for the next patch release.
