### PR TITLE
Remove unnecessary executeBlocking call

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -224,7 +224,7 @@ public class CaReconciler {
         String clientsCaKeyName = KafkaResources.clientsCaKeySecretName(reconciliation.name());
 
         return secretOperator.listAsync(reconciliation.namespace(), Labels.EMPTY.withStrimziKind(reconciliation.kind()).withStrimziCluster(reconciliation.name()))
-                .compose(clusterSecrets -> vertx.executeBlocking(() -> {
+                .compose(clusterSecrets -> {
                     Secret clusterCaCertSecret = null;
                     Secret clusterCaKeySecret = null;
                     Secret clientsCaCertSecret = null;
@@ -267,9 +267,6 @@ public class CaReconciler {
                             clientsCaConfig != null && !clientsCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,
                             Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant()));
 
-                    return null;
-                }))
-                .compose(i -> {
                     Promise<Void> caUpdatePromise = Promise.promise();
 
                     List<Future<ReconcileResult<Secret>>> secretReconciliations = new ArrayList<>(2);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Remove unnecessary executeBlocking call.
PR #9250 removed the blocking call to list Secrets. As a result there is currently no actions taken in the code that should block the VertX event loop, so the executeBlocking is not needed at all.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

