### PR TITLE
[system test] [perf] Fix executor handling

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/TopicOperatorPerformanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/TopicOperatorPerformanceUtils.java
@@ -214,7 +214,7 @@ public class TopicOperatorPerformanceUtils {
 
         for (int topicIndex = warmUpTasksToProcess; topicIndex < numberOfTopics + warmUpTasksToProcess; topicIndex++) {
             final int finalTopicIndex = topicIndex;
-            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> performFullLifecycle(finalTopicIndex, testStorage, extensionContext), EXECUTOR);
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> performFullLifecycle(finalTopicIndex, testStorage, extensionContext), executorService);
             futures.add(future);
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/TopicOperatorPerformanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/TopicOperatorPerformanceUtils.java
@@ -37,7 +37,7 @@ public class TopicOperatorPerformanceUtils {
         "segment.ms", 123456L, "retention.bytes", 9876543L, "segment.bytes", 321654L, "flush.messages", 456123L);
     private static final int AVAILABLE_CPUS = Runtime.getRuntime().availableProcessors();
 
-    public static ExecutorService executorService = Executors.newFixedThreadPool(AVAILABLE_CPUS);
+    private static ExecutorService executorService = Executors.newFixedThreadPool(AVAILABLE_CPUS);
 
     private TopicOperatorPerformanceUtils() {}  // Prevent instantiation
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR fixes how we handle the ExecutorService. Currently, when the 1st run of the test case would fail it would shutdown the executor service and then on the second run it would not run.  

I have fixed it in a way that for each test we create an `ExecutorService` if it's not created so that we can proceed with the execution.

### Checklist


- [x] Write tests
- [x] Make sure all tests pass