### PR TITLE
Fixed missing deletion of the migration znode on KRaft migration rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.45.1
 
-* Dependency updates (Vert.x 4.5.13, Netty 4.1.118.Final)
+* Dependency updates (Vert.x 4.5.13, Netty 4.1.118.Final).
+* Fixed bug which may lead to a broken cluster when restarting a KRaft migration after a previous rollback due to missing `/migration` znode deletion.
 
 ## 0.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.45.1
 
 * Dependency updates (Vert.x 4.5.13, Netty 4.1.118.Final).
-* Fixed bug which may lead to a broken cluster when restarting a KRaft migration after a previous rollback due to missing `/migration` znode deletion.
+* Fixed bug which may lead to metadata loss within the cluster when restarting a KRaft migration after a previous rollback due to missing `/migration` znode deletion.
 
 ## 0.45.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
@@ -34,8 +34,8 @@ public class KRaftMigrationUtils {
     /**
      * This method deletes the /controller znode from ZooKeeper to allow the brokers, which are now in ZooKeeper mode again,
      * to elect a new controller among them taking the KRaft controllers out of the picture.
-     * It also deletes the /migration znode from ZooKeeper to reset the migration status in case of rollback and the user
-     * wants to start a KRaft migration again.
+     * It also deletes the /migration znode from ZooKeeper to reset the migration status and not skipping
+     * the initial ZooKeeper to KRaft sync, in case of rollback and the user wants to start a KRaft migration again.
      *
      * @param reconciliation            Reconciliation information
      * @param vertx                     Vert.x instance

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
 
 import java.io.File;
@@ -59,7 +60,10 @@ public class KRaftMigrationUtils {
                         zkAdmin.delete("/controller", -1);
                         LOGGER.infoCr(reconciliation, "Deleted the '/controller' znode as part of the KRaft migration rollback");
                         return Future.succeededFuture(zkAdmin);
-                    } catch (Exception e)    {
+                    } catch (KeeperException.NoNodeException noNodeException) {
+                        LOGGER.warnCr(reconciliation, "The '/controller' znode doesn't exist already. Nothing to delete as part of the KRaft migration rollback");
+                        return Future.succeededFuture(zkAdmin);
+                    } catch (Exception e) {
                         closeZooKeeperConnection(reconciliation, vertx, zkAdmin, trustStoreFile, keyStoreFile, operationTimeoutMs);
                         return Future.failedFuture(e);
                     }
@@ -69,7 +73,10 @@ public class KRaftMigrationUtils {
                         zkAdmin.delete("/migration", -1);
                         LOGGER.infoCr(reconciliation, "Deleted the '/migration' znode as part of the KRaft migration rollback");
                         return Future.succeededFuture();
-                    } catch (Exception e)    {
+                    } catch (KeeperException.NoNodeException noNodeException) {
+                        LOGGER.warnCr(reconciliation, "The '/migration' znode doesn't exist already. Nothing to delete as part of the KRaft migration rollback");
+                        return Future.succeededFuture();
+                    } catch (Exception e) {
                         return Future.failedFuture(e);
                     } finally {
                         closeZooKeeperConnection(reconciliation, vertx, zkAdmin, trustStoreFile, keyStoreFile, operationTimeoutMs);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
@@ -33,6 +33,8 @@ public class KRaftMigrationUtils {
     /**
      * This method deletes the /controller znode from ZooKeeper to allow the brokers, which are now in ZooKeeper mode again,
      * to elect a new controller among them taking the KRaft controllers out of the picture.
+     * It also deletes the /migration znode from ZooKeeper to reset the migration status in case of rollback and the user
+     * wants to start a KRaft migration again.
      *
      * @param reconciliation            Reconciliation information
      * @param vertx                     Vert.x instance
@@ -41,30 +43,41 @@ public class KRaftMigrationUtils {
      * @param operationTimeoutMs        Timeout to be set on the ZooKeeper request configuration
      * @param zkConnectionString        Connection string to the ZooKeeper ensemble to connect to
      *
-     * @return Completes when the /controller znode deletion is done or any error
+     * @return Completes when the /controller and /migration znodes deletion is done or any error
      */
-    public static Future<Void> deleteZooKeeperControllerZnode(Reconciliation reconciliation, Vertx vertx, ZooKeeperAdminProvider zooKeeperAdminProvider, TlsPemIdentity coTlsPemIdentity, long operationTimeoutMs, String zkConnectionString) {
+    public static Future<Void> deleteZooKeeperControllerAndMigrationZnodes(Reconciliation reconciliation, Vertx vertx, ZooKeeperAdminProvider zooKeeperAdminProvider, TlsPemIdentity coTlsPemIdentity, long operationTimeoutMs, String zkConnectionString) {
         // Setup truststore from PEM file in cluster CA secret
         File trustStoreFile = Util.createFileStore(KRaftMigrationUtils.class.getName(), PemTrustSet.CERT_SUFFIX, coTlsPemIdentity.pemTrustSet().trustedCertificatesPemBytes());
 
         // Setup keystore from PEM in cluster-operator secret
         File keyStoreFile = Util.createFileStore(KRaftMigrationUtils.class.getName(), PemAuthIdentity.PEM_SUFFIX, coTlsPemIdentity.pemAuthIdentity().pemKeyStore());
 
-        return connectToZooKeeper(reconciliation, vertx, zooKeeperAdminProvider, trustStoreFile, keyStoreFile, operationTimeoutMs, zkConnectionString)
+        Promise<Void> znodesDeleted = Promise.promise();
+        connectToZooKeeper(reconciliation, vertx, zooKeeperAdminProvider, trustStoreFile, keyStoreFile, operationTimeoutMs, zkConnectionString)
                 .compose(zkAdmin -> {
-                    Promise<Void> znodeDeleted = Promise.promise();
                     try {
                         zkAdmin.delete("/controller", -1);
                         LOGGER.infoCr(reconciliation, "Deleted the '/controller' znode as part of the KRaft migration rollback");
-                        znodeDeleted.complete();
+                        return Future.succeededFuture(zkAdmin);
                     } catch (Exception e)    {
-                        LOGGER.warnCr(reconciliation, "Failed to delete '/controller' znode", e);
-                        znodeDeleted.fail(e);
+                        closeZooKeeperConnection(reconciliation, vertx, zkAdmin, trustStoreFile, keyStoreFile, operationTimeoutMs);
+                        return Future.failedFuture(e);
+                    }
+                })
+                .compose(zkAdmin -> {
+                    try {
+                        zkAdmin.delete("/migration", -1);
+                        LOGGER.infoCr(reconciliation, "Deleted the '/migration' znode as part of the KRaft migration rollback");
+                        return Future.succeededFuture();
+                    } catch (Exception e)    {
+                        return Future.failedFuture(e);
                     } finally {
                         closeZooKeeperConnection(reconciliation, vertx, zkAdmin, trustStoreFile, keyStoreFile, operationTimeoutMs);
                     }
-                    return znodeDeleted.future();
-                });
+                })
+                .onSuccess(v -> znodesDeleted.complete())
+                .onFailure(e -> znodesDeleted.fail(e));
+        return znodesDeleted.future();
     }
 
     private static Future<ZooKeeperAdmin> connectToZooKeeper(Reconciliation reconciliation, Vertx vertx, ZooKeeperAdminProvider zooKeeperAdminProvider, File trustStoreFile, File keyStoreFile, long operationTimeoutMs, String zkConnectionString) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -889,23 +889,27 @@ public class ZooKeeperReconciler {
      * Defers to the Kafka metadata state manager to determine if there is a KRaft migration rollback ongoing and in such case,
      * it will delete the /controller znode to allow brokers to elect a new controller among them, now that KRaft
      * controllers are out of the picture.
+     * It will also delete the /migration znode to reset the migration status in case of rollback and the user
+     * wants to start a KRaft migration again.
      *
-     * @return  Completes when the possible /controller znode deletion is done or no deletion is required
+     * @return  Completes when the possible /controller and /migration znode deletion is done or no deletion is required
      */
     protected Future<Void> maybeDeleteControllerZnode() {
-        return this.isKRaftMigrationRollback ? deleteControllerZnode() : Future.succeededFuture();
+        return this.isKRaftMigrationRollback ? deleteControllerAndMigrationZnodes() : Future.succeededFuture();
     }
 
     /**
      * Deletes the /controller znode to allow brokers to elect a new controller among them, now that KRaft
      * controllers are out of the picture.
+     * Also deletes the /migration znode to reset the migration status in case of rollback and the user
+     * wants to start a KRaft migration again.
      *
-     * @return  Completes when the /controller znode deletion is done
+     * @return  Completes when the /controller and /migration znodes deletion is done
      */
-    protected Future<Void> deleteControllerZnode() {
+    protected Future<Void> deleteControllerAndMigrationZnodes() {
         // migration rollback process ongoing
         String zkConnectionString = DnsNameGenerator.serviceDnsNameWithoutClusterDomain(reconciliation.namespace(), KafkaResources.zookeeperServiceName(reconciliation.name()))  + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
-        return KRaftMigrationUtils.deleteZooKeeperControllerZnode(
+        return KRaftMigrationUtils.deleteZooKeeperControllerAndMigrationZnodes(
                 reconciliation,
                 vertx,
                 this.zooKeeperAdminProvider,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -901,8 +901,8 @@ public class ZooKeeperReconciler {
     /**
      * Deletes the /controller znode to allow brokers to elect a new controller among them, now that KRaft
      * controllers are out of the picture.
-     * Also deletes the /migration znode to reset the migration status in case of rollback and the user
-     * wants to start a KRaft migration again.
+     * Also deletes the /migration znode from ZooKeeper to reset the migration status and not skipping
+     * the initial ZooKeeper to KRaft sync, in case of rollback and the user wants to start a KRaft migration again.
      *
      * @return  Completes when the /controller and /migration znodes deletion is done
      */

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZookeeperReconcilerKRaftMigrationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZookeeperReconcilerKRaftMigrationTest.java
@@ -145,7 +145,7 @@ public class ZookeeperReconcilerKRaftMigrationTest {
 
         zookeeperReconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(v -> context.verify(() -> {
             verify(zookeeperReconciler, times(1)).maybeDeleteControllerZnode();
-            verify(zookeeperReconciler, times(1)).deleteControllerZnode();
+            verify(zookeeperReconciler, times(1)).deleteControllerAndMigrationZnodes();
             async.flag();
         })));
     }
@@ -191,7 +191,7 @@ public class ZookeeperReconcilerKRaftMigrationTest {
 
         zookeeperReconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(res -> context.verify(() -> {
             verify(zookeeperReconciler, times(1)).maybeDeleteControllerZnode();
-            verify(zookeeperReconciler, times(0)).deleteControllerZnode();
+            verify(zookeeperReconciler, times(0)).deleteControllerAndMigrationZnodes();
             async.flag();
         })));
     }
@@ -207,7 +207,7 @@ public class ZookeeperReconcilerKRaftMigrationTest {
         }
 
         @Override
-        protected Future<Void> deleteControllerZnode() {
+        protected Future<Void> deleteControllerAndMigrationZnodes() {
             return Future.succeededFuture();
         }
     }

--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -261,6 +261,11 @@ The brokers are rolled back so that they can be connected to ZooKeeper again and
 kubectl delete KafkaNodePool controller -n my-project
 ----
 
+WARNING: Together with the controllers node pool, delete the corresponding PVCs used for storing the cluster metadata.
+If a new KRaft migration is started, but the old PVCs are retained after a rollback, it won't work.
+This is due to an inconsistency between the new ZooKeeper-based metadata and the old KRaft-based metadata in the existing PVCs.
+The new controllers must start from clean storage so that they can migrate the metadata from ZooKeeper successfully.
+
 . Apply the `strimzi.io/kraft="disabled"` annotation to the `Kafka` resource to return the metadata state to `ZooKeeper`.
 +
 [source,shell]

--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -261,10 +261,29 @@ The brokers are rolled back so that they can be connected to ZooKeeper again and
 kubectl delete KafkaNodePool controller -n my-project
 ----
 
-WARNING: Together with the controllers node pool, delete the corresponding PVCs used for storing the cluster metadata.
-If a new KRaft migration is started, but the old PVCs are retained after a rollback, it won't work.
-This is due to an inconsistency between the new ZooKeeper-based metadata and the old KRaft-based metadata in the existing PVCs.
-The new controllers must start from clean storage so that they can migrate the metadata from ZooKeeper successfully.
+. IMPORTANT: After deleting the controllers node pool, remove the corresponding PVCs storing cluster metadata.
++
+Delete each controller using specific names.
++
+For example:
++
+[source,shell]
+----
+kubectl get pvc -n my-project | grep data-my-cluster-controller
+
+kubectl delete pvc data-my-cluster-controller-0 -n my-project
+kubectl delete pvc data-my-cluster-controller-1 -n my-project
+kubectl delete pvc data-my-cluster-controller-2 -n my-project
+----
++
+PVCs take the name format `data-<kafka_cluster_name>-<pool_name>-<pod_id>`.
+For JBOD volumes, the name format includes a volume ID: `data-<id>-<kafka_cluster_name>-<pool_name>-<pod_id>`.
++
+WARNING: Deleting the controllers node pool also requires deleting the corresponding PVCs that store cluster metadata.
+If old PVCs remain after a rollback, KRaft migration fails due to metadata inconsistencies.
+The new controllers must start with an empty metadata directory to migrate metadata from ZooKeeper successfully.
+This operation should only be performed with an understanding of the potential for data loss when deleting PVCs.
+Before proceeding, ensure you have taken appropriate backups of any critical data.
 
 . Apply the `strimzi.io/kraft="disabled"` annotation to the `Kafka` resource to return the metadata state to `ZooKeeper`.
 +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #11262 by adding the deletion of the `/migration` znode when rolling back from a KRaft migration.

### Checklist

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md