### PR TITLE
Store CA generation in Ca class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -383,8 +383,8 @@ public class CaReconciler {
                         return Future.succeededFuture();
                     }
 
-                    int clusterCaCertGeneration = clusterCa.certGeneration();
-                    int clusterCaKeyGeneration = clusterCa.keyGeneration();
+                    int clusterCaCertGeneration = clusterCa.caCertGeneration();
+                    int clusterCaKeyGeneration = clusterCa.caKeyGeneration();
 
                     LOGGER.debugCr(reconciliation, "Current cluster CA cert generation {}", clusterCaCertGeneration);
                     LOGGER.debugCr(reconciliation, "Current cluster CA key generation {}", clusterCaKeyGeneration);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -30,7 +30,6 @@ import io.strimzi.operator.common.auth.PemAuthIdentity;
 import io.strimzi.operator.common.auth.PemTrustSet;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Ca;
-import io.strimzi.operator.common.model.ClientsCa;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.Future;
@@ -192,7 +191,7 @@ public class ReconcilerUtils {
             if (ca.certsRemoved()) {
                 restartReasons.add(RestartReason.CA_CERT_REMOVED, ca + " certificate removal");
             }
-            if (!isPodCaCertUpToDate(pod, ca)) {
+            if (ca.hasCaCertGenerationChanged(pod)) {
                 restartReasons.add(RestartReason.CA_CERT_HAS_OLD_GENERATION, "Pod has old " + ca + " certificate generation");
             }
         }
@@ -211,29 +210,6 @@ public class ReconcilerUtils {
         }
 
         return restartReasons;
-    }
-
-    /**
-     * Extracts and compares CA generation from the pod and from the CA class
-     *
-     * @param pod   Pod with the generation annotation
-     * @param ca    Certificate Authority
-     *
-     * @return      True when the generations match, false otherwise
-     */
-    private static boolean isPodCaCertUpToDate(Pod pod, Ca ca) {
-        return ca.caCertGeneration() == Annotations.intAnnotation(pod, getCaCertAnnotation(ca), Ca.INIT_GENERATION);
-    }
-
-    /**
-     * Gets the right annotation for the CA generation depending on whether it is a Cluster or Clients CA
-     *
-     * @param ca    Certification Authority
-     *
-     * @return      Name of the annotation for given CA
-     */
-    private static String getCaCertAnnotation(Ca ca) {
-        return ca instanceof ClientsCa ? Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION : Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION;
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -294,10 +294,10 @@ public abstract class Ca {
     protected final boolean generateCa;
     protected String caCertSecretName;
     protected Secret caCertSecret;
-    private int caCertGeneration;
+    protected int caCertGeneration;
     protected String caKeySecretName;
     protected Secret caKeySecret;
-    private int caKeyGeneration;
+    protected int caKeyGeneration;
     protected RenewalType renewalType;
     protected boolean caCertsRemoved;
     protected final CertificateExpirationPolicy policy;
@@ -330,10 +330,10 @@ public abstract class Ca {
         this.commonName = commonName;
         this.caCertSecret = caCertSecret;
         this.caCertSecretName = caCertSecretName;
-        this.caCertGeneration = initCaCertGeneration();
+        this.caCertGeneration = initCaCertGeneration(caCertSecret);
         this.caKeySecret = caKeySecret;
         this.caKeySecretName = caKeySecretName;
-        this.caKeyGeneration = initCaKeyGeneration();
+        this.caKeyGeneration = initCaKeyGeneration(caKeySecret);
         this.certManager = certManager;
         this.passwordGenerator = passwordGenerator;
         this.validityDays = validityDays;
@@ -357,11 +357,12 @@ public abstract class Ca {
     }
 
     /**
-     * Extracts the CA generation from the CA
+     * Extracts the CA generation from the CA cert Secret
      *
+     * @param caCertSecret Secret to extract the CA cert from
      * @return CA generation or the initial generation if no generation is set
      */
-    private int initCaCertGeneration() {
+    private int initCaCertGeneration(Secret caCertSecret) {
         if (caCertSecret != null) {
             if (!Annotations.hasAnnotation(caCertSecret, ANNO_STRIMZI_IO_CA_CERT_GENERATION)) {
                 LOGGER.warnOp("Secret {}/{} is missing generation annotation {}",
@@ -373,11 +374,12 @@ public abstract class Ca {
     }
 
     /**
-     * Extracts the CA key generation from the CA
+     * Extracts the CA key generation from the CA key Secret
      *
+     * @param caKeySecret Secret to extract the CA key from
      * @return CA key generation or the initial generation if no generation is set
      */
-    private int initCaKeyGeneration() {
+    private int initCaKeyGeneration(Secret caKeySecret) {
         if (caKeySecret != null) {
             if (!Annotations.hasAnnotation(caKeySecret, ANNO_STRIMZI_IO_CA_KEY_GENERATION)) {
                 LOGGER.warnOp("Secret {}/{} is missing generation annotation {}",

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -294,8 +294,10 @@ public abstract class Ca {
     protected final boolean generateCa;
     protected String caCertSecretName;
     protected Secret caCertSecret;
+    private int caCertGeneration;
     protected String caKeySecretName;
     protected Secret caKeySecret;
+    private int caKeyGeneration;
     protected RenewalType renewalType;
     protected boolean caCertsRemoved;
     protected final CertificateExpirationPolicy policy;
@@ -328,8 +330,10 @@ public abstract class Ca {
         this.commonName = commonName;
         this.caCertSecret = caCertSecret;
         this.caCertSecretName = caCertSecretName;
+        this.caCertGeneration = initCaCertGeneration();
         this.caKeySecret = caKeySecret;
         this.caKeySecretName = caKeySecretName;
+        this.caKeyGeneration = initCaKeyGeneration();
         this.certManager = certManager;
         this.passwordGenerator = passwordGenerator;
         this.validityDays = validityDays;
@@ -357,8 +361,15 @@ public abstract class Ca {
      *
      * @return CA generation or the initial generation if no generation is set
      */
-    public int caCertGeneration() {
-        return Annotations.intAnnotation(caCertSecret(), ANNO_STRIMZI_IO_CA_CERT_GENERATION, INIT_GENERATION);
+    private int initCaCertGeneration() {
+        if (caCertSecret != null) {
+            if (!Annotations.hasAnnotation(caCertSecret, ANNO_STRIMZI_IO_CA_CERT_GENERATION)) {
+                LOGGER.warnOp("Secret {}/{} is missing generation annotation {}",
+                        caCertSecret.getMetadata().getNamespace(), caCertSecret.getMetadata().getName(), ANNO_STRIMZI_IO_CA_CERT_GENERATION);
+            }
+            return Annotations.intAnnotation(caCertSecret(), ANNO_STRIMZI_IO_CA_CERT_GENERATION, INIT_GENERATION);
+        }
+        return INIT_GENERATION;
     }
 
     /**
@@ -366,8 +377,15 @@ public abstract class Ca {
      *
      * @return CA key generation or the initial generation if no generation is set
      */
-    public int caKeyGeneration() {
-        return Annotations.intAnnotation(caKeySecret(), ANNO_STRIMZI_IO_CA_KEY_GENERATION, INIT_GENERATION);
+    private int initCaKeyGeneration() {
+        if (caKeySecret != null) {
+            if (!Annotations.hasAnnotation(caKeySecret, ANNO_STRIMZI_IO_CA_KEY_GENERATION)) {
+                LOGGER.warnOp("Secret {}/{} is missing generation annotation {}",
+                        caKeySecret.getMetadata().getNamespace(), caKeySecret.getMetadata().getName(), ANNO_STRIMZI_IO_CA_KEY_GENERATION);
+            }
+            return Annotations.intAnnotation(caKeySecret(), ANNO_STRIMZI_IO_CA_KEY_GENERATION, INIT_GENERATION);
+        }
+        return INIT_GENERATION;
     }
 
     protected static void delete(Reconciliation reconciliation, File file) {
@@ -536,9 +554,6 @@ public abstract class Ca {
         X509Certificate currentCert = cert(caCertSecret, CA_CRT);
         Map<String, String> certData;
         Map<String, String> keyData;
-        int caCertGeneration = certGeneration();
-        int caKeyGeneration = keyGeneration();
-
         if (!generateCa) {
             certData = caCertSecret.getData();
             keyData = singletonMap(CA_KEY, caKeySecret.getData().get(CA_KEY));
@@ -778,36 +793,22 @@ public abstract class Ca {
     /**
      * @return the generation of the current CA certificate
      */
-    public int certGeneration() {
-        if (caCertSecret != null) {
-            if (!Annotations.hasAnnotation(caCertSecret, ANNO_STRIMZI_IO_CA_CERT_GENERATION)) {
-                LOGGER.warnOp("Secret {}/{} is missing generation annotation {}",
-                        caCertSecret.getMetadata().getNamespace(), caCertSecret.getMetadata().getName(), ANNO_STRIMZI_IO_CA_CERT_GENERATION);
-            }
-            return caCertGeneration();
-        }
-        return INIT_GENERATION;
+    public int caCertGeneration() {
+        return caCertGeneration;
     }
 
     /**
      * @return the generation of the current CA certificate as an annotation
      */
     public Map.Entry<String, String> caCertGenerationFullAnnotation() {
-        return Map.entry(caCertGenerationAnnotation(), String.valueOf(certGeneration()));
+        return Map.entry(caCertGenerationAnnotation(), String.valueOf(caCertGeneration));
     }
 
     /**
      * @return the generation of the current CA key
      */
-    public int keyGeneration() {
-        if (caKeySecret != null) {
-            if (!Annotations.hasAnnotation(caKeySecret, ANNO_STRIMZI_IO_CA_KEY_GENERATION)) {
-                LOGGER.warnOp("Secret {}/{} is missing generation annotation {}",
-                        caKeySecret.getMetadata().getNamespace(), caKeySecret.getMetadata().getName(), ANNO_STRIMZI_IO_CA_KEY_GENERATION);
-            }
-            return caKeyGeneration();
-        }
-        return INIT_GENERATION;
+    public int caKeyGeneration() {
+        return caKeyGeneration;
     }
 
     /**
@@ -1059,23 +1060,21 @@ public abstract class Ca {
 
     /**
      * It checks if the current (cluster or clients) CA certificate generation is changed compared to the one
-     * brought by the corresponding annotation on the provided Secret (i.e. Kafka brokers, ...)
+     * brought by the corresponding annotation on the provided Resource (i.e. Secret containing Kafka broker certificates, Kafka Pods presenting certificates...)
      *
-     * @param secret Secret containing certificates signed by the current (clients or cluster) CA
+     * @param resource Resource (Secret or Pod) containing or presenting certificates signed by the current (clients or cluster) CA
      * @return if the current (cluster or clients) CA certificate generation is changed compared to the one
-     *         brought by the corresponding annotation on the provided Secret
+     *         brought by the corresponding annotation on the provided Resource
      */
-    public boolean hasCaCertGenerationChanged(HasMetadata secret) {
-        if (secret != null) {
-            String caCertGenerationAnno = Annotations.stringAnnotation(secret, caCertGenerationAnnotation(), null);
-            int currentCaCertGeneration = certGeneration();
+    public boolean hasCaCertGenerationChanged(HasMetadata resource) {
+        if (resource != null && Annotations.hasAnnotation(resource, caCertGenerationAnnotation())) {
+            int caCertGenerationAnno = Annotations.intAnnotation(resource, caCertGenerationAnnotation(), INIT_GENERATION);
             LOGGER.debugOp("Secret {}/{} generation anno = {}, current CA generation = {}",
-                    secret.getMetadata().getNamespace(), secret.getMetadata().getName(), caCertGenerationAnno, currentCaCertGeneration);
-            return caCertGenerationAnno != null && Integer.parseInt(caCertGenerationAnno) != currentCaCertGeneration;
+                    resource.getMetadata().getNamespace(), resource.getMetadata().getName(), caCertGenerationAnno, caCertGeneration);
+            return caCertGenerationAnno != caCertGeneration;
         }
         return false;
     }
-
 
     /**
      * Generates the expiration date as epoch of the CA certificate.


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Refactoring CA generation methods in Ca class:
* Store CA generation directly in Ca class
* Simplify getter methods
* Remove duplicate methods from ReconcilerUtils

This change stores the CA generation in a variable, rather than relying on the generation inside the Secret class. This will help with future refactoring for cert-manager integration that will remove the direct use of the Secret in this class. It also simplifies the code, making it easier to follow.

Finally there was a duplicate method in ReconcilerUtils for determining if the CA generation changed, so this method has been removed and the code updated to use the method in the Ca class.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

