### PR TITLE
[ST] Add test for migration-rollback-migration with additional checks

### DIFF
--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -27,7 +27,7 @@ spec:
             name: strimzi-cluster-operator
       containers:
         - name: strimzi-cluster-operator
-          image: quay.io/strimzi/operator:0.45.0
+          image: quay.io/ppatierno/operator:delete-migration
           ports:
             - containerPort: 8080
               name: http
@@ -72,11 +72,11 @@ spec:
                 3.8.1=quay.io/strimzi/kafka:0.45.0-kafka-3.8.1
                 3.9.0=quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:0.45.0
+              value: quay.io/ppatierno/operator:delete-migration
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:0.45.0
+              value: quay.io/ppatierno/operator:delete-migration
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: quay.io/strimzi/operator:0.45.0
+              value: quay.io/ppatierno/operator:delete-migration
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
               value: quay.io/strimzi/kafka-bridge:0.31.1
             - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -27,7 +27,7 @@ spec:
             name: strimzi-cluster-operator
       containers:
         - name: strimzi-cluster-operator
-          image: quay.io/ppatierno/operator:delete-migration
+          image: quay.io/strimzi/operator:0.45.0
           ports:
             - containerPort: 8080
               name: http
@@ -72,11 +72,11 @@ spec:
                 3.8.1=quay.io/strimzi/kafka:0.45.0-kafka-3.8.1
                 3.9.0=quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: quay.io/ppatierno/operator:delete-migration
+              value: quay.io/strimzi/operator:0.45.0
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: quay.io/ppatierno/operator:delete-migration
+              value: quay.io/strimzi/operator:0.45.0
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: quay.io/ppatierno/operator:delete-migration
+              value: quay.io/strimzi/operator:0.45.0
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
               value: quay.io/strimzi/kafka-bridge:0.31.1
             - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -588,7 +588,7 @@ public class KafkaUtils {
     }
 
     public static void waitUntilKafkaStatusContainsKafkaMetadataState(String namespaceName, String clusterName, KafkaMetadataState desiredKafkaMetadataState) {
-        TestUtils.waitFor(String.join("Kafka status to be contain kafkaMetadataState: %s", desiredKafkaMetadataState.name()), TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT, () -> {
+        TestUtils.waitFor(String.format("Kafka status to contain kafkaMetadataState: %s", desiredKafkaMetadataState.name()), TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT, () -> {
             Kafka k = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get();
             return k.getStatus().getKafkaMetadataState().equals(desiredKafkaMetadataState);
         });

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -308,7 +308,7 @@ public class MigrationST extends AbstractST {
 
         // Do the full migration to KRaft
         doFirstPartOfMigration(testStorage, deleteCoDuringProcess, withJbodStorage, false);
-        doSecondPartOfMigration(testStorage, deleteCoDuringProcess, zkDeleteClaim, false);
+        doSecondPartOfMigration(testStorage, deleteCoDuringProcess, zkDeleteClaim);
 
         // Check that all topics are present
         assertThatTopicIsPresentInKRaftMetadata(testStorage.getNamespaceName(), controllerSelector, postMigrationTopicName);
@@ -558,10 +558,6 @@ public class MigrationST extends AbstractST {
     }
 
     private void doSecondPartOfMigration(TestStorage testStorage, boolean deleteCoDuringProcess, boolean zkDeleteClaim) {
-        doSecondPartOfMigration(testStorage, deleteCoDuringProcess, zkDeleteClaim, true);
-    }
-
-    private void doSecondPartOfMigration(TestStorage testStorage, boolean deleteCoDuringProcess, boolean zkDeleteClaim, boolean createTopic) {
         LOGGER.info("Finishing migration - applying the {} annotation with value: {}, controllers should be rolled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled");
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getNamespaceName(), testStorage.getClusterName(), kafka -> kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"));
 
@@ -592,9 +588,7 @@ public class MigrationST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, 3, brokerPodsSnapshot);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), controllerSelector, 3, controllerPodsSnapshot);
 
-        if (createTopic) {
-            createKafkaTopicAndCheckMetadataWithMessageTransmission(testStorage, kraftTopicName, false);
-        }
+        createKafkaTopicAndCheckMetadataWithMessageTransmission(testStorage, kraftTopicName, false);
 
         LOGGER.info("Migration is completed, waiting for continuous clients to finish");
         ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), continuousClients.getConsumerName(), continuousClients.getProducerName(), continuousClients.getMessageCount());


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds test for checking the fix of #11262 - so it does the first migration to the `KRaftPostMigration`, rollback it to ZooKeeper, in the meantime it creates and checks the topics. After we are in ZK mode again, the Controllers and their PVCs are deleted, new topic is created and then, we are doing the full migration until the end. 
Finally, once we are fully migrated to KRaft, the test is checking that all the topics created in the meantime are successfully migrated to KRaft.

Resolves #11274 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

