### PR TITLE
Update GitHub actions/cache plugin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,7 +59,7 @@ jobs:
 
     # Setup Maven cache
     - name: Cache local Maven repository
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This small PR fixes issue with deprecation of the GitHub actions/cache plugin, which was fixed on main branch, however it's missing in the `release-0.45.x` branch and because of that the whole CodeQL build fails.

### Checklist

- [ ] Make sure all tests pass

