### PR TITLE
Mount OAuth related client configuration via volume within Kafka Connect

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -97,6 +97,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected static final String EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH = "/opt/kafka/external-configuration/";
     protected static final String EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX = "ext-conf-";
     protected static final String OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/oauth-certs/";
+    protected static final String OAUTH_SECRETS_BASE_VOLUME_MOUNT = "/opt/kafka/oauth/";
     protected static final String KAFKA_CONNECT_CONFIG_VOLUME_NAME = "kafka-connect-configurations";
     protected static final String KAFKA_CONNECT_CONFIG_VOLUME_MOUNT = "/opt/kafka/custom-config/";
 
@@ -114,15 +115,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected static final String ENV_VAR_KAFKA_CONNECT_TRUSTED_CERTS = "KAFKA_CONNECT_TRUSTED_CERTS";
     protected static final String ENV_VAR_KAFKA_CONNECT_TLS_AUTH_CERT = "KAFKA_CONNECT_TLS_AUTH_CERT";
     protected static final String ENV_VAR_KAFKA_CONNECT_TLS_AUTH_KEY = "KAFKA_CONNECT_TLS_AUTH_KEY";
-    protected static final String ENV_VAR_KAFKA_CONNECT_SASL_PASSWORD_FILE = "KAFKA_CONNECT_SASL_PASSWORD_FILE";
-    protected static final String ENV_VAR_KAFKA_CONNECT_SASL_USERNAME = "KAFKA_CONNECT_SASL_USERNAME";
-    protected static final String ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM = "KAFKA_CONNECT_SASL_MECHANISM";
-    protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG = "KAFKA_CONNECT_OAUTH_CONFIG";
-    protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_CLIENT_SECRET = "KAFKA_CONNECT_OAUTH_CLIENT_SECRET";
-    protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_ACCESS_TOKEN = "KAFKA_CONNECT_OAUTH_ACCESS_TOKEN";
-    protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_REFRESH_TOKEN = "KAFKA_CONNECT_OAUTH_REFRESH_TOKEN";
-    protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_PASSWORD_GRANT_PASSWORD = "KAFKA_CONNECT_OAUTH_PASSWORD_GRANT_PASSWORD";
-    protected static final String ENV_VAR_KAFKA_CONNECT_OAUTH_CLIENT_ASSERTION = "KAFKA_CONNECT_OAUTH_CLIENT_ASSERTION";
     protected static final String ENV_VAR_STRIMZI_TRACING = "STRIMZI_TRACING";
 
     protected static final String CO_ENV_VAR_CUSTOM_CONNECT_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS";
@@ -386,7 +378,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         if (tls != null) {
             CertUtils.createTrustedCertificatesVolumes(volumeList, tls.getTrustedCertificates(), isOpenShift);
         }
-        AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift);
+        AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift, "", true);
         volumeList.addAll(getExternalConfigurationVolumes(isOpenShift));
         
         TemplateUtils.addAdditionalVolumes(templatePod, volumeList);
@@ -450,7 +442,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         if (tls != null) {
             CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, tls.getTrustedCertificates(), TLS_CERTS_BASE_VOLUME_MOUNT);
         }
-        AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT, "oauth-certs");
+        AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT, "oauth-certs", "", true, OAUTH_SECRETS_BASE_VOLUME_MOUNT);
         volumeMountList.addAll(getExternalConfigurationVolumeMounts());
 
         TemplateUtils.addAdditionalVolumeMounts(volumeMountList, templateContainer);
@@ -628,6 +620,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
             populateTLSEnvVars(varList);
         }
 
+        // This is still needed to generate oauth truststore certificates in PKCS12 format
         AuthenticationUtils.configureClientAuthenticationEnvVars(authentication, varList, name -> ENV_VAR_PREFIX + name);
 
         if (tracing != null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -128,6 +128,7 @@ class KafkaConnectConfigurationBuilderTest {
     @ParallelTest
     public void testWithPlainAndSaslMechanism() {
         KafkaClientAuthenticationPlain authPlain = new KafkaClientAuthenticationPlainBuilder()
+                .withUsername("user1")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -145,13 +146,13 @@ class KafkaConnectConfigurationBuilderTest {
                 "consumer.security.protocol=SASL_PLAINTEXT",
                 "admin.security.protocol=SASL_PLAINTEXT",
                 "sasl.mechanism=PLAIN",
-                "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "producer.sasl.mechanism=PLAIN",
-                "producer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "producer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "consumer.sasl.mechanism=PLAIN",
-                "consumer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "consumer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "admin.sasl.mechanism=PLAIN",
-                "admin.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};"
+                "admin.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";"
         ));
     }
 
@@ -165,6 +166,7 @@ class KafkaConnectConfigurationBuilderTest {
                 .build();
 
         KafkaClientAuthenticationPlain authPlain = new KafkaClientAuthenticationPlainBuilder()
+                .withUsername("user1")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -192,19 +194,20 @@ class KafkaConnectConfigurationBuilderTest {
                 "admin.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12",
                 "admin.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
                 "sasl.mechanism=PLAIN",
-                "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "producer.sasl.mechanism=PLAIN",
-                "producer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "producer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "consumer.sasl.mechanism=PLAIN",
-                "consumer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "consumer.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "admin.sasl.mechanism=PLAIN",
-                "admin.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};"
+                "admin.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";"
         ));
     }
 
     @ParallelTest
     public void testWithPlainAndScramSha256() {
         KafkaClientAuthenticationScramSha256 authScramSha256 = new KafkaClientAuthenticationScramSha256Builder()
+                .withUsername("my-user")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -222,13 +225,13 @@ class KafkaConnectConfigurationBuilderTest {
                 "consumer.security.protocol=SASL_PLAINTEXT",
                 "admin.security.protocol=SASL_PLAINTEXT",
                 "sasl.mechanism=SCRAM-SHA-256",
-                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "producer.sasl.mechanism=SCRAM-SHA-256",
-                "producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "consumer.sasl.mechanism=SCRAM-SHA-256",
-                "consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "admin.sasl.mechanism=SCRAM-SHA-256",
-                "admin.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};"
+                "admin.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";"
         ));
     }
 
@@ -242,6 +245,7 @@ class KafkaConnectConfigurationBuilderTest {
                 .build();
 
         KafkaClientAuthenticationScramSha256 authScramSha256 = new KafkaClientAuthenticationScramSha256Builder()
+                .withUsername("my-user")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -269,19 +273,20 @@ class KafkaConnectConfigurationBuilderTest {
                 "admin.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12",
                 "admin.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
                 "sasl.mechanism=SCRAM-SHA-256",
-                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "producer.sasl.mechanism=SCRAM-SHA-256",
-                "producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "consumer.sasl.mechanism=SCRAM-SHA-256",
-                "consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "admin.sasl.mechanism=SCRAM-SHA-256",
-                "admin.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};"
+                "admin.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";"
         ));
     }
 
     @ParallelTest
     public void testWithPlainAndScramSha512() {
         KafkaClientAuthenticationScramSha512 authScramSha512 = new KafkaClientAuthenticationScramSha512Builder()
+                .withUsername("my-user")
                 .withNewPasswordSecret()
                     .withSecretName("my-auth-secret")
                     .withPassword("my-password-key")
@@ -299,13 +304,13 @@ class KafkaConnectConfigurationBuilderTest {
                 "consumer.security.protocol=SASL_PLAINTEXT",
                 "admin.security.protocol=SASL_PLAINTEXT",
                 "sasl.mechanism=SCRAM-SHA-512",
-                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "producer.sasl.mechanism=SCRAM-SHA-512",
-                "producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "producer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "consumer.sasl.mechanism=SCRAM-SHA-512",
-                "consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};",
+                "consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";",
                 "admin.sasl.mechanism=SCRAM-SHA-512",
-                "admin.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=${strimzienv:KAFKA_CONNECT_SASL_USERNAME} password=${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key};"
+                "admin.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user\" password=\"${strimzidir:/opt/kafka/connect-password/my-auth-secret:my-password-key}\";"
         ));
     }
 
@@ -324,7 +329,7 @@ class KafkaConnectConfigurationBuilderTest {
                     .withKey("my-refresh-token-key")
                 .endRefreshToken()
                 .withNewAccessToken()
-                    .withSecretName("my-access-token-secret")
+                    .withSecretName("my-refresh-token-secret")
                     .withKey("my-access-token-key")
                 .endAccessToken()
                 .withNewPasswordSecret()
@@ -342,12 +347,15 @@ class KafkaConnectConfigurationBuilderTest {
                 .build();
 
         String saslJaasConfig = "sasl.jaas.config=" +
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${strimzienv:KAFKA_CONNECT_OAUTH_CONFIG}" +
-                " oauth.client.secret=${strimzienv:KAFKA_CONNECT_OAUTH_CLIENT_SECRET}" +
-                " oauth.refresh.token=${strimzienv:KAFKA_CONNECT_OAUTH_REFRESH_TOKEN}" +
-                " oauth.access.token=${strimzienv:KAFKA_CONNECT_OAUTH_ACCESS_TOKEN}" +
-                " oauth.password.grant.password=${strimzienv:KAFKA_CONNECT_OAUTH_PASSWORD_GRANT_PASSWORD}" +
-                " oauth.ssl.truststore.location=\"/tmp/kafka/oauth.truststore.p12\" oauth.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD} oauth.ssl.truststore.type=\"PKCS12\";";
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required" +
+                " oauth.client.id=\"oauth-client-id\"" +
+                " oauth.password.grant.username=\"oauth-username\"" +
+                " oauth.token.endpoint.uri=\"http://token-endpoint-uri\"" +
+                " oauth.client.secret=\"${strimzidir:/opt/kafka/oauth/my-client-secret-secret:my-client-secret-key}\"" +
+                " oauth.refresh.token=\"${strimzidir:/opt/kafka/oauth/my-refresh-token-secret:my-refresh-token-key}\"" +
+                " oauth.access.token=\"${strimzidir:/opt/kafka/oauth/my-refresh-token-secret:my-access-token-key}\"" +
+                " oauth.password.grant.password=\"${strimzidir:/opt/kafka/oauth/my-password-secret-secret:my-password-key}\"" +
+                " oauth.ssl.truststore.location=\"/tmp/kafka/oauth.truststore.p12\" oauth.ssl.truststore.password=\"${strimzienv:CERTS_STORE_PASSWORD}\" oauth.ssl.truststore.type=\"PKCS12\";";
 
         assertThat(configuration, isEquivalent(
                 "bootstrap.servers=my-cluster-kafka-bootstrap:9092",


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Mount OAuth related secrets and use them for configurations, rather than exposing as environment variables and using them for configurations. This is consistent with how it's done for MirrorMaker2 (and the same change is being made for KafkaBrifge). The environment variables will be eventually removed once we use PEM certificates directly for configurations instead of the script generated PKCS certificates for truststore.

Closes https://github.com/strimzi/strimzi-kafka-operator/issues/11227. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

