### PR TITLE
Fix default value typo in README.md

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -108,7 +108,7 @@ the documentation for more details.
 | `defaultImageTag`                           | Default image tag for all the images except Kafka Bridge                        | `latest`                     |
 | `image.registry`                            | Override default Cluster Operator image registry                                | `nil`                        |
 | `image.repository`                          | Override default Cluster Operator image repository                              | `nil`                        |
-| `image.name`                                | Cluster Operator image name                                                     | `cluster-operator`           |
+| `image.name`                                | Cluster Operator image name                                                     | `operator`                   |
 | `image.tag`                                 | Override default Cluster Operator image tag                                     | `nil`                        |
 | `image.digest`                              | Override Cluster Operator image tag with digest                                 | `nil`                        |
 | `image.imagePullPolicy`                     | Image pull policy for all pods deployed by Cluster Operator                     | `IfNotPresent`               |


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
Default value for image.name is operator, not cluster-operator.

### Checklist

Did nothing

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

