### PR TITLE
Clean Azure agent in AZPs before running tests

### DIFF
--- a/.azure/templates/steps/clean_up_workspace.yaml
+++ b/.azure/templates/steps/clean_up_workspace.yaml
@@ -1,0 +1,50 @@
+# Uninstall things that are not needed for running the test, so we clean up memory
+steps:
+  - bash: |
+      sudo apt-get purge --auto-remove dotnet-hostfxr-* || true
+      sudo apt-get purge --auto-remove dotnet-runtime-* || true
+      sudo apt-get purge --auto-remove dotnet-runtime-deps-* || true
+      sudo apt-get purge --auto-remove dotnet-sdk-* || true
+      sudo apt-get purge --auto-remove dotnet-targeting-pack-* || true
+      sudo apt-get purge --auto-remove gcc-* || true
+      sudo apt-get purge --auto-remove cpp-* || true
+      sudo apt-get purge --auto-remove google-chrome-stable || true
+      sudo apt-get purge --auto-remove microsoft-edge-stable || true
+      sudo apt-get purge --auto-remove mysql-server mysql-client mysql-common mysql-server-core-* mysql-client-core-* || true
+      sudo apt-get purge --auto-remove php* || true
+      sudo apt-get purge --auto-remove ruby* || true
+
+      sudo apt-get purge --auto-remove golang* || true
+      sudo apt-get purge --auto-remove perl* || true
+      sudo apt-get purge --auto-remove podman* || true
+      sudo apt-get purge --auto-remove postgresql* || true
+      sudo apt-get purge --auto-remove firefox* || true
+
+      sudo apt-get --purge remove r-base r-base-dev r-recommended r-cran-* || true
+
+      sudo rm -rf /usr/share/dotnet || true
+      sudo rm -rf /usr/local/lib/R || true
+      sudo rm -rf /usr/local/lib/android || true
+      sudo rm -rf /usr/local/lib/nodejs || true
+      sudo rm -rf /opt/ghc || true
+      sudo rm -rf /usr/local/go || true
+      sudo rm -rf /usr/local/aws-cli || true
+      sudo rm -rf /usr/local/aws-sam-cli || true
+      sudo rm -rf /usr/local/games || true
+      sudo rm -rf /usr/share/doc/ || true
+      sudo rm -rf /usr/share/man/ || true
+      sudo rm -rf /usr/share/locale/ || true
+      sudo rm -rf /var/cache/apt/archives || true
+
+      echo "listing /usr/local/lib"
+      sudo ls /usr/local/lib/ || true
+      echo "listing /opt"
+      sudo ls /opt/ || true
+
+      echo "listing /usr/local"
+      sudo ls /usr/local/ || true
+    displayName: "Uninstall unnecessary dependencies and tools"
+  - bash: |
+      docker system prune -af
+      df -h
+    displayName: "Clear the Docker"

--- a/.azure/templates/steps/clean_up_workspace.yaml
+++ b/.azure/templates/steps/clean_up_workspace.yaml
@@ -35,16 +35,7 @@ steps:
       sudo rm -rf /usr/share/man/ || true
       sudo rm -rf /usr/share/locale/ || true
       sudo rm -rf /var/cache/apt/archives || true
-
-      echo "listing /usr/local/lib"
-      sudo ls /usr/local/lib/ || true
-      echo "listing /opt"
-      sudo ls /opt/ || true
-
-      echo "listing /usr/local"
-      sudo ls /usr/local/ || true
     displayName: "Uninstall unnecessary dependencies and tools"
   - bash: |
       docker system prune -af
-      df -h
     displayName: "Clear the Docker"

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -31,6 +31,9 @@ jobs:
     - template: 'default_variables.yaml'
   # Set timeout for jobs
   timeoutInMinutes: ${{ parameters.timeout }}
+  # Clean up whole workspace
+  workspace:
+    clean: all
   # Pipeline steps
   steps:
     - script: echo "##vso[task.setvariable variable=docker_tag]${{ parameters.releaseVersion }}"
@@ -46,6 +49,9 @@ jobs:
 
     # Log variables
     - template: "log_variables.yaml"
+
+    # Clean up unnecessary tools
+    - template: "clean_up_workspace.yaml"
 
     # Get cached Maven repository
     - template: "./maven_cache.yaml"


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds "clean up" of the workspace before running the STs.
Currently, we are hitting situations when we have just 5% of memory left on our agents during the STs.
Agents contain a lot of unused and unnecessary dependencies that are taking a lot of space.

The clean up routine will remove all the unnecessary dependencies and removes the already pre-pulled images from Docker (which should give us some space back as well).

### Checklist

- [x] Make sure all tests pass

