### PR TITLE
[Stretch Cluster] Add stretch cluster feature gate

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
@@ -95,7 +95,7 @@ public class FeatureGates {
     /**
      * @return  Returns true when the StretchCluster feature gate is enabled
      */
-    public boolean UseStretchClusterEnabled() {
+    public boolean useStretchClusterEnabled() {
         return useStretchCluster.isEnabled();
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
@@ -19,10 +19,12 @@ public class FeatureGates {
     /* test */ static final FeatureGates NONE = new FeatureGates("");
 
     private static final String CONTINUE_ON_MANUAL_RU_FAILURE = "ContinueReconciliationOnManualRollingUpdateFailure";
+    private static final String USE_STRETCH_CLUSTER = "UseStretchCluster";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates(), toString(), equals(), and `hashCode() methods
     private final FeatureGate continueOnManualRUFailure =
         new FeatureGate(CONTINUE_ON_MANUAL_RU_FAILURE, true);
+    private final FeatureGate useStretchCluster = new FeatureGate(USE_STRETCH_CLUSTER, false);
 
     /**
      * Constructs the feature gates configuration.
@@ -44,6 +46,9 @@ public class FeatureGates {
                 featureGate = featureGate.substring(1);
 
                 switch (featureGate) {
+                    case USE_STRETCH_CLUSTER:
+                        setValueOnlyOnce(useStretchCluster, value);
+                        break;
                     case CONTINUE_ON_MANUAL_RU_FAILURE:
                         setValueOnlyOnce(continueOnManualRUFailure, value);
                         break;
@@ -88,18 +93,27 @@ public class FeatureGates {
     }
 
     /**
+     * @return  Returns true when the StretchCluster feature gate is enabled
+     */
+    public boolean UseStretchClusterEnabled() {
+        return useStretchCluster.isEnabled();
+    }
+
+
+    /**
      * Returns a list of all Feature gates. Used for testing.
      *
      * @return  List of all Feature Gates
      */
     /*test*/ List<FeatureGate> allFeatureGates()  {
-        return List.of(continueOnManualRUFailure);
+        return List.of(continueOnManualRUFailure, useStretchCluster);
     }
 
     @Override
     public String toString() {
         return "FeatureGates(" +
-                "ContinueReconciliationOnManualRollingUpdateFailure=" + continueOnManualRUFailure.isEnabled() +
+                "ContinueReconciliationOnManualRollingUpdateFailure=" + continueOnManualRUFailure.isEnabled() + "," +
+                "UseStretchCluster=" + useStretchCluster.isEnabled() +
                 ")";
     }
 
@@ -131,13 +145,13 @@ public class FeatureGates {
             return false;
         } else {
             FeatureGates other = (FeatureGates) o;
-            return Objects.equals(continueOnManualRUFailure, other.continueOnManualRUFailure);
+            return Objects.equals(continueOnManualRUFailure, other.continueOnManualRUFailure) && Objects.equals(useStretchCluster, other.useStretchCluster);
         }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(continueOnManualRUFailure);
+        return Objects.hash(continueOnManualRUFailure, useStretchCluster);
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
@@ -57,17 +57,17 @@ public class FeatureGatesTest {
         assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
         assertThat(new FeatureGates("  -ContinueReconciliationOnManualRollingUpdateFailure    ").continueOnManualRUFailureEnabled(), is(false));
 
-        assertThat(new FeatureGates("+UseStretchCluster").UseStretchClusterEnabled(), is(true));
-        assertThat(new FeatureGates("-UseStretchCluster").UseStretchClusterEnabled(), is(false));
-        assertThat(new FeatureGates("  -UseStretchCluster").UseStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("+UseStretchCluster").useStretchClusterEnabled(), is(true));
+        assertThat(new FeatureGates("-UseStretchCluster").useStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("  -UseStretchCluster").useStretchClusterEnabled(), is(false));
 
-        assertThat(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure").UseStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure").useStretchClusterEnabled(), is(false));
         assertThat(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
 
-        assertThat(new FeatureGates("  +UseStretchCluster    ,    +ContinueReconciliationOnManualRollingUpdateFailure").UseStretchClusterEnabled(), is(true));
+        assertThat(new FeatureGates("  +UseStretchCluster    ,    +ContinueReconciliationOnManualRollingUpdateFailure").useStretchClusterEnabled(), is(true));
         assertThat(new FeatureGates("  +UseStretchCluster    ,    +ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(true));
 
-        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").UseStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").useStretchClusterEnabled(), is(false));
         assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").continueOnManualRUFailureEnabled(), is(true));
 
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
@@ -56,6 +56,22 @@ public class FeatureGatesTest {
         assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(true));
         assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
         assertThat(new FeatureGates("  -ContinueReconciliationOnManualRollingUpdateFailure    ").continueOnManualRUFailureEnabled(), is(false));
+
+        assertThat(new FeatureGates("+UseStretchCluster").UseStretchClusterEnabled(), is(true));
+        assertThat(new FeatureGates("-UseStretchCluster").UseStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("  -UseStretchCluster").UseStretchClusterEnabled(), is(false));
+
+        assertThat(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure").UseStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
+
+        assertThat(new FeatureGates("  +UseStretchCluster    ,    +ContinueReconciliationOnManualRollingUpdateFailure").UseStretchClusterEnabled(), is(true));
+        assertThat(new FeatureGates("  +UseStretchCluster    ,    +ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(true));
+
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").UseStretchClusterEnabled(), is(false));
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").continueOnManualRUFailureEnabled(), is(true));
+
+
+
         // TODO: Add more tests with various feature gate combinations once we have multiple feature gates again.
         //       The commented out code below shows the tests we used to have with multiple feature gates.
         //assertThat(new FeatureGates("-UseKRaft,-ContinueReconciliationOnManualRollingUpdateFailure").useKRaftEnabled(), is(false));
@@ -68,10 +84,19 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testFeatureGatesEquals() {
-        FeatureGates fg = new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure");
-        assertThat(fg, is(fg));
-        assertThat(fg, is(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure")));
-        assertThat(fg, is(not(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure"))));
+        FeatureGates fgPositive = new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,+UseStretchCluster");
+        assertThat(fgPositive, is(fgPositive));
+        assertThat(fgPositive, is(new FeatureGates("+UseStretchCluster,+ContinueReconciliationOnManualRollingUpdateFailure")));
+        assertThat(fgPositive, is(not(new FeatureGates("+UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure"))));
+        assertThat(fgPositive, is(not(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure"))));
+        assertThat(fgPositive, is(not(new FeatureGates("-UseStretchCluster,+ContinueReconciliationOnManualRollingUpdateFailure"))));
+
+        FeatureGates fgNegative = new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster");
+        assertThat(fgNegative, is(fgNegative));
+        assertThat(fgNegative, is(new FeatureGates("-UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure")));
+        assertThat(fgNegative, is(not(new FeatureGates("+UseStretchCluster,-ContinueReconciliationOnManualRollingUpdateFailure"))));
+        assertThat(fgNegative, is(not(new FeatureGates("+UseStretchCluster,+ContinueReconciliationOnManualRollingUpdateFailure"))));
+        assertThat(fgNegative, is(not(new FeatureGates("-UseStretchCluster,+ContinueReconciliationOnManualRollingUpdateFailure"))));
     }
 
     @ParallelTest
@@ -117,7 +142,11 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testEnvironmentVariable()   {
         assertThat(new FeatureGates("").toEnvironmentVariable(), is(""));
-        assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure").toEnvironmentVariable(), is("-ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure,+UseStretchCluster").toEnvironmentVariable(), is("-ContinueReconciliationOnManualRollingUpdateFailure,+UseStretchCluster"));
+        assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").toEnvironmentVariable(), is("-ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,+UseStretchCluster").toEnvironmentVariable(), is("+UseStretchCluster"));
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseStretchCluster").toEnvironmentVariable(), is(""));
         assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure").toEnvironmentVariable(), is(""));
+        assertThat(new FeatureGates("+UseStretchCluster").toEnvironmentVariable(), is("+UseStretchCluster"));
     }
 }


### PR DESCRIPTION
### Type of change
- Introduced a 'UseStretchCluster' feature gate

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR enables a feature gate called UseStretchCluster to enable stretch cluster on the strimzi operator. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

Signed-off-by: Rohan Anil Kumar <rohananilpnr@gmail.com>
