### PR TITLE
Add re-try mechanims within signing manifest when using recursive

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -72,11 +72,27 @@ docker_push_manifest_default:
 
 .PHONY: docker_sign_manifest_default
 docker_sign_manifest_default:
-	# Signs the manifest and its images
-	@echo $$COSIGN_PRIVATE_KEY | base64 -d > cosign.key
+	@echo $$COSIGN_PRIVATE_KEY | base64 -d > cosign.key; \
 	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --format '{{ json . }}' | jq -r .manifest.digest); \
-	cosign sign --recursive --tlog-upload=false -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) --key cosign.key $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
-	@rm cosign.key
+	RETRIES=5; \
+	COUNT=0; \
+	while [ $$COUNT -lt $$RETRIES ]; do \
+		cosign sign --recursive --tlog-upload=false \
+			-a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) \
+			--key cosign.key $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST; \
+		if [ $$? -eq 0 ]; then \
+			echo "Cosign succeeded"; \
+			break; \
+		fi; \
+		COUNT=$$((COUNT + 1)); \
+		echo "Retrying... ($$COUNT)"; \
+		sleep 2; \
+	done; \
+	if [ $$COUNT -eq $$RETRIES ]; then \
+		echo "Cosign failed after $$RETRIES attempts"; \
+		exit 1; \
+	fi; \
+	rm cosign.key
 
 .PHONY: docker_delete_manifest_default
 docker_delete_manifest_default:


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

#### Why

Fixes [1]:
```java
Error: signing [quay.io/strimzi/kaniko-executor@sha256:ef1a39c363e145041d80103c3c12da9429ce06cf21dff6fb1fb75d0c0ed9c35b]: recursively signing: signing digest:  context deadline exceeded
main.go:74: error during command execution: signing [quay.io/strimzi/kaniko-executor@sha256:ef1a39c363e145041d80103c3c12da9429ce06cf21dff6fb1fb75d0c0ed9c35b]: recursively signing: signing digest: context deadline exceeded
make[1]: *** [../../Makefile.docker:77: docker_sign_manifest_default] Error 1
make: *** [Makefile:185: docker-images/kaniko-executor] Error 2
make[1]: Leaving directory '/home/vsts/work/1/s/docker-images/kaniko-executor'
```

This PR adds a retry mechanism because of the dozens of problems we hit during signing manifests. I have done only change to https://github.com/strimzi/strimzi-kafka-operator/blob/83236e5335e3ca2f3955d21602ba185cd4bdcbbf/Makefile.docker#L78, because I only saw it fail in that part.

These parts I thin,k should be safe:
https://github.com/strimzi/strimzi-kafka-operator/blob/83236e5335e3ca2f3955d21602ba185cd4bdcbbf/Makefile.docker#L111

and 
https://github.com/strimzi/strimzi-kafka-operator/blob/83236e5335e3ca2f3955d21602ba185cd4bdcbbf/Makefile.docker#L99-L102

[1] - https://dev.azure.com/cncf/strimzi/_build/results?buildId=183956&view=logs&j=3d72a2f4-aa53-5c85-1963-3e9abd2e3bb0&t=16fddc62-1491-5038-9cc9-c79f7f3fde48

### Checklist

- [x] Make sure all tests pass