### PR TITLE
Update restart events to put resource in regarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
 * Update OAuth library to 0.16.2.
 * Update HTTP bridge to 0.32.0.
+* Kubernetes events emitted during a Pod restart updated to have the Kafka resource as the `regardingObject` and the Pod in the `related` field.
 
 ### Major changes, deprecations and removals
 
@@ -45,6 +46,8 @@
   Please use the template section to configure additional volumes instead.
 * Kafka 4.0 and newer is using Log4j2 for logging instead of Reload4j/Log4j1.
   If you have any custom logging configuration, you might need to update it during the upgrade to Kafka 4.0.
+* Kubernetes events for Pod restarts no longer have the Pod as the `regardingObject`.
+  If you are using `regardingObject` as a `field-selector` for listing events you must update the selector to specify the Kafka resource instead.
 
 ## 0.45.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -903,7 +903,7 @@ public class KafkaRoller {
     protected Future<Void> restart(Pod pod, RestartContext restartContext) {
         return podOperations.restart(reconciliation, pod, operationTimeoutMs)
                              .onComplete(i -> vertx.executeBlocking(() -> {
-                                 eventsPublisher.publishRestartEvents(pod, restartContext.restartReasons);
+                                 eventsPublisher.publishRestartEvents(reconciliation, pod, restartContext.restartReasons);
                                  return null;
                              }));
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
@@ -71,7 +71,7 @@ public class KubernetesRestartEventPublisher {
 
         try {
             for (RestartReason reason : reasons) {
-                String note = maybeTruncated(reasons.getNoteFor(reason));
+                String note = maybeTruncated("Rolling Pod " + pod.getMetadata().getName() + " due to " + reasons.getNoteFor(reason));
                 String type = "Normal";
                 String k8sFormattedReason = reason.pascalCased();
                 LOG.debug("Publishing K8s event, time {}, type, {}, reason, {}, note, {}, resource {}, pod, {}",

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
@@ -74,7 +74,7 @@ public class KubernetesRestartEventPublisher {
                 String note = maybeTruncated("Rolling Pod " + pod.getMetadata().getName() + " due to " + reasons.getNoteFor(reason));
                 String type = "Normal";
                 String k8sFormattedReason = reason.pascalCased();
-                LOG.debug("Publishing K8s event, time {}, type, {}, reason, {}, note, {}, resource {}, pod, {}",
+                LOG.debug("Publishing K8s event, time={}, type={}, reason={}, note={}, resource={}, pod={}",
                         k8sEventTime, type, k8sFormattedReason, note, resourceReference, podReference);
                 publishEvent(k8sEventTime, resourceReference, podReference, k8sFormattedReason, type, note);
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
@@ -197,7 +197,7 @@ class KubernetesRestartEventPublisherTest {
         assertThat(publishedEvent.getReason(), is("FileSystemResizeNeeded"));
         assertThat(publishedEvent.getAction(), is("StrimziInitiatedPodRestart"));
         assertThat(publishedEvent.getType(), is("Normal"));
-        assertThat(publishedEvent.getNote(), is(RestartReason.FILE_SYSTEM_RESIZE_NEEDED.getDefaultNote()));
+        assertThat(publishedEvent.getNote(), is("Rolling Pod " + POD_NAME + " due to " + RestartReason.FILE_SYSTEM_RESIZE_NEEDED.getDefaultNote()));
         assertThat(publishedEvent.getEventTime().getTime(), is("2020-10-11T00:00:00.000000Z"));
 
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -555,7 +555,9 @@ public class KubernetesRestartEventsMockTest {
             }
 
             Event restartEvent = maybeEvent.get();
-            assertThat(restartEvent.getRegarding().getName(), is(kafkaPod().getMetadata().getName()));
+            assertThat(restartEvent.getRelated().getName(), is(kafkaPod().getMetadata().getName()));
+            assertThat(restartEvent.getRegarding().getName(), is(CLUSTER_NAME));
+            assertThat(restartEvent.getRegarding().getKind(), is(Kafka.RESOURCE_KIND));
             context.completeNow();
         }));
     }

--- a/documentation/modules/deploying/proc-operator-restart-events.adoc
+++ b/documentation/modules/deploying/proc-operator-restart-events.adoc
@@ -28,10 +28,10 @@ kubectl -n kafka get events --field-selector reportingController=strimzi.io/clus
 .Example showing events returned
 [source,shell]
 ----
-LAST SEEN   TYPE     REASON                   OBJECT                        MESSAGE
-2m          Normal   CaCertRenewed            pod/strimzi-cluster-kafka-0   CA certificate renewed
-58m         Normal   PodForceRestartOnError   pod/strimzi-cluster-kafka-1   Pod needs to be forcibly restarted due to an error
-5m47s       Normal   ManualRollingUpdate      pod/strimzi-cluster-kafka-2   Pod was manually annotated to be rolled
+LAST SEEN   TYPE     REASON                   OBJECT                  MESSAGE
+2m          Normal   CaCertRenewed            kafka/strimzi-cluster   Rolling Pod strimzi-cluster-kafka-0 due to CA certificate renewed
+58m         Normal   PodForceRestartOnError   kafka/strimzi-cluster   Rolling Pod strimzi-cluster-kafka-1 due to Pod needs to be forcibly restarted due to an error
+5m47s       Normal   ManualRollingUpdate      kafka/strimzi-cluster   Rolling Pod strimzi-cluster-kafka-2 due to Pod was manually annotated to be rolled
 ----
 +
 You can also specify a `reason` or other `field-selector` options to constrain the events returned.
@@ -60,12 +60,12 @@ items:
   eventTime: "2022-05-13T00:22:34.168086Z"
   firstTimestamp: null
   involvedObject:
-      kind: Pod
-      name: strimzi-cluster-kafka-1
+      kind: Kafka
+      name: strimzi-cluster
       namespace: kafka
   kind: Event
   lastTimestamp: null
-  message: Pod needs to be forcibly restarted due to an error
+  message: Rolling Pod strimzi-cluster-kafka-1 due to Pod needs to be forcibly restarted due to an error
   metadata:
       creationTimestamp: "2022-05-13T00:22:34Z"
       generateName: strimzi-event
@@ -74,6 +74,10 @@ items:
       resourceVersion: "432961"
       uid: 29fcdb9e-f2cf-4c95-a165-a5efcd48edfc
   reason: PodForceRestartOnError
+  related:
+      kind: Pod
+      name: strimzi-cluster-kafka-1
+      namespace: kafka
   reportingController: strimzi.io/cluster-operator
   reportingInstance: strimzi-cluster-operator-6458cfb4c6-6bpdp
   source: {}

--- a/documentation/modules/deploying/ref-operator-restart-events-fields.adoc
+++ b/documentation/modules/deploying/ref-operator-restart-events-fields.adoc
@@ -10,11 +10,11 @@ When checking restart events from the command line, you can specify a `field-sel
 
 The following fields are available when filtering events with `field-selector`.
 
-`regardingObject.kind`:: The object that was restarted, and for restart events, the kind is always `Pod`.
-`regarding.namespace`:: The namespace that the pod belongs to.
-`regardingObject.name`:: The pod's name, for example, `strimzi-cluster-kafka-0`.
-`regardingObject.uid`:: The unique ID of the pod.
-`reason`:: The reason the pod was restarted, for example, `JbodVolumesChanged`.
+`regardingObject.kind`:: The resource that owns the Pod being restarted, and for restart events, the kind is always `Kafka`.
+`regarding.namespace`:: The namespace that the resource belongs to.
+`regardingObject.name`:: The resource's name, for example, `strimzi-cluster`.
+`regardingObject.uid`:: The unique ID of the resource.
+`reason`:: The reason the Pod was restarted, for example, `JbodVolumesChanged`.
 `reportingController`:: The reporting component is always `strimzi.io/cluster-operator` for Strimzi restart events.
 `source`:: `source` is an older version of `reportingController`. The reporting component is always `strimzi.io/cluster-operator` for Strimzi restart events.
 `type`:: The event type, which is either `Warning` or `Normal`. For Strimzi restart events, the type is `Normal`.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Update restart events to put resource in `regarding` field and move pod being rolled to `related` field.
Implementation of [proposal 101](https://github.com/strimzi/proposals/blob/main/101-redesign-restart-events.md)

Closes #10958

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

