### PR TITLE
docs(mm2): updates the deployment instructions for MirrorMaker 2

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -216,7 +216,8 @@ spec:
 <2> Kafka cluster alias for Kafka Connect, which must specify the *target* Kafka cluster. The Kafka cluster is used by Kafka Connect for its internal topics.
 <3> Specification for the Kafka clusters being synchronized.
 <4> Cluster alias for the source Kafka cluster.
-<5> Authentication for the source cluster, specified as mTLS, token-based OAuth, SASL-based SCRAM-SHA-256/SCRAM-SHA-512, or PLAIN.
+<5> Authentication for the source cluster, specified as `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, or `oauth`.
+For details on configuring authentication, see the link:{BookURLConfiguring}#type-KafkaMirrorMaker2ClusterSpec-schema-reference[`KafkaMirrorMaker2Spec` schema properties^]
 <6> Bootstrap address for connection to the source Kafka cluster. The address takes the format `<cluster_name>-kafka-bootstrap:<port_number>`. The Kafka cluster doesn't need to be managed by Strimzi or deployed to a Kubernetes cluster.
 <7> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
 <8> Cluster alias for the target Kafka cluster.

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -6,7 +6,7 @@
 = Deploying Kafka MirrorMaker to your Kubernetes cluster
 
 [role="_abstract"]
-This procedure shows how to deploy a Kafka MirrorMaker cluster to your Kubernetes cluster using the Cluster Operator.
+This procedure shows how to deploy a Kafka MirrorMaker 2 cluster to your Kubernetes cluster using the Cluster Operator.
 
 The deployment uses a YAML file to provide the specification to create a `KafkaMirrorMaker2` resource.
 MirrorMaker 2 is based on Kafka Connect and uses its configuration properties. 
@@ -16,46 +16,63 @@ In this procedure, we use the following example file:
 
 * `examples/mirror-maker/kafka-mirror-maker-2.yaml`
 
-IMPORTANT: If deploying MirrorMaker 2 clusters to run in parallel, using the same target Kafka cluster, each instance must use unique names for internal Kafka Connect topics. 
-To do this, xref:con-config-mm2-multiple-instances-{context}[configure each MirrorMaker 2 instance to replace the defaults].  
-
 .Prerequisites
 
-* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* Cluster Operator is deployed.
+* Kafka cluster is running.
++
+This procedure assumes that the Kafka cluster was deployed using Strimzi.
 
 .Procedure
 
+. Edit the deployment file to configure connection details (if required). 
++ 
+In `examples/mirror-maker/kafka-mirror-maker-2.yaml`, add or update the following properties as needed: 
++
+* `spec.clusters[].bootstrapServers` to specify the Kafka bootstrap address for the source and target clusters.
+* `spec.clusters[].alias` to specify a unique identifier for each cluster.
+* `spec.clusters[].authentication` to specify the authentication type for each cluster as `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, or `oauth`. +
+See the link:{BookURLConfiguring}#type-KafkaMirrorMaker2ClusterSpec-schema-reference[`KafkaMirrorMaker2Spec` schema properties^] for configuration details.
+* `spec.clusters[].tls.trustedCertificates` to configure the TLS certificate for each cluster. +
+Use `[]` (an empty array) to trust the default Java CAs, or specify secrets containing trusted certificates. +
+See link:{BookURLConfiguring}#con-common-configuration-trusted-certificates-reference[`trustedCertificates` properties^] for configuration details.
+
+. Configure the deployment for multiple MirrorMaker 2 clusters (if required).
++ 
+If you plan to run more than one MirrorMaker 2 cluster in the same environment, each instance must use unique internal topic names and a unique group ID.
++ 
+Update the `spec.clusters[].config` properties in `kafka-mirror-maker-2.yaml` to replace the default values.
++
+See xref:con-config-mm2-multiple-instances-{context}[Configuring multiple MirrorMaker 2 clusters] for details.
+
 . Deploy Kafka MirrorMaker to your Kubernetes cluster:
 +
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 kubectl apply -f examples/mirror-maker/kafka-mirror-maker-2.yaml
 ----
 
 . Check the status of the deployment:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl get pods -n _<my_cluster_operator_namespace>_
+kubectl get pods -n <my_cluster_operator_namespace>
 ----
 +
 .Output shows the deployment name and readiness
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
 NAME                                    READY  STATUS   RESTARTS
 my-mm2-cluster-mirrormaker2-<pod_id>    1/1    Running  1
 ----
 +
-`my-mm2-cluster` is the name of the Kafka MirrorMaker 2 cluster.
-+
-A pod ID identifies each pod created.
-+
-With the default deployment, you install a single MirrorMaker 2 pod.
-+
-`READY` shows the number of replicas that are ready/expected.
-The deployment is successful when the `STATUS` displays as `Running`.
+In this example, `my-mm2-cluster` is the name of the Kafka MirrorMaker 2 cluster.
+A pod ID identifies each created pod.
+By default, the deployment creates a single MirrorMaker 2 pod.
+`READY` shows the number of ready versus expected replicas. 
+The deployment is successful when the `STATUS` is `Running`.
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:con-config-mirrormaker2-str[Kafka MirrorMaker cluster configuration]
+* xref:con-config-mirrormaker2-str[Kafka MirrorMaker 2 cluster configuration]


### PR DESCRIPTION
**Documentation**

Refined MirrorMaker 2 deployment procedure. 
Improved structure, clarified optional configuration for connection and multiple instances.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

