### PR TITLE
fix QuotasOperator javadoc

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
@@ -200,7 +200,9 @@ public class QuotasOperator implements AdminApiOperator<KafkaUserQuotas, Set<Str
     }
 
     /**
-     * @return Set with all usernames which have some ACLs set
+     * Returns the set of usernames that have quota configurations stored in the cache.
+     *
+     * @return A CompletionStage containing a Set of usernames with quotas
      */
     @Override
     public CompletionStage<Set<String>> getAllUsers() {


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes a copy-paste problem with JavaDoc within the QuotasOperator class. It seems it was copied from `SimpleAclOperator`. 

### Checklist

- [x] Make sure all tests pass