### PR TITLE
ST: Make several systemtests checks more resilient

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
@@ -240,7 +240,7 @@ public class NamespaceManager {
      * @param namespaceName name of the Namespace that should be deleted
      */
     private void waitForNamespaceDeletion(String namespaceName) {
-        TestUtils.waitFor("Namespace: " + namespaceName + "to be deleted", TestConstants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT, () -> {
+        TestUtils.waitFor("Namespace: " + namespaceName + " to be deleted", TestConstants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT, () -> {
             Namespace namespace = kubeClient().getNamespace(namespaceName);
 
             if (namespace == null) {
@@ -249,6 +249,9 @@ public class NamespaceManager {
                 LOGGER.debug("There are KafkaTopics with finalizers remaining in Namespace: {}, going to set those finalizers to null", namespaceName);
                 KafkaTopicUtils.setFinalizersInAllTopicsToNull(namespaceName);
             }
+            // Try to delete it once-again in case something is stuck
+            deleteNamespace(namespaceName);
+
             return false;
         });
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
@@ -90,7 +90,7 @@ public class HelmResource implements SpecificResourceType {
         values.put("kafkaBridge.image.tag", bridgeTag);
 
         // Additional config
-        values.put("image.imagePullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY);
+        values.put("image.imagePullPolicy", Environment.COMPONENTS_IMAGE_PULL_POLICY);
         values.put("resources.requests.memory", TestConstants.CO_REQUESTS_MEMORY);
         values.put("resources.requests.cpu", TestConstants.CO_REQUESTS_CPU);
         values.put("resources.limits.memory", TestConstants.CO_LIMITS_MEMORY);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -321,8 +321,8 @@ public class ClientUtils {
     }
 
     private static long timeoutForClientFinishJob(int messagesCount) {
-        // need to add at least 2minutes for finishing the job
-        return (long) messagesCount * 1000 + Duration.ofMinutes(2).toMillis();
+        // need to add at least 3 minutes for finishing the job (due to slow environments)
+        return (long) messagesCount * 1000 + Duration.ofMinutes(3).toMillis();
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftKafkaUpgradeDowngradeST.java
@@ -23,6 +23,7 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -249,13 +250,17 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
 
         if (!isUpgrade) {
             LOGGER.info("Verifying that metadataVersion attribute updated correctly to version {}", initMetadataVersion);
-            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(CLUSTER_NAME)
-                .get().getStatus().getKafkaMetadataVersion().contains(initMetadataVersion), is(true));
+            TestUtils.waitFor(String.format("metadataVersion attribute updated correctly to version %s", initMetadataVersion),
+                TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT,
+                () -> Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(CLUSTER_NAME)
+                    .get().getStatus().getKafkaMetadataVersion().contains(initMetadataVersion));
         } else {
             if (currentMetadataVersion != null) {
                 LOGGER.info("Verifying that metadataVersion attribute updated correctly to version {}", newVersion.metadataVersion());
-                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(CLUSTER_NAME)
-                    .get().getStatus().getKafkaMetadataVersion().contains(newVersion.metadataVersion()), is(true));
+                TestUtils.waitFor(String.format("metadataVersion attribute updated correctly to version %s", newVersion.metadataVersion()),
+                    TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT,
+                    () -> Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(CLUSTER_NAME)
+                        .get().getStatus().getKafkaMetadataVersion().contains(newVersion.metadataVersion()));
             }
         }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During https://github.com/strimzi/strimzi-kafka-operator/pull/11331/ I found that couple of tests are flaky just due to insufficient wait mechanism. I updated the following things as part of this PR:

- `helm` install type now uses proper config for operands image pull policy
- namespace deletion is retried once the check fails to make sure it is not just stuck (hapend form time to time on minikube)
- jobs timeout default value is set to 3 minutes...I don't like this change, but atm I don't know how to properly fix it, because it was clearly just timing issue base don the logs from failures. Maybe we could improve starting mechanism for clients or rewrite wait mechanism a little bit.
- KRaft upgrade tests now use dynamic wait for metadata change
- check for volume names and labels in KafkaST now uses dynamic wait

### Checklist

- [x] Make sure all tests pass

