### PR TITLE
Use more human-readable appender format for STs logs

### DIFF
--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@ name = STConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [T-%.3T] %notEmpty{[%X{testClass}]}%notEmpty{[%X{testMethod}]} %highlight{%-5p} [%c{1}:%L] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [T-%.3T] %highlight{%-5p}%notEmpty{[%X{testClass}]}%notEmpty{[%X{testMethod}]} [%c{1}:%L] %m%n
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
 appender.rolling.fileName = ${env:TEST_LOG_DIR:-target/logs}/strimzi-debug-${env:BUILD_ID:-0}.log
@@ -14,7 +14,7 @@ appender.rolling.policies.size.size=100MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 5
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} [T-%3.3T] %notEmpty{[%X{testClass}]}%notEmpty{[%X{testMethod}]} %highlight{%-5p} [%c{1}:%L] %m%n
+appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} [T-%.3T] %highlight{%-5p}%notEmpty{[%X{testClass}]}%notEmpty{[%X{testMethod}]} [%c{1}:%L] %m%n
 
 rootLogger.level = ${env:STRIMZI_TEST_ROOT_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRef.console.ref = STDOUT

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -139,10 +139,12 @@ public abstract class AbstractST implements TestSeparator {
 
     @BeforeEach
     void setUpTestCase(ExtensionContext extensionContext) {
-        if (extensionContext.getTestClass().isPresent()) {
+        // Check if we execute tests in parallel to update logger appender dynamically
+        boolean parallelEnabled = Boolean.getBoolean("junit.jupiter.execution.parallel.enabled");
+        if (extensionContext.getTestClass().isPresent() && parallelEnabled) {
             ThreadContext.put("testClass", extensionContext.getTestClass().get().getSimpleName());
         }
-        if (extensionContext.getTestMethod().isPresent()) {
+        if (extensionContext.getTestMethod().isPresent() && parallelEnabled) {
             ThreadContext.put("testMethod", extensionContext.getTestMethod().get().getName());
         }
         ResourceManager.setTestContext(extensionContext);
@@ -154,7 +156,9 @@ public abstract class AbstractST implements TestSeparator {
 
     @BeforeAll
     void setUpTestSuite(ExtensionContext extensionContext) {
-        if (extensionContext.getTestClass().isPresent()) {
+        // Check if we execute tests in parallel to update logger appender dynamically
+        boolean parallelEnabled = Boolean.getBoolean("junit.jupiter.execution.parallel.enabled");
+        if (extensionContext.getTestClass().isPresent() && parallelEnabled) {
             ThreadContext.put("testClass", extensionContext.getTestClass().get().getSimpleName());
         }
         ResourceManager.setTestContext(extensionContext);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR change the format of console and rolling appender for system tests to make it more human readable. It adds info which test class and test method calls the log:

```
2025-04-23 07:21:55 [T-92] [UserST] INFO  [DeploymentUtils:180] Waiting for 1 Pod(s) of Deployment: test-suite-namespace/cluster-2ac2af89-scraper to be ready
2025-04-23 07:21:55 [T-92] [UserST] INFO  [DeploymentUtils:183] Deployment: test-suite-namespace/cluster-2ac2af89-scraper is ready
2025-04-23 07:21:55 [T-92] [UserST] INFO  [TestSeparator:37] ############################################################################
2025-04-23 07:21:55 [T-97]  INFO  [TestSeparator:37] ############################################################################
2025-04-23 07:21:55 [T-92] [UserST] INFO  [TestSeparator:38] io.strimzi.systemtest.operators.user.UserST.testCreatingUsersWithSecretPrefix-STARTED
2025-04-23 07:21:55 [T-97]  INFO  [TestSeparator:38] io.strimzi.systemtest.operators.user.UserST.testTlsExternalUserWithQuotas-STARTED
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [AbstractST:106] Not first test we are gonna generate cluster name
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [TestSuiteNamespaceManager:96] Creating Namespace: namespace-0 for TestCase: testCreatingUsersWithSecretPrefix
2025-04-23 07:21:55 [T-172]  INFO  [TestSeparator:37] ############################################################################
2025-04-23 07:21:55 [T-172]  INFO  [TestSeparator:38] io.strimzi.systemtest.operators.user.UserST.testUpdateUser-STARTED
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [NamespaceManager:106] Creating Namespace: namespace-0
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:260] Setting Namespace: namespace-0 to resource: NetworkPolicy/global-network-policy
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:600] Creating/Updating NetworkPolicy namespace-0/global-network-policy
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [NetworkPolicyResource:287] NetworkPolicy successfully set to: true for Namespace: namespace-0
2025-04-23 07:21:55 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [AbstractST:106] Not first test we are gonna generate cluster name
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:260] Setting Namespace: namespace-0 to resource: KafkaNodePool/b-7efe740b
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:600] Creating/Updating KafkaNodePool namespace-0/b-7efe740b
2025-04-23 07:21:55 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [ResourceManager:600] Creating/Updating KafkaUser test-suite-namespace/my-user-1295152100-507152825
2025-04-23 07:21:55 [T-175]  INFO  [TestSeparator:37] ############################################################################
2025-04-23 07:21:55 [T-175]  INFO  [TestSeparator:38] io.strimzi.systemtest.operators.user.UserST.testTlsExternalUser-STARTED
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:260] Setting Namespace: namespace-0 to resource: KafkaNodePool/c-7efe740b
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:600] Creating/Updating KafkaNodePool namespace-0/c-7efe740b
2025-04-23 07:21:55 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [ResourceManager:493] Waiting for KafkaUser: test-suite-namespace/my-user-1295152100-507152825 will have desired state: Ready
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:260] Setting Namespace: namespace-0 to resource: Kafka/cluster-56d6ccde
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:600] Creating/Updating Kafka namespace-0/cluster-56d6ccde
2025-04-23 07:21:55 [T-92] [UserST][testCreatingUsersWithSecretPrefix] INFO  [ResourceManager:493] Waiting for Kafka: namespace-0/cluster-56d6ccde will have desired state: Ready
2025-04-23 07:21:56 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [ResourceManager:504] KafkaUser: test-suite-namespace/my-user-1295152100-507152825 is in desired state: Ready
2025-04-23 07:21:58 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [Exec:451] Command: 'kubectl --namespace test-suite-namespace exec cluster-2ac2af89-scraper-65d5c89dc9-2fr8x -- /bin/bash -c bin/kafka-configs.sh --bootstrap-server cluster-2ac2af89-kafka-bootstrap:9092 --entity-type users --entity-name CN=my-user-1295152100-507152825 --describe' (return code: 0)
2025-04-23 07:21:58 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [KafkaClients:98] Consumer group were not specified going to create the random one
2025-04-23 07:21:58 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [OpenSsl:121] Creating client RSA private key with size of 2048 bits
2025-04-23 07:21:58 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [OpenSsl:138] Creating Certificate Signing Request file
2025-04-23 07:21:58 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [OpenSsl:156] Creating signed certificate file
2025-04-23 07:22:08 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [SecretUtils:48] Waiting for Secret: test-suite-namespace/my-user-1295152100-507152825 to exist
2025-04-23 07:22:08 [T-97] [UserST][testTlsExternalUserWithQuotas] INFO  [SecretUtils:52] Secret: test-suite-namespace/my-user-1295152100-507152825 created
```

it also shrink the thread log format from whole name into `T-<THREAD_ID>` 

Rolling appender: https://artifacts.dev.testing-farm.io/3c2b0297-55b0-4715-8c57-b9ec2fd801a7/work-regression-operatorseb5qos8_/systemtest/tmt/plans/regression-operators/data/logs/logs/strimzi-debug-0.log
Console appender: https://artifacts.dev.testing-farm.io/3c2b0297-55b0-4715-8c57-b9ec2fd801a7/

### Checklist

- [x] Make sure all tests pass
