### PR TITLE
Bump test-clients to 0.11.0

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -197,7 +197,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.9.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.10.0";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -196,8 +196,8 @@ public class Environment {
     private static final String RESOURCE_ALLOCATION_STRATEGY_DEFAULT = "SHARE_MEMORY_FOR_ALL_COMPONENTS";
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
-    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.9.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
+    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "4.0.0";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.11.0";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1080,8 +1080,6 @@ class KafkaST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
-            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -100,8 +100,6 @@ class AlternativeReconcileTriggersST extends AbstractST {
         final KafkaClients continuousClients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
-            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(continuousClients.producerStrimzi(), continuousClients.consumerStrimzi());
@@ -364,8 +362,6 @@ class AlternativeReconcileTriggersST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
-            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());
@@ -507,8 +503,6 @@ class AlternativeReconcileTriggersST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
-            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is bumping the version of test-clients used in STs to 0.11.0.

### Checklist

- [x] Make sure all tests pass
