### PR TITLE
Update Fabric8 Kubernetes Client to 7.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,9 +143,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.1.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.1.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.1.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.2.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.2.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.2.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>


### PR DESCRIPTION
This PR updates the Fabric8 Kubernetes Client to version 7.2.0. 
Other than additional improvements and bugs, it fixes #11386 via https://github.com/fabric8io/kubernetes-client/issues/7037