### PR TITLE
Chery-pick Update Fabric8 Kubernetes Client to 7.2.0 to 0.45.x release branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.1.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.1.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.1.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.2.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.2.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.2.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.16.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.16.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
Trivial PR to cherry-pick the bump of Fabric8 Kubernetes Client to 7.2.0 from PR https://github.com/strimzi/strimzi-kafka-operator/pull/11392 to the 0.45 release branch for the next patch release.