### PR TITLE
docs(volumes): updates JBOD reassignment procedure to include volume cleanup step

### DIFF
--- a/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
@@ -334,3 +334,61 @@ In this example, the log directories for volumes 1 and 2 no longer have partitio
       ]
     }
 ----
+
+. To prevent empty volumes from being used in future rebalances or topic allocations, update the configuration and remove the associated persistent volume claims (PVCs).
+
+.. Update the node pool configuration to exclude the volumes.
++
+WARNING: Before making changes, verify that all partitions have been successfully moved using `kafka-log-dirs.sh`. 
+Removing volumes prematurely can cause data loss.
++
+In this example, volumes 1 and 2 are removed, and only volume 0 is retained:
++
+.Updated node pool configuration with single volume JBOD storage
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 2000Gi
+        deleteClaim: false
+  # ...
+----
+
+.. Delete the unused PVCs:
++
+PVCs are named using the format `data-<id>-<kafka_cluster_name>-kafka-<pod_id>`. 
+You can list them using:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get pvc -n my-project
+----
++
+Then delete the unused PVCs:
++
+[source,shell,subs="+quotes"]
+----
+kubectl delete pvc data-<id>-<kafka_cluster_name>-kafka-<pod_id> -n my-project
+----
++
+NOTE: Deleting a PVC removes the underlying storage unless `deleteClaim: false` is set in the volume configuration.
+
+.. (Optional) Delete the helper pod used earlier:
++
+[source,shell]
+----
+kubectl delete pod helper-pod
+----


### PR DESCRIPTION
**Documentation**

Adds a final step to the "Using Cruise Control to reassign partitions on JBOD disks" procedure. 
The new step covers how to update the node pool configuration and delete unused PVCs after partition reassignment. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

