### PR TITLE
Add AKI on certificate generation for brokers

### DIFF
--- a/certificate-manager/src/main/resources/openssl.conf
+++ b/certificate-manager/src/main/resources/openssl.conf
@@ -48,3 +48,4 @@ req_extensions       = v3_req
 # basicConstraints = critical,CA:true,pathlen:1 may be added programmatically
 # "subjectAltName = @alt_names" may be added programmatically
 # [alt_names] section may be added programmatically
+# "authorityKeyIdentifier = keyid,issuer" may be added programmatically

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
@@ -323,6 +323,9 @@ public class OpenSslCertManagerIT {
         ssl.generateSelfSignedCert(caKey, caCert, caSbj, 365);
         doGenerateSignedCert(caKey, caCert, caSbj, key, csr, cert, store, "123456", subject);
 
+        X509Certificate certificate = loadCertificate(cert);
+        assertThat(certificate.getExtensionValue("2.5.29.35"), is(notNullValue()));
+
         caKey.delete();
         caCert.delete();
         key.delete();


### PR DESCRIPTION
### Type of change

Bugfix

### Description

Closes #11375
This PR changes generation of secrets with alternative names which happens for broker and cruise control certificates (they have IP or DNS name). For them it adds AKI (authorityKeyIdentifier) which is required by Python >=3.13 Before this PR Python scripts failed on connection with exception 
```
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1020)
```
This could be fixed by flag VERIFY_X509_STRICT=false.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

