### PR TITLE
Added json-smart 2.5.2 as dependency to fix CVE-2024-57699 on 0.45.x release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dependency updates (Vert.x 4.5.13, Netty 4.1.118.Final).
 * Fixed bug which may lead to metadata loss within the cluster when restarting a KRaft migration after a previous rollback due to missing `/migration` znode deletion.
+* Fixed CVE-2024-57699 by overriding json-smart dependency with 2.5.2 version. 
 
 ## 0.45.0
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -25,7 +25,7 @@
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
-        <json-smart.version>2.4.9</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
@@ -25,7 +25,7 @@
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
-        <json-smart.version>2.4.9</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <netty.version>4.1.118.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
+        <jsonsmart.version>2.5.2</jsonsmart.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>
 
@@ -727,6 +728,12 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${jayway-jsonpath.version}</version>
+            </dependency>
+            <!-- Transitive override to address CVE-2024-57699. Remove in the future. -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${jsonsmart.version}</version>
             </dependency>
             <!-- The skodjob dependency is required at compile time, not solely in the test scope, due to the creation of custom metrics components. -->
             <dependency>


### PR DESCRIPTION
This PR fixes #11346 on the 0.45.x release branch by bumping json-smart to 2.5.2 in the third party libs (Kafka 3.8.x and 3.9.x) and adding it as part of the dependency management in the main pom.xml to fix the CVE within the cluster operator as well. 
It's going to override the one brought by the old oauth 0.15.0 like this:

```shell
[INFO] +- io.strimzi:kafka-oauth-common:jar:0.15.0:compile
[INFO] |  +- com.nimbusds:nimbus-jose-jwt:jar:9.37.2:compile
[INFO] |  |  \- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile
[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.9.0:compile
[INFO] |     \- net.minidev:json-smart:jar:2.5.2:runtime
[INFO] |        \- net.minidev:accessors-smart:jar:2.5.2:runtime
```

and also within the direct json-path dependency like this:

```shell
[INFO] +- com.jayway.jsonpath:json-path:jar:2.9.0:compile
[INFO] |  \- net.minidev:json-smart:jar:2.5.2:runtime
[INFO] |     \- net.minidev:accessors-smart:jar:2.5.2:runtime
[INFO] |        \- org.ow2.asm:asm:jar:9.7.1:runtime
```