### PR TITLE
Update tiered storage doc for moving to GA

### DIFF
--- a/documentation/modules/configuring/ref-storage-tiered.adoc
+++ b/documentation/modules/configuring/ref-storage-tiered.adoc
@@ -1,12 +1,12 @@
 [id='ref-tiered-storage-{context}']
-= Tiered storage (early access)
+= Tiered storage
 
 [role="_abstract"]
 Tiered storage introduces a flexible approach to managing Kafka data whereby log segments are moved to a separate storage system. 
 For example, you can combine the use of block storage on brokers for frequently accessed data and offload older or less frequently accessed data from the block storage to more cost-effective, scalable remote storage solutions, such as Amazon S3, without compromising data accessibility and durability.
 
-WARNING: Tiered storage is an early access Kafka feature, which is also available in Strimzi. 
-Due to its https://kafka.apache.org/documentation/#tiered_storage_limitation[current limitations^], it is not recommended for production environments. 
+WARNING: Tiered storage is a production ready Kafka feature since Kafka 3.9.0, which is also available in Strimzi.
+Please read the https://kafka.apache.org/documentation/#tiered_storage_limitation[limitations^] of this feature before using it.
 
 Tiered storage requires an implementation of Kafka's `RemoteStorageManager` interface to handle communication between Kafka and the remote storage system, which is enabled through configuration of the `Kafka` resource.
 Strimzi uses Kafka's https://github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java[`TopicBasedRemoteLogMetadataManager`^] for Remote Log Metadata Management (RLMM) when custom tiered storage is enabled.


### PR DESCRIPTION
### Type of change

Update tiered storage doc to mention the feature is moved to production ready [in kafka 3.9.0](https://kafka.apache.org/39/documentation/#upgrade_390_notable).

- Documentation

### Description

Update tiered storage doc to mention the feature is moved to production ready in kafka 3.9.0.

### Checklist


- [ ] Write tests
- [ ] Make sure all tests pass
- [V ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

