### PR TITLE
Fix doc after removal of the example/kraft folder

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-cluster-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster-kraft.adoc
@@ -12,11 +12,11 @@ The deployment uses a YAML file to provide the specification to create a `Kafka`
 
 Strimzi provides the following xref:config-examples-{context}[example deployment files] that you can use to create a Kafka cluster that uses node pools:
 
-`kafka/kraft/kafka-with-dual-role-nodes.yaml`:: Deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.
-`kafka/kraft/kafka-persistent.yaml`:: Deploys a persistent Kafka cluster with one pool of controller nodes and one pool of broker nodes.
-`kafka/kraft/kafka-ephemeral.yaml`:: Deploys an ephemeral Kafka cluster with one pool of controller nodes and one pool of broker nodes.
-`kafka/kraft/kafka-single-node.yaml`:: Deploys a Kafka cluster with a single node.
-`kafka/kraft/kafka-jbod.yaml`:: Deploys a Kafka cluster with multiple volumes in each broker node.
+`kafka/kafka-with-dual-role-nodes.yaml`:: Deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.
+`kafka/kafka-persistent.yaml`:: Deploys a persistent Kafka cluster with one pool of controller nodes and one pool of broker nodes.
+`kafka/kafka-ephemeral.yaml`:: Deploys an ephemeral Kafka cluster with one pool of controller nodes and one pool of broker nodes.
+`kafka/kafka-single-node.yaml`:: Deploys a Kafka cluster with a single node.
+`kafka/kafka-jbod.yaml`:: Deploys a Kafka cluster with multiple volumes in each broker node.
 
 In this procedure, we use the example deployment file that deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Fix #11418: after the `examples/kraft` folder was removed the doc link needs to be fixed.

Also see https://github.com/strimzi/strimzi.github.io/pull/489

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

