### PR TITLE
Fix MirrorMaker 2 client rack init container override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.47.0
 
+* Fixed MirrorMaker 2 client rack init container override being ignored.
 
 ## 0.46.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -139,7 +139,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                 .withJvmOptions(spec.getJvmOptions())
                 .withJmxOptions(spec.getJmxOptions())
                 .withMetricsConfig(spec.getMetricsConfig())
-                .withClientRackInitImage(System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "quay.io/strimzi/operator:latest"))
+                .withClientRackInitImage(spec.getClientRackInitImage())
                 .withRack(spec.getRack())
                 .withTracing(spec.getTracing())
                 .withTemplate(spec.getTemplate())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -19,7 +19,6 @@ import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpecBuilder;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Spec;
-import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.InvalidResourceException;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -86,6 +86,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import static java.util.Collections.singletonMap;
@@ -2243,11 +2244,14 @@ public class KafkaMirrorMaker2ClusterTest {
 
     @ParallelTest
     public void testPodSetWithRack() {
+        String clientRackInitImage = "client-rack-init-image";
+        
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editOrNewSpec()
                     .withNewRack()
                         .withTopologyKey("topology-key")
                     .endRack()
+                    .withClientRackInitImage(clientRackInitImage)
                 .endSpec()
                 .build();
 
@@ -2261,8 +2265,9 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(initContainers, is(notNullValue()));
             assertThat(initContainers.size() > 0, is(true));
 
-            boolean isKafkaInitContainer = initContainers.stream().anyMatch(container -> container.getName().equals(KafkaConnectCluster.INIT_NAME));
-            assertThat(isKafkaInitContainer, is(true));
+            Optional<Container> matchedKafkaInitContainer = initContainers.stream().filter(container -> container.getName().equals(KafkaConnectCluster.INIT_NAME)).findAny();
+            assertThat(matchedKafkaInitContainer.isPresent(), is(true));
+            assertThat(matchedKafkaInitContainer.get().getImage(), is(clientRackInitImage));
         });
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fixes MirrorMaker 2 client rack init container override strimzi#11422

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [X] Update documentation
- [X] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [X] Update CHANGELOG.md
- [X] Supply screenshots for visual changes, such as Grafana dashboards

NOTE: Had some issues executing tests on machine, but I will validate this small change with the pipeline.