### PR TITLE
Enhance CI scripts to better work with arm runners and bump Minikube version

### DIFF
--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -10,6 +10,7 @@ KIND_CLOUD_PROVIDER_VERSION=${KIND_CLOUD_PROVIDER_VERSION:-"v0.6.0"}
 KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"kindest/node:v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b"}
 COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
 DOCKER_CMD="${DOCKER_CMD:-docker}"
+REGISTRY_IMAGE=${REGISTRY_IMAGE:-"registry:2"}
 
 KIND_CLUSTER_NAME="kind-cluster"
 
@@ -388,7 +389,7 @@ if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
     if [ "$($DOCKER_CMD inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
         $DOCKER_CMD run \
           -d --restart=always -p "${hostname}:${reg_port}:5000" --name "${reg_name}" --network "${network_name}" \
-          registry:2
+          ${REGISTRY_IMAGE}
     fi
 
     # Add the registry config to the nodes
@@ -429,7 +430,7 @@ elif [[ "$IP_FAMILY" = "ipv6" ]]; then
     if [ "$($DOCKER_CMD inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
         $DOCKER_CMD run \
           -d --restart=always -p "[${ula_fixed_ipv6}::1]:${reg_port}:5000" --name "${reg_name}" --network "${network_name}" \
-          registry:2
+          ${REGISTRY_IMAGE}
     fi
     # we need to also make a DNS record for docker tag because it seems that such version does not support []:: format
     echo "${ula_fixed_ipv6}::1    ${registry_dns}" >> /etc/hosts

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -64,11 +64,13 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     docker run -d -p 5000:5000 ${MINIKUBE_REGISTRY_IMAGE}
 
     export KUBECONFIG=$HOME/.kube/config
+    # TODO - check if ITs are working with cni=calico
     # We can turn on network polices support by adding the following options --network-plugin=cni --cni=calico
     # We have to allow trafic for ITS when NPs are turned on
     # We can allow NP after Strimzi#4092 which should fix some issues on STs side
-    minikube start --vm-driver=docker --kubernetes-version=${KUBE_VERSION} \
+    minikube start --driver=docker --kubernetes-version=${KUBE_VERSION} \
       --insecure-registry=localhost:5000 --extra-config=apiserver.authorization-mode=Node,RBAC \
+      --cni calico \
       --cpus=${MINIKUBE_CPU} --memory=${MINIKUBE_MEMORY} --force
 
     if [ $? -ne 0 ]
@@ -103,15 +105,8 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
         minikube image load ${ARCH}/registry:2.8.2 gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH}
         minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.0-beta.1,KubeRegistryProxy=google_containers/kube-registry-proxy:0.4-${ARCH}"
         rm -rf kubernetes
-    elif [[ "$ARCH" = "arm64" ]]; then
-        git clone -b v1.9.11 --depth 1 https://github.com/kubernetes/kubernetes.git
-        sed -i 's/:1.11/:1.25.0/' kubernetes/cluster/addons/registry/images/Dockerfile
-        minikube image build -t google_containers/kube-registry-proxy:0.5-SNAPSHOT kubernetes/cluster/addons/registry/images/
-        minikube addons enable registry --images="Registry=arm64v8/registry:2.8.2,KubeRegistryProxy=google_containers/kube-registry-proxy:0.5-SNAPSHOT"
-        rm -rf kubernetes
     else
-
-        minikube addons enable registry --images="KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4"
+        minikube addons enable registry --images="Registry=${MINIKUBE_REGISTRY_IMAGE}"
     fi
 
     minikube addons enable registry-aliases

--- a/.azure/scripts/setup_shellcheck.sh
+++ b/.azure/scripts/setup_shellcheck.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+ARCH=$1
+if [ -z "$ARCH" ] || [ "$ARCH" == "amd64" ]; then
+    ARCH="x86_64"
+fi
+
+if [ "$ARCH" == "arm64" ]; then
+    ARCH="aarch64"
+fi
+
 readonly VERSION="0.9.0"
-wget https://github.com/koalaman/shellcheck/releases/download/v$VERSION/shellcheck-v$VERSION.linux.x86_64.tar.xz -O shellcheck.tar.xz
+wget https://github.com/koalaman/shellcheck/releases/download/v$VERSION/shellcheck-v$VERSION.linux.$ARCH.tar.xz -O shellcheck.tar.xz
 tar xf shellcheck.tar.xz -C /tmp --strip-components 1
 chmod +x /tmp/shellcheck
 sudo mv /tmp/shellcheck /usr/bin

--- a/.azure/templates/steps/prerequisites/install_minikube.yaml
+++ b/.azure/templates/steps/prerequisites/install_minikube.yaml
@@ -4,4 +4,4 @@ steps:
     env:
       TEST_CLUSTER: minikube
       TEST_KUBECTL_VERSION: v1.25.0
-      TEST_MINIKUBE_VERSION: v1.33.1
+      TEST_MINIKUBE_VERSION: v1.35.0


### PR DESCRIPTION


### Type of change

- Enhancement / new feature

### Description

This PR bumps Minikube version to 1.35.0 to bump version of images used for registry addon. It also add option to run `setup_shellcheck.sh` on arm runners.

### Checklist
- [ ] Make sure all tests pass

