### PR TITLE
Provide full qualified name for KubeRegistryProxy for s390x

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -94,7 +94,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
         sed -i 's/:1.11/:1.22.1/' kubernetes/cluster/addons/registry/images/Dockerfile
         docker build --pull -t gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH} kubernetes/cluster/addons/registry/images/
         minikube image load ${ARCH}/registry:2.8.2 gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH}
-        minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.2,KubeRegistryProxy=google_containers/kube-registry-proxy:0.4-${ARCH}"
+        minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.2,KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH}"
         rm -rf kubernetes
     elif [[ "$ARCH" = "ppc64le" ]]; then
         git clone -b v1.9.11 --depth 1 https://github.com/kubernetes/kubernetes.git


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Appending gcr.io to image name as newer minikube/kubernetes version require fully qualified image names. This change is to rectify s390x CI build cc @im-konge 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

