### PR TITLE
Cherry-pick: Add deploymentAnnotations to helm chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -106,6 +106,7 @@ the documentation for more details.
 | `defaultImageRegistry`                      | Default image registry for all the images                                       | `quay.io`                    |
 | `defaultImageRepository`                    | Default image registry for all the images                                       | `strimzi`                    |
 | `defaultImageTag`                           | Default image tag for all the images except Kafka Bridge                        | `0.46.0`                     |
+| `deploymentAnnotations`                     | Annotations for the operator deployment                                         | `{}`                         |
 | `image.registry`                            | Override default Cluster Operator image registry                                | `nil`                        |
 | `image.repository`                          | Override default Cluster Operator image repository                              | `nil`                        |
 | `image.name`                                | Cluster Operator image name                                                     | `operator`                   |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -9,6 +9,10 @@ metadata:
     component: deployment
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}    
 spec:
   replicas: {{ .Values.replicas }}
   {{- if .Values.revisionHistoryLimit }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -41,6 +41,7 @@ affinity: {}
 annotations: {}
 labels: {}
 nodeSelector: {}
+deploymentAnnotations: {}
 priorityClassName: ""
 
 podSecurityContext: {}


### PR DESCRIPTION
### Type of change

Cherry pick PR #11376 to allow deployment annotations to the 0.46 release branch for next patch release

