### PR TITLE
Bump Jaeger version to 1.65.0 to make tests working on Kube 1.33

### DIFF
--- a/systemtest/src/test/resources/tracing/jaeger-instance.yaml
+++ b/systemtest/src/test/resources/tracing/jaeger-instance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   strategy: allInOne
   allInOne:
-    image: 'quay.io/jaegertracing/all-in-one:1.57'
+    image: 'quay.io/jaegertracing/all-in-one:1.65.0'
     options:
       log-level: debug
       query:

--- a/systemtest/src/test/resources/tracing/jaeger-operator.yaml
+++ b/systemtest/src/test/resources/tracing/jaeger-operator.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: observability/jaeger-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     name: jaeger-operator
   name: jaegers.jaegertracing.io
@@ -7280,6 +7280,8 @@ spec:
                           type: string
                         skipLogout:
                           type: boolean
+                        timeout:
+                          type: string
                       type: object
                     options:
                       type: object
@@ -16207,7 +16209,7 @@ spec:
               value: DEBUG
             - name: KAFKA-PROVISIONING-MINIMAL
               value: "true"
-          image: quay.io/jaegertracing/jaeger-operator:1.57.0
+          image: quay.io/jaegertracing/jaeger-operator:1.65.0
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Bump Jaeger version to 1.65.0 used within System tests

### Checklist

- [ ] Make sure all tests pass

