### PR TITLE
Disable CC resource goals when resource capacities are not set.

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import static io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE;
 import static io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS;
 import static io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration.CRUISE_CONTROL_GOALS;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration.generateCruiseControlDefaultPropertiesMap;
 import static java.lang.String.format;
 
 /**
@@ -197,7 +198,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
             result.image = image;
 
             KafkaConfiguration kafkaConfiguration = new KafkaConfiguration(reconciliation, kafkaClusterSpec.getConfig().entrySet());
-            result.updateConfigurationWithDefaults(ccSpec, kafkaConfiguration);
+            result.updateConfigurationWithDefaults(ccSpec, kafkaConfiguration, kafkaBrokerResources);
 
             CruiseControlConfiguration ccConfiguration = result.configuration;
             result.sslEnabled = ccConfiguration.isApiSslEnabled();
@@ -243,8 +244,10 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         }
     }
 
-    private void updateConfigurationWithDefaults(CruiseControlSpec ccSpec, KafkaConfiguration kafkaConfiguration) {
-        Map<String, String> defaultCruiseControlProperties = new HashMap<>(CruiseControlConfiguration.getCruiseControlDefaultPropertiesMap());
+    private void updateConfigurationWithDefaults(CruiseControlSpec ccSpec,
+                                                 KafkaConfiguration kafkaConfiguration,
+                                                 Map<String, ResourceRequirements> kafkaBrokerResources) {
+        Map<String, String> defaultCruiseControlProperties = generateCruiseControlDefaultPropertiesMap(ccSpec.getBrokerCapacity(), kafkaBrokerResources);
         if (kafkaConfiguration.getConfigOption(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR) != null)  {
             defaultCruiseControlProperties.put(CruiseControlConfigurationParameters.SAMPLE_STORE_TOPIC_REPLICATION_FACTOR.getValue(), kafkaConfiguration.getConfigOption(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR));
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacityEntry.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacityEntry.java
@@ -5,9 +5,9 @@
 package io.strimzi.operator.cluster.model.cruisecontrol;
 
 /**
- * Configures the Kafka broker capacity
+ * Configures the Kafka broker capacity entry.
  */
-public class BrokerCapacity {
+public class BrokerCapacityEntry {
     // CC allows specifying a generic "default" broker entry in the capacity configuration to apply to all brokers without a specific broker entry.
     // CC designates the id of this default broker entry as "-1".
     /**
@@ -44,7 +44,7 @@ public class BrokerCapacity {
      * @param inboundNetwork    Inbound network capacity
      * @param outboundNetwork   Outbound network capacity
      */
-    public BrokerCapacity(int brokerId, CpuCapacity cpu, DiskCapacity disk, String inboundNetwork, String outboundNetwork) {
+    public BrokerCapacityEntry(int brokerId, CpuCapacity cpu, DiskCapacity disk, String inboundNetwork, String outboundNetwork) {
         this.id = brokerId;
         this.cpu = cpu;
         this.disk = disk;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaSpec;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.kafka.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.kafka.Storage;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacity;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacityOverride;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec;
 import io.strimzi.operator.cluster.model.NodeRef;
@@ -26,8 +27,14 @@ import io.vertx.core.json.JsonObject;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.CPU;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.DISK;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.INBOUND_NETWORK;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.OUTBOUND_NETWORK;
 
 /**
  * Uses information in a Kafka Custom Resource to generate a capacity configuration file to be used for
@@ -125,7 +132,7 @@ import java.util.TreeMap;
 public class Capacity {
     protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(Capacity.class.getName());
     private final Reconciliation reconciliation;
-    private final TreeMap<Integer, BrokerCapacity> capacityEntries;
+    private final TreeMap<Integer, BrokerCapacityEntry> capacityEntries;
 
     /**
      * Broker capacities key
@@ -138,46 +145,39 @@ public class Capacity {
     public static final String CAPACITY_KEY = "capacity";
 
     /**
-     * Disk key
-     */
-    public static final String DISK_KEY = "DISK";
-
-    /**
-     * CPU key
-     */
-    public static final String CPU_KEY = "CPU";
-
-    /**
-     * Inbound network key
-     */
-    public static final String INBOUND_NETWORK_KEY = "NW_IN";
-
-    /**
-     * Outbound network key
-     */
-    public static final String OUTBOUND_NETWORK_KEY = "NW_OUT";
-
-    /**
      * Resource type
      */
-    public static final String RESOURCE_TYPE = "cpu";
+    public static final String CPU_RESOURCE_REQUIREMENT_TYPE = "cpu";
 
     private static final String KAFKA_MOUNT_PATH = "/var/lib/kafka";
     private static final String KAFKA_LOG_DIR = "kafka-log";
     private static final String BROKER_ID_KEY = "brokerId";
     private static final String DOC_KEY = "doc";
 
+    /**
+     * Represents the type of resource requirement from `Kafka` custom resource.
+     * <p>
+     * This enum is used to distinguish between resource requests and limits for a given resource type
+     * (e.g. CPU or memory).
+     */
     private enum ResourceRequirementType {
+        /**
+         * Represents the resource request value.
+         */
         REQUEST,
+
+        /**
+         * Represents the resource limit value.
+         */
         LIMIT;
 
-        private Quantity getQuantity(ResourceRequirements resources) {
+        private Quantity getCpuQuantity(ResourceRequirements resources) {
             Map<String, Quantity> resourceRequirement = switch (this) {
                 case REQUEST -> resources.getRequests();
                 case LIMIT -> resources.getLimits();
             };
             if (resourceRequirement != null) {
-                return resourceRequirement.get(RESOURCE_TYPE);
+                return resourceRequirement.get(CPU_RESOURCE_REQUIREMENT_TYPE);
             }
             return null;
         }
@@ -205,9 +205,9 @@ public class Capacity {
         processCapacityEntries(spec.getCruiseControl(), kafkaBrokerNodes, kafkaStorage, kafkaBrokerResources);
     }
 
-    private static Integer getResourceRequirement(ResourceRequirements resources, ResourceRequirementType requirementType) {
+    private static Integer getCpuResourceRequirement(ResourceRequirements resources, ResourceRequirementType requirementType) {
         if (resources != null) {
-            Quantity quantity = requirementType.getQuantity(resources);
+            Quantity quantity = requirementType.getCpuQuantity(resources);
             if (quantity != null) {
                 return Quantities.parseCpuAsMilliCpus(quantity.toString());
             }
@@ -215,16 +215,36 @@ public class Capacity {
         return null;
     }
 
+    /**
+     * Checks whether all Kafka broker pods have their CPU resource requests equal to their CPU limits.
+     *
+     * @param kafkaBrokerResources a map of broker pod names to their {@link ResourceRequirements}
+     * @return {@code true} if all brokers have matching CPU requests and limits; {@code false} otherwise
+     */
+    public static boolean cpuRequestsMatchLimits(Map<String, ResourceRequirements> kafkaBrokerResources) {
+        if (kafkaBrokerResources == null) {
+            return false;
+        }
+        for (ResourceRequirements resourceRequirements : kafkaBrokerResources.values()) {
+            Integer request = getCpuResourceRequirement(resourceRequirements, Capacity.ResourceRequirementType.REQUEST);
+            Integer limit = getCpuResourceRequirement(resourceRequirements, Capacity.ResourceRequirementType.LIMIT);
+            if (request == null || !Objects.equals(request, limit)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static CpuCapacity getCpuBasedOnRequirements(ResourceRequirements resourceRequirements) {
-        Integer request = getResourceRequirement(resourceRequirements, ResourceRequirementType.REQUEST);
-        Integer limit = getResourceRequirement(resourceRequirements, ResourceRequirementType.LIMIT);
+        Integer request = getCpuResourceRequirement(resourceRequirements, ResourceRequirementType.REQUEST);
+        Integer limit = getCpuResourceRequirement(resourceRequirements, ResourceRequirementType.LIMIT);
 
         if (request != null) {
             return new CpuCapacity(CpuCapacity.milliCpuToCpu(request));
         } else if (limit != null) {
             return new CpuCapacity(CpuCapacity.milliCpuToCpu(limit));
         } else {
-            return new CpuCapacity(BrokerCapacity.DEFAULT_CPU_CORE_CAPACITY);
+            return new CpuCapacity(BrokerCapacityEntry.DEFAULT_CPU_CORE_CAPACITY);
         }
     }
 
@@ -265,7 +285,7 @@ public class Capacity {
         } else if (bc != null && bc.getInboundNetwork() != null) {
             return getThroughputInKiB(bc.getInboundNetwork());
         } else {
-            return BrokerCapacity.DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
+            return BrokerCapacityEntry.DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
         }
     }
 
@@ -275,7 +295,7 @@ public class Capacity {
         } else if (bc != null && bc.getOutboundNetwork() != null) {
             return getThroughputInKiB(bc.getOutboundNetwork());
         } else {
-            return BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
+            return BrokerCapacityEntry.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
         }
     }
 
@@ -317,7 +337,7 @@ public class Capacity {
             if (((EphemeralStorage) storage).getSizeLimit() != null) {
                 return DiskCapacity.of(getSizeInMiB(((EphemeralStorage) storage).getSizeLimit()));
             } else {
-                return DiskCapacity.of(BrokerCapacity.DEFAULT_DISK_CAPACITY_IN_MIB);
+                return DiskCapacity.of(BrokerCapacityEntry.DEFAULT_DISK_CAPACITY_IN_MIB);
             }
         } else if (storage == null) {
             throw new IllegalStateException("The storage declaration is missing");
@@ -335,7 +355,7 @@ public class Capacity {
      */
     private static String getSizeInMiB(String size) {
         if (size == null) {
-            return BrokerCapacity.DEFAULT_DISK_CAPACITY_IN_MIB;
+            return BrokerCapacityEntry.DEFAULT_DISK_CAPACITY_IN_MIB;
         }
         return String.valueOf(StorageUtils.convertTo(size, "Mi"));
     }
@@ -353,7 +373,7 @@ public class Capacity {
     }
 
     private void processCapacityEntries(CruiseControlSpec spec, Set<NodeRef> kafkaBrokerNodes, Map<String, Storage> kafkaStorage, Map<String, ResourceRequirements> kafkaBrokerResources) {
-        io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacity brokerCapacity = spec.getBrokerCapacity();
+        BrokerCapacity brokerCapacity = spec.getBrokerCapacity();
 
         String inboundNetwork = processInboundNetwork(brokerCapacity, null);
         String outboundNetwork = processOutboundNetwork(brokerCapacity, null);
@@ -363,7 +383,7 @@ public class Capacity {
             DiskCapacity disk = processDisk(kafkaStorage.get(node.poolName()), node.nodeId());
             CpuCapacity cpu = processCpu(null, brokerCapacity, kafkaBrokerResources.get(node.poolName()));
 
-            BrokerCapacity broker = new BrokerCapacity(node.nodeId(), cpu, disk, inboundNetwork, outboundNetwork);
+            BrokerCapacityEntry broker = new BrokerCapacityEntry(node.nodeId(), cpu, disk, inboundNetwork, outboundNetwork);
             capacityEntries.put(node.nodeId(), broker);
         }
 
@@ -382,12 +402,12 @@ public class Capacity {
                         inboundNetwork = processInboundNetwork(brokerCapacity, override);
                         outboundNetwork = processOutboundNetwork(brokerCapacity, override);
                         for (int id : ids) {
-                            if (id == BrokerCapacity.DEFAULT_BROKER_ID) {
+                            if (id == BrokerCapacityEntry.DEFAULT_BROKER_ID) {
                                 LOGGER.warnCr(reconciliation, "Ignoring broker capacity override with illegal broker id -1.");
                             } else {
                                 if (capacityEntries.containsKey(id)) {
                                     if (overrideIds.add(id)) {
-                                        BrokerCapacity brokerCapacityEntry = capacityEntries.get(id);
+                                        BrokerCapacityEntry brokerCapacityEntry = capacityEntries.get(id);
                                         brokerCapacityEntry.setCpu(processCpu(override, brokerCapacity, kafkaBrokerResources.get(Integer.toString(id))));
                                         brokerCapacityEntry.setInboundNetwork(inboundNetwork);
                                         brokerCapacityEntry.setOutboundNetwork(outboundNetwork);
@@ -411,14 +431,14 @@ public class Capacity {
      * @param brokerCapacity Broker capacity object
      * @return Broker entry as a JsonObject
      */
-    private JsonObject generateBrokerCapacity(BrokerCapacity brokerCapacity) {
+    private JsonObject generateBrokerCapacityEntry(BrokerCapacityEntry brokerCapacity) {
         return new JsonObject()
             .put(BROKER_ID_KEY, brokerCapacity.getId())
             .put(CAPACITY_KEY, new JsonObject()
-                .put(DISK_KEY, brokerCapacity.getDisk().getJson())
-                .put(CPU_KEY, brokerCapacity.getCpu().getJson())
-                .put(INBOUND_NETWORK_KEY, brokerCapacity.getInboundNetwork())
-                .put(OUTBOUND_NETWORK_KEY, brokerCapacity.getOutboundNetwork())
+                .put(DISK.getKey(), brokerCapacity.getDisk().getJson())
+                .put(CPU.getKey(), brokerCapacity.getCpu().getJson())
+                .put(INBOUND_NETWORK.getKey(), brokerCapacity.getInboundNetwork())
+                .put(OUTBOUND_NETWORK.getKey(), brokerCapacity.getOutboundNetwork())
             )
             .put(DOC_KEY, brokerCapacity.getDoc());
     }
@@ -430,8 +450,8 @@ public class Capacity {
      */
     public JsonObject generateCapacityConfig() {
         JsonArray brokerList = new JsonArray();
-        for (BrokerCapacity brokerCapacity : capacityEntries.values()) {
-            JsonObject brokerEntry = generateBrokerCapacity(brokerCapacity);
+        for (BrokerCapacityEntry brokerCapacity : capacityEntries.values()) {
+            JsonObject brokerEntry = generateBrokerCapacityEntry(brokerCapacity);
             brokerList.add(brokerEntry);
         }
 
@@ -449,7 +469,7 @@ public class Capacity {
     /**
      * @return  Capacity entries
      */
-    public TreeMap<Integer, BrokerCapacity> getCapacityEntries() {
+    public TreeMap<Integer, BrokerCapacityEntry> getCapacityEntries() {
         return capacityEntries;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CapacityResourceType.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CapacityResourceType.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacity;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacityOverride;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Enum representing the various types of resource capacities used in Cruise Control configuration.
+ * Each enum constant maps to a specific resource type (e.g. CPU, Disk, Network), with methods for
+ * retrieving configured values from both default broker capacity and broker-specific overrides.
+ */
+public enum CapacityResourceType {
+    /**
+     * Disk capacity configuration.
+     * <p>
+     * Note: Disk capacity does not support default values and broker-specific overrides.
+     */
+    DISK("DISK",  null, null),
+
+    /**
+     * CPU capacity configuration.
+     * <p>
+     * Supports default values and broker-specific overrides.
+     */
+    CPU("CPU", BrokerCapacity::getCpu, BrokerCapacityOverride::getCpu),
+
+    /**
+     * Inbound network capacity configuration.
+     * <p>
+     * Supports default values and broker-specific overrides.
+     */
+    INBOUND_NETWORK("NW_IN", BrokerCapacity::getInboundNetwork, BrokerCapacityOverride::getInboundNetwork),
+
+    /**
+     * Outbound network capacity configuration.
+     * <p>
+     * Supports default values and broker-specific overrides.
+     */
+    OUTBOUND_NETWORK("NW_OUT", BrokerCapacity::getOutboundNetwork, BrokerCapacityOverride::getOutboundNetwork);
+
+    private final String key;
+    private final Function<BrokerCapacity, Object> defaultCapacityGetter;
+    private final Function<BrokerCapacityOverride, Object> defaultOverrideGetter;
+
+    CapacityResourceType(String key,
+                         Function<BrokerCapacity, Object> brokerDefaultGetter,
+                         Function<BrokerCapacityOverride, Object> overrideGetter) {
+        this.key = key;
+        this.defaultCapacityGetter = brokerDefaultGetter;
+        this.defaultOverrideGetter = overrideGetter;
+    }
+
+    /**
+     * Returns the string key associated with this resource type, as used in Cruise Control capacity JSON
+     * (e.g., "CPU", "DISK", "NW_IN", "NW_OUT").
+     *
+     * @return the string key identifying this resource type
+     */
+    public String getKey() {
+        return key;
+    }
+
+    private Object getCapacityDefault(BrokerCapacity brokerCapacity) {
+        return defaultCapacityGetter.apply(brokerCapacity);
+    }
+
+    private Object getCapacityOverride(BrokerCapacityOverride override) {
+        return defaultOverrideGetter.apply(override);
+    }
+
+    /**
+     * Checks whether this resource type has its capacity properly configured.
+     * <p>
+     * The configuration can come from:
+     * <ul>
+     *     <li>The default capacity defined in the {@link BrokerCapacity} section of the Cruise Control spec</li>
+     *     <li>Broker-specific overrides, where each override must define a value for this resource type</li>
+     *     <li>For {@link #CPU}, it may also be configured via Kafka custom resource resource requests and limits.
+     * </ul>
+     *
+     * @param brokerCapacity The brokerCapacity section of the Cruise Control specification from the Kafka custom resource.
+     * @param kafkaBrokerResources A map of broker IDs to their Kubernetes resource requirements
+     * @return {@code true} if the capacity for this resource type is considered configured, otherwise {@code false}
+     */
+    public boolean isCapacityConfigured(BrokerCapacity brokerCapacity, Map<String, ResourceRequirements> kafkaBrokerResources) {
+        if (this == CPU && Capacity.cpuRequestsMatchLimits(kafkaBrokerResources)) {
+            return true;
+        }
+
+        if (brokerCapacity == null) {
+            return false;
+        }
+
+        if (getCapacityDefault(brokerCapacity) != null) {
+            return true;
+        }
+
+        List<BrokerCapacityOverride> overrides = brokerCapacity.getOverrides();
+        return overrides != null && overrides.stream().allMatch(o -> getCapacityOverride(o) != null);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-
 package io.strimzi.operator.cluster.model.cruisecontrol;
 
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacity;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec;
 import io.strimzi.operator.cluster.model.AbstractConfiguration;
 import io.strimzi.operator.cluster.model.CruiseControl;
@@ -12,11 +13,15 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.CPU;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.INBOUND_NETWORK;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.OUTBOUND_NETWORK;
 
 /**
  * Class for handling Cruise Control configuration passed by the user
@@ -43,6 +48,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             CruiseControlGoals.CPU_USAGE_DISTRIBUTION_GOAL.toString(),
             CruiseControlGoals.TOPIC_REPLICA_DISTRIBUTION_GOAL.toString(),
             CruiseControlGoals.LEADER_REPLICA_DISTRIBUTION_GOAL.toString(),
+            // TODO: Take a closer look at the required conditions for this function to work properly
             CruiseControlGoals.LEADER_BYTES_IN_DISTRIBUTION_GOAL.toString(),
             CruiseControlGoals.PREFERRED_LEADER_ELECTION_GOAL.toString()
     );
@@ -65,8 +71,6 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             CruiseControlGoals.CPU_CAPACITY_GOAL.toString()
     );
 
-    private static final String CRUISE_CONTROL_HARD_GOALS = String.join(",", CRUISE_CONTROL_HARD_GOALS_LIST);
-
     protected static final List<String> CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST = List.of(
             CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
             CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
@@ -81,26 +85,34 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             String.join(",", CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST);
 
     /**
-     * Map containing default values for required configuration properties. The map needs to be sorted so that the order
+     * Generates map containing default values for required configuration properties. The map needs to be sorted so that the order
      * of the entries in the Cruise Control configuration is deterministic and does not cause unnecessary rolling updates
      * of Cruise Control deployment.
+     *
+     * @param brokerCapacity The brokerCapacity of the Cruise Control spec.
+     * @param kafkaBrokerResources A map with resource configuration used by the Kafka cluster and its broker pools.
+     *
+     * @return Map containing default values for required configuration properties.
      */
-    private static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP = Collections.unmodifiableSortedMap(new TreeMap<>(Map.ofEntries(
-            Map.entry(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
-            Map.entry(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1"),
-            Map.entry(CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
-            Map.entry(CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "20"),
-            Map.entry(CruiseControlConfigurationParameters.COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(), Long.toString(TimeUnit.DAYS.toMillis(1))),
-            Map.entry(CruiseControlConfigurationParameters.GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
-            Map.entry(CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
-            Map.entry(CruiseControlConfigurationParameters.HARD_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_HARD_GOALS),
-            Map.entry(CruiseControlConfigurationParameters.WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED)),
-            Map.entry(CruiseControlConfigurationParameters.WEBSERVER_AUTH_CREDENTIALS_FILE.getValue(), CruiseControl.API_AUTH_CREDENTIALS_FILE),
-            Map.entry(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED)),
-            Map.entry(CruiseControlConfigurationParameters.PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME),
-            Map.entry(CruiseControlConfigurationParameters.BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME),
-            Map.entry(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)
-    )));
+    public static Map<String, String> generateCruiseControlDefaultPropertiesMap(BrokerCapacity brokerCapacity,
+                                                                                Map<String, ResourceRequirements> kafkaBrokerResources) {
+        TreeMap<String, String> map = new TreeMap<>();
+        map.put(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000));
+        map.put(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1");
+        map.put(CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000));
+        map.put(CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "20");
+        map.put(CruiseControlConfigurationParameters.COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(), Long.toString(TimeUnit.DAYS.toMillis(1)));
+        map.put(CruiseControlConfigurationParameters.GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS);
+        map.put(CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY.getValue(), String.join(",", filterResourceGoalsWithoutCapacityConfig(CRUISE_CONTROL_GOALS_LIST, brokerCapacity, kafkaBrokerResources)));
+        map.put(CruiseControlConfigurationParameters.HARD_GOALS_CONFIG_KEY.getValue(), String.join(",", filterResourceGoalsWithoutCapacityConfig(CRUISE_CONTROL_HARD_GOALS_LIST, brokerCapacity, kafkaBrokerResources)));
+        map.put(CruiseControlConfigurationParameters.WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED));
+        map.put(CruiseControlConfigurationParameters.WEBSERVER_AUTH_CREDENTIALS_FILE.getValue(), CruiseControl.API_AUTH_CREDENTIALS_FILE);
+        map.put(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED));
+        map.put(CruiseControlConfigurationParameters.PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME);
+        map.put(CruiseControlConfigurationParameters.BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME);
+        map.put(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME);
+        return map;
+    }
 
     private static final List<String> FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
     private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
@@ -118,10 +130,33 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * @return Map Cruise Control's default configuration properties
+     * Filters out Cruise Control resource goals if the necessary resource capacity settings are not defined in
+     * the user's Kafka custom resource.
+     *
+     * @param goalList The initial list of supported Cruise Control goals.
+     * @param brokerCapacity The brokerCapacity section of the Cruise Control specification from the Kafka custom resource.
+     * @param kafkaBrokerResources The map of Kafka broker resource definitions (e.g., CPU requests/limits)
+     * @return A new list containing only the goals that are safe to enable given the configured capacities.
      */
-    public static Map<String, String> getCruiseControlDefaultPropertiesMap() {
-        return CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
+    /* test */ static List<String> filterResourceGoalsWithoutCapacityConfig(List<String> goalList,
+                                                                            BrokerCapacity brokerCapacity,
+                                                                            Map<String, ResourceRequirements> kafkaBrokerResources) {
+        List<String> filteredGoalList = new ArrayList<>(goalList);
+        if (!INBOUND_NETWORK.isCapacityConfigured(brokerCapacity, kafkaBrokerResources)) {
+            filteredGoalList.remove(CruiseControlGoals.NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL.toString());
+            filteredGoalList.remove(CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL.toString());
+        }
+        if (!OUTBOUND_NETWORK.isCapacityConfigured(brokerCapacity, kafkaBrokerResources)) {
+            filteredGoalList.remove(CruiseControlGoals.NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL.toString());
+            filteredGoalList.remove(CruiseControlGoals.NETWORK_OUTBOUND_CAPACITY_GOAL.toString());
+            filteredGoalList.remove(CruiseControlGoals.POTENTIAL_NETWORK_OUTAGE_GOAL.toString());
+        }
+        if (!CPU.isCapacityConfigured(brokerCapacity, kafkaBrokerResources)) {
+            filteredGoalList.remove(CruiseControlGoals.CPU_CAPACITY_GOAL.toString());
+            filteredGoalList.remove(CruiseControlGoals.CPU_USAGE_DISTRIBUTION_GOAL.toString());
+        }
+
+        return filteredGoalList;
     }
 
     private boolean isEnabledInConfiguration(String s1, String s2) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -56,7 +56,7 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.cruisecontrol.BrokerCapacity;
+import io.strimzi.operator.cluster.model.cruisecontrol.BrokerCapacityEntry;
 import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
 import io.strimzi.operator.cluster.model.cruisecontrol.CpuCapacity;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
@@ -87,6 +87,10 @@ import java.util.Properties;
 import java.util.Set;
 
 import static io.strimzi.operator.cluster.model.CruiseControl.API_HEALTHCHECK_PATH;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.CPU;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.DISK;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.INBOUND_NETWORK;
+import static io.strimzi.operator.cluster.model.cruisecontrol.CapacityResourceType.OUTBOUND_NETWORK;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters.ANOMALY_DETECTION_CONFIG_KEY;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY;
 import static java.lang.String.format;
@@ -171,7 +175,7 @@ public class CruiseControlTest {
                 .endSpec()
                 .build();
         Map<String, Storage> storage = Map.of("brokers", new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("50Gi").build(), new PersistentClaimStorageBuilder().withId(1).withSize("60Gi").build()).build());
-        Map<String, ResourceRequirements> resources = Map.of("brokers", new ResourceRequirementsBuilder().withRequests(Map.of(Capacity.RESOURCE_TYPE, new Quantity("400m"))).withLimits(Map.of(Capacity.RESOURCE_TYPE, new Quantity("0.5"))).build());
+        Map<String, ResourceRequirements> resources = Map.of("brokers", new ResourceRequirementsBuilder().withRequests(Map.of(Capacity.CPU_RESOURCE_REQUIREMENT_TYPE, new Quantity("400m"))).withLimits(Map.of(Capacity.CPU_RESOURCE_REQUIREMENT_TYPE, new Quantity("0.5"))).build());
         CruiseControl cc = createCruiseControl(kafka, NODES, storage, resources);
 
         ConfigMap configMap = cc.generateConfigMap(new MetricsAndLogging(null, null));
@@ -180,8 +184,8 @@ public class CruiseControlTest {
 
         for (Object brokerEntry : brokerEntries) {
             JsonObject brokerCapacity = ((JsonObject) brokerEntry).getJsonObject(Capacity.CAPACITY_KEY);
-            Object diskCapacity = brokerCapacity.getValue(Capacity.DISK_KEY);
-            JsonObject cpuCapacity  = brokerCapacity.getJsonObject(Capacity.CPU_KEY);
+            Object diskCapacity = brokerCapacity.getValue(DISK.getKey());
+            JsonObject cpuCapacity  = brokerCapacity.getJsonObject(CPU.getKey());
 
             assertThat(isJBOD(diskCapacity), is(true));
             assertThat(cpuCapacity, is(expectedCpuCapacity));
@@ -226,7 +230,7 @@ public class CruiseControlTest {
                 .endSpec()
                 .build();
         Map<String, Storage> storage = Map.of("brokers", new PersistentClaimStorageBuilder().withId(0).withSize("50Gi").build());
-        Map<String, ResourceRequirements> resources = Map.of("brokers", new ResourceRequirementsBuilder().withRequests(Map.of(Capacity.RESOURCE_TYPE, new Quantity("400m"))).withLimits(Map.of(Capacity.RESOURCE_TYPE, new Quantity("0.5"))).build());
+        Map<String, ResourceRequirements> resources = Map.of("brokers", new ResourceRequirementsBuilder().withRequests(Map.of(Capacity.CPU_RESOURCE_REQUIREMENT_TYPE, new Quantity("400m"))).withLimits(Map.of(Capacity.CPU_RESOURCE_REQUIREMENT_TYPE, new Quantity("0.5"))).build());
         CruiseControl cc = createCruiseControl(kafka, NODES, storage, resources);
 
         ConfigMap configMap = cc.generateConfigMap(new MetricsAndLogging(null, null));
@@ -235,25 +239,25 @@ public class CruiseControlTest {
 
         for (Object brokerEntry : brokerEntries) {
             JsonObject brokerCapacity = ((JsonObject) brokerEntry).getJsonObject(Capacity.CAPACITY_KEY);
-            Object diskCapacity = brokerCapacity.getValue(Capacity.DISK_KEY);
+            Object diskCapacity = brokerCapacity.getValue(DISK.getKey());
 
             assertThat(isJBOD(diskCapacity), is(false));
         }
 
         JsonObject brokerEntry0 = brokerEntries.getJsonObject(broker0).getJsonObject(Capacity.CAPACITY_KEY);
-        assertThat(brokerEntry0.getJsonObject(Capacity.CPU_KEY), is(new CpuCapacity(userDefinedCpuCapacityOverride0).getJson()));
-        assertThat(brokerEntry0.getString(Capacity.INBOUND_NETWORK_KEY), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
-        assertThat(brokerEntry0.getString(Capacity.OUTBOUND_NETWORK_KEY), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        assertThat(brokerEntry0.getJsonObject(CPU.getKey()), is(new CpuCapacity(userDefinedCpuCapacityOverride0).getJson()));
+        assertThat(brokerEntry0.getString(INBOUND_NETWORK.getKey()), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(brokerEntry0.getString(OUTBOUND_NETWORK.getKey()), is(BrokerCapacityEntry.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
         // When the same broker id is specified in brokers list of multiple overrides, use the value specified in the first override.
         JsonObject brokerEntry1 = brokerEntries.getJsonObject(broker1).getJsonObject(Capacity.CAPACITY_KEY);
-        assertThat(brokerEntry1.getJsonObject(Capacity.CPU_KEY), is(new CpuCapacity(userDefinedCpuCapacityOverride0).getJson()));
-        assertThat(brokerEntry1.getString(Capacity.INBOUND_NETWORK_KEY), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
-        assertThat(brokerEntry1.getString(Capacity.OUTBOUND_NETWORK_KEY), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        assertThat(brokerEntry1.getJsonObject(CPU.getKey()), is(new CpuCapacity(userDefinedCpuCapacityOverride0).getJson()));
+        assertThat(brokerEntry1.getString(INBOUND_NETWORK.getKey()), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(brokerEntry1.getString(OUTBOUND_NETWORK.getKey()), is(BrokerCapacityEntry.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
         JsonObject brokerEntry2 = brokerEntries.getJsonObject(broker2).getJsonObject(Capacity.CAPACITY_KEY);
-        assertThat(brokerEntry2.getJsonObject(Capacity.CPU_KEY), is(new CpuCapacity(userDefinedCpuCapacityOverride0).getJson()));
-        assertThat(brokerEntry2.getString(Capacity.INBOUND_NETWORK_KEY), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(brokerEntry2.getJsonObject(CPU.getKey()), is(new CpuCapacity(userDefinedCpuCapacityOverride0).getJson()));
+        assertThat(brokerEntry2.getString(INBOUND_NETWORK.getKey()), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
     }
 
     @ParallelTest
@@ -293,7 +297,7 @@ public class CruiseControlTest {
                 .endSpec()
                 .build();
         Map<String, Storage> storage = Map.of("brokers", new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("50Gi").build(), new PersistentClaimStorageBuilder().withId(1).withSize("60Gi").build()).build());
-        Map<String, ResourceRequirements> resources = Map.of("brokers", new ResourceRequirementsBuilder().withRequests(Map.of(Capacity.RESOURCE_TYPE, new Quantity("500m"))).withLimits(Map.of(Capacity.RESOURCE_TYPE, new Quantity("0.5"))).build());
+        Map<String, ResourceRequirements> resources = Map.of("brokers", new ResourceRequirementsBuilder().withRequests(Map.of(Capacity.CPU_RESOURCE_REQUIREMENT_TYPE, new Quantity("500m"))).withLimits(Map.of(Capacity.CPU_RESOURCE_REQUIREMENT_TYPE, new Quantity("0.5"))).build());
         CruiseControl cc = createCruiseControl(kafka, NODES, storage, resources);
 
         ConfigMap configMap = cc.generateConfigMap(new MetricsAndLogging(null, null));
@@ -302,7 +306,7 @@ public class CruiseControlTest {
         JsonArray brokerEntries = capacity.getJsonArray(Capacity.CAPACITIES_KEY);
         for (Object brokerEntry : brokerEntries) {
             JsonObject brokerCapacity = ((JsonObject) brokerEntry).getJsonObject(Capacity.CAPACITY_KEY);
-            JsonObject cpuCapacity  = brokerCapacity.getJsonObject(Capacity.CPU_KEY);
+            JsonObject cpuCapacity  = brokerCapacity.getJsonObject(CPU.getKey());
             assertThat(cpuCapacity, is(expectedCpuCapacity));
         }
     }
@@ -337,49 +341,49 @@ public class CruiseControlTest {
         // Broker 0
         JsonObject brokerEntry = brokerEntries.getJsonObject(0);
         assertThat(brokerEntry.getInteger("brokerId"), is(0));
-        JsonObject brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY);
+        JsonObject brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey());
         assertThat(brokerCpuCapacity.getString("num.cores"), is("4.0"));
-        JsonObject brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.DISK_KEY);
+        JsonObject brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(DISK.getKey());
         assertThat(brokerDiskCapacity.getString("/var/lib/kafka/data-0/kafka-log0"), is("102400.0"));
 
         // Broker 1
         brokerEntry = brokerEntries.getJsonObject(1);
         assertThat(brokerEntry.getInteger("brokerId"), is(1));
-        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY);
+        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey());
         assertThat(brokerCpuCapacity.getString("num.cores"), is("4.0"));
-        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.DISK_KEY);
+        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(DISK.getKey());
         assertThat(brokerDiskCapacity.getString("/var/lib/kafka/data-0/kafka-log1"), is("102400.0"));
 
         // Broker 2
         brokerEntry = brokerEntries.getJsonObject(2);
         assertThat(brokerEntry.getInteger("brokerId"), is(2));
-        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY);
+        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey());
         assertThat(brokerCpuCapacity.getString("num.cores"), is("4.0"));
-        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.DISK_KEY);
+        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(DISK.getKey());
         assertThat(brokerDiskCapacity.getString("/var/lib/kafka/data-0/kafka-log2"), is("102400.0"));
 
         // Broker 10
         brokerEntry = brokerEntries.getJsonObject(3);
         assertThat(brokerEntry.getInteger("brokerId"), is(10));
-        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY);
+        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey());
         assertThat(brokerCpuCapacity.getString("num.cores"), is("5.0"));
-        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.DISK_KEY);
+        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(DISK.getKey());
         assertThat(brokerDiskCapacity.getString("/var/lib/kafka/data-1/kafka-log10"), is("1048576.0"));
 
         // Broker 11
         brokerEntry = brokerEntries.getJsonObject(4);
         assertThat(brokerEntry.getInteger("brokerId"), is(11));
-        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY);
+        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey());
         assertThat(brokerCpuCapacity.getString("num.cores"), is("5.0"));
-        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.DISK_KEY);
+        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(DISK.getKey());
         assertThat(brokerDiskCapacity.getString("/var/lib/kafka/data-1/kafka-log11"), is("1048576.0"));
 
         // Broker 12
         brokerEntry = brokerEntries.getJsonObject(5);
         assertThat(brokerEntry.getInteger("brokerId"), is(12));
-        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY);
+        brokerCpuCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey());
         assertThat(brokerCpuCapacity.getString("num.cores"), is("5.0"));
-        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.DISK_KEY);
+        brokerDiskCapacity = brokerEntry.getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(DISK.getKey());
         assertThat(brokerDiskCapacity.getString("/var/lib/kafka/data-1/kafka-log12"), is("1048576.0"));
     }
 
@@ -791,7 +795,7 @@ public class CruiseControlTest {
            the CPU capacity will be set to DEFAULT_CPU_CORE_CAPACITY */
         resources = Map.of("brokers", new ResourceRequirementsBuilder().build());
 
-        verifyBrokerCapacity(storage, resources, brokerCapacityThree, BrokerCapacity.DEFAULT_CPU_CORE_CAPACITY, BrokerCapacity.DEFAULT_CPU_CORE_CAPACITY, BrokerCapacity.DEFAULT_CPU_CORE_CAPACITY);
+        verifyBrokerCapacity(storage, resources, brokerCapacityThree, BrokerCapacityEntry.DEFAULT_CPU_CORE_CAPACITY, BrokerCapacityEntry.DEFAULT_CPU_CORE_CAPACITY, BrokerCapacityEntry.DEFAULT_CPU_CORE_CAPACITY);
     }
 
     private void verifyBrokerCapacity(Map<String, Storage> storage,
@@ -814,9 +818,9 @@ public class CruiseControlTest {
         JsonObject capacity = new JsonObject(configMap.getData().get(CruiseControl.CAPACITY_CONFIG_FILENAME));
         JsonArray brokerEntries = capacity.getJsonArray(Capacity.CAPACITIES_KEY);
 
-        assertThat(brokerEntries.getJsonObject(0).getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY).getString("num.cores"), is(Matchers.equalTo(brokerOneCpuValue)));
-        assertThat(brokerEntries.getJsonObject(1).getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY).getString("num.cores"), is(Matchers.equalTo(brokerTwoCpuValue)));
-        assertThat(brokerEntries.getJsonObject(2).getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(Capacity.CPU_KEY).getString("num.cores"), is(Matchers.equalTo(brokerThreeCpuValue)));
+        assertThat(brokerEntries.getJsonObject(0).getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey()).getString("num.cores"), is(Matchers.equalTo(brokerOneCpuValue)));
+        assertThat(brokerEntries.getJsonObject(1).getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey()).getString("num.cores"), is(Matchers.equalTo(brokerTwoCpuValue)));
+        assertThat(brokerEntries.getJsonObject(2).getJsonObject(Capacity.CAPACITY_KEY).getJsonObject(CPU.getKey()).getString("num.cores"), is(Matchers.equalTo(brokerThreeCpuValue)));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfigurationTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacity;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacityBuilder;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacityOverride;
+import io.strimzi.api.kafka.model.kafka.cruisecontrol.BrokerCapacityOverrideBuilder;
+import io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration.filterResourceGoalsWithoutCapacityConfig;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.CPU_CAPACITY_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.CPU_USAGE_DISTRIBUTION_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.LEADER_BYTES_IN_DISTRIBUTION_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.NETWORK_OUTBOUND_CAPACITY_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL;
+import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlGoals.POTENTIAL_NETWORK_OUTAGE_GOAL;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class CruiseControlConfigurationTest {
+
+    private static final String DEFAULT_CPU_CAPACITY = "1000m";
+    private static final String DEFAULT_NETWORK_CAPACITY = "10000KiB/s";
+
+    private static final List<String> GOAL_LIST = List.of(
+            NETWORK_INBOUND_CAPACITY_GOAL.toString(),
+            NETWORK_OUTBOUND_CAPACITY_GOAL.toString(),
+            CPU_CAPACITY_GOAL.toString(),
+            POTENTIAL_NETWORK_OUTAGE_GOAL.toString(),
+            NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL.toString(),
+            NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL.toString(),
+            CPU_USAGE_DISTRIBUTION_GOAL.toString(),
+            LEADER_BYTES_IN_DISTRIBUTION_GOAL.toString());
+
+
+    private static BrokerCapacity createBrokerCapacity(String cpuCapacity,
+                                                       String inboundNetworkCapacity,
+                                                       String outboundNetworkCapacity) {
+        return new BrokerCapacityBuilder()
+                .withCpu(cpuCapacity)
+                .withInboundNetwork(inboundNetworkCapacity)
+                .withOutboundNetwork(outboundNetworkCapacity)
+                .build();
+    }
+
+    private static BrokerCapacityOverride createBrokerCapacityOverride(List<Integer> brokerIds,
+                                                                       String cpuCapacity,
+                                                                       String inboundNetworkCapacity,
+                                                                       String outboundNetworkCapacity) {
+        return new BrokerCapacityOverrideBuilder()
+                .addAllToBrokers(brokerIds)
+                .withCpu(cpuCapacity)
+                .withInboundNetwork(inboundNetworkCapacity)
+                .withOutboundNetwork(outboundNetworkCapacity)
+                .build();
+    }
+
+    private static ResourceRequirements createCpuResourceRequirement(String request, String limit) {
+        return new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity(request))
+                .addToLimits("cpu", new Quantity(limit))
+                .build();
+    }
+
+    private void assertGoalsPresent(List<String> actual, CruiseControlGoals... expected) {
+        for (CruiseControlGoals goal : expected) {
+            assertThat("Expected goal to be present: " + goal, actual.contains(goal.toString()), is(true));
+        }
+    }
+
+    private void assertGoalsAbsent(List<String> actual, CruiseControlGoals... expected) {
+        for (CruiseControlGoals goal : expected) {
+            assertThat("Expected goal to be absent: " + goal, actual.contains(goal.toString()), is(false));
+        }
+    }
+
+    @Test
+    public void testFilterResourceGoalsWithoutCapacityConfig() {
+        // The capacities of resources are all properly configured - no goals should be filtered.
+        BrokerCapacity bc = createBrokerCapacity(DEFAULT_CPU_CAPACITY, DEFAULT_NETWORK_CAPACITY, DEFAULT_NETWORK_CAPACITY);
+        BrokerCapacityOverride bco = null;
+        Map<String, ResourceRequirements>  kafkaBrokerResources = null;
+        List<String> filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, kafkaBrokerResources);
+        assertThat(filteredGoals, containsInAnyOrder(GOAL_LIST.toArray()));
+
+        // Default CPU capacity not specified; Filter CPU goals.
+        bc = createBrokerCapacity(null, DEFAULT_NETWORK_CAPACITY, DEFAULT_NETWORK_CAPACITY);
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, kafkaBrokerResources);
+        assertGoalsAbsent(filteredGoals, CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL);
+        assertGoalsPresent(filteredGoals,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+
+        // CPU resource limits == requests; Don't filter CPU goals.
+        kafkaBrokerResources = Map.of("pool1", createCpuResourceRequirement(DEFAULT_CPU_CAPACITY, DEFAULT_CPU_CAPACITY));
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, kafkaBrokerResources);
+        assertGoalsPresent(filteredGoals,
+                CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+
+        // CPU resource limits != requests; Filter CPU goals
+        kafkaBrokerResources = Map.of("pool1", createCpuResourceRequirement(DEFAULT_CPU_CAPACITY, "2000m"));
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, kafkaBrokerResources);
+        assertGoalsAbsent(filteredGoals, CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL);
+        assertGoalsPresent(filteredGoals,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+
+        // CPU override capacities provided; Don't filter CPU goals
+        bco = createBrokerCapacityOverride(List.of(1, 2, 3), DEFAULT_CPU_CAPACITY, null, null);
+        bc.setOverrides(List.of(bco));
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, null);
+        assertGoalsPresent(filteredGoals,
+                CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+
+        // Default inbound network capacity not specified; Filter inbound network related goals.
+        bc = createBrokerCapacity(DEFAULT_CPU_CAPACITY, null, DEFAULT_NETWORK_CAPACITY);
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, null);
+        assertGoalsAbsent(filteredGoals, NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL);
+        assertGoalsPresent(filteredGoals,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL,
+                POTENTIAL_NETWORK_OUTAGE_GOAL, CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL);
+
+        // Inbound network override capacities provided; Don't filter inbound network goals
+        bco = createBrokerCapacityOverride(List.of(1, 2, 3), DEFAULT_CPU_CAPACITY, DEFAULT_NETWORK_CAPACITY, DEFAULT_NETWORK_CAPACITY);
+        bc.setOverrides(List.of(bco));
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, null);
+        assertGoalsPresent(filteredGoals,
+                CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+
+        // Default outbound network capacity not specified; Filter outbound network related goals.
+        bc = createBrokerCapacity(DEFAULT_CPU_CAPACITY, DEFAULT_NETWORK_CAPACITY, null);
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, null);
+        assertGoalsAbsent(filteredGoals,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+        assertGoalsPresent(filteredGoals,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL);
+
+        // Outbound network override capacities provided; Don't filter outbound network goals
+        bco = createBrokerCapacityOverride(List.of(1, 2, 3), DEFAULT_CPU_CAPACITY, DEFAULT_NETWORK_CAPACITY, DEFAULT_NETWORK_CAPACITY);
+        bc.setOverrides(List.of(bco));
+        filteredGoals = filterResourceGoalsWithoutCapacityConfig(GOAL_LIST, bc, null);
+        assertGoalsPresent(filteredGoals,
+                CPU_CAPACITY_GOAL, CPU_USAGE_DISTRIBUTION_GOAL,
+                NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_INBOUND_CAPACITY_GOAL,
+                NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL, NETWORK_OUTBOUND_CAPACITY_GOAL, POTENTIAL_NETWORK_OUTAGE_GOAL);
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -244,7 +244,7 @@ public class CruiseControlReconcilerTest {
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
                     assertThat(deployCaptor.getValue().getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION), is("0"));
                     assertThat(deployCaptor.getValue().getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION), is("0"));
-                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH), is("67b9cda0"));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH), is("e104ddb6"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("3a5e63e7"));
                     assertThat(deployCaptor.getValue().getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH), is("4d715cdd"));
                     if (topicOperatorEnabled && apiUsersEnabled) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds logic to the Strimzi Cluster Operator to remove resource related Cruise Control goals from the `default.goals` and `hard.goals` lists by default if the capacity configurations for those resources are not explicitly set in the  `.spec.kafka.resources` or `.spec.cruiseControl.brokerCapacity` sections of the `Kafka` custom resource. The following Cruise Control goals are affected:

```
com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal
com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal
com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal
com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal
com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal
com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal
```

This will prevent users from balancing partitions based on compute resources without defining capacities for those compute resources in their `Kafka` custom resource.

Addresses the issue raised here: https://github.com/strimzi/strimzi-kafka-operator/issues/11409

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

