### PR TITLE
Add support for Image Volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Kafka 3.9.1
 * Fixed MirrorMaker 2 client rack init container override being ignored.
+* Support for Kubernetes Image Volumes to mount custom plugins
 
 ### Major changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
@@ -62,7 +62,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.name = name;
     }
 
-    @Description("Secret to use populate the volume.")
+    @Description("`Secret` to use populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "secretvolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public SecretVolumeSource getSecret() {
@@ -73,7 +73,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.secret = secret;
     }
 
-    @Description("ConfigMap to use to populate the volume.")
+    @Description("`ConfigMap` to use to populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "configmapvolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ConfigMapVolumeSource getConfigMap() {
@@ -84,7 +84,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.configMap = configMap;
     }
 
-    @Description("EmptyDir to use to populate the volume.")
+    @Description("`EmptyDir` to use to populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "emptydirvolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public EmptyDirVolumeSource getEmptyDir() {
@@ -95,7 +95,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.emptyDir = emptyDir;
     }
 
-    @Description("PersistentVolumeClaim object to use to populate the volume.")
+    @Description("`PersistentVolumeClaim` object to use to populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "persistentvolumeclaimvolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public PersistentVolumeClaimVolumeSource getPersistentVolumeClaim() {
@@ -106,7 +106,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.persistentVolumeClaim = persistentVolumeClaim;
     }
 
-    @Description("CSIVolumeSource object to use to populate the volume.")
+    @Description("`CSIVolumeSource` object to use to populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "csivolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public CSIVolumeSource getCsi() {
@@ -117,7 +117,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.csi = csi;
     }
 
-    @Description("ImageVolumeSource object to use to populate the volume.")
+    @Description("`ImageVolumeSource` object to use to populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "imagevolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ImageVolumeSource getImage() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.CSIVolumeSource;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
+import io.fabric8.kubernetes.api.model.ImageVolumeSource;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.strimzi.api.kafka.model.common.Constants;
@@ -28,14 +29,15 @@ import java.util.Map;
  */
 @Buildable(editableEnabled = false, builderPackage = Constants.FABRIC8_KUBERNETES_API)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "name", "secret", "configMap", "emptyDir", "persistentVolumeClaim", "csi" })
+@JsonPropertyOrder({ "name", "secret", "configMap", "emptyDir", "persistentVolumeClaim", "csi", "image" })
 @OneOf({
     @OneOf.Alternative({
         @OneOf.Alternative.Property(value = "secret", required = false),
         @OneOf.Alternative.Property(value = "configMap", required = false),
         @OneOf.Alternative.Property(value = "emptyDir", required = false),
         @OneOf.Alternative.Property(value = "persistentVolumeClaim", required = false),
-        @OneOf.Alternative.Property(value = "csi", required = false)
+        @OneOf.Alternative.Property(value = "csi", required = false),
+        @OneOf.Alternative.Property(value = "image", required = false)
         })
 })
 @EqualsAndHashCode
@@ -47,6 +49,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
     private EmptyDirVolumeSource emptyDir;
     private PersistentVolumeClaimVolumeSource persistentVolumeClaim;
     private CSIVolumeSource csi;
+    private ImageVolumeSource image;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Name to use for the volume. Required.")
@@ -112,6 +115,17 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
 
     public void setCsi(CSIVolumeSource csi) {
         this.csi = csi;
+    }
+
+    @Description("ImageVolumeSource object to use to populate the volume.")
+    @KubeLink(group = "core", version = "v1", kind = "imagevolumesource")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ImageVolumeSource getImage() {
+        return image;
+    }
+
+    public void setImage(ImageVolumeSource image) {
+        this.image = image;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
@@ -62,7 +62,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
         this.name = name;
     }
 
-    @Description("`Secret` to use populate the volume.")
+    @Description("`Secret` to use to populate the volume.")
     @KubeLink(group = "core", version = "v1", kind = "secretvolumesource")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public SecretVolumeSource getSecret() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ImageArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ImageArtifact.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.connect;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * JAR artifact represents an artifact which is simply downloaded
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "type", "reference", "pullPolicy" })
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ImageArtifact extends MountedArtifact {
+    private String reference;
+    private String pullPolicy;
+
+    @Description("Must be `" + TYPE_IMAGE + "`")
+    @Override
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getType() {
+        return TYPE_IMAGE;
+    }
+
+    @Description("Image or artifact reference to be used. " +
+            "Required.")
+    @JsonProperty(required = true)
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    @Description("Policy for pulling OCI objects. " +
+            "Possible values are:\n\n" +
+            "* `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n" +
+            "* `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n" +
+            "* `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\n" +
+            "Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getPullPolicy() {
+        return pullPolicy;
+    }
+
+    public void setPullPolicy(String pullPolicy) {
+        this.pullPolicy = pullPolicy;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ImageArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ImageArtifact.java
@@ -35,7 +35,8 @@ public class ImageArtifact extends MountedArtifact {
         return TYPE_IMAGE;
     }
 
-    @Description("Image or artifact reference to be used. " +
+    @Description("Reference to the container image (OCI artifact) containing the connector plugin. " +
+            "The image is mounted as a volume and provides the plugin binary. " +
             "Required.")
     @JsonProperty(required = true)
     public String getReference() {
@@ -46,11 +47,11 @@ public class ImageArtifact extends MountedArtifact {
         this.reference = reference;
     }
 
-    @Description("Policy for pulling OCI objects. " +
+    @Description("Policy that determines when the container image (OCI artifact) is pulled.\n\n" +
             "Possible values are:\n\n" +
-            "* `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n" +
-            "* `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n" +
-            "* `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\n" +
+            "* `Always`: Always pull the image. If the pull fails, container creation fails.\n" +
+            "* `Never`: Never pull the image. Use only a locally available image. Container creation fails if the image isn’t present.\n" +
+            "* `IfNotPresent`: Pull the image only if it’s not already available locally. Container creation fails if the image isn’t present and the pull fails.\n\n" +
             "Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getPullPolicy() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ImageArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ImageArtifact.java
@@ -14,7 +14,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * JAR artifact represents an artifact which is simply downloaded
+ * Image Volume artifact represents an artifact which is mounted as a Kubernetes Image Volume
  */
 @Buildable(
         editableEnabled = false,
@@ -35,7 +35,7 @@ public class ImageArtifact extends MountedArtifact {
         return TYPE_IMAGE;
     }
 
-    @Description("Reference to the container image (OCI artifact) containing the connector plugin. " +
+    @Description("Reference to the container image (OCI artifact) containing the Kafka Connect plugin. " +
             "The image is mounted as a volume and provides the plugin binary. " +
             "Required.")
     @JsonProperty(required = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -18,6 +18,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @DescriptionFile
@@ -28,7 +29,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "version", "replicas", "image", "bootstrapServers", "tls", "authentication", "config", "resources",
     "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "logging", "clientRackInitImage", "rack",
-    "metricsConfig", "tracing", "template", "externalConfiguration", "build" })
+    "metricsConfig", "tracing", "template", "externalConfiguration", "build", "plugins" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
@@ -40,6 +41,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private Build build;
+    private List<MountedPlugin> plugins;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
@@ -90,5 +92,14 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     public void setBuild(Build build) {
         this.build = build;
+    }
+
+    @Description("List of connector plugins which should be mounted to the Kafka Connect.")
+    public List<MountedPlugin> getPlugins() {
+        return plugins;
+    }
+
+    public void setPlugins(List<MountedPlugin> plugins) {
+        this.plugins = plugins;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -94,7 +94,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
         this.build = build;
     }
 
-    @Description("List of connector plugins which should be mounted to the Kafka Connect.")
+    @Description("List of connector plugins to mount into the `KafkaConnect` pod.")
     public List<MountedPlugin> getPlugins() {
         return plugins;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/MountedArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/MountedArtifact.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.connect;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Abstract baseclass for different representations of mounted connector artifacts, discriminated by {@link #getType() type}.
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type"
+)
+@JsonSubTypes(
+    {
+        @JsonSubTypes.Type(value = ImageArtifact.class, name = MountedArtifact.TYPE_IMAGE)
+    }
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+@ToString
+public abstract class MountedArtifact implements UnknownPropertyPreserving {
+    public static final String TYPE_IMAGE = "image";
+
+    private Map<String, Object> additionalProperties;
+
+    @Description("Artifact type. " +
+            "Currently, the only supported artifact type is `image`.")
+    public abstract String getType();
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/MountedPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/MountedPlugin.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.connect;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.Pattern;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation a connector plugin within a Kafka Connect (not Kafka Connect Build)
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "name", "artifacts" })
+@DescriptionFile
+@EqualsAndHashCode
+@ToString
+public class MountedPlugin implements UnknownPropertyPreserving {
+    private String name;
+    private List<MountedArtifact> artifacts;
+    private Map<String, Object> additionalProperties;
+
+    @Description("The unique name of the connector plugin. " +
+            "Will be used to generate the path where the connector artifacts will be mounted. " +
+            "The name has to be unique within the KafkaConnect resource. " +
+            "The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. " +
+            "Required")
+    @JsonProperty(required = true)
+    @Pattern("^[a-z0-9][-_a-z0-9]*[a-z0-9]$")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Description("List of artifacts which belong to this connector plugin. " +
+            "Required.")
+    @JsonProperty(required = true)
+    public List<MountedArtifact> getArtifacts() {
+        return artifacts;
+    }
+
+    public void setArtifacts(List<MountedArtifact> artifacts) {
+        this.artifacts = artifacts;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}
+

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/MountedPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/MountedPlugin.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Representation a connector plugin within a Kafka Connect (not Kafka Connect Build)
+ * Represents a connector plugin in Kafka Connect (not in Kafka Connect Build)
  */
 @Buildable(
         editableEnabled = false,
@@ -37,10 +37,10 @@ public class MountedPlugin implements UnknownPropertyPreserving {
     private List<MountedArtifact> artifacts;
     private Map<String, Object> additionalProperties;
 
-    @Description("The unique name of the connector plugin. " +
-            "Will be used to generate the path where the connector artifacts will be mounted. " +
+    @Description("A unique name for the connector plugin. " +
+            "This name is used to generate the mount path for the connector artifacts. " +
             "The name has to be unique within the KafkaConnect resource. " +
-            "The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. " +
+            "The name must be unique within the `KafkaConnect` resource and match the pattern: `^[a-z][-_a-z0-9]*[a-z]$`. " +
             "Required")
     @JsonProperty(required = true)
     @Pattern("^[a-z0-9][-_a-z0-9]*[a-z0-9]$")
@@ -52,7 +52,7 @@ public class MountedPlugin implements UnknownPropertyPreserving {
         this.name = name;
     }
 
-    @Description("List of artifacts which belong to this connector plugin. " +
+    @Description("List of artifacts associated with this connector plugin. " +
             "Required.")
     @JsonProperty(required = true)
     public List<MountedArtifact> getArtifacts() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -130,6 +130,8 @@ public class TemplateUtils {
             volumeBuilder.withPersistentVolumeClaim(volumeConfig.getPersistentVolumeClaim());
         } else if (volumeConfig.getCsi() != null) {
             volumeBuilder.withCsi(volumeConfig.getCsi());
+        } else if (volumeConfig.getImage() != null) {
+            volumeBuilder.withImage(volumeConfig.getImage());
         }
 
         return volumeBuilder.build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.CSIVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.ImageVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
@@ -128,12 +129,16 @@ public class TemplateUtilsTest {
                         new AdditionalVolumeBuilder()
                                 .withName("csi-volume")
                                 .withCsi(new CSIVolumeSourceBuilder().withDriver("csi.cert-manager.io").withReadOnly().withVolumeAttributes(Map.of("csi.cert-manager.io/issuer-name", "my-ca", "csi.cert-manager.io/dns-names", "${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local")).build())
+                                .build(),
+                        new AdditionalVolumeBuilder()
+                                .withName("oci-volume")
+                                .withImage(new ImageVolumeSourceBuilder().withReference("my-custom-oci-plugin:latest").withPullPolicy("Never").build())
                                 .build())
                 .build();
 
         TemplateUtils.addAdditionalVolumes(templatePod, existingVolumes);
 
-        assertThat(existingVolumes.size(), is(6));
+        assertThat(existingVolumes.size(), is(7));
 
         assertThat(existingVolumes.get(0).getName(), is("existingVolume1"));
 
@@ -143,6 +148,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(1).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(1).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(1).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getImage(), is(nullValue()));
 
         assertThat(existingVolumes.get(2).getName(), is("cm-volume"));
         assertThat(existingVolumes.get(2).getConfigMap().getName(), is("my-cm"));
@@ -150,6 +156,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(2).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(2).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(2).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getImage(), is(nullValue()));
 
         assertThat(existingVolumes.get(3).getName(), is("empty-dir-volume"));
         assertThat(existingVolumes.get(3).getEmptyDir().getMedium(), is("Memory"));
@@ -158,6 +165,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(3).getConfigMap(), is(nullValue()));
         assertThat(existingVolumes.get(3).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(3).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getImage(), is(nullValue()));
 
         assertThat(existingVolumes.get(4).getName(), is("pvc-volume"));
         assertThat(existingVolumes.get(4).getPersistentVolumeClaim().getClaimName(), is("my-pvc"));
@@ -165,6 +173,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(4).getConfigMap(), is(nullValue()));
         assertThat(existingVolumes.get(4).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(4).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getImage(), is(nullValue()));
 
         assertThat(existingVolumes.get(5).getName(), is("csi-volume"));
         assertThat(existingVolumes.get(5).getCsi().getDriver(), is("csi.cert-manager.io"));
@@ -175,6 +184,16 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(5).getConfigMap(), is(nullValue()));
         assertThat(existingVolumes.get(5).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(5).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getImage(), is(nullValue()));
+
+        assertThat(existingVolumes.get(6).getName(), is("oci-volume"));
+        assertThat(existingVolumes.get(6).getImage().getReference(), is("my-custom-oci-plugin:latest"));
+        assertThat(existingVolumes.get(6).getImage().getPullPolicy(), is("Never"));
+        assertThat(existingVolumes.get(6).getSecret(), is(nullValue()));
+        assertThat(existingVolumes.get(6).getConfigMap(), is(nullValue()));
+        assertThat(existingVolumes.get(6).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(6).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(6).getCsi(), is(nullValue()));
     }
 
     @ParallelTest

--- a/documentation/api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc
@@ -1,0 +1,1 @@
+IMPORTANT: This feature requires that the Kubernetes Image Volume feature is enabled and supported by your Kubernetes cluster.

--- a/documentation/api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc
@@ -1,1 +1,1 @@
-IMPORTANT: This feature requires that the Kubernetes Image Volume feature is enabled and supported by your Kubernetes cluster.
+IMPORTANT: This feature requires Kubernetes support for the Image Volume feature.

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -28,6 +28,8 @@ You can also create new connector instances using these options.
 
 //Procedure to create container images using Strimzi and Kafka Connect build
 include::../../modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc[leveloffset=+1]
+//Procedure to use Image Volumes to add connector plugins to Kafka Connect
+include::../../modules/deploying/proc-deploy-kafka-connect-using-image-volumes.adoc[leveloffset=+1]
 //Procedure to create container images from base image
 include::../../modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc[leveloffset=+1]
 //Procedure to deploy a KafkaConnector resource

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1320,6 +1320,9 @@ Used in: xref:type-PodTemplate-{context}[`PodTemplate`]
 |csi
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#csivolumesource-v1-core[CSIVolumeSource]
 |CSIVolumeSource object to use to populate the volume.
+|image
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#imagevolumesource-v1-core[ImageVolumeSource]
+|ImageVolumeSource object to use to populate the volume.
 |====
 
 [id='type-InternalServiceTemplate-{context}']
@@ -2543,6 +2546,9 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |build
 |xref:type-Build-{context}[`Build`]
 |Configures how the Connect container image should be built. Optional.
+|plugins
+|xref:type-MountedPlugin-{context}[`MountedPlugin`] array
+|List of connector plugins which should be mounted to the Kafka Connect.
 |====
 
 [id='type-ClientTls-{context}']
@@ -3193,6 +3199,58 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |insecure
 |boolean
 |By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
+|====
+
+[id='type-MountedPlugin-{context}']
+= `MountedPlugin` schema reference
+
+Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+
+xref:type-MountedPlugin-schema-{context}[Full list of `MountedPlugin` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc[leveloffset=+1]
+
+[id='type-MountedPlugin-schema-{context}']
+== `MountedPlugin` schema properties
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|name
+|string
+|The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be mounted. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required.
+|artifacts
+|xref:type-ImageArtifact-{context}[`ImageArtifact`] array
+|List of artifacts which belong to this connector plugin. Required.
+|====
+
+[id='type-ImageArtifact-{context}']
+= `ImageArtifact` schema reference
+
+Used in: xref:type-MountedPlugin-{context}[`MountedPlugin`]
+
+
+The `type` property is a discriminator that distinguishes use of the `ImageArtifact` type from other subtypes which may be added in the future.
+It must have the value `image` for the type `ImageArtifact`.
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|type
+|string
+|Must be `image`.
+|reference
+|string
+|Image or artifact reference to be used. Required.
+|pullPolicy
+|string
+|Policy for pulling OCI objects. Possible values are:
+
+* `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+* `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+* `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
 |====
 
 [id='type-KafkaConnectStatus-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1307,7 +1307,7 @@ Used in: xref:type-PodTemplate-{context}[`PodTemplate`]
 |Name to use for the volume. Required.
 |secret
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#secretvolumesource-v1-core[SecretVolumeSource]
-|`Secret` to use populate the volume.
+|`Secret` to use to populate the volume.
 |configMap
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
 |`ConfigMap` to use to populate the volume.
@@ -3241,7 +3241,7 @@ It must have the value `image` for the type `ImageArtifact`.
 |Must be `image`.
 |reference
 |string
-|Reference to the container image (OCI artifact) containing the connector plugin. The image is mounted as a volume and provides the plugin binary. Required.
+|Reference to the container image (OCI artifact) containing the Kafka Connect plugin. The image is mounted as a volume and provides the plugin binary. Required.
 |pullPolicy
 |string
 |Policy that determines when the container image (OCI artifact) is pulled.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1307,22 +1307,22 @@ Used in: xref:type-PodTemplate-{context}[`PodTemplate`]
 |Name to use for the volume. Required.
 |secret
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#secretvolumesource-v1-core[SecretVolumeSource]
-|Secret to use populate the volume.
+|`Secret` to use populate the volume.
 |configMap
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
-|ConfigMap to use to populate the volume.
+|`ConfigMap` to use to populate the volume.
 |emptyDir
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#emptydirvolumesource-v1-core[EmptyDirVolumeSource]
-|EmptyDir to use to populate the volume.
+|`EmptyDir` to use to populate the volume.
 |persistentVolumeClaim
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#persistentvolumeclaimvolumesource-v1-core[PersistentVolumeClaimVolumeSource]
-|PersistentVolumeClaim object to use to populate the volume.
+|`PersistentVolumeClaim` object to use to populate the volume.
 |csi
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#csivolumesource-v1-core[CSIVolumeSource]
-|CSIVolumeSource object to use to populate the volume.
+|`CSIVolumeSource` object to use to populate the volume.
 |image
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#imagevolumesource-v1-core[ImageVolumeSource]
-|ImageVolumeSource object to use to populate the volume.
+|`ImageVolumeSource` object to use to populate the volume.
 |====
 
 [id='type-InternalServiceTemplate-{context}']
@@ -2548,7 +2548,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Configures how the Connect container image should be built. Optional.
 |plugins
 |xref:type-MountedPlugin-{context}[`MountedPlugin`] array
-|List of connector plugins which should be mounted to the Kafka Connect.
+|List of connector plugins to mount into the `KafkaConnect` pod.
 |====
 
 [id='type-ClientTls-{context}']
@@ -3219,10 +3219,10 @@ include::../api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc[leveloffse
 |Property |Property type |Description
 |name
 |string
-|The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be mounted. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required.
+|A unique name for the connector plugin. This name is used to generate the mount path for the connector artifacts. The name has to be unique within the KafkaConnect resource. The name must be unique within the `KafkaConnect` resource and match the pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required.
 |artifacts
 |xref:type-ImageArtifact-{context}[`ImageArtifact`] array
-|List of artifacts which belong to this connector plugin. Required.
+|List of artifacts associated with this connector plugin. Required.
 |====
 
 [id='type-ImageArtifact-{context}']
@@ -3241,14 +3241,16 @@ It must have the value `image` for the type `ImageArtifact`.
 |Must be `image`.
 |reference
 |string
-|Image or artifact reference to be used. Required.
+|Reference to the container image (OCI artifact) containing the connector plugin. The image is mounted as a volume and provides the plugin binary. Required.
 |pullPolicy
 |string
-|Policy for pulling OCI objects. Possible values are:
+|Policy that determines when the container image (OCI artifact) is pulled.
 
-* `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-* `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-* `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+Possible values are:
+
+* `Always`: Always pull the image. If the pull fails, container creation fails.
+* `Never`: Never pull the image. Use only a locally available image. Container creation fails if the image isn’t present.
+* `IfNotPresent`: Pull the image only if it’s not already available locally. Container creation fails if the image isn’t present and the pull fails.
 
 Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
 |====

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -702,6 +702,7 @@ Supported Volume Types
 * EmptyDir
 * PersistentVolumeClaims
 * CSI Volumes
+* Image Volumes
 
 .Example configuration for additional volumes
 [source,yaml,subs=attributes+]
@@ -731,6 +732,9 @@ spec:
               volumeAttributes:
                 csi.cert-manager.io/issuer-name: my-ca
                 csi.cert-manager.io/dns-names: ${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local
+          - name: example-oci-plugin
+            image:
+              reference: my-registry.io/oci-artifacts/example-plugin:latest
       kafkaContainer:
         volumeMounts:
           - name: example-secret
@@ -743,7 +747,16 @@ spec:
             mountPath: /mnt/data
           - name: example-csi-volume
             mountPath: /mnt/certificate
+          - name: example-oci-plugin
+            mountPath: /mnt/example-plugin
 ----
 
 You can use volumes to store files containing configuration values for a Kafka component and then load those values using a configuration provider.
 For more information, see link:{BookURLDeploying}#assembly-loading-config-with-providers-str[Loading configuration values from external sources^].
+
+You can also use additional volumes to mount custom plugins:
+
+* For the User and Topic Operators, you can use the environment variable `JAVA_CLASSPATH` to modify the Java classpath and have your custom plugin(s) included in it.
+* For the Kafka operands and Cruise Control, you can use the environment variable `CLASSPATH` to modify the Java classpath and have your custom plugin(s) included in it.
+* For adding Kafka Connect connectors, see link:{BookURLDeploying}#using-kafka-connect-with-plug-ins-str[Adding Kafka Connect connectors^].
+* Some other plugins - such as the Tiered Storage plugins - might use their own classpath configuration.

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -756,7 +756,7 @@ For more information, see link:{BookURLDeploying}#assembly-loading-config-with-p
 
 You can also use additional volumes to mount custom plugins:
 
-* For the User and Topic Operators, you can use the environment variable `JAVA_CLASSPATH` to modify the Java classpath and have your custom plugin(s) included in it.
-* For the Kafka operands and Cruise Control, you can use the environment variable `CLASSPATH` to modify the Java classpath and have your custom plugin(s) included in it.
-* For adding Kafka Connect connectors, see link:{BookURLDeploying}#using-kafka-connect-with-plug-ins-str[Adding Kafka Connect connectors^].
-* Some other plugins - such as the Tiered Storage plugins - might use their own classpath configuration.
+* To include custom plugins in the User Operator and Topic Operator, set the `JAVA_CLASSPATH` environment variable  to modify the Java classpath.
+* To include custom plugins in the Kafka operands and Cruise Control, set the `CLASSPATH` environment variable to modify the Java classpath.
+* To add Kafka Connect connectors, see link:{BookURLDeploying}#using-kafka-connect-with-plug-ins-str[Adding Kafka Connect connectors^].
+* Some plugins, such as the Tiered Storage plugins, may require their own classpath configuration.

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-image-volumes.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-image-volumes.adoc
@@ -8,14 +8,14 @@
 [role="_abstract"]
 Configure Kafka Connect so that connectors are automatically mounted as link:https://kubernetes.io/docs/concepts/storage/volumes/#image[Kubernetes Image Volumes^].
 You define the connector plugins using the `.spec.plugins` property of the `KafkaConnect` custom resource.
-Strimzi will automatically mount them into the Kafka Connect deployment.
+Strimzi automatically mounts them into the Kafka Connect deployment.
 
 IMPORTANT: This feature requires that the Kubernetes Image Volume feature is enabled and supported by your Kubernetes cluster.
 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* Your connector plugins are available in your container registry as container images or OCI artifacts
+* Your connector plugins must be available in your container registry as container images (OCI artifacts).
 
 .Procedure
 
@@ -43,7 +43,7 @@ spec: # <1>
   #...
 ----
 <1> link:{BookURLConfiguring}#type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster^].
-<2> (Required) List of connector plugins and their artifacts to add to mount in the Kafka Connect deployment. Each plugin must be configured with at least one `artifact`.
+<2> (Required) List of connector plugins and their artifacts to mount in the Kafka Connect deployment. Each plugin must be configured with at least one `artifact`.
 
 . Create or update the resource:
 +
@@ -54,7 +54,7 @@ $ kubectl apply -f <kafka_connect_configuration_file>
 
 . Wait for the Kafka Connect cluster to be deployed.
 
-. Use the Kafka Connect REST API or `KafkaConnector` custom resources to use the connector plugins you added.
+. Use the Kafka Connect REST API or `KafkaConnector` custom resources to configure and run connectors based on the plugins you added.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-image-volumes.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-image-volumes.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// assembly-deploy-kafka-connect-with-plugins.adoc
+
+[id='using-image-volumes-to-add-connector-plugins-{context}']
+= Using Kubernetes Image Volumes to add connector plugins
+
+[role="_abstract"]
+Configure Kafka Connect so that connectors are automatically mounted as link:https://kubernetes.io/docs/concepts/storage/volumes/#image[Kubernetes Image Volumes^].
+You define the connector plugins using the `.spec.plugins` property of the `KafkaConnect` custom resource.
+Strimzi will automatically mount them into the Kafka Connect deployment.
+
+IMPORTANT: This feature requires that the Kubernetes Image Volume feature is enabled and supported by your Kubernetes cluster.
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* Your connector plugins are available in your container registry as container images or OCI artifacts
+
+.Procedure
+
+. Configure the `KafkaConnect` custom resource by specifying the additional connector plugins in`.spec.plugins`:
++
+[source,yaml,subs=attributes+,options="nowrap"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec: # <1>
+  #...
+  plugins: # <2>
+    - name: connector-1
+      artifacts:
+        - type: image
+          reference: <reference_to_container_image_or_OCI_artifact>
+          pullPolicy: <pull_policy>
+    - name: connector-2
+      artifacts:
+        - type: image
+          reference: <reference_to_container_image_or_OCI_artifact>
+          pullPolicy: <pull_policy>
+  #...
+----
+<1> link:{BookURLConfiguring}#type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster^].
+<2> (Required) List of connector plugins and their artifacts to add to mount in the Kafka Connect deployment. Each plugin must be configured with at least one `artifact`.
+
+. Create or update the resource:
++
+[source,subs="+quotes"]
+----
+$ kubectl apply -f <kafka_connect_configuration_file>
+----
+
+. Wait for the Kafka Connect cluster to be deployed.
+
+. Use the Kafka Connect REST API or `KafkaConnector` custom resources to use the connector plugins you added.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:{BookURLConfiguring}#type-MountedPlugin-reference[Kafka Connect `plugins` schema reference^]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1569,7 +1569,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: Secret to use populate the volume.
+                                    description: '`Secret` to use populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -1590,7 +1590,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: ConfigMap to use to populate the volume.
+                                    description: '`ConfigMap` to use to populate the volume.'
                                   emptyDir:
                                     type: object
                                     properties:
@@ -1603,7 +1603,7 @@ spec:
                                             type: string
                                           format:
                                             type: string
-                                    description: EmptyDir to use to populate the volume.
+                                    description: '`EmptyDir` to use to populate the volume.'
                                   persistentVolumeClaim:
                                     type: object
                                     properties:
@@ -1611,7 +1611,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
-                                    description: PersistentVolumeClaim object to use to populate the volume.
+                                    description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                   csi:
                                     type: object
                                     properties:
@@ -1630,7 +1630,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
-                                    description: CSIVolumeSource object to use to populate the volume.
+                                    description: '`CSIVolumeSource` object to use to populate the volume.'
                                   image:
                                     type: object
                                     properties:
@@ -1638,7 +1638,7 @@ spec:
                                         type: string
                                       reference:
                                         type: string
-                                    description: ImageVolumeSource object to use to populate the volume.
+                                    description: '`ImageVolumeSource` object to use to populate the volume.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -3179,7 +3179,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: Secret to use populate the volume.
+                                    description: '`Secret` to use populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -3200,7 +3200,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: ConfigMap to use to populate the volume.
+                                    description: '`ConfigMap` to use to populate the volume.'
                                   emptyDir:
                                     type: object
                                     properties:
@@ -3213,7 +3213,7 @@ spec:
                                             type: string
                                           format:
                                             type: string
-                                    description: EmptyDir to use to populate the volume.
+                                    description: '`EmptyDir` to use to populate the volume.'
                                   persistentVolumeClaim:
                                     type: object
                                     properties:
@@ -3221,7 +3221,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
-                                    description: PersistentVolumeClaim object to use to populate the volume.
+                                    description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                   csi:
                                     type: object
                                     properties:
@@ -3240,7 +3240,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
-                                    description: CSIVolumeSource object to use to populate the volume.
+                                    description: '`CSIVolumeSource` object to use to populate the volume.'
                                   image:
                                     type: object
                                     properties:
@@ -3248,7 +3248,7 @@ spec:
                                         type: string
                                       reference:
                                         type: string
-                                    description: ImageVolumeSource object to use to populate the volume.
+                                    description: '`ImageVolumeSource` object to use to populate the volume.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -4595,7 +4595,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: Secret to use populate the volume.
+                                    description: '`Secret` to use populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -4616,7 +4616,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: ConfigMap to use to populate the volume.
+                                    description: '`ConfigMap` to use to populate the volume.'
                                   emptyDir:
                                     type: object
                                     properties:
@@ -4629,7 +4629,7 @@ spec:
                                             type: string
                                           format:
                                             type: string
-                                    description: EmptyDir to use to populate the volume.
+                                    description: '`EmptyDir` to use to populate the volume.'
                                   persistentVolumeClaim:
                                     type: object
                                     properties:
@@ -4637,7 +4637,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
-                                    description: PersistentVolumeClaim object to use to populate the volume.
+                                    description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                   csi:
                                     type: object
                                     properties:
@@ -4656,7 +4656,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
-                                    description: CSIVolumeSource object to use to populate the volume.
+                                    description: '`CSIVolumeSource` object to use to populate the volume.'
                                   image:
                                     type: object
                                     properties:
@@ -4664,7 +4664,7 @@ spec:
                                         type: string
                                       reference:
                                         type: string
-                                    description: ImageVolumeSource object to use to populate the volume.
+                                    description: '`ImageVolumeSource` object to use to populate the volume.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -6060,7 +6060,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: Secret to use populate the volume.
+                                    description: '`Secret` to use populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -6081,7 +6081,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: ConfigMap to use to populate the volume.
+                                    description: '`ConfigMap` to use to populate the volume.'
                                   emptyDir:
                                     type: object
                                     properties:
@@ -6094,7 +6094,7 @@ spec:
                                             type: string
                                           format:
                                             type: string
-                                    description: EmptyDir to use to populate the volume.
+                                    description: '`EmptyDir` to use to populate the volume.'
                                   persistentVolumeClaim:
                                     type: object
                                     properties:
@@ -6102,7 +6102,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
-                                    description: PersistentVolumeClaim object to use to populate the volume.
+                                    description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                   csi:
                                     type: object
                                     properties:
@@ -6121,7 +6121,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
-                                    description: CSIVolumeSource object to use to populate the volume.
+                                    description: '`CSIVolumeSource` object to use to populate the volume.'
                                   image:
                                     type: object
                                     properties:
@@ -6129,7 +6129,7 @@ spec:
                                         type: string
                                       reference:
                                         type: string
-                                    description: ImageVolumeSource object to use to populate the volume.
+                                    description: '`ImageVolumeSource` object to use to populate the volume.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -7324,7 +7324,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: Secret to use populate the volume.
+                                    description: '`Secret` to use populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -7345,7 +7345,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: ConfigMap to use to populate the volume.
+                                    description: '`ConfigMap` to use to populate the volume.'
                                   emptyDir:
                                     type: object
                                     properties:
@@ -7358,7 +7358,7 @@ spec:
                                             type: string
                                           format:
                                             type: string
-                                    description: EmptyDir to use to populate the volume.
+                                    description: '`EmptyDir` to use to populate the volume.'
                                   persistentVolumeClaim:
                                     type: object
                                     properties:
@@ -7366,7 +7366,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
-                                    description: PersistentVolumeClaim object to use to populate the volume.
+                                    description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                   csi:
                                     type: object
                                     properties:
@@ -7385,7 +7385,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
-                                    description: CSIVolumeSource object to use to populate the volume.
+                                    description: '`CSIVolumeSource` object to use to populate the volume.'
                                   image:
                                     type: object
                                     properties:
@@ -7393,7 +7393,7 @@ spec:
                                         type: string
                                       reference:
                                         type: string
-                                    description: ImageVolumeSource object to use to populate the volume.
+                                    description: '`ImageVolumeSource` object to use to populate the volume.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -8266,7 +8266,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: Secret to use populate the volume.
+                                    description: '`Secret` to use populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -8287,7 +8287,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: ConfigMap to use to populate the volume.
+                                    description: '`ConfigMap` to use to populate the volume.'
                                   emptyDir:
                                     type: object
                                     properties:
@@ -8300,7 +8300,7 @@ spec:
                                             type: string
                                           format:
                                             type: string
-                                    description: EmptyDir to use to populate the volume.
+                                    description: '`EmptyDir` to use to populate the volume.'
                                   persistentVolumeClaim:
                                     type: object
                                     properties:
@@ -8308,7 +8308,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
-                                    description: PersistentVolumeClaim object to use to populate the volume.
+                                    description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                   csi:
                                     type: object
                                     properties:
@@ -8327,7 +8327,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         type: object
-                                    description: CSIVolumeSource object to use to populate the volume.
+                                    description: '`CSIVolumeSource` object to use to populate the volume.'
                                   image:
                                     type: object
                                     properties:
@@ -8335,7 +8335,7 @@ spec:
                                         type: string
                                       reference:
                                         type: string
-                                    description: ImageVolumeSource object to use to populate the volume.
+                                    description: '`ImageVolumeSource` object to use to populate the volume.'
                                 oneOf:
                                   - properties:
                                       secret: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1631,6 +1631,14 @@ spec:
                                           type: string
                                         type: object
                                     description: CSIVolumeSource object to use to populate the volume.
+                                  image:
+                                    type: object
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    description: ImageVolumeSource object to use to populate the volume.
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -1638,6 +1646,7 @@ spec:
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
                                       csi: {}
+                                      image: {}
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Kafka `Pods`.
                         bootstrapService:
@@ -3232,6 +3241,14 @@ spec:
                                           type: string
                                         type: object
                                     description: CSIVolumeSource object to use to populate the volume.
+                                  image:
+                                    type: object
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    description: ImageVolumeSource object to use to populate the volume.
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -3239,6 +3256,7 @@ spec:
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
                                       csi: {}
+                                      image: {}
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for ZooKeeper `Pods`.
                         clientService:
@@ -4639,6 +4657,14 @@ spec:
                                           type: string
                                         type: object
                                     description: CSIVolumeSource object to use to populate the volume.
+                                  image:
+                                    type: object
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    description: ImageVolumeSource object to use to populate the volume.
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -4646,6 +4672,7 @@ spec:
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
                                       csi: {}
+                                      image: {}
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Entity Operator `Pods`.
                         topicOperatorContainer:
@@ -6095,6 +6122,14 @@ spec:
                                           type: string
                                         type: object
                                     description: CSIVolumeSource object to use to populate the volume.
+                                  image:
+                                    type: object
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    description: ImageVolumeSource object to use to populate the volume.
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -6102,6 +6137,7 @@ spec:
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
                                       csi: {}
+                                      image: {}
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Cruise Control `Pods`.
                         apiService:
@@ -7350,6 +7386,14 @@ spec:
                                           type: string
                                         type: object
                                     description: CSIVolumeSource object to use to populate the volume.
+                                  image:
+                                    type: object
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    description: ImageVolumeSource object to use to populate the volume.
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -7357,6 +7401,7 @@ spec:
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
                                       csi: {}
+                                      image: {}
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for JmxTrans `Pods`.
                         container:
@@ -8283,6 +8328,14 @@ spec:
                                           type: string
                                         type: object
                                     description: CSIVolumeSource object to use to populate the volume.
+                                  image:
+                                    type: object
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    description: ImageVolumeSource object to use to populate the volume.
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -8290,6 +8343,7 @@ spec:
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
                                       csi: {}
+                                      image: {}
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Kafka Exporter `Pods`.
                         service:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1569,7 +1569,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: '`Secret` to use populate the volume.'
+                                    description: '`Secret` to use to populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -3179,7 +3179,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: '`Secret` to use populate the volume.'
+                                    description: '`Secret` to use to populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -4595,7 +4595,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: '`Secret` to use populate the volume.'
+                                    description: '`Secret` to use to populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -6060,7 +6060,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: '`Secret` to use populate the volume.'
+                                    description: '`Secret` to use to populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -7324,7 +7324,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: '`Secret` to use populate the volume.'
+                                    description: '`Secret` to use to populate the volume.'
                                   configMap:
                                     type: object
                                     properties:
@@ -8266,7 +8266,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         type: string
-                                    description: '`Secret` to use populate the volume.'
+                                    description: '`Secret` to use to populate the volume.'
                                   configMap:
                                     type: object
                                     properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1109,7 +1109,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: Secret to use populate the volume.
+                                description: '`Secret` to use populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -1130,7 +1130,7 @@ spec:
                                     type: string
                                   optional:
                                     type: boolean
-                                description: ConfigMap to use to populate the volume.
+                                description: '`ConfigMap` to use to populate the volume.'
                               emptyDir:
                                 type: object
                                 properties:
@@ -1143,7 +1143,7 @@ spec:
                                         type: string
                                       format:
                                         type: string
-                                description: EmptyDir to use to populate the volume.
+                                description: '`EmptyDir` to use to populate the volume.'
                               persistentVolumeClaim:
                                 type: object
                                 properties:
@@ -1151,7 +1151,7 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
-                                description: PersistentVolumeClaim object to use to populate the volume.
+                                description: '`PersistentVolumeClaim` object to use to populate the volume.'
                               csi:
                                 type: object
                                 properties:
@@ -1170,7 +1170,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
-                                description: CSIVolumeSource object to use to populate the volume.
+                                description: '`CSIVolumeSource` object to use to populate the volume.'
                               image:
                                 type: object
                                 properties:
@@ -1178,7 +1178,7 @@ spec:
                                     type: string
                                   reference:
                                     type: string
-                                description: ImageVolumeSource object to use to populate the volume.
+                                description: '`ImageVolumeSource` object to use to populate the volume.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2164,7 +2164,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: Secret to use populate the volume.
+                                description: '`Secret` to use populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -2185,7 +2185,7 @@ spec:
                                     type: string
                                   optional:
                                     type: boolean
-                                description: ConfigMap to use to populate the volume.
+                                description: '`ConfigMap` to use to populate the volume.'
                               emptyDir:
                                 type: object
                                 properties:
@@ -2198,7 +2198,7 @@ spec:
                                         type: string
                                       format:
                                         type: string
-                                description: EmptyDir to use to populate the volume.
+                                description: '`EmptyDir` to use to populate the volume.'
                               persistentVolumeClaim:
                                 type: object
                                 properties:
@@ -2206,7 +2206,7 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
-                                description: PersistentVolumeClaim object to use to populate the volume.
+                                description: '`PersistentVolumeClaim` object to use to populate the volume.'
                               csi:
                                 type: object
                                 properties:
@@ -2225,7 +2225,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
-                                description: CSIVolumeSource object to use to populate the volume.
+                                description: '`CSIVolumeSource` object to use to populate the volume.'
                               image:
                                 type: object
                                 properties:
@@ -2233,7 +2233,7 @@ spec:
                                     type: string
                                   reference:
                                     type: string
-                                description: ImageVolumeSource object to use to populate the volume.
+                                description: '`ImageVolumeSource` object to use to populate the volume.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2679,7 +2679,7 @@ spec:
                       name:
                         type: string
                         pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
-                        description: "The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be mounted. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
+                        description: "A unique name for the connector plugin. This name is used to generate the mount path for the connector artifacts. The name has to be unique within the KafkaConnect resource. The name must be unique within the `KafkaConnect` resource and match the pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
                       artifacts:
                         type: array
                         items:
@@ -2688,16 +2688,18 @@ spec:
                             pullPolicy:
                               type: string
                               description: |-
-                                Policy for pulling OCI objects. Possible values are:
+                                Policy that determines when the container image (OCI artifact) is pulled.
 
-                                * `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                * `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                * `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                Possible values are:
+
+                                * `Always`: Always pull the image. If the pull fails, container creation fails.
+                                * `Never`: Never pull the image. Use only a locally available image. Container creation fails if the image isn’t present.
+                                * `IfNotPresent`: Pull the image only if it’s not already available locally. Container creation fails if the image isn’t present and the pull fails.
 
                                 Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
                             reference:
                               type: string
-                              description: Image or artifact reference to be used. Required.
+                              description: Reference to the container image (OCI artifact) containing the connector plugin. The image is mounted as a volume and provides the plugin binary. Required.
                             type:
                               type: string
                               enum:
@@ -2706,11 +2708,11 @@ spec:
                           required:
                             - reference
                             - type
-                        description: List of artifacts which belong to this connector plugin. Required.
+                        description: List of artifacts associated with this connector plugin. Required.
                     required:
                       - name
                       - artifacts
-                  description: List of connector plugins which should be mounted to the Kafka Connect.
+                  description: List of connector plugins to mount into the `KafkaConnect` pod.
               required:
                 - bootstrapServers
               description: The specification of the Kafka Connect cluster.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1109,7 +1109,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: '`Secret` to use populate the volume.'
+                                description: '`Secret` to use to populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -2164,7 +2164,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: '`Secret` to use populate the volume.'
+                                description: '`Secret` to use to populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -2699,7 +2699,7 @@ spec:
                                 Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
                             reference:
                               type: string
-                              description: Reference to the container image (OCI artifact) containing the connector plugin. The image is mounted as a volume and provides the plugin binary. Required.
+                              description: Reference to the container image (OCI artifact) containing the Kafka Connect plugin. The image is mounted as a volume and provides the plugin binary. Required.
                             type:
                               type: string
                               enum:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1171,6 +1171,14 @@ spec:
                                       type: string
                                     type: object
                                 description: CSIVolumeSource object to use to populate the volume.
+                              image:
+                                type: object
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                description: ImageVolumeSource object to use to populate the volume.
                             oneOf:
                               - properties:
                                   secret: {}
@@ -1178,6 +1186,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect `Pods`.
                     apiService:
@@ -2217,6 +2226,14 @@ spec:
                                       type: string
                                     type: object
                                 description: CSIVolumeSource object to use to populate the volume.
+                              image:
+                                type: object
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                description: ImageVolumeSource object to use to populate the volume.
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2224,6 +2241,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                     buildContainer:
@@ -2653,6 +2671,46 @@ spec:
                     - output
                     - plugins
                   description: Configures how the Connect container image should be built. Optional.
+                plugins:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
+                        description: "The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be mounted. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
+                      artifacts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            pullPolicy:
+                              type: string
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+
+                                * `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                * `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                * `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
+                            reference:
+                              type: string
+                              description: Image or artifact reference to be used. Required.
+                            type:
+                              type: string
+                              enum:
+                                - image
+                              description: "Artifact type. Currently, the only supported artifact type is `image`."
+                          required:
+                            - reference
+                            - type
+                        description: List of artifacts which belong to this connector plugin. Required.
+                    required:
+                      - name
+                      - artifacts
+                  description: List of connector plugins which should be mounted to the Kafka Connect.
               required:
                 - bootstrapServers
               description: The specification of the Kafka Connect cluster.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -822,7 +822,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: '`Secret` to use populate the volume.'
+                                description: '`Secret` to use to populate the volume.'
                               configMap:
                                 type: object
                                 properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -884,6 +884,14 @@ spec:
                                       type: string
                                     type: object
                                 description: CSIVolumeSource object to use to populate the volume.
+                              image:
+                                type: object
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                description: ImageVolumeSource object to use to populate the volume.
                             oneOf:
                               - properties:
                                   secret: {}
@@ -891,6 +899,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka `Pods`.
                     perPodService:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -822,7 +822,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: Secret to use populate the volume.
+                                description: '`Secret` to use populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -843,7 +843,7 @@ spec:
                                     type: string
                                   optional:
                                     type: boolean
-                                description: ConfigMap to use to populate the volume.
+                                description: '`ConfigMap` to use to populate the volume.'
                               emptyDir:
                                 type: object
                                 properties:
@@ -856,7 +856,7 @@ spec:
                                         type: string
                                       format:
                                         type: string
-                                description: EmptyDir to use to populate the volume.
+                                description: '`EmptyDir` to use to populate the volume.'
                               persistentVolumeClaim:
                                 type: object
                                 properties:
@@ -864,7 +864,7 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
-                                description: PersistentVolumeClaim object to use to populate the volume.
+                                description: '`PersistentVolumeClaim` object to use to populate the volume.'
                               csi:
                                 type: object
                                 properties:
@@ -883,7 +883,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
-                                description: CSIVolumeSource object to use to populate the volume.
+                                description: '`CSIVolumeSource` object to use to populate the volume.'
                               image:
                                 type: object
                                 properties:
@@ -891,7 +891,7 @@ spec:
                                     type: string
                                   reference:
                                     type: string
-                                description: ImageVolumeSource object to use to populate the volume.
+                                description: '`ImageVolumeSource` object to use to populate the volume.'
                             oneOf:
                               - properties:
                                   secret: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1084,7 +1084,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: '`Secret` to use populate the volume.'
+                                description: '`Secret` to use to populate the volume.'
                               configMap:
                                 type: object
                                 properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1146,6 +1146,14 @@ spec:
                                       type: string
                                     type: object
                                 description: CSIVolumeSource object to use to populate the volume.
+                              image:
+                                type: object
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                description: ImageVolumeSource object to use to populate the volume.
                             oneOf:
                               - properties:
                                   secret: {}
@@ -1153,6 +1161,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Bridge `Pods`.
                     apiService:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1084,7 +1084,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: Secret to use populate the volume.
+                                description: '`Secret` to use populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -1105,7 +1105,7 @@ spec:
                                     type: string
                                   optional:
                                     type: boolean
-                                description: ConfigMap to use to populate the volume.
+                                description: '`ConfigMap` to use to populate the volume.'
                               emptyDir:
                                 type: object
                                 properties:
@@ -1118,7 +1118,7 @@ spec:
                                         type: string
                                       format:
                                         type: string
-                                description: EmptyDir to use to populate the volume.
+                                description: '`EmptyDir` to use to populate the volume.'
                               persistentVolumeClaim:
                                 type: object
                                 properties:
@@ -1126,7 +1126,7 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
-                                description: PersistentVolumeClaim object to use to populate the volume.
+                                description: '`PersistentVolumeClaim` object to use to populate the volume.'
                               csi:
                                 type: object
                                 properties:
@@ -1145,7 +1145,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
-                                description: CSIVolumeSource object to use to populate the volume.
+                                description: '`CSIVolumeSource` object to use to populate the volume.'
                               image:
                                 type: object
                                 properties:
@@ -1153,7 +1153,7 @@ spec:
                                     type: string
                                   reference:
                                     type: string
-                                description: ImageVolumeSource object to use to populate the volume.
+                                description: '`ImageVolumeSource` object to use to populate the volume.'
                             oneOf:
                               - properties:
                                   secret: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1326,7 +1326,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: Secret to use populate the volume.
+                                description: '`Secret` to use populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -1347,7 +1347,7 @@ spec:
                                     type: string
                                   optional:
                                     type: boolean
-                                description: ConfigMap to use to populate the volume.
+                                description: '`ConfigMap` to use to populate the volume.'
                               emptyDir:
                                 type: object
                                 properties:
@@ -1360,7 +1360,7 @@ spec:
                                         type: string
                                       format:
                                         type: string
-                                description: EmptyDir to use to populate the volume.
+                                description: '`EmptyDir` to use to populate the volume.'
                               persistentVolumeClaim:
                                 type: object
                                 properties:
@@ -1368,7 +1368,7 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
-                                description: PersistentVolumeClaim object to use to populate the volume.
+                                description: '`PersistentVolumeClaim` object to use to populate the volume.'
                               csi:
                                 type: object
                                 properties:
@@ -1387,7 +1387,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
-                                description: CSIVolumeSource object to use to populate the volume.
+                                description: '`CSIVolumeSource` object to use to populate the volume.'
                               image:
                                 type: object
                                 properties:
@@ -1395,7 +1395,7 @@ spec:
                                     type: string
                                   reference:
                                     type: string
-                                description: ImageVolumeSource object to use to populate the volume.
+                                description: '`ImageVolumeSource` object to use to populate the volume.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2381,7 +2381,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: Secret to use populate the volume.
+                                description: '`Secret` to use populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -2402,7 +2402,7 @@ spec:
                                     type: string
                                   optional:
                                     type: boolean
-                                description: ConfigMap to use to populate the volume.
+                                description: '`ConfigMap` to use to populate the volume.'
                               emptyDir:
                                 type: object
                                 properties:
@@ -2415,7 +2415,7 @@ spec:
                                         type: string
                                       format:
                                         type: string
-                                description: EmptyDir to use to populate the volume.
+                                description: '`EmptyDir` to use to populate the volume.'
                               persistentVolumeClaim:
                                 type: object
                                 properties:
@@ -2423,7 +2423,7 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
-                                description: PersistentVolumeClaim object to use to populate the volume.
+                                description: '`PersistentVolumeClaim` object to use to populate the volume.'
                               csi:
                                 type: object
                                 properties:
@@ -2442,7 +2442,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
-                                description: CSIVolumeSource object to use to populate the volume.
+                                description: '`CSIVolumeSource` object to use to populate the volume.'
                               image:
                                 type: object
                                 properties:
@@ -2450,7 +2450,7 @@ spec:
                                     type: string
                                   reference:
                                     type: string
-                                description: ImageVolumeSource object to use to populate the volume.
+                                description: '`ImageVolumeSource` object to use to populate the volume.'
                             oneOf:
                               - properties:
                                   secret: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1388,6 +1388,14 @@ spec:
                                       type: string
                                     type: object
                                 description: CSIVolumeSource object to use to populate the volume.
+                              image:
+                                type: object
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                description: ImageVolumeSource object to use to populate the volume.
                             oneOf:
                               - properties:
                                   secret: {}
@@ -1395,6 +1403,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect `Pods`.
                     apiService:
@@ -2434,6 +2443,14 @@ spec:
                                       type: string
                                     type: object
                                 description: CSIVolumeSource object to use to populate the volume.
+                              image:
+                                type: object
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                description: ImageVolumeSource object to use to populate the volume.
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2441,6 +2458,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                     buildContainer:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1326,7 +1326,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: '`Secret` to use populate the volume.'
+                                description: '`Secret` to use to populate the volume.'
                               configMap:
                                 type: object
                                 properties:
@@ -2381,7 +2381,7 @@ spec:
                                     type: boolean
                                   secretName:
                                     type: string
-                                description: '`Secret` to use populate the volume.'
+                                description: '`Secret` to use to populate the volume.'
                               configMap:
                                 type: object
                                 properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1568,7 +1568,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: Secret to use populate the volume.
+                                  description: '`Secret` to use populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -1589,7 +1589,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: ConfigMap to use to populate the volume.
+                                  description: '`ConfigMap` to use to populate the volume.'
                                 emptyDir:
                                   type: object
                                   properties:
@@ -1602,7 +1602,7 @@ spec:
                                           type: string
                                         format:
                                           type: string
-                                  description: EmptyDir to use to populate the volume.
+                                  description: '`EmptyDir` to use to populate the volume.'
                                 persistentVolumeClaim:
                                   type: object
                                   properties:
@@ -1610,7 +1610,7 @@ spec:
                                       type: string
                                     readOnly:
                                       type: boolean
-                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                  description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                 csi:
                                   type: object
                                   properties:
@@ -1629,7 +1629,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                  description: CSIVolumeSource object to use to populate the volume.
+                                  description: '`CSIVolumeSource` object to use to populate the volume.'
                                 image:
                                   type: object
                                   properties:
@@ -1637,7 +1637,7 @@ spec:
                                       type: string
                                     reference:
                                       type: string
-                                  description: ImageVolumeSource object to use to populate the volume.
+                                  description: '`ImageVolumeSource` object to use to populate the volume.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -3178,7 +3178,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: Secret to use populate the volume.
+                                  description: '`Secret` to use populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -3199,7 +3199,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: ConfigMap to use to populate the volume.
+                                  description: '`ConfigMap` to use to populate the volume.'
                                 emptyDir:
                                   type: object
                                   properties:
@@ -3212,7 +3212,7 @@ spec:
                                           type: string
                                         format:
                                           type: string
-                                  description: EmptyDir to use to populate the volume.
+                                  description: '`EmptyDir` to use to populate the volume.'
                                 persistentVolumeClaim:
                                   type: object
                                   properties:
@@ -3220,7 +3220,7 @@ spec:
                                       type: string
                                     readOnly:
                                       type: boolean
-                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                  description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                 csi:
                                   type: object
                                   properties:
@@ -3239,7 +3239,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                  description: CSIVolumeSource object to use to populate the volume.
+                                  description: '`CSIVolumeSource` object to use to populate the volume.'
                                 image:
                                   type: object
                                   properties:
@@ -3247,7 +3247,7 @@ spec:
                                       type: string
                                     reference:
                                       type: string
-                                  description: ImageVolumeSource object to use to populate the volume.
+                                  description: '`ImageVolumeSource` object to use to populate the volume.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -4594,7 +4594,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: Secret to use populate the volume.
+                                  description: '`Secret` to use populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -4615,7 +4615,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: ConfigMap to use to populate the volume.
+                                  description: '`ConfigMap` to use to populate the volume.'
                                 emptyDir:
                                   type: object
                                   properties:
@@ -4628,7 +4628,7 @@ spec:
                                           type: string
                                         format:
                                           type: string
-                                  description: EmptyDir to use to populate the volume.
+                                  description: '`EmptyDir` to use to populate the volume.'
                                 persistentVolumeClaim:
                                   type: object
                                   properties:
@@ -4636,7 +4636,7 @@ spec:
                                       type: string
                                     readOnly:
                                       type: boolean
-                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                  description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                 csi:
                                   type: object
                                   properties:
@@ -4655,7 +4655,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                  description: CSIVolumeSource object to use to populate the volume.
+                                  description: '`CSIVolumeSource` object to use to populate the volume.'
                                 image:
                                   type: object
                                   properties:
@@ -4663,7 +4663,7 @@ spec:
                                       type: string
                                     reference:
                                       type: string
-                                  description: ImageVolumeSource object to use to populate the volume.
+                                  description: '`ImageVolumeSource` object to use to populate the volume.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -6059,7 +6059,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: Secret to use populate the volume.
+                                  description: '`Secret` to use populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -6080,7 +6080,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: ConfigMap to use to populate the volume.
+                                  description: '`ConfigMap` to use to populate the volume.'
                                 emptyDir:
                                   type: object
                                   properties:
@@ -6093,7 +6093,7 @@ spec:
                                           type: string
                                         format:
                                           type: string
-                                  description: EmptyDir to use to populate the volume.
+                                  description: '`EmptyDir` to use to populate the volume.'
                                 persistentVolumeClaim:
                                   type: object
                                   properties:
@@ -6101,7 +6101,7 @@ spec:
                                       type: string
                                     readOnly:
                                       type: boolean
-                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                  description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                 csi:
                                   type: object
                                   properties:
@@ -6120,7 +6120,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                  description: CSIVolumeSource object to use to populate the volume.
+                                  description: '`CSIVolumeSource` object to use to populate the volume.'
                                 image:
                                   type: object
                                   properties:
@@ -6128,7 +6128,7 @@ spec:
                                       type: string
                                     reference:
                                       type: string
-                                  description: ImageVolumeSource object to use to populate the volume.
+                                  description: '`ImageVolumeSource` object to use to populate the volume.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -7323,7 +7323,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: Secret to use populate the volume.
+                                  description: '`Secret` to use populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -7344,7 +7344,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: ConfigMap to use to populate the volume.
+                                  description: '`ConfigMap` to use to populate the volume.'
                                 emptyDir:
                                   type: object
                                   properties:
@@ -7357,7 +7357,7 @@ spec:
                                           type: string
                                         format:
                                           type: string
-                                  description: EmptyDir to use to populate the volume.
+                                  description: '`EmptyDir` to use to populate the volume.'
                                 persistentVolumeClaim:
                                   type: object
                                   properties:
@@ -7365,7 +7365,7 @@ spec:
                                       type: string
                                     readOnly:
                                       type: boolean
-                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                  description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                 csi:
                                   type: object
                                   properties:
@@ -7384,7 +7384,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                  description: CSIVolumeSource object to use to populate the volume.
+                                  description: '`CSIVolumeSource` object to use to populate the volume.'
                                 image:
                                   type: object
                                   properties:
@@ -7392,7 +7392,7 @@ spec:
                                       type: string
                                     reference:
                                       type: string
-                                  description: ImageVolumeSource object to use to populate the volume.
+                                  description: '`ImageVolumeSource` object to use to populate the volume.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -8265,7 +8265,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: Secret to use populate the volume.
+                                  description: '`Secret` to use populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -8286,7 +8286,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: ConfigMap to use to populate the volume.
+                                  description: '`ConfigMap` to use to populate the volume.'
                                 emptyDir:
                                   type: object
                                   properties:
@@ -8299,7 +8299,7 @@ spec:
                                           type: string
                                         format:
                                           type: string
-                                  description: EmptyDir to use to populate the volume.
+                                  description: '`EmptyDir` to use to populate the volume.'
                                 persistentVolumeClaim:
                                   type: object
                                   properties:
@@ -8307,7 +8307,7 @@ spec:
                                       type: string
                                     readOnly:
                                       type: boolean
-                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                  description: '`PersistentVolumeClaim` object to use to populate the volume.'
                                 csi:
                                   type: object
                                   properties:
@@ -8326,7 +8326,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                  description: CSIVolumeSource object to use to populate the volume.
+                                  description: '`CSIVolumeSource` object to use to populate the volume.'
                                 image:
                                   type: object
                                   properties:
@@ -8334,7 +8334,7 @@ spec:
                                       type: string
                                     reference:
                                       type: string
-                                  description: ImageVolumeSource object to use to populate the volume.
+                                  description: '`ImageVolumeSource` object to use to populate the volume.'
                               oneOf:
                               - properties:
                                   secret: {}

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1568,7 +1568,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: '`Secret` to use populate the volume.'
+                                  description: '`Secret` to use to populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -3178,7 +3178,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: '`Secret` to use populate the volume.'
+                                  description: '`Secret` to use to populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -4594,7 +4594,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: '`Secret` to use populate the volume.'
+                                  description: '`Secret` to use to populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -6059,7 +6059,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: '`Secret` to use populate the volume.'
+                                  description: '`Secret` to use to populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -7323,7 +7323,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: '`Secret` to use populate the volume.'
+                                  description: '`Secret` to use to populate the volume.'
                                 configMap:
                                   type: object
                                   properties:
@@ -8265,7 +8265,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       type: string
-                                  description: '`Secret` to use populate the volume.'
+                                  description: '`Secret` to use to populate the volume.'
                                 configMap:
                                   type: object
                                   properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1630,6 +1630,14 @@ spec:
                                         type: string
                                       type: object
                                   description: CSIVolumeSource object to use to populate the volume.
+                                image:
+                                  type: object
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  description: ImageVolumeSource object to use to populate the volume.
                               oneOf:
                               - properties:
                                   secret: {}
@@ -1637,6 +1645,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
@@ -3231,6 +3240,14 @@ spec:
                                         type: string
                                       type: object
                                   description: CSIVolumeSource object to use to populate the volume.
+                                image:
+                                  type: object
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  description: ImageVolumeSource object to use to populate the volume.
                               oneOf:
                               - properties:
                                   secret: {}
@@ -3238,6 +3255,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
@@ -4638,6 +4656,14 @@ spec:
                                         type: string
                                       type: object
                                   description: CSIVolumeSource object to use to populate the volume.
+                                image:
+                                  type: object
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  description: ImageVolumeSource object to use to populate the volume.
                               oneOf:
                               - properties:
                                   secret: {}
@@ -4645,6 +4671,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Entity Operator `Pods`.
                       topicOperatorContainer:
@@ -6094,6 +6121,14 @@ spec:
                                         type: string
                                       type: object
                                   description: CSIVolumeSource object to use to populate the volume.
+                                image:
+                                  type: object
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  description: ImageVolumeSource object to use to populate the volume.
                               oneOf:
                               - properties:
                                   secret: {}
@@ -6101,6 +6136,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Cruise Control `Pods`.
                       apiService:
@@ -7349,6 +7385,14 @@ spec:
                                         type: string
                                       type: object
                                   description: CSIVolumeSource object to use to populate the volume.
+                                image:
+                                  type: object
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  description: ImageVolumeSource object to use to populate the volume.
                               oneOf:
                               - properties:
                                   secret: {}
@@ -7356,6 +7400,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for JmxTrans `Pods`.
                       container:
@@ -8282,6 +8327,14 @@ spec:
                                         type: string
                                       type: object
                                   description: CSIVolumeSource object to use to populate the volume.
+                                image:
+                                  type: object
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  description: ImageVolumeSource object to use to populate the volume.
                               oneOf:
                               - properties:
                                   secret: {}
@@ -8289,6 +8342,7 @@ spec:
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
                                   csi: {}
+                                  image: {}
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Kafka Exporter `Pods`.
                       service:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1170,6 +1170,14 @@ spec:
                                     type: string
                                   type: object
                               description: CSIVolumeSource object to use to populate the volume.
+                            image:
+                              type: object
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              description: ImageVolumeSource object to use to populate the volume.
                           oneOf:
                           - properties:
                               secret: {}
@@ -1177,6 +1185,7 @@ spec:
                               emptyDir: {}
                               persistentVolumeClaim: {}
                               csi: {}
+                              image: {}
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
@@ -2216,6 +2225,14 @@ spec:
                                     type: string
                                   type: object
                               description: CSIVolumeSource object to use to populate the volume.
+                            image:
+                              type: object
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              description: ImageVolumeSource object to use to populate the volume.
                           oneOf:
                           - properties:
                               secret: {}
@@ -2223,6 +2240,7 @@ spec:
                               emptyDir: {}
                               persistentVolumeClaim: {}
                               csi: {}
+                              image: {}
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:
@@ -2652,6 +2670,46 @@ spec:
                 - output
                 - plugins
                 description: Configures how the Connect container image should be built. Optional.
+              plugins:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
+                      description: "The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be mounted. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
+                    artifacts:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          pullPolicy:
+                            type: string
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+
+                              * `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              * `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              * `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
+                          reference:
+                            type: string
+                            description: Image or artifact reference to be used. Required.
+                          type:
+                            type: string
+                            enum:
+                            - image
+                            description: "Artifact type. Currently, the only supported artifact type is `image`."
+                        required:
+                        - reference
+                        - type
+                      description: List of artifacts which belong to this connector plugin. Required.
+                  required:
+                  - name
+                  - artifacts
+                description: List of connector plugins which should be mounted to the Kafka Connect.
             required:
             - bootstrapServers
             description: The specification of the Kafka Connect cluster.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1108,7 +1108,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: '`Secret` to use populate the volume.'
+                              description: '`Secret` to use to populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -2163,7 +2163,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: '`Secret` to use populate the volume.'
+                              description: '`Secret` to use to populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -2698,7 +2698,7 @@ spec:
                               Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
                           reference:
                             type: string
-                            description: Reference to the container image (OCI artifact) containing the connector plugin. The image is mounted as a volume and provides the plugin binary. Required.
+                            description: Reference to the container image (OCI artifact) containing the Kafka Connect plugin. The image is mounted as a volume and provides the plugin binary. Required.
                           type:
                             type: string
                             enum:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1108,7 +1108,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: Secret to use populate the volume.
+                              description: '`Secret` to use populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -1129,7 +1129,7 @@ spec:
                                   type: string
                                 optional:
                                   type: boolean
-                              description: ConfigMap to use to populate the volume.
+                              description: '`ConfigMap` to use to populate the volume.'
                             emptyDir:
                               type: object
                               properties:
@@ -1142,7 +1142,7 @@ spec:
                                       type: string
                                     format:
                                       type: string
-                              description: EmptyDir to use to populate the volume.
+                              description: '`EmptyDir` to use to populate the volume.'
                             persistentVolumeClaim:
                               type: object
                               properties:
@@ -1150,7 +1150,7 @@ spec:
                                   type: string
                                 readOnly:
                                   type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
+                              description: '`PersistentVolumeClaim` object to use to populate the volume.'
                             csi:
                               type: object
                               properties:
@@ -1169,7 +1169,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                              description: CSIVolumeSource object to use to populate the volume.
+                              description: '`CSIVolumeSource` object to use to populate the volume.'
                             image:
                               type: object
                               properties:
@@ -1177,7 +1177,7 @@ spec:
                                   type: string
                                 reference:
                                   type: string
-                              description: ImageVolumeSource object to use to populate the volume.
+                              description: '`ImageVolumeSource` object to use to populate the volume.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -2163,7 +2163,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: Secret to use populate the volume.
+                              description: '`Secret` to use populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -2184,7 +2184,7 @@ spec:
                                   type: string
                                 optional:
                                   type: boolean
-                              description: ConfigMap to use to populate the volume.
+                              description: '`ConfigMap` to use to populate the volume.'
                             emptyDir:
                               type: object
                               properties:
@@ -2197,7 +2197,7 @@ spec:
                                       type: string
                                     format:
                                       type: string
-                              description: EmptyDir to use to populate the volume.
+                              description: '`EmptyDir` to use to populate the volume.'
                             persistentVolumeClaim:
                               type: object
                               properties:
@@ -2205,7 +2205,7 @@ spec:
                                   type: string
                                 readOnly:
                                   type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
+                              description: '`PersistentVolumeClaim` object to use to populate the volume.'
                             csi:
                               type: object
                               properties:
@@ -2224,7 +2224,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                              description: CSIVolumeSource object to use to populate the volume.
+                              description: '`CSIVolumeSource` object to use to populate the volume.'
                             image:
                               type: object
                               properties:
@@ -2232,7 +2232,7 @@ spec:
                                   type: string
                                 reference:
                                   type: string
-                              description: ImageVolumeSource object to use to populate the volume.
+                              description: '`ImageVolumeSource` object to use to populate the volume.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -2678,7 +2678,7 @@ spec:
                     name:
                       type: string
                       pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
-                      description: "The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be mounted. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
+                      description: "A unique name for the connector plugin. This name is used to generate the mount path for the connector artifacts. The name has to be unique within the KafkaConnect resource. The name must be unique within the `KafkaConnect` resource and match the pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
                     artifacts:
                       type: array
                       items:
@@ -2687,16 +2687,18 @@ spec:
                           pullPolicy:
                             type: string
                             description: |-
-                              Policy for pulling OCI objects. Possible values are:
+                              Policy that determines when the container image (OCI artifact) is pulled.
 
-                              * `Always`: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                              * `Never`: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                              * `IfNotPresent`: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Possible values are:
+
+                              * `Always`: Always pull the image. If the pull fails, container creation fails.
+                              * `Never`: Never pull the image. Use only a locally available image. Container creation fails if the image isn’t present.
+                              * `IfNotPresent`: Pull the image only if it’s not already available locally. Container creation fails if the image isn’t present and the pull fails.
 
                               Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
                           reference:
                             type: string
-                            description: Image or artifact reference to be used. Required.
+                            description: Reference to the container image (OCI artifact) containing the connector plugin. The image is mounted as a volume and provides the plugin binary. Required.
                           type:
                             type: string
                             enum:
@@ -2705,11 +2707,11 @@ spec:
                         required:
                         - reference
                         - type
-                      description: List of artifacts which belong to this connector plugin. Required.
+                      description: List of artifacts associated with this connector plugin. Required.
                   required:
                   - name
                   - artifacts
-                description: List of connector plugins which should be mounted to the Kafka Connect.
+                description: List of connector plugins to mount into the `KafkaConnect` pod.
             required:
             - bootstrapServers
             description: The specification of the Kafka Connect cluster.

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -821,7 +821,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: Secret to use populate the volume.
+                              description: '`Secret` to use populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -842,7 +842,7 @@ spec:
                                   type: string
                                 optional:
                                   type: boolean
-                              description: ConfigMap to use to populate the volume.
+                              description: '`ConfigMap` to use to populate the volume.'
                             emptyDir:
                               type: object
                               properties:
@@ -855,7 +855,7 @@ spec:
                                       type: string
                                     format:
                                       type: string
-                              description: EmptyDir to use to populate the volume.
+                              description: '`EmptyDir` to use to populate the volume.'
                             persistentVolumeClaim:
                               type: object
                               properties:
@@ -863,7 +863,7 @@ spec:
                                   type: string
                                 readOnly:
                                   type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
+                              description: '`PersistentVolumeClaim` object to use to populate the volume.'
                             csi:
                               type: object
                               properties:
@@ -882,7 +882,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                              description: CSIVolumeSource object to use to populate the volume.
+                              description: '`CSIVolumeSource` object to use to populate the volume.'
                             image:
                               type: object
                               properties:
@@ -890,7 +890,7 @@ spec:
                                   type: string
                                 reference:
                                   type: string
-                              description: ImageVolumeSource object to use to populate the volume.
+                              description: '`ImageVolumeSource` object to use to populate the volume.'
                           oneOf:
                           - properties:
                               secret: {}

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -883,6 +883,14 @@ spec:
                                     type: string
                                   type: object
                               description: CSIVolumeSource object to use to populate the volume.
+                            image:
+                              type: object
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              description: ImageVolumeSource object to use to populate the volume.
                           oneOf:
                           - properties:
                               secret: {}
@@ -890,6 +898,7 @@ spec:
                               emptyDir: {}
                               persistentVolumeClaim: {}
                               csi: {}
+                              image: {}
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka `Pods`.
                   perPodService:

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -821,7 +821,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: '`Secret` to use populate the volume.'
+                              description: '`Secret` to use to populate the volume.'
                             configMap:
                               type: object
                               properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1145,6 +1145,14 @@ spec:
                                     type: string
                                   type: object
                               description: CSIVolumeSource object to use to populate the volume.
+                            image:
+                              type: object
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              description: ImageVolumeSource object to use to populate the volume.
                           oneOf:
                           - properties:
                               secret: {}
@@ -1152,6 +1160,7 @@ spec:
                               emptyDir: {}
                               persistentVolumeClaim: {}
                               csi: {}
+                              image: {}
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Bridge `Pods`.
                   apiService:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1083,7 +1083,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: '`Secret` to use populate the volume.'
+                              description: '`Secret` to use to populate the volume.'
                             configMap:
                               type: object
                               properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1083,7 +1083,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: Secret to use populate the volume.
+                              description: '`Secret` to use populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -1104,7 +1104,7 @@ spec:
                                   type: string
                                 optional:
                                   type: boolean
-                              description: ConfigMap to use to populate the volume.
+                              description: '`ConfigMap` to use to populate the volume.'
                             emptyDir:
                               type: object
                               properties:
@@ -1117,7 +1117,7 @@ spec:
                                       type: string
                                     format:
                                       type: string
-                              description: EmptyDir to use to populate the volume.
+                              description: '`EmptyDir` to use to populate the volume.'
                             persistentVolumeClaim:
                               type: object
                               properties:
@@ -1125,7 +1125,7 @@ spec:
                                   type: string
                                 readOnly:
                                   type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
+                              description: '`PersistentVolumeClaim` object to use to populate the volume.'
                             csi:
                               type: object
                               properties:
@@ -1144,7 +1144,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                              description: CSIVolumeSource object to use to populate the volume.
+                              description: '`CSIVolumeSource` object to use to populate the volume.'
                             image:
                               type: object
                               properties:
@@ -1152,7 +1152,7 @@ spec:
                                   type: string
                                 reference:
                                   type: string
-                              description: ImageVolumeSource object to use to populate the volume.
+                              description: '`ImageVolumeSource` object to use to populate the volume.'
                           oneOf:
                           - properties:
                               secret: {}

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1325,7 +1325,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: Secret to use populate the volume.
+                              description: '`Secret` to use populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -1346,7 +1346,7 @@ spec:
                                   type: string
                                 optional:
                                   type: boolean
-                              description: ConfigMap to use to populate the volume.
+                              description: '`ConfigMap` to use to populate the volume.'
                             emptyDir:
                               type: object
                               properties:
@@ -1359,7 +1359,7 @@ spec:
                                       type: string
                                     format:
                                       type: string
-                              description: EmptyDir to use to populate the volume.
+                              description: '`EmptyDir` to use to populate the volume.'
                             persistentVolumeClaim:
                               type: object
                               properties:
@@ -1367,7 +1367,7 @@ spec:
                                   type: string
                                 readOnly:
                                   type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
+                              description: '`PersistentVolumeClaim` object to use to populate the volume.'
                             csi:
                               type: object
                               properties:
@@ -1386,7 +1386,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                              description: CSIVolumeSource object to use to populate the volume.
+                              description: '`CSIVolumeSource` object to use to populate the volume.'
                             image:
                               type: object
                               properties:
@@ -1394,7 +1394,7 @@ spec:
                                   type: string
                                 reference:
                                   type: string
-                              description: ImageVolumeSource object to use to populate the volume.
+                              description: '`ImageVolumeSource` object to use to populate the volume.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -2380,7 +2380,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: Secret to use populate the volume.
+                              description: '`Secret` to use populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -2401,7 +2401,7 @@ spec:
                                   type: string
                                 optional:
                                   type: boolean
-                              description: ConfigMap to use to populate the volume.
+                              description: '`ConfigMap` to use to populate the volume.'
                             emptyDir:
                               type: object
                               properties:
@@ -2414,7 +2414,7 @@ spec:
                                       type: string
                                     format:
                                       type: string
-                              description: EmptyDir to use to populate the volume.
+                              description: '`EmptyDir` to use to populate the volume.'
                             persistentVolumeClaim:
                               type: object
                               properties:
@@ -2422,7 +2422,7 @@ spec:
                                   type: string
                                 readOnly:
                                   type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
+                              description: '`PersistentVolumeClaim` object to use to populate the volume.'
                             csi:
                               type: object
                               properties:
@@ -2441,7 +2441,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                              description: CSIVolumeSource object to use to populate the volume.
+                              description: '`CSIVolumeSource` object to use to populate the volume.'
                             image:
                               type: object
                               properties:
@@ -2449,7 +2449,7 @@ spec:
                                   type: string
                                 reference:
                                   type: string
-                              description: ImageVolumeSource object to use to populate the volume.
+                              description: '`ImageVolumeSource` object to use to populate the volume.'
                           oneOf:
                           - properties:
                               secret: {}

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1387,6 +1387,14 @@ spec:
                                     type: string
                                   type: object
                               description: CSIVolumeSource object to use to populate the volume.
+                            image:
+                              type: object
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              description: ImageVolumeSource object to use to populate the volume.
                           oneOf:
                           - properties:
                               secret: {}
@@ -1394,6 +1402,7 @@ spec:
                               emptyDir: {}
                               persistentVolumeClaim: {}
                               csi: {}
+                              image: {}
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
@@ -2433,6 +2442,14 @@ spec:
                                     type: string
                                   type: object
                               description: CSIVolumeSource object to use to populate the volume.
+                            image:
+                              type: object
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              description: ImageVolumeSource object to use to populate the volume.
                           oneOf:
                           - properties:
                               secret: {}
@@ -2440,6 +2457,7 @@ spec:
                               emptyDir: {}
                               persistentVolumeClaim: {}
                               csi: {}
+                              image: {}
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1325,7 +1325,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: '`Secret` to use populate the volume.'
+                              description: '`Secret` to use to populate the volume.'
                             configMap:
                               type: object
                               properties:
@@ -2380,7 +2380,7 @@ spec:
                                   type: boolean
                                 secretName:
                                   type: string
-                              description: '`Secret` to use populate the volume.'
+                              description: '`Secret` to use to populate the volume.'
                             configMap:
                               type: object
                               properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the proposal [SP-102](https://github.com/strimzi/proposals/blob/main/102-using-image-volumes-to-improve-extensibility-of-Strimzi-operands.md) and adds support for Image Volumes to add plugins using OCI artifacts or container images.

It allows to add them using the additional volumes to any container as well as through a new API dedicated for Kafka Connect connectors.

As requested in the proposal, issue #11466 covers the future system tests, which can be added once there is more widespread support for the Kubernetes Image Volumes feature among our environments

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md