### PR TITLE
Use available image for kube-registry-proxy in minikube startup script

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -103,7 +103,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
         minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.0-beta.1,KubeRegistryProxy=google_containers/kube-registry-proxy:0.4-${ARCH}"
         rm -rf kubernetes
     else
-        minikube addons enable registry --images="Registry=${MINIKUBE_REGISTRY_IMAGE}"
+        minikube addons enable registry --images="Registry=${MINIKUBE_REGISTRY_IMAGE},KubeRegistryProxy=gcr.io/k8s-minikube/kube-registry-proxy:0.0.9"
     fi
 
     minikube addons enable registry-aliases


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It seems there is an issue with tags used by the `registry` addon in minikube - https://github.com/kubernetes/minikube/issues/20838

This PR uses the one available in the registry to unblock our pipelines.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

