### PR TITLE
Fixed adding new Kafka versions documentation

### DIFF
--- a/development-docs/KAFKA_VERSIONS.md
+++ b/development-docs/KAFKA_VERSIONS.md
@@ -14,7 +14,7 @@ But these are some of the tasks you usually have to do.
 * If the version you are adding is the latest
   * Update the Kafka versions and protocol versions in the documentation `attributes.adoc`
   * If needed, update the examples (only in the `packaging/examples` directory):
-    * The `version` and the `inter.broker.protocol.version` fields
+    * The `version` field
     * The Docker image tag in the Kafka connect Build example
   * Update the main `pom.xml` to use the latest Kafka version in the operator
   * Update `systemtest/src/test/resources/upgrade/BundleUpgrade.yaml` with the new version

--- a/development-docs/KAFKA_VERSIONS.md
+++ b/development-docs/KAFKA_VERSIONS.md
@@ -14,7 +14,7 @@ But these are some of the tasks you usually have to do.
 * If the version you are adding is the latest
   * Update the Kafka versions and protocol versions in the documentation `attributes.adoc`
   * If needed, update the examples (only in the `packaging/examples` directory):
-    * The `version` field
+    * The `version` and the `spec.kafka.metadataVersion` fields within the `Kafka` custom resource
     * The Docker image tag in the Kafka connect Build example
   * Update the main `pom.xml` to use the latest Kafka version in the operator
   * Update `systemtest/src/test/resources/upgrade/BundleUpgrade.yaml` with the new version

--- a/development-docs/KAFKA_VERSIONS.md
+++ b/development-docs/KAFKA_VERSIONS.md
@@ -14,7 +14,8 @@ But these are some of the tasks you usually have to do.
 * If the version you are adding is the latest
   * Update the Kafka versions and protocol versions in the documentation `attributes.adoc`
   * If needed, update the examples (only in the `packaging/examples` directory):
-    * The `version` and the `spec.kafka.metadataVersion` fields within the `Kafka` custom resource
+    * The `.spec.kafka.version` and the `spec.kafka.metadataVersion` fields within the `Kafka` custom resource
+    * The `.spec.version` field within the `KafkaConnect` and `KafkaMirrorMaker2` custom resources
     * The Docker image tag in the Kafka connect Build example
   * Update the main `pom.xml` to use the latest Kafka version in the operator
   * Update `systemtest/src/test/resources/upgrade/BundleUpgrade.yaml` with the new version


### PR DESCRIPTION
Trivial PR to fix a leftover on adding a new Kafka version within Strimzi.
Updating the `inter.broker.protocol.version` field in the examples doesn't make any sense anymore because only KRaft is supported.
