### PR TITLE
Ignore user config provider aliases with conflict

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -810,19 +810,16 @@ public class KafkaBrokerConfigurationBuilder {
         if (userConfig != null
                 && !userConfig.getConfiguration().isEmpty()
                 && userConfig.getConfigOption("config.providers") != null) {
-            String aliases = userConfig.getConfigOption("config.providers");
-            Collection<String> userAliases = Arrays.asList(aliases.split(","));
+            String userAliases = userConfig.getConfigOption("config.providers");
             
-            for (final String alias: strimziAliases) {
-                if (userAliases.contains(alias)) {
-                    throw new InvalidConfigurationException("config.provider " + alias + " not permitted as it reserved for Strimzi. Not permitted aliases: " + strimziAliases); 
-                } else {
-                    aliases += "," + alias;
+            Arrays.asList(userAliases.split(",")).stream().forEach(userAlias -> {
+                if (strimziAliases.contains(userAlias)) {
+                    throw new InvalidConfigurationException("config.provider " + userAlias + " not permitted as it reserved for Strimzi. Not permitted aliases: " + strimziAliases); 
                 }
-            }
+            });
 
             userConfig.removeConfigOption("config.providers");
-            return aliases;
+            return userAliases + "," + String.join(",", strimziAliases);
         } else {
             return String.join(",", strimziAliases);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -784,7 +784,7 @@ public class KafkaBrokerConfigurationBuilder {
         }
         
         final String userConfigProviders = getUserConfigProviderAliases(strimziConfigProviders, userConfig);
-        if ("".equals(userConfigProviders)) {
+        if (userConfigProviders.isEmpty()) {
             writer.println("# Configuration providers configured by Strimzi");
             writer.println("config.providers=" + strimziConfigProviders);
         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -807,7 +807,7 @@ public class KafkaBrokerConfigurationBuilder {
     }
     
     /**
-     * Get the user provided Kafka configuration provider aliases, throwing an InvalidConfigurationException if any are found that would that overwrite the Strimzi defined configuration providers
+     * Get the user provided Kafka configuration provider aliases, throwing an InvalidConfigurationException if any are found that would overwrite the Strimzi defined configuration providers
      * 
      * @param strimziConfigProviders    The Strimzi defined configuration providers
      * @param userConfig                The user configuration to extract the possible user-provided config provider configuration from

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -33,6 +33,7 @@ import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsRepor
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 
 import java.io.PrintWriter;
@@ -40,8 +41,10 @@ import java.io.StringWriter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -58,6 +61,7 @@ import java.util.stream.Collectors;
  * generate the configuration file, it is using the PrintWriter.
  */
 public class KafkaBrokerConfigurationBuilder {
+    private final static ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaBrokerConfigurationBuilder.class.getName());
     private final static String CONTROL_PLANE_LISTENER_NAME = "CONTROLPLANE-9090";
     private final static String REPLICATION_LISTENER_NAME = "REPLICATION-9091";
     // Names of environment variables expanded through config providers inside the Kafka node
@@ -780,16 +784,14 @@ public class KafkaBrokerConfigurationBuilder {
         } else {
             strimziConfigProviders = "strimzienv";
         }
-
-        if (userConfig != null
-                && !userConfig.getConfiguration().isEmpty()
-                && userConfig.getConfigOption("config.providers") != null) {
-            writer.println("# Configuration providers configured by the user and by Strimzi");
-            writer.println("config.providers=" + userConfig.getConfigOption("config.providers") + "," + strimziConfigProviders);
-            userConfig.removeConfigOption("config.providers");
-        } else {
+        
+        final String userConfigProviders = getUserConfigProviderAliases(strimziConfigProviders, userConfig);
+        if ("".equals(userConfigProviders)) {
             writer.println("# Configuration providers configured by Strimzi");
             writer.println("config.providers=" + strimziConfigProviders);
+        } else {
+            writer.println("# Configuration providers configured by the user and by Strimzi");
+            writer.println("config.providers=" + userConfigProviders + "," + strimziConfigProviders);
         }
 
         writer.println("config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider");
@@ -804,6 +806,35 @@ public class KafkaBrokerConfigurationBuilder {
         }
 
         writer.println();
+    }
+    
+    /**
+     * Get the user provided Kafka configuration provider aliases, dropping any that would overwrite the Strimzi defined configuration providers
+     * 
+     * @param strimziConfigProviders    The Strimzi defined configuration providers
+     * @param userConfig                The user configuration to extract the possible user-provided config provider configuration from
+     * @return                          The user defined Kafka configuration provider aliases or empty string
+     */
+    private String getUserConfigProviderAliases(String strimziConfigProviders, KafkaConfiguration userConfig) {
+        if (userConfig != null
+                && !userConfig.getConfiguration().isEmpty()
+                && userConfig.getConfigOption("config.providers") != null) {
+            Collection<String> userAliases = Arrays.asList(userConfig.getConfigOption("config.providers").split(","));
+            Collection<String> strimziAliases = Arrays.asList(strimziConfigProviders.split(","));
+            
+            Set<String> validUserAliases = new HashSet<>();
+            userAliases.stream().forEach(alias -> {
+                if (strimziAliases.contains(alias)) {
+                    LOGGER.warnCr(reconciliation, "config.provider " + alias + " ignored as it is not permitted. Not permitted aliases: " + strimziAliases);
+                    userConfig.removeConfigOption("config.providers." + alias + ".class");  
+                } else {
+                    validUserAliases.add(alias);
+                }
+            });
+            userConfig.removeConfigOption("config.providers");
+            return String.join(",", validUserAliases);
+        }
+        return "";
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -569,8 +569,9 @@ public class KafkaBrokerConfigurationBuilderTest {
     @ParallelTest
     public void testUserConfigurationWithConfigProviders()  {
         Map<String, Object> userConfiguration = new HashMap<>();
-        userConfiguration.put("config.providers", "env");
+        userConfiguration.put("config.providers", "env,strimzienv");
         userConfiguration.put("config.providers.env.class", "org.apache.kafka.common.config.provider.EnvVarConfigProvider");
+        userConfiguration.put("config.providers.strimzienv.class", "org.apache.kafka.common.config.provider.UserConfigProvider");
 
         KafkaConfiguration kafkaConfiguration = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -36,6 +36,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -569,9 +570,8 @@ public class KafkaBrokerConfigurationBuilderTest {
     @ParallelTest
     public void testUserConfigurationWithConfigProviders()  {
         Map<String, Object> userConfiguration = new HashMap<>();
-        userConfiguration.put("config.providers", "env,strimzienv");
+        userConfiguration.put("config.providers", "env");
         userConfiguration.put("config.providers.env.class", "org.apache.kafka.common.config.provider.EnvVarConfigProvider");
-        userConfiguration.put("config.providers.strimzienv.class", "org.apache.kafka.common.config.provider.UserConfigProvider");
 
         KafkaConfiguration kafkaConfiguration = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
 
@@ -600,6 +600,22 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "config.providers.strimzienv.param.allowlist.pattern=.*",
                 "config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider"));
+    }
+    
+    @ParallelTest
+    public void testUserConfigurationWithInvalidConfigProviders()  {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("config.providers", "env,strimzienv");
+        userConfiguration.put("config.providers.env.class", "org.apache.kafka.common.config.provider.EnvVarConfigProvider");
+        userConfiguration.put("config.providers.strimzienv.class", "org.apache.kafka.common.config.provider.UserConfigProvider");
+
+        KafkaConfiguration kafkaConfiguration = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
+
+        assertThrows(InvalidConfigurationException.class, () -> {
+            new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
+                .withUserConfiguration(kafkaConfiguration, false, false, false)
+                .build();
+        }, "InvalidConfigurationException was expected");
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Closes #11349. Handles the scenario where the user specifies config providers than conflict with the Strimzi defined config providers. When the situation arises, a warning is generated and the conflicting user config providers are ignored (as agreed at community call 29th May) 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

