### PR TITLE
Update different dependencies - Kaniko, Fabric8, JMX Exporter, Maven builder

### DIFF
--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -81,8 +81,8 @@ COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 # Add Prometheus JMX Exporter
 #####
 ENV JMX_EXPORTER_HOME=/opt/prometheus-jmx-exporter
-ENV JMX_EXPORTER_VERSION=1.1.0
-ENV JMX_EXPORTER_CHECKSUM="63f9ff5297c6add9ecd19633a54300ffcec0df2e09afca7212e80506b801ea20aa009efc4b582b6ed8a4616b1ed68c98e30cc5b9dbf2cf6fe68b7cf2e3c5db3c  jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
+ENV JMX_EXPORTER_VERSION=1.3.0
+ENV JMX_EXPORTER_CHECKSUM="58b87e0c7f14cdbd3cdac3408e377be0bf0b30b3cd878669e94bf48181e878e3e4d30b2c2219c74da7f694fe85bcf81014520d84294da44e302247126bd92753  jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
 
 RUN set -ex; \
     curl -LO https://github.com/prometheus/jmx_exporter/releases/download/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar; \

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.23.2
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.24.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.22
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 

--- a/pom.xml
+++ b/pom.xml
@@ -143,9 +143,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.2.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.2.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.2.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.3.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.3.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.3.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates several dependencies:
* Fabric8 Kubernetes client
* Kaniko container builder
* Maven builder image (used by KafkaConnect Build to pull the Maven artiacts)
* And JMX Prometheus Exporter

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

