### PR TITLE
Use sudo for docker manupulation in Kind script

### DIFF
--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -157,8 +157,8 @@ EOF
     fi
 
     if is_docker; then
-        echo "$docker_config" | tee /etc/docker/daemon.json
-        systemctl restart docker
+        echo "$docker_config" | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
     else
         # Ensure the podman_config is inserted correctly after unqualified-search-registries
         sudo awk -v config="$podman_config" '


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This is just a sync of missing `sudo` call as I added for drain-cleaner https://github.com/strimzi/drain-cleaner/pull/155 and access-operator https://github.com/strimzi/kafka-access-operator/pull/79

### Checklist

- [ ] Write tests

