### PR TITLE
Add note/warning about Kubernetes 1.25 and 1.26 support removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Add support for Kafka 3.9.1
 * Fixed MirrorMaker 2 client rack init container override being ignored.
 
+### Major changes, deprecations and removals
+
+* Strimzi 0.47.0 (and any of its patch releases) is the last Strimzi version with support for Kubernetes 1.25 and 1.26.
+  From Strimzi 0.48.0 on, we will support only Kubernetes 1.27 and newer.
+
 ## 0.46.0
 
 * Add support for Kafka 4.0.0.


### PR DESCRIPTION
### Type of change

- Support update notification

### Description

This PR adds note/warning about support removal of Kubernetes 1.25 and 1.26 - as we agreed on community call.
Strimzi 0.47.0 will be the last release supporting these versions, from Strimzi 0.48.0 on we will support Kubernetes 1.27 and above.

### Checklist

- [x] Update CHANGELOG.md
