### PR TITLE
add option to use targetPortName in create service port function

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -303,7 +303,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
                 labels,
                 ownerReference,
                 templateService,
-                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"))
+                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT,REST_API_PORT_NAME, "TCP"))
         );
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -303,7 +303,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
                 labels,
                 ownerReference,
                 templateService,
-                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT,REST_API_PORT_NAME, "TCP"))
+                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME, "TCP"))
         );
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -303,7 +303,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
                 labels,
                 ownerReference,
                 templateService,
-                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME, "TCP"))
+                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT_NAME, "TCP"))
         );
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -234,7 +234,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
                 labels,
                 ownerReference,
                 templateService,
-                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, port, port, "TCP")),
+                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, port, port, REST_API_PORT_NAME, "TCP")),
                 labels.strimziSelectorLabels(),
                 ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_SERVICE_LABELS),
                 Util.mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_SERVICE_ANNOTATIONS))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -234,7 +234,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
                 labels,
                 ownerReference,
                 templateService,
-                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, port, port, REST_API_PORT_NAME, "TCP")),
+                List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, port, REST_API_PORT_NAME, "TCP")),
                 labels.strimziSelectorLabels(),
                 ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_SERVICE_LABELS),
                 Util.mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_SERVICE_ANNOTATIONS))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -650,10 +650,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<GenericKafkaListener> internalListeners = ListenersUtils.internalListeners(listeners);
 
         List<ServicePort> ports = new ArrayList<>(internalListeners.size() + 1);
-        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT,REPLICATION_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, REPLICATION_PORT_NAME, "TCP"));
 
         for (GenericKafkaListener listener : internalListeners) {
-            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(),ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
+            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(), ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
         }
 
         return ports;
@@ -669,12 +669,12 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<GenericKafkaListener> internalListeners = ListenersUtils.internalListeners(listeners);
 
         List<ServicePort> ports = new ArrayList<>(internalListeners.size() + 3);
-        ports.add(ServiceUtils.createServicePort(CONTROLPLANE_PORT_NAME, CONTROLPLANE_PORT, CONTROLPLANE_PORT, CONTROLPLANE_PORT_NAME,"TCP"));
-        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, REPLICATION_PORT_NAME,"TCP"));
-        ports.add(ServiceUtils.createServicePort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT_NAME,"TCP"));
+        ports.add(ServiceUtils.createServicePort(CONTROLPLANE_PORT_NAME, CONTROLPLANE_PORT, CONTROLPLANE_PORT, CONTROLPLANE_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, REPLICATION_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT_NAME, "TCP"));
 
         for (GenericKafkaListener listener : internalListeners) {
-            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(),ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
+            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(), ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
         }
 
         ports.addAll(jmx.servicePorts());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -650,10 +650,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<GenericKafkaListener> internalListeners = ListenersUtils.internalListeners(listeners);
 
         List<ServicePort> ports = new ArrayList<>(internalListeners.size() + 1);
-        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, REPLICATION_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT_NAME, "TCP"));
 
         for (GenericKafkaListener listener : internalListeners) {
-            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(), ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
+            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
         }
 
         return ports;
@@ -669,12 +669,12 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<GenericKafkaListener> internalListeners = ListenersUtils.internalListeners(listeners);
 
         List<ServicePort> ports = new ArrayList<>(internalListeners.size() + 3);
-        ports.add(ServiceUtils.createServicePort(CONTROLPLANE_PORT_NAME, CONTROLPLANE_PORT, CONTROLPLANE_PORT, CONTROLPLANE_PORT_NAME, "TCP"));
-        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, REPLICATION_PORT_NAME, "TCP"));
-        ports.add(ServiceUtils.createServicePort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(CONTROLPLANE_PORT_NAME, CONTROLPLANE_PORT, CONTROLPLANE_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT_NAME, "TCP"));
 
         for (GenericKafkaListener listener : internalListeners) {
-            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(), ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
+            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
         }
 
         ports.addAll(jmx.servicePorts());
@@ -746,7 +746,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
 
             List<ServicePort> ports = Collections.singletonList(
                     ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener),
-                            listener.getPort(),
                             listener.getPort(),
                             ListenersUtils.backwardsCompatiblePortName(listener),
                             ListenersUtils.bootstrapNodePort(listener),
@@ -838,7 +837,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                         List<ServicePort> ports = Collections.singletonList(
                                 ServiceUtils.createServicePort(
                                         ListenersUtils.backwardsCompatiblePortName(listener),
-                                        listener.getPort(),
                                         listener.getPort(),
                                         ListenersUtils.backwardsCompatiblePortName(listener),
                                         ListenersUtils.brokerNodePort(listener, node.nodeId()),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -650,10 +650,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<GenericKafkaListener> internalListeners = ListenersUtils.internalListeners(listeners);
 
         List<ServicePort> ports = new ArrayList<>(internalListeners.size() + 1);
-        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT,REPLICATION_PORT_NAME, "TCP"));
 
         for (GenericKafkaListener listener : internalListeners) {
-            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(), "TCP"));
+            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(),ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
         }
 
         return ports;
@@ -669,12 +669,12 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<GenericKafkaListener> internalListeners = ListenersUtils.internalListeners(listeners);
 
         List<ServicePort> ports = new ArrayList<>(internalListeners.size() + 3);
-        ports.add(ServiceUtils.createServicePort(CONTROLPLANE_PORT_NAME, CONTROLPLANE_PORT, CONTROLPLANE_PORT, "TCP"));
-        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, "TCP"));
-        ports.add(ServiceUtils.createServicePort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT, "TCP"));
+        ports.add(ServiceUtils.createServicePort(CONTROLPLANE_PORT_NAME, CONTROLPLANE_PORT, CONTROLPLANE_PORT, CONTROLPLANE_PORT_NAME,"TCP"));
+        ports.add(ServiceUtils.createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, REPLICATION_PORT_NAME,"TCP"));
+        ports.add(ServiceUtils.createServicePort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT, KAFKA_AGENT_PORT_NAME,"TCP"));
 
         for (GenericKafkaListener listener : internalListeners) {
-            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(), "TCP"));
+            ports.add(ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener), listener.getPort(), listener.getPort(),ListenersUtils.backwardsCompatiblePortName(listener), "TCP"));
         }
 
         ports.addAll(jmx.servicePorts());
@@ -748,6 +748,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     ServiceUtils.createServicePort(ListenersUtils.backwardsCompatiblePortName(listener),
                             listener.getPort(),
                             listener.getPort(),
+                            ListenersUtils.backwardsCompatiblePortName(listener),
                             ListenersUtils.bootstrapNodePort(listener),
                             "TCP")
             );
@@ -839,6 +840,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                                         ListenersUtils.backwardsCompatiblePortName(listener),
                                         listener.getPort(),
                                         listener.getPort(),
+                                        ListenersUtils.backwardsCompatiblePortName(listener),
                                         ListenersUtils.brokerNodePort(listener, node.nodeId()),
                                         "TCP")
                         );

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -342,7 +342,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      */
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(1);
-        ports.add(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME,"TCP"));
+        ports.add(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME, "TCP"));
 
         ports.addAll(jmx.servicePorts());
 
@@ -362,7 +362,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      * @return The generated Service
      */
     public Service generateHeadlessService() {
-        List<ServicePort> ports = List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME,"TCP"));
+        List<ServicePort> ports = List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME, "TCP"));
 
         return ServiceUtils.createHeadlessService(
                 componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -342,7 +342,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      */
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(1);
-        ports.add(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT_NAME, "TCP"));
 
         ports.addAll(jmx.servicePorts());
 
@@ -362,7 +362,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      * @return The generated Service
      */
     public Service generateHeadlessService() {
-        List<ServicePort> ports = List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME, "TCP"));
+        List<ServicePort> ports = List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT_NAME, "TCP"));
 
         return ServiceUtils.createHeadlessService(
                 componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -342,7 +342,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      */
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(1);
-        ports.add(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"));
+        ports.add(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME,"TCP"));
 
         ports.addAll(jmx.servicePorts());
 
@@ -362,7 +362,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      * @return The generated Service
      */
     public Service generateHeadlessService() {
-        List<ServicePort> ports = List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"));
+        List<ServicePort> ports = List.of(ServiceUtils.createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, REST_API_PORT_NAME,"TCP"));
 
         return ServiceUtils.createHeadlessService(
                 componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -6,7 +6,9 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.strimzi.api.kafka.model.common.template.HasMetadataTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.IpFamily;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -18,7 +18,6 @@ import io.strimzi.operator.common.model.Labels;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -227,7 +226,7 @@ public class ServiceUtils {
      * @return  Created port
      */
     public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, String protocol)   {
-        return createServicePort(name, port, targetPort, targetPortName, null, protocol);
+        return createServicePort(name, port, targetPortName, null, protocol);
     }
 
     /**
@@ -235,14 +234,13 @@ public class ServiceUtils {
      *
      * @param name          Name of the port
      * @param port          The port on the service which can be accessed by clients
-     * @param targetPort    The port on the container / Pod where the connections will be routed
      * @param targetPortName the name of the target port on the container / Pod where the connections will be routed
      * @param nodePort      The desired node port number
      * @param protocol      Protocol used by this port
      *
      * @return  Created port
      */
-    public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, Integer nodePort, String protocol)   {
+    public static ServicePort createServicePort(String name, int port, String targetPortName, Integer nodePort, String protocol)   {
         return new ServicePortBuilder()
                 .withName(name)
                 .withProtocol(protocol)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -219,13 +219,12 @@ public class ServiceUtils {
      *
      * @param name          Name of the port
      * @param port          The port on the service which can be accessed by clients
-     * @param targetPort    The port on the container / Pod where the connections will be routed
      * @param targetPortName the name of the target port on the container / Pod where the connections will be routed
      * @param protocol      Protocol used by this port
      *
      * @return  Created port
      */
-    public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, String protocol)   {
+    public static ServicePort createServicePort(String name, int port, String targetPortName, String protocol)   {
         return createServicePort(name, port, targetPortName, null, protocol);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -227,7 +227,7 @@ public class ServiceUtils {
      * @return  Created port
      */
     public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, String protocol)   {
-        return createServicePort(name, port, targetPort, targetPortName,null, protocol);
+        return createServicePort(name, port, targetPort, targetPortName, null, protocol);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -227,7 +227,7 @@ public class ServiceUtils {
      * @return  Created port
      */
     public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, String protocol)   {
-        return createServicePort(name, port, targetPort, targetPortName, protocol);
+        return createServicePort(name, port, targetPort, targetPortName,null, protocol);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -4,11 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServicePort;
-import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.*;
 import io.strimzi.api.kafka.model.common.template.HasMetadataTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
@@ -18,6 +14,7 @@ import io.strimzi.operator.common.model.Labels;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -224,8 +221,8 @@ public class ServiceUtils {
      *
      * @return  Created port
      */
-    public static ServicePort createServicePort(String name, int port, int targetPort, String protocol)   {
-        return createServicePort(name, port, targetPort, null, protocol);
+    public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, String protocol)   {
+        return createServicePort(name, port, targetPort, targetPortName, protocol);
     }
 
     /**
@@ -239,12 +236,12 @@ public class ServiceUtils {
      *
      * @return  Created port
      */
-    public static ServicePort createServicePort(String name, int port, int targetPort, Integer nodePort, String protocol)   {
+    public static ServicePort createServicePort(String name, int port, int targetPort, String targetPortName, Integer nodePort, String protocol)   {
         return new ServicePortBuilder()
                 .withName(name)
                 .withProtocol(protocol)
                 .withPort(port)
-                .withNewTargetPort(targetPort)
+                .withNewTargetPort(Objects.requireNonNullElse(targetPortName, targetPort))
                 .withNodePort(nodePort)
                 .build();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -247,7 +247,7 @@ public class ServiceUtils {
                 .withName(name)
                 .withProtocol(protocol)
                 .withPort(port)
-                .withNewTargetPort(Objects.requireNonNullElse(targetPortName, targetPort))
+                .withNewTargetPort(targetPortName)
                 .withNodePort(nodePort)
                 .build();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -4,7 +4,9 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
 import io.strimzi.api.kafka.model.common.template.HasMetadataTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
@@ -217,6 +219,7 @@ public class ServiceUtils {
      * @param name          Name of the port
      * @param port          The port on the service which can be accessed by clients
      * @param targetPort    The port on the container / Pod where the connections will be routed
+     * @param targetPortName the name of the target port on the container / Pod where the connections will be routed
      * @param protocol      Protocol used by this port
      *
      * @return  Created port
@@ -231,6 +234,7 @@ public class ServiceUtils {
      * @param name          Name of the port
      * @param port          The port on the service which can be accessed by clients
      * @param targetPort    The port on the container / Pod where the connections will be routed
+     * @param targetPortName the name of the target port on the container / Pod where the connections will be routed
      * @param nodePort      The desired node port number
      * @param protocol      Protocol used by this port
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/jmx/JmxModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/jmx/JmxModel.java
@@ -115,7 +115,7 @@ public class JmxModel {
      */
     public List<ServicePort> servicePorts()    {
         if (isEnabled)  {
-            return List.of(ServiceUtils.createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT, JMX_PORT_NAME, "TCP"));
+            return List.of(ServiceUtils.createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT_NAME, "TCP"));
         } else {
             return List.of();
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/jmx/JmxModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/jmx/JmxModel.java
@@ -115,7 +115,7 @@ public class JmxModel {
      */
     public List<ServicePort> servicePorts()    {
         if (isEnabled)  {
-            return List.of(ServiceUtils.createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT, JMX_PORT_NAME,  "TCP"));
+            return List.of(ServiceUtils.createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT, JMX_PORT_NAME, "TCP"));
         } else {
             return List.of();
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/jmx/JmxModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/jmx/JmxModel.java
@@ -115,7 +115,7 @@ public class JmxModel {
      */
     public List<ServicePort> servicePorts()    {
         if (isEnabled)  {
-            return List.of(ServiceUtils.createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT, "TCP"));
+            return List.of(ServiceUtils.createServicePort(JMX_PORT_NAME, JMX_PORT, JMX_PORT, JMX_PORT_NAME,  "TCP"));
         } else {
             return List.of();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -1169,7 +1169,7 @@ public class KafkaClusterListenersTest {
         for (Service service : perPodServices) {
             assertThat(service.getSpec().getAllocateLoadBalancerNodePorts(), is(false));
             assertThat(service.getSpec().getPorts(), hasSize(1));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-lb1"));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -775,7 +775,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().size(), is(1));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
@@ -799,7 +799,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getPorts().size(), is(1));
             assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
             assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
             assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
             assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         }
@@ -1006,7 +1006,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().size(), is(1));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(bootstrapServices.get(0).getSpec().getLoadBalancerIP(), is(nullValue()));
@@ -1035,7 +1035,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getPorts().size(), is(1));
             assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
             assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
             assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
             assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             assertThat(service.getSpec().getLoadBalancerIP(), is(nullValue()));
@@ -1162,14 +1162,14 @@ public class KafkaClusterListenersTest {
         assertThat(externalServices, hasSize(1));
         assertThat(externalServices.get(0).getSpec().getAllocateLoadBalancerNodePorts(), is(false));
         assertThat(externalServices.get(0).getSpec().getPorts(), hasSize(1));
-        assertThat(externalServices.get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(externalServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-lb1"));
 
         List<Service> perPodServices = kc.generatePerPodServices();
         assertThat(perPodServices, hasSize(5));
         for (Service service : perPodServices) {
             assertThat(service.getSpec().getAllocateLoadBalancerNodePorts(), is(false));
             assertThat(service.getSpec().getPorts(), hasSize(1));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         }
     }
 
@@ -1426,7 +1426,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().size(), is(1));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
@@ -1450,7 +1450,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getPorts().size(), is(1));
             assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
             assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
             assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
             assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         }
@@ -1612,7 +1612,7 @@ public class KafkaClusterListenersTest {
         assertThat(ext.getSpec().getPorts().size(), is(1));
         assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
         assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(32001));
         assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
@@ -1627,21 +1627,21 @@ public class KafkaClusterListenersTest {
                 assertThat(service.getSpec().getPorts().size(), is(1));
                 assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
                 assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
                 assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(32106));
                 assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             } else if (service.getMetadata().getName().startsWith("foo-mixed-3")) {
                 assertThat(service.getSpec().getPorts().size(), is(1));
                 assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
                 assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
                 assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(32103));
                 assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             } else {
                 assertThat(service.getSpec().getPorts().size(), is(1));
                 assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
                 assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
                 assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
                 assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             }
@@ -1744,7 +1744,7 @@ public class KafkaClusterListenersTest {
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().size(), is(1));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32189));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
@@ -1757,21 +1757,21 @@ public class KafkaClusterListenersTest {
                 assertThat(service.getSpec().getPorts().size(), is(1));
                 assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
                 assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
                 assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(32006));
                 assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             } else if (service.getMetadata().getName().startsWith("foo-mixed-3")) {
                 assertThat(service.getSpec().getPorts().size(), is(1));
                 assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
                 assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
                 assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(32003));
                 assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             } else {
                 assertThat(service.getSpec().getPorts().size(), is(1));
                 assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
                 assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
                 assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
                 assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             }
@@ -1895,7 +1895,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().size(), is(1));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
@@ -1919,7 +1919,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getPorts().size(), is(1));
             assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
             assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
             assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
             assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         }
@@ -2130,7 +2130,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().size(), is(1));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getName(), is("tcp-clusterip"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getPort(), is(9094));
-        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-clusterip"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
@@ -2167,7 +2167,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getPorts().size(), is(1));
             assertThat(service.getSpec().getPorts().get(0).getName(), is("tcp-clusterip"));
             assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
-            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-clusterip"));
             assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
             assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -58,7 +58,7 @@ public class ServiceUtilsTest {
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));
-        assertThat(port.getTargetPort().getIntVal(), is(5678));
+        assertThat(port.getTargetPort().getStrVal(), is(PORT_NAME));
         assertThat(port.getNodePort(), is(nullValue()));
         assertThat(port.getProtocol(), is("HTTP"));
     }
@@ -69,7 +69,7 @@ public class ServiceUtilsTest {
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));
-        assertThat(port.getTargetPort().getIntVal(), is(5678));
+        assertThat(port.getTargetPort().getStrVal(), is(PORT_NAME));
         assertThat(port.getNodePort(), is(30000));
         assertThat(port.getProtocol(), is("HTTP"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -42,7 +42,7 @@ public class ServiceUtilsTest {
             .withStrimziComponentType("my-component-type")
             .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
     private static final String PORT_NAME = "my-port";
-    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, "HTTP");
+    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME,"HTTP");
     private static final InternalServiceTemplate TEMPLATE = new InternalServiceTemplateBuilder()
             .withNewMetadata()
                 .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
@@ -54,7 +54,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServicePort() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, "HTTP");
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678,PORT_NAME, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));
@@ -65,7 +65,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServiceWithNodePort() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, 30000, "HTTP");
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME,30000, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -42,7 +42,7 @@ public class ServiceUtilsTest {
             .withStrimziComponentType("my-component-type")
             .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
     private static final String PORT_NAME = "my-port";
-    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, "HTTP");
+    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, PORT_NAME, "HTTP");
     private static final InternalServiceTemplate TEMPLATE = new InternalServiceTemplateBuilder()
             .withNewMetadata()
                 .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
@@ -54,7 +54,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServicePortName() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, "HTTP");
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, PORT_NAME, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));
@@ -65,7 +65,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServiceWithNodePort() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, 30000, "HTTP");
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, PORT_NAME, 30000, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -42,7 +42,7 @@ public class ServiceUtilsTest {
             .withStrimziComponentType("my-component-type")
             .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
     private static final String PORT_NAME = "my-port";
-    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME,"HTTP");
+    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, "HTTP");
     private static final InternalServiceTemplate TEMPLATE = new InternalServiceTemplateBuilder()
             .withNewMetadata()
                 .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
@@ -54,7 +54,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServicePort() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678,PORT_NAME, "HTTP");
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));
@@ -65,7 +65,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServiceWithNodePort() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME,30000, "HTTP");
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, 30000, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -64,17 +64,6 @@ public class ServiceUtilsTest {
     }
 
     @ParallelTest
-    public void testCreateServicePortNumber() {
-        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, null, "HTTP");
-
-        assertThat(port.getName(), is(PORT_NAME));
-        assertThat(port.getPort(), is(1234));
-        assertThat(port.getTargetPort().getIntVal(), is(5678));
-        assertThat(port.getNodePort(), is(nullValue()));
-        assertThat(port.getProtocol(), is("HTTP"));
-    }
-
-    @ParallelTest
     public void testCreateServiceWithNodePort() {
         ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, 30000, "HTTP");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -53,12 +53,23 @@ public class ServiceUtilsTest {
             .build();
 
     @ParallelTest
-    public void testCreateServicePort() {
+    public void testCreateServicePortName() {
         ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, PORT_NAME, "HTTP");
 
         assertThat(port.getName(), is(PORT_NAME));
         assertThat(port.getPort(), is(1234));
         assertThat(port.getTargetPort().getStrVal(), is(PORT_NAME));
+        assertThat(port.getNodePort(), is(nullValue()));
+        assertThat(port.getProtocol(), is("HTTP"));
+    }
+
+    @ParallelTest
+    public void testCreateServicePortNumber() {
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, null, "HTTP");
+
+        assertThat(port.getName(), is(PORT_NAME));
+        assertThat(port.getPort(), is(1234));
+        assertThat(port.getTargetPort().getIntVal(), is(5678));
         assertThat(port.getNodePort(), is(nullValue()));
         assertThat(port.getProtocol(), is("HTTP"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/jmx/JmxModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/jmx/JmxModelTest.java
@@ -86,7 +86,7 @@ public class JmxModelTest {
 
         assertThat(jmx.networkPolicyIngresRules().size(), is(1));
         assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().size(), is(1));
-        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getStrVal(), is("jmx"));
+        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getIntVal(), is(9999));
         assertThat(jmx.networkPolicyIngresRules().get(0).getFrom(), is(List.of()));
 
         assertThat(jmx.jmxSecret(null), is(nullValue()));
@@ -127,7 +127,7 @@ public class JmxModelTest {
 
         assertThat(jmx.networkPolicyIngresRules().size(), is(1));
         assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().size(), is(1));
-        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getStrVal(), is("jmx"));
+        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getIntVal(), is(9999));
         assertThat(jmx.networkPolicyIngresRules().get(0).getFrom(), is(List.of()));
 
         Secret newSecret = jmx.jmxSecret(null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/jmx/JmxModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/jmx/JmxModelTest.java
@@ -73,7 +73,7 @@ public class JmxModelTest {
         assertThat(jmx.servicePorts().size(), is(1));
         assertThat(jmx.servicePorts().get(0).getName(), is("jmx"));
         assertThat(jmx.servicePorts().get(0).getPort(), is(9999));
-        assertThat(jmx.servicePorts().get(0).getTargetPort().getIntVal(), is(9999));
+        assertThat(jmx.servicePorts().get(0).getTargetPort().getStrVal(), is("jmx"));
         assertThat(jmx.servicePorts().get(0).getProtocol(), is("TCP"));
 
         assertThat(jmx.containerPorts().size(), is(1));
@@ -86,7 +86,7 @@ public class JmxModelTest {
 
         assertThat(jmx.networkPolicyIngresRules().size(), is(1));
         assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().size(), is(1));
-        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getIntVal(), is(9999));
+        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getStrVal(), is("jmx"));
         assertThat(jmx.networkPolicyIngresRules().get(0).getFrom(), is(List.of()));
 
         assertThat(jmx.jmxSecret(null), is(nullValue()));
@@ -108,7 +108,7 @@ public class JmxModelTest {
         assertThat(jmx.servicePorts().size(), is(1));
         assertThat(jmx.servicePorts().get(0).getName(), is("jmx"));
         assertThat(jmx.servicePorts().get(0).getPort(), is(9999));
-        assertThat(jmx.servicePorts().get(0).getTargetPort().getIntVal(), is(9999));
+        assertThat(jmx.servicePorts().get(0).getTargetPort().getStrVal(), is("jmx"));
         assertThat(jmx.servicePorts().get(0).getProtocol(), is("TCP"));
 
         assertThat(jmx.containerPorts().size(), is(1));
@@ -127,7 +127,7 @@ public class JmxModelTest {
 
         assertThat(jmx.networkPolicyIngresRules().size(), is(1));
         assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().size(), is(1));
-        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getIntVal(), is(9999));
+        assertThat(jmx.networkPolicyIngresRules().get(0).getPorts().get(0).getPort().getStrVal(), is("jmx"));
         assertThat(jmx.networkPolicyIngresRules().get(0).getFrom(), is(List.of()));
 
         Secret newSecret = jmx.jmxSecret(null);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement

### Description

this PR add the option and moved services to use named ports instead of plain port numbers
fixes #11393

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

