### PR TITLE
[ST] Fix methods used in the ConnectST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -562,7 +562,8 @@ class ConnectST extends AbstractST {
                 .withType("Opaque")
                 .addToData("ca2.crt", encodedCertMock)
                 .build();
-        kubeClient(testStorage.getNamespaceName()).createSecret(secondCertSecret);
+
+        KubeResourceManager.get().createResourceWithWait(secondCertSecret);
 
         KafkaConnect connect = KafkaConnectTemplates.kafkaConnectWithFilePlugin(testStorage.getNamespaceName(), testStorage.getClusterName(), 1)
             .editSpec()
@@ -598,7 +599,7 @@ class ConnectST extends AbstractST {
         // This is an internal secret created by the operator with copy of certificates from the trusted certificates secrets specified in the CR
         String tlsCertSecretName = KafkaConnectResources.internalTlsTrustedCertsSecretName(testStorage.getClusterName());
         LOGGER.info("Verifying that tls cert secret {} is created for KafkaConnect truststore", tlsCertSecretName);
-        Secret tlsCertSecret = kubeClient(testStorage.getNamespaceName()).getSecret(tlsCertSecretName);
+        Secret tlsCertSecret = KubeResourceManager.get().kubeClient().getClient().secrets().inNamespace(testStorage.getNamespaceName()).withName(tlsCertSecretName).get();
         // The secret should contain certificates from both secrets
         assertThat(tlsCertSecret.getData().containsKey(testStorage.getClusterName() + "-cluster-ca-cert-ca.crt"), is(true));
         assertThat(tlsCertSecret.getData().containsKey("my-secret-ca2.crt"), is(true));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After merge of the test-frame integration PR, one other PR wasn't rebased and used methods that no longer exist, so the build on the main branch is failing.
This PR fixes this issue.

### Checklist

- [ ] Make sure all tests pass
