### PR TITLE
Add documentation for tracking progress of Cruise Control rebalances.

### DIFF
--- a/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
+++ b/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
@@ -31,6 +31,8 @@ include::../../modules/cruise-control/proc-generating-optimization-proposals.ado
 
 include::../../modules/cruise-control/proc-approving-optimization-proposal.adoc[leveloffset=+1]
 
+include::../../modules/cruise-control/proc-tracking-cluster-rebalance.adoc[leveloffset=+1]
+
 include::../../modules/cruise-control/proc-stopping-cluster-rebalance.adoc[leveloffset=+1]
 
 include::../../modules/cruise-control/proc-fixing-problems-with-kafkarebalance.adoc[leveloffset=+1]

--- a/documentation/modules/cruise-control/proc-tracking-cluster-rebalance.adoc
+++ b/documentation/modules/cruise-control/proc-tracking-cluster-rebalance.adoc
@@ -32,19 +32,19 @@ The information is updated on each reconciliation of the `KafkaRebalance` resour
 +
 [source,shell]
 ----
-kubectl get configmaps <my_rebalance_configmap_name> -o json | jq '.["data"]["estimatedTimeToCompletionInMinutes"]'
+kubectl get configmaps <my_rebalance_configmap_name> -o jsonpath="{['data']['estimatedTimeToCompletionInMinutes']}"
 ----
 
 - Accessing `completedByteMovementPercentage` field.:
 +
 [source,shell]
 ----
-kubectl get configmaps <my_rebalance_configmap_name> -o json | jq '.["data"]["completedByteMovementPercentage"]'
+kubectl get configmaps <my_rebalance_configmap_name> -o jsonpath="{['data']['completedByteMovementPercentage']}"
 ----
 
 - Accessing `executorState.json` field.
 +
 [source,shell]
 ----
-kubectl get configmaps <my_rebalance_configmap_name> -o json | jq '.["data"]["executorState.json"] | fromjson | .'
+kubectl get configmaps <my_rebalance_configmap_name> -o jsonpath="{['data']['executorState.json']}"
 ----

--- a/documentation/modules/cruise-control/proc-tracking-cluster-rebalance.adoc
+++ b/documentation/modules/cruise-control/proc-tracking-cluster-rebalance.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// assembly-cruise-control-concepts.adoc
+
+[id='proc-tracking-cluster-rebalance-{context}']
+
+= Tracking rebalances
+
+You can track the progress of a partition rebalance using status information in the `KafkaRebalance` resource.
+Tracking an active partition rebalance supports planning of cluster operations, including worker node maintenance, scaling, and broker upgrades. 
+Understanding key details, such as duration and the remaining data to transfer, helps with scheduling maintenance windows and assessing the impact of proceeding or canceling the rebalance.
+
+When a rebalance is in progress, Strimzi stores progress information in a `ConfigMap`.
+The `ConfigMap` is referenced by the `status.progress.rebalanceProgressConfigMap` property of the `KafkaRebalance` resource .
+The `ConfigMap` includes the following fields:
+
+- `estimatedTimeToCompletionInMinutes`: The estimated time it will take in minutes until the partition rebalance is complete.
+
+- `completedByteMovementPercentage`: The percentage of data movement completed (in bytes), as a rounded down integer from 0-100.
+
+- `executorState.json`: The “non-verbose” JSON payload from the link:https://github.com/linkedin/cruise-control/wiki/REST-APIs#query-the-state-of-cruise-control[/kafkacruisecontrol/state?substates=executor] endpoint, providing details about the executor's current status, including partition movement progress, concurrency limits, and total data to move.
+
+The information is updated on each reconciliation of the `KafkaRebalance` resource.
+
+.Prerequisites
+
+* The `KafkaRebalance` custom resource is in a `Rebalancing` state.
+
+.Procedure
+
+- Accessing `estimatedTimeToCompletionInMinutes` field.:
++
+[source,shell]
+----
+kubectl get configmaps <my_rebalance_configmap_name> -o json | jq '.["data"]["estimatedTimeToCompletionInMinutes"]'
+----
+
+- Accessing `completedByteMovementPercentage` field.:
++
+[source,shell]
+----
+kubectl get configmaps <my_rebalance_configmap_name> -o json | jq '.["data"]["completedByteMovementPercentage"]'
+----
+
+- Accessing `executorState.json` field.
++
+[source,shell]
+----
+kubectl get configmaps <my_rebalance_configmap_name> -o json | jq '.["data"]["executorState.json"] | fromjson | .'
+----

--- a/documentation/modules/cruise-control/proc-tracking-cluster-rebalance.adoc
+++ b/documentation/modules/cruise-control/proc-tracking-cluster-rebalance.adoc
@@ -11,7 +11,7 @@ Tracking an active partition rebalance supports planning of cluster operations, 
 Understanding key details, such as duration and the remaining data to transfer, helps with scheduling maintenance windows and assessing the impact of proceeding or canceling the rebalance.
 
 When a rebalance is in progress, Strimzi stores progress information in a `ConfigMap`.
-The `ConfigMap` is referenced by the `status.progress.rebalanceProgressConfigMap` property of the `KafkaRebalance` resource .
+The `ConfigMap` is referenced by the `status.progress.rebalanceProgressConfigMap` property of the `KafkaRebalance` resource and has the same name as the `KafkaRebalance` resource.
 The `ConfigMap` includes the following fields:
 
 - `estimatedTimeToCompletionInMinutes`: The estimated time it will take in minutes until the partition rebalance is complete.
@@ -32,19 +32,19 @@ The information is updated on each reconciliation of the `KafkaRebalance` resour
 +
 [source,shell]
 ----
-kubectl get configmaps <my_rebalance_configmap_name> -o jsonpath="{['data']['estimatedTimeToCompletionInMinutes']}"
+kubectl get configmaps <my_rebalance> -o jsonpath="{['data']['estimatedTimeToCompletionInMinutes']}"
 ----
 
 - Accessing `completedByteMovementPercentage` field.:
 +
 [source,shell]
 ----
-kubectl get configmaps <my_rebalance_configmap_name> -o jsonpath="{['data']['completedByteMovementPercentage']}"
+kubectl get configmaps <my_rebalance> -o jsonpath="{['data']['completedByteMovementPercentage']}"
 ----
 
 - Accessing `executorState.json` field.
 +
 [source,shell]
 ----
-kubectl get configmaps <my_rebalance_configmap_name> -o jsonpath="{['data']['executorState.json']}"
+kubectl get configmaps <my_rebalance> -o jsonpath="{['data']['executorState.json']}"
 ----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Documents how to monitor the progression of an ongoing partition rebalance leveraging the new KafkaRebalance tracking feature https://github.com/strimzi/strimzi-kafka-operator/pull/11348 using the Kubernetes CLI as described by the proposal here [1].

[1] https://github.com/strimzi/proposals/blob/main/098-rebalance-progress-status.md#accessing-progress-fields-using-kubernetes-cli

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

