### PR TITLE
docs(overview): clarifies role of the entity operator

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-intro-operators.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-intro-operators.adoc
@@ -8,26 +8,32 @@
 
 [role="_abstract"]
 Strimzi uses operators to deploy and manage Kafka components.
-The operators monitor Strimzi custom resources (like `Kafka`, `KafkaTopic`, and `KafkaUser`) and ensure that the Kafka components are configured and running as specified.
+The operators continuously monitor Strimzi custom resources (like `Kafka`, `KafkaTopic`, and `KafkaUser`) and reconcile the state of Kafka components to match their configuration.
 
 Strimzi provides the following operators, each responsible for different aspects of a Kafka deployment:
 
-Cluster Operator (required):: The Cluster Operator must be deployed first. 
-It handles the deployment and management of Apache Kafka clusters on Kubernetes, automating the setup of Kafka nodes and related resources.
-If enabled, it can also deploy the Entity Operator, which may include the Topic Operator, User Operator, or both.
+Cluster Operator (required):: The Cluster Operator is the core operator and must be deployed first. 
+It handles the deployment and lifecycle of Apache Kafka clusters on Kubernetes, automating the setup of Kafka nodes and related resources.
 +
 Additionally, Strimzi provides *Drain Cleaner*, which is deployed separately.
 Drain Cleaner supports the Cluster Operator in managing pod evictions for Kafka clusters.
 
-Entity Operator (recommended):: Manage topics and users through dedicated operators:
-* *Topic Operator* manages Kafka topics.
-* *User Operator* manages Kafka users.
+Entity Operator (recommended):: The Entity Operator can be deployed by the Cluster Operator.
+It runs in a single pod and includes one or both of the following operators:
++
+--
+* *Topic Operator* to manage Kafka topics.
+* *User Operator* to manage Kafka users.
+--
++
+Each operator runs in a separate container within the Entity Operator pod.
+
 ifdef::Section[]
 Access Operator (optional):: Manages and shares Kafka cluster connection details.
 It is deployed independently of the Cluster Operator.
 endif::Section[]
 
-NOTE: The Topic Operator and User Operator can also be deployed standalone to manage topics and users for a Kafka cluster that is not managed by Strimzi.
+NOTE: The Topic Operator and User Operator can also be deployed standalone (without the Entity Operator) to manage topics and users for a Kafka cluster that is not managed by Strimzi.
 
 //operator namespace 
 include::../../modules/operators/con-operators-namespaces.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-overview-components.adoc
+++ b/documentation/assemblies/overview/assembly-overview-components.adoc
@@ -9,15 +9,22 @@
 Operators are Kubernetes components that package, deploy, and manage applications by extending the Kubernetes API. 
 They simplify administrative tasks and reduce manual intervention.
 
-Strimzi operators automate the deployment and management of Apache Kafka components on Kubernetes. 
-Strimzi custom resources define the deployment configuration.
+Strimzi provides a set of operators to automate the deployment and management of Apache Kafka on Kubernetes. 
+Strimzi custom resources define the configuration for each deployment.
 
-The following operators manage Kafka in a Kubernetes cluster:
+Strimzi includes the following operators:
 
-Cluster Operator:: Manages Kafka clusters and related components.
-Entity Operator:: Comprises the Topic Operator and User Operator.
-Topic Operator:: Creates, configures, and deletes Kafka topics.
-User Operator:: Manages Kafka users and their authentication credentials.
+Cluster Operator:: Manages Kafka clusters and related components
+Topic Operator:: Creates, configures, and deletes Kafka topics
+User Operator:: Manages Kafka users and their authentication credentials
+
+The Cluster Operator can deploy the Entity Operator, which runs the Topic Operator and User Operator in a single pod. 
+The Entity Operator can be configured to run one or both operators.
+
+NOTE: The Entity Operator does not manage Kafka clusters. 
+It simply runs the Topic Operator and User Operator in separate containers within its pod, allowing them to handle topic and user management.
+
+For Kafka clusters not managed by Strimzi, the Topic Operator and User Operator can also be deployed standalone (without the Entity Operator).
 
 Additionally, Strimzi provides Drain Cleaner, a separate tool that can be used alongside the Cluster Operator to assist with safe pod eviction during maintenance or upgrades. 
 


### PR DESCRIPTION
**Documentation**

There is some confusion around the role of the entity operator.
This doc update clarifies its role in the Overview.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

