### PR TITLE
MINOR: Fix example readme

### DIFF
--- a/packaging/examples/README.md
+++ b/packaging/examples/README.md
@@ -5,7 +5,7 @@ This folder contains different examples of Strimzi custom resources and demonstr
 * [Kafka cluster](./kafka)
     * Kafka deployments with different types of storage
 * [Kafka Connect and Kafka Connect Connector](./connect)
-* [Kafka Mirror Maker 1 and 2](./mirror-maker)
+* [Kafka Mirror Maker 2](./mirror-maker)
 * [Kafka Bridge](./bridge)
 * [Cruise Control and Kafka Rebalance](./cruise-control)
 * [Kafka users](./user)


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This patch removes MM1 mention from the example readme, as it is not supported anymore.

### Checklist

- [x] Update documentation


