### PR TITLE
docs(headings): adds attribute for links on headings

### DIFF
--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -6,6 +6,7 @@
 :imagesdir: images
 :numbered:
 :sectanchors!:
+:sectlinks:
 :sectnums:
 :source-highlighter: highlightjs
 :toc: left


### PR DESCRIPTION
**Documentation**

Introduces an asciidoc attribute so that headings have links

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

