### PR TITLE
Avoid infinite reconciliation loop of Ingress resources on Rancher

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/IngressOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/IngressOperator.java
@@ -25,6 +25,7 @@ public class IngressOperator extends AbstractNamespacedResourceOperator<Kubernet
      * List of predicates that allows existing ingress annotations to be retained while reconciling the resources.
      */
     private static final List<Predicate<String>> INGRESS_ANNOTATION_IGNORELIST = List.of(
+            // field.cattle.io annotations are used by Rancher. For ignore them to avoid conflicts.
             annotation -> annotation.startsWith("field.cattle.io")
     );
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/IngressOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/IngressOperator.java
@@ -14,10 +14,19 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 /**
  * Operations for {@code Ingress}es.
  */
 public class IngressOperator extends AbstractNamespacedResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
+    /**
+     * List of predicates that allows existing ingress annotations to be retained while reconciling the resources.
+     */
+    private static final List<Predicate<String>> INGRESS_ANNOTATION_IGNORELIST = List.of(
+            annotation -> annotation.startsWith("field.cattle.io")
+    );
 
     /**
      * Constructor
@@ -60,6 +69,7 @@ public class IngressOperator extends AbstractNamespacedResourceOperator<Kubernet
     @Override
     protected Future<ReconcileResult<Ingress>> internalUpdate(Reconciliation reconciliation, String namespace, String name, Ingress current, Ingress desired) {
         patchIngressClassName(current, desired);
+        KubernetesResourceOperatorUtils.patchAnnotations(current, desired, INGRESS_ANNOTATION_IGNORELIST);
 
         return super.internalUpdate(reconciliation, namespace, name, current, desired);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KubernetesResourceOperatorUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KubernetesResourceOperatorUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.strimzi.operator.common.Util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Static utility methods for working with Kubernetes resources
+ */
+class KubernetesResourceOperatorUtils {
+    /**
+     * Finds annotations managed by some other entities (for example by Rancher cattle agents), and merge them with
+     * the annotations from the Strimzi desired resource.
+     * <p>
+     * This makes sure there is no infinite loop where other tools try to add annotations, while Strimzi keeps
+     * removing them during reconciliation.
+     *
+     * @param current    Current resource
+     * @param desired    Desired resource
+     * @param ignoreList List with predicates to detect annotations that should be preserved
+     */
+    static void patchAnnotations(HasMetadata current, HasMetadata desired, List<Predicate<String>> ignoreList) {
+        Map<String, String> currentAnnotations = current.getMetadata().getAnnotations();
+        if (currentAnnotations != null) {
+            Map<String, String> matchedAnnotations = currentAnnotations.keySet().stream()
+                    .filter(annotation -> ignoreList.stream().anyMatch(ignoreAnnotation -> ignoreAnnotation.test(annotation)))
+                    .collect(Collectors.toMap(Function.identity(), currentAnnotations::get));
+
+            if (!matchedAnnotations.isEmpty()) {
+                desired.getMetadata().setAnnotations(Util.mergeLabelsOrAnnotations(
+                        desired.getMetadata().getAnnotations(),
+                        matchedAnnotations
+                ));
+            }
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperator.java
@@ -44,6 +44,7 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
      * List of predicates that allows existing load balancer service annotations to be retained while reconciling the resources.
      */
     private static final List<Predicate<String>> LOADBALANCER_ANNOTATION_IGNORELIST = List.of(
+            // cattle.io and field.cattle.io annotations are used by Rancher. For ignore them to avoid conflicts.
             annotation -> annotation.startsWith("cattle.io/"),
             annotation -> annotation.startsWith("field.cattle.io")
     );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KubernetesResourceOperatorUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KubernetesResourceOperatorUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KubernetesResourceOperatorUtilsTest {
+    private static final List<Predicate<String>> IGNORELIST = List.of(annotation -> annotation.startsWith("foo"));
+
+    @Test
+    public void testCurrentAnnotationsAreNull() {
+        Pod current = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                .endMetadata()
+                .build();
+        Pod desired = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                    .withAnnotations(Map.of("avfc", "1874"))
+                .endMetadata()
+                .build();
+
+        KubernetesResourceOperatorUtils.patchAnnotations(current, desired, IGNORELIST);
+        assertThat(desired.getMetadata().getAnnotations(), is(Map.of("avfc", "1874")));
+    }
+
+    @Test
+    public void testNonMatchingAnnotationsAreRemoved() {
+        Pod current = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                    .withAnnotations(Map.of("baz", "value", "bar", "value2"))
+                .endMetadata()
+                .build();
+        Pod desired = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                    .withAnnotations(Map.of("avfc", "1874"))
+                .endMetadata()
+                .build();
+
+        KubernetesResourceOperatorUtils.patchAnnotations(current, desired, IGNORELIST);
+        assertThat(desired.getMetadata().getAnnotations(), is(Map.of("avfc", "1874")));
+    }
+
+    @Test
+    public void testMatchingAnnotationsAreIgnored() {
+        Pod current = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                    .withAnnotations(Map.of("foo", "value", "bar", "value2"))
+                .endMetadata()
+                .build();
+        Pod desired = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                    .withAnnotations(Map.of("avfc", "1874"))
+                .endMetadata()
+                .build();
+
+        KubernetesResourceOperatorUtils.patchAnnotations(current, desired, IGNORELIST);
+        assertThat(desired.getMetadata().getAnnotations(), is(Map.of("avfc", "1874", "foo", "value")));
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -11,9 +11,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.ResourceAnnotations;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static java.lang.Boolean.parseBoolean;
@@ -83,14 +81,6 @@ public class Annotations extends ResourceAnnotations {
      * Annotation for tracking Deployment revisions
      */
     public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";
-
-    /**
-     * List of predicates that allows existing load balancer service annotations to be retained while reconciling the resources.
-     */
-    public static final List<Predicate<String>> LOADBALANCER_ANNOTATION_IGNORELIST = List.of(
-        annotation -> annotation.startsWith("cattle.io/"),
-        annotation -> annotation.startsWith("field.cattle.io")
-    );
 
     private static Map<String, String> annotations(ObjectMeta metadata) {
         Map<String, String> annotations = metadata.getAnnotations();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using Ingress listener on Rancher clusters, Rancher might set additional annotations to the Ingress resources. And Strimzi will be removing them and thus they wil be running a there and back again and again. This PR adds an ignore list to the Ingress reconciliation, similarly to what we already have for Services (also on Rancher) to avoid the sam eproblem.

As part of this, it also:
* Moves the ignore list definition from the `Annotations` class to the operator classes (there is no reason to have these constants as public in the common module when each of them is used only in one place in the cluster operator module and thus can be private). The ignore list is anyway different from the annotations used by Strimzi directly, so not sure why we had it in that class.
* Uses a single static method in a new `KubernetesResourceOperatorUtils` -> this seemed better than having it in one of the abstract classes as the use of this method is only in two classes out of almost 30.

This PR should resolve #11414 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging