### PR TITLE
add note in doc to mention no controller scale up/down supported

### DIFF
--- a/documentation/modules/configuring/con-config-node-pool-roles.adoc
+++ b/documentation/modules/configuring/con-config-node-pool-roles.adoc
@@ -23,3 +23,6 @@ If partitions are assigned, the change is prevented.
 No replicas must be left on the node before removing the broker role.
 The best way to reassign partitions before changing roles is to apply a Cruise Control optimization proposal in `remove-brokers` mode.
 For more information, see xref:proc-generating-optimization-proposals-str[].
+
+Note that currently scaling up or scaling down the controller nodes in node pools is not supported because this feature
+in Kafka is not completed, yet. See link:https://issues.apache.org/jira/browse/KAFKA-16538[KAFKA-16538] for more information.

--- a/documentation/modules/configuring/con-config-node-pool-roles.adoc
+++ b/documentation/modules/configuring/con-config-node-pool-roles.adoc
@@ -24,5 +24,5 @@ No replicas must be left on the node before removing the broker role.
 The best way to reassign partitions before changing roles is to apply a Cruise Control optimization proposal in `remove-brokers` mode.
 For more information, see xref:proc-generating-optimization-proposals-str[].
 
-Note that currently scaling up or scaling down the controller nodes in node pools is not supported because this feature
-in Kafka is not completed, yet. See link:https://issues.apache.org/jira/browse/KAFKA-16538[KAFKA-16538] for more information.
+NOTE: Scaling controller nodes in node pools is currently not supported because the related Kafka feature is still under development. 
+For more information, see link:https://issues.apache.org/jira/browse/KAFKA-16538[KAFKA-16538].


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In the "Changing node pool roles" section of [doc](https://strimzi.io/docs/operators/latest/deploying#config-node-pools-roles-str), we said you can change the roles in node pool. And that makes users think all kinds of role change is working. But actually we don't support controller node scale up/down due to the missing feature in Kafka (should be available in kafka v4.1.0 [KAFKA-16538](https://issues.apache.org/jira/browse/KAFKA-16538)). And when looking into the examples we provided to moving dual role -> dedicated controller + broker, or moving  dedicated controller + broker -> dual role, we actually only change roles in broker nodes, not touching the controller nodes. We have to make it clear in the doc to avoid confusion.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [V ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

