### PR TITLE
Roll controller-only nodes when tiered storage is enabled or disabled

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -110,6 +110,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
             "offsets.topic.replication.factor",
             "principal.builder.class",
             "process.roles",
+            "remote.log.storage.system.enable",
             "replica.selector.class",
             "reserved.broker.max.id",
             "sasl.enabled.mechanisms",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We currently don't roll the controller-only nodes when tiered storage (TS) is enabled or disabled. This could mean that the TS will be enabled on the brokers, but it will not be enabled in the controllers, and thus, no topics with TS can be created.

This PR adds the `remote.log.storage.system.enable` option to the controller relevant options to make sure the controller-only nodes are also rolled when TS is enabled or disabled.

This should close #11595.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging