### PR TITLE
Split vendors and users in ADOPTERS.md file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,10 +6,12 @@ Please let us know by adding your company name and, if you want, a description o
 
 ### Vendors
 
+* [Ænix](https://aenix.io)
+  * Use Strimzi to provide Kafka as a Service in Open Source platform [Cozystack](https://cozystack.io)
 * [Axual](https://axual.com/)
     * [Optimizing Kafka Cluster Deployments in Kubernetes](https://itnext.io/optimizing-kafka-cluster-deployments-in-kubernetes-ceda3f95c157)
 * [Cloudera](https://www.cloudera.com/products/stream-processing.html)
-* [IBM](https://www.ibm.com/cloud/event-streams)
+* [IBM](https://www.ibm.com/products/event-streams)
 * [Red Hat](https://www.redhat.com/en/)
     * [Streams for Apache Kafka](https://developers.redhat.com/products/streams-for-apache-kafka/overview)
 
@@ -33,8 +35,6 @@ Please let us know by adding your company name and, if you want, a description o
 * [Skillsoft](https://www.skillsoft.com/)
     * Utilizes Strimzi to deploy Kafka Connect on Kubernetes for Apache Kafka backup & disaster recovery.
 * [Hetzner](https://www.hetzner.com/)
-* [Ænix](https://aenix.io)
-    * Use Strimzi to provide Kafka as a Service in Open Source platform [Cozystack](https://cozystack.io)
 * [Reddit](https://www.reddit.com/r/RedditEng/)
     * Use Strimzi to run their Kafka fleet of 500 brokers, data replication with Mirror Maker and CDC pipelines with Kafka Connect.
 * [Alauda](https://www.alauda.io/)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,15 +1,25 @@
 ## Strimzi adopters
 
+Are you currently using Strimzi in production?
+Do you have products based on Strimzi or provide Strimzi-related services?
+Please let us know by adding your company name and, if you want, a description of your use case to this document!
+
+### Vendors
+
 * [Axual](https://axual.com/)
     * [Optimizing Kafka Cluster Deployments in Kubernetes](https://itnext.io/optimizing-kafka-cluster-deployments-in-kubernetes-ceda3f95c157)
+* [Cloudera](https://www.cloudera.com/products/stream-processing.html)
+* [IBM](https://www.ibm.com/cloud/event-streams)
+* [Red Hat](https://www.redhat.com/en/)
+    * [Streams for Apache Kafka](https://developers.redhat.com/products/streams-for-apache-kafka/overview)
+
+### Users
+
 * [Grupo MASMOVIL](https://www.grupomasmovil.com/)
 * [Helvetia](https://helvetia.com/)
 * [Baloise](https://baloise.ch/)
-* [IBM](https://www.ibm.com/cloud/event-streams)
 * [Lightbend](https://www.lightbend.com/)
 * [Marlow Navigation](https://marlow-navigation.com/)
-* [Red Hat](https://www.redhat.com/en/)
-    * [AMQ Streams](https://www.redhat.com/en/resources/amq-streams-datasheet)
 * [Randoli](https://www.randoli.io)
     * Use Strimzi for powering a distributed control plane in our Observability & Cost Management solutions
 * [SBB CFF FFS](https://www.sbb.ch/en/home.html)
@@ -26,14 +36,10 @@
 * [Ænix](https://aenix.io)
     * Use Strimzi to provide Kafka as a Service in Open Source platform [Cozystack](https://cozystack.io)
 * [Reddit](https://www.reddit.com/r/RedditEng/)
-    * Use Strimzi to run their Kafka fleet of 500 brokers, data replication with Mirror Maker and CDC pipelines with Kafka Connect. 
+    * Use Strimzi to run their Kafka fleet of 500 brokers, data replication with Mirror Maker and CDC pipelines with Kafka Connect.
 * [Alauda](https://www.alauda.io/)
     * Use Strimzi to provide Kafka as a Service on a cloud native platform
-* [Cloudera](https://www.cloudera.com/products/stream-processing.html)
 * [SURF](https://surf.nl)
    * Use Strimzi to create a (streaming) telemetry platform and EDA for Network Orchestration.
 * [AppsFlyer](https://www.appsflyer.com/)
   * Running dozens of high-throughput clusters, handling tens of millions of messages per second, relying on the local ephemeral storage.
-
-Are you currently using Strimzi in production?
-Please let us know by adding your company name and, if you want, a description of your use case to this document!

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,17 +4,6 @@ Are you currently using Strimzi in production?
 Do you have products based on Strimzi or provide Strimzi-related services?
 Please let us know by adding your company name and, if you want, a description of your use case to this document!
 
-### Vendors
-
-* [Ænix](https://aenix.io)
-  * Use Strimzi to provide Kafka as a Service in Open Source platform [Cozystack](https://cozystack.io)
-* [Axual](https://axual.com/)
-    * [Optimizing Kafka Cluster Deployments in Kubernetes](https://itnext.io/optimizing-kafka-cluster-deployments-in-kubernetes-ceda3f95c157)
-* [Cloudera](https://www.cloudera.com/products/stream-processing.html)
-* [IBM](https://www.ibm.com/products/event-streams)
-* [Red Hat](https://www.redhat.com/en/)
-    * [Streams for Apache Kafka](https://developers.redhat.com/products/streams-for-apache-kafka/overview)
-
 ### Users
 
 * [Grupo MASMOVIL](https://www.grupomasmovil.com/)
@@ -43,3 +32,14 @@ Please let us know by adding your company name and, if you want, a description o
    * Use Strimzi to create a (streaming) telemetry platform and EDA for Network Orchestration.
 * [AppsFlyer](https://www.appsflyer.com/)
   * Running dozens of high-throughput clusters, handling tens of millions of messages per second, relying on the local ephemeral storage.
+
+### Vendors
+
+* [Ænix](https://aenix.io)
+  * Use Strimzi to provide Kafka as a Service in Open Source platform [Cozystack](https://cozystack.io)
+* [Axual](https://axual.com/)
+  * [Optimizing Kafka Cluster Deployments in Kubernetes](https://itnext.io/optimizing-kafka-cluster-deployments-in-kubernetes-ceda3f95c157)
+* [Cloudera](https://www.cloudera.com/products/stream-processing.html)
+* [IBM](https://www.ibm.com/products/event-streams)
+* [Red Hat](https://www.redhat.com/en/)
+  * [Streams for Apache Kafka](https://developers.redhat.com/products/streams-for-apache-kafka/overview)


### PR DESCRIPTION
### Type of change

- Documentation

### Description

As discussed earlier on Slack, this PR splits the users and vendors in the ADOPTERS.md file. The main purpose of this split is to make it easier for new users to:
* Find references (Strimzi end-users)
* Find who might be able to help them / provide support, etc. (vendors)

Currently, the PR moves to vendors that we spoke with or know are vendors.

From those where I wasn't completely sure:
* @sinbadonline You add Alauda to the ADOPTERS.md list. Any chance you can comment on whether it should be among vendors or users?
* @tym83 You added Aenix to the ADOPTERS.md list. Any chance you can comment on whether it should be among vendors or users?

I would be happy to update this PR as well as the related website change if you let me know.