### PR TITLE
Validate volume name when injecting trusted certificates + add corresponding tests

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -298,12 +298,13 @@ public class CertUtils {
     }
 
     /**
-     * Generates the volume name that is used in the Volume definition and in the Volume mounts
+     * Adds a prefix to the Secret name used in Volume and VolumeMounts definitions.
+     * The returned string may exceed the maximum resource name length.
      *
      * @param certSecretSource      Represents a certificate inside a Secret
      * @param prefix                Prefix used to generate the volume name
      *
-     * @return  The generated volume name
+     * @return  The prefixed secret name, or the secret name if the prefix is null.
      */
     private static String trustedCertificateVolumeName(CertSecretSource certSecretSource, String prefix)    {
         return prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -301,7 +301,7 @@ public class CertUtils {
      * @return  The generated volume name
      */
     private static String trustedCertificateVolumeName(CertSecretSource certSecretSource, String prefix)    {
-        return prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
+        return VolumeUtils.getValidVolumeName(prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -237,11 +237,14 @@ public class CertUtils {
      * @param prefix            Prefix used to generate the volume name
      */
     private static void maybeAddTrustedCertificateVolume(List<Volume> volumeList, CertSecretSource certSecretSource, boolean isOpenShift, String prefix) {
-        String volumeName = trustedCertificateVolumeName(certSecretSource, prefix);
+        Volume secretVolume = VolumeUtils.createSecretVolume(
+            trustedCertificateVolumeName(certSecretSource, prefix),
+            certSecretSource.getSecretName(),
+            isOpenShift);
 
         // skipping if a volume with same name was already added
-        if (volumeList.stream().noneMatch(v -> v.getName().equals(volumeName))) {
-            volumeList.add(VolumeUtils.createSecretVolume(volumeName, certSecretSource.getSecretName(), isOpenShift));
+        if (volumeList.stream().noneMatch(v -> v.getName().equals(secretVolume.getName()))) {
+            volumeList.add(secretVolume);
         }
     }
 
@@ -284,11 +287,13 @@ public class CertUtils {
      * @param prefix                Prefix used to generate the volume name
      */
     private static void maybeAddTrustedCertificateVolumeMount(List<VolumeMount> volumeMountList, CertSecretSource certSecretSource, String tlsVolumeMountPath, String prefix) {
-        String volumeName = trustedCertificateVolumeName(certSecretSource, prefix);
+        VolumeMount secretVolumeMount = VolumeUtils.createVolumeMount(
+            trustedCertificateVolumeName(certSecretSource, prefix),
+            tlsVolumeMountPath + certSecretSource.getSecretName());
 
         // skipping if a volume mount with same Secret name was already added
-        if (volumeMountList.stream().noneMatch(vm -> vm.getName().equals(volumeName))) {
-            volumeMountList.add(VolumeUtils.createVolumeMount(volumeName, tlsVolumeMountPath + certSecretSource.getSecretName()));
+        if (volumeMountList.stream().noneMatch(vm -> vm.getName().equals(secretVolumeMount.getName()))) {
+            volumeMountList.add(secretVolumeMount);
         }
     }
 
@@ -301,7 +306,7 @@ public class CertUtils {
      * @return  The generated volume name
      */
     private static String trustedCertificateVolumeName(CertSecretSource certSecretSource, String prefix)    {
-        return VolumeUtils.getValidVolumeName(prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName());
+        return prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CertUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CertUtilsTest.java
@@ -142,6 +142,26 @@ public class CertUtilsTest {
     }
 
     @Test
+    public void testShortenedTrustedCertificatesVolumesWithPrefix() {
+        CertSecretSource cert1 = new CertSecretSourceBuilder()
+                .withSecretName("long-secret-name-60-chars-ooooooooooooooooooooooooooooooooo")
+                .withCertificate("first.crt")
+                .build();
+
+        CertSecretSource cert2 = new CertSecretSourceBuilder()
+                .withSecretName("long-secret-name-60-chars-ooooooooooooooooooooooooooooooooo")
+                .withCertificate("second.crt")
+                .build();
+
+        List<Volume> volumes = new ArrayList<>();
+
+        // if len(prefix + secretname) > 63, then the volume name is shortened.
+        // Volume name references in both the volume and volumeMount sections should not be duplicated.
+        CertUtils.createTrustedCertificatesVolumes(volumes, List.of(cert1, cert2), false, "some-long-prefix");
+        assertThat(volumes.size(), is(1));
+    }
+
+    @Test
     public void testTrustedCertificatesVolumesWithPrefix()    {
         CertSecretSource cert1 = new CertSecretSourceBuilder()
                 .withSecretName("first-certificate")
@@ -166,6 +186,26 @@ public class CertUtilsTest {
         assertThat(volumes.get(0).getSecret().getSecretName(), is("first-certificate"));
         assertThat(volumes.get(1).getName(), is("prefixed-second-certificate"));
         assertThat(volumes.get(1).getSecret().getSecretName(), is("second-certificate"));
+    }
+
+    @Test
+    public void testShortenedTrustedCertificatesVolumeMountsWithPrefix() {
+        CertSecretSource cert1 = new CertSecretSourceBuilder()
+                .withSecretName("long-secret-name-60-chars-ooooooooooooooooooooooooooooooooo")
+                .withCertificate("first.crt")
+                .build();
+
+        CertSecretSource cert2 = new CertSecretSourceBuilder()
+                .withSecretName("long-secret-name-60-chars-ooooooooooooooooooooooooooooooooo")
+                .withCertificate("second.crt")
+                .build();
+
+        List<VolumeMount> mounts = new ArrayList<>();
+
+        // if len(prefix + secretname) > 63, then the volume name is shortened.
+        // Volume name references in both the volume and volumeMount sections should not be duplicated.
+        CertUtils.createTrustedCertificatesVolumeMounts(mounts, List.of(cert1, cert2), "/my/path/", "some-long-prefix");
+        assertThat(mounts.size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/11394 — if trusted certificate is configured, and the `length(secretName + clusterAlias) > 63`, the volume name is shortened and duplicated in `volumes:` and `volumeMounts:` sections of `StrimziPodSet`.

Additionally, 2 new test cases are added to check if duplicated volume names are absent if shortening happens. 


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

