### PR TITLE
Add Drain Cleaner 1.4.0 to the Operators repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed MirrorMaker 2 client rack init container override being ignored.
 * Support for Kubernetes Image Volumes to mount custom plugins
 * Adding support for [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html) in Operators, Cruise Control and Kafka 4.0.0 or greater.
+* Strimzi Drain Cleaner updated to 1.4.0 (included in the Strimzi installation files)
 
 ### Major changes, deprecations and removals
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -33,7 +33,7 @@
 :BridgeVersion: 0.32.0
 
 // Drain Cleaner Version
-:DrainCleanerVersion: 1.3.0
+:DrainCleanerVersion: 1.4.0
 
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub releases page^]

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.3.0
+          image: quay.io/strimzi/drain-cleaner:1.4.0
           ports:
             - containerPort: 8080
               name: http
@@ -67,5 +67,3 @@ spec:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
           emptyDir: {}
-  strategy:
-    type: RollingUpdate

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.3.0
+          image: quay.io/strimzi/drain-cleaner:1.4.0
           ports:
             - containerPort: 8080
               name: http
@@ -67,5 +67,3 @@ spec:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
           emptyDir: {}
-  strategy:
-    type: RollingUpdate

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.3.0
+          image: quay.io/strimzi/drain-cleaner:1.4.0
           ports:
             - containerPort: 8080
               name: http
@@ -67,5 +67,3 @@ spec:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
           emptyDir: {}
-  strategy:
-    type: RollingUpdate


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds Drain Cleaner 1.4.0 to the operators repository after the release - adds installation files for the new version, updates docs and CHANGELOG.

### Checklist

- [] Make sure all tests pass
- [x] Update documentation
- [x] Update CHANGELOG.md