### PR TITLE
Speedup test runs by enabling asyncDeletion of deployed resources

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest;
 
 import io.fabric8.kubernetes.api.model.Namespace;
+import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.resources.BuildConfigType;
 import io.skodjob.testframe.resources.ClusterRoleBindingType;
 import io.skodjob.testframe.resources.ClusterRoleType;
@@ -67,7 +68,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith({TestExecutionWatcher.class})
 @DisplayNameGeneration(IndicativeSentences.class)
-@io.skodjob.testframe.annotations.ResourceManager(asyncDeletion = false)
+@ResourceManager()
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public abstract class AbstractST implements TestSeparator {
     public static final List<String> LB_FINALIZERS;
@@ -158,7 +159,7 @@ public abstract class AbstractST implements TestSeparator {
 
     protected void afterEachMayOverride() {
         if (!Environment.SKIP_TEARDOWN) {
-            KubeResourceManager.get().deleteResources(false);
+            KubeResourceManager.get().deleteResources(true);
         }
     }
 
@@ -170,7 +171,7 @@ public abstract class AbstractST implements TestSeparator {
 
     protected synchronized void afterAllMayOverride() {
         if (!Environment.SKIP_TEARDOWN) {
-            KubeResourceManager.get().deleteResources(false);
+            KubeResourceManager.get().deleteResources(true);
             testSuiteNamespaceManager.deleteTestSuiteNamespace();
         }
     }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

Test-frame 1.0.0 allows to set async deletion and wait for resources.
This PR enable it to speedup test runs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass

