### PR TITLE
fix(operator): operator stuck when failing in parse kubernetes version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.48.0
 
-* n/a
+* Fixed operator stuck when `STRIMZI_KUBERNETES_VERSION` is set but with wrong value.
 
 ## 0.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.48.0
 
-* Fixed operator stuck when `STRIMZI_KUBERNETES_VERSION` is set but with wrong value.
+* n/a
 
 ## 0.47.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -223,7 +223,6 @@ public class Main {
                         // New leader => complete the future
                         LOGGER.info("I'm the new leader");
                         context.runOnContext(v -> leader.complete());
-
                     },
                     isShuttingDown -> {
                         // Not a leader anymore

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -22,6 +22,7 @@ import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -88,7 +89,11 @@ public class Main {
                 .onComplete(res -> {
                     if (res.failed())   {
                         LOGGER.error("Unable to start operator for 1 or more namespace", res.cause());
-                        System.exit(1);
+                        vertx.executeBlocking(() -> {
+                            System.exit(1);
+                            return true;
+                        });
+
                     }
                 });
     }
@@ -209,6 +214,7 @@ public class Main {
      */
     private static Future<Void> leaderElection(KubernetesClient client, ClusterOperatorConfig config, ShutdownHook shutdownHook)    {
         Promise<Void> leader = Promise.promise();
+        Context context = Vertx.currentContext();
 
         if (config.getLeaderElectionConfig() != null) {
             LeaderElectionManager leaderElection = new LeaderElectionManager(
@@ -216,7 +222,8 @@ public class Main {
                     () -> {
                         // New leader => complete the future
                         LOGGER.info("I'm the new leader");
-                        leader.complete();
+                        context.runOnContext(v -> leader.complete());
+
                     },
                     isShuttingDown -> {
                         // Not a leader anymore


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #11384. The operator stuck on running state when `STRIMZI_KUBERNETES_VERSION` is set but with wrong value.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

