### PR TITLE
Fixed ambiguos call with varargs parameter

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -218,7 +218,7 @@ public class Annotations extends ResourceAnnotations {
      */
     public static boolean hasAnnotation(HasMetadata resource, String annotation) {
         ObjectMeta metadata = resource.getMetadata();
-        String str = annotation(annotation, null, metadata, (String[]) null);
+        String str = annotation(annotation, null, metadata);
         return str != null;
     }
 


### PR DESCRIPTION
While developing on a new laptop with new IntelliJ installation I have started to get following warning:

```shell
/home/ppatiern/github/strimzi-kafka-operator/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java:221:61
java: non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
```

which is then "translated" to error because of our -Werror usage:

```shell
/home/ppatiern/github/strimzi-kafka-operator/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
java: warnings found and -Werror specified
```

Not sure why it doesn't happen when using `mvn test` (despite we have such configuration in the pom.xml) and it seems not happening to other folks using IntelliJ.
Anyway, this PR fixes the warning that should not happen in the first place because of an ambiguous call with a varargs parameter.