### PR TITLE
Fixed deletion of rebalancing related ConfigMap

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAutoRebalancingReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAutoRebalancingReconciler.java
@@ -460,7 +460,8 @@ public class KafkaAutoRebalancingReconciler {
                 .endMetadata()
                 .build();
         return kafkaRebalanceOperator.patchAsync(reconciliation, kafkaRebalancePatched)
-                .compose(kr -> kafkaRebalanceOperator.deleteAsync(reconciliation, kr.getMetadata().getNamespace(), kr.getMetadata().getName(), false))
+                // cascading flag is needed in order to delete the corresponding ConfigMap storing the rebalancing progress and load
+                .compose(kr -> kafkaRebalanceOperator.deleteAsync(reconciliation, kr.getMetadata().getNamespace(), kr.getMetadata().getName(), true))
                 .mapEmpty();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/ConfigMapUtils.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.strimzi.systemtest.resources.CrdClients.kafkaRebalanceClient;
+
 public class ConfigMapUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ConfigMapUtils.class);
@@ -50,6 +52,16 @@ public class ConfigMapUtils {
             TestConstants.GLOBAL_TIMEOUT,
             () -> KubeResourceManager.get().kubeClient().getClient().configMaps().inNamespace(namespaceName).withName(configMapName).get() != null
         );
+    }
+
+    /**
+     * Waits for ConfigMap with specified name and in specified Namespace to be deleted.
+     *
+     * @param namespaceName name of the Namespace where the ConfigMap lives
+     * @param configMapName name of the ConfigMap that should be deleted
+     */
+    public static void waitForConfigMapIsDeleted(final String namespaceName, final String configMapName) {
+        TestUtils.waitFor("ConfigMap is deleted", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT, () -> KubeResourceManager.get().kubeClient().getClient().configMaps().inNamespace(namespaceName).withName(configMapName).get() == null);
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -55,6 +55,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.ConfigMapUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
@@ -734,8 +735,9 @@ public class CruiseControlST extends AbstractST {
         // and then afterward we again move to Idle state after all is done
         KafkaUtils.waitUntilKafkaHasAutoRebalanceState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaAutoRebalanceState.Idle);
 
-        // check that KafkaRebalance <cluster-name>-auto-rebalancing-<mode> is deleted
+        // check that KafkaRebalance <cluster-name>-auto-rebalancing-<mode> is deleted together with the corresponding ConfigMap
         KafkaRebalanceUtils.waitForKafkaRebalanceIsDeleted(testStorage.getNamespaceName(), KafkaResources.autoRebalancingKafkaRebalanceResourceName(testStorage.getClusterName(), KafkaAutoRebalanceMode.ADD_BROKERS));
+        ConfigMapUtils.waitForConfigMapIsDeleted(testStorage.getNamespaceName(), KafkaResources.autoRebalancingKafkaRebalanceResourceName(testStorage.getClusterName(), KafkaAutoRebalanceMode.ADD_BROKERS));
 
         KafkaTopicUtils.waitForTopicReplicasOnBrokers(testStorage.getNamespaceName(), testStorage.getTopicName(),
             scraperPodName, KafkaResources.plainBootstrapAddress(testStorage.getClusterName()), Arrays.asList("3", "4"));
@@ -764,8 +766,9 @@ public class CruiseControlST extends AbstractST {
         // and then afterward we again move to Idle state after all is done
         KafkaUtils.waitUntilKafkaHasAutoRebalanceState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaAutoRebalanceState.Idle);
 
-        // check that KafkaRebalance <cluster-name>-auto-rebalancing-<mode> is deleted
+        // check that KafkaRebalance <cluster-name>-auto-rebalancing-<mode> is deleted together with the corresponding ConfigMap
         KafkaRebalanceUtils.waitForKafkaRebalanceIsDeleted(testStorage.getNamespaceName(), KafkaResources.autoRebalancingKafkaRebalanceResourceName(testStorage.getClusterName(), KafkaAutoRebalanceMode.REMOVE_BROKERS));
+        ConfigMapUtils.waitForConfigMapIsDeleted(testStorage.getNamespaceName(), KafkaResources.autoRebalancingKafkaRebalanceResourceName(testStorage.getClusterName(), KafkaAutoRebalanceMode.REMOVE_BROKERS));
     }
 
     @ParallelNamespaceTest


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #11643 in order to delete the corresponding ConfigMap when an auto-rebalancing process ends and the `KafkaRebalance` custom resource is deleted.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
