### PR TITLE
Use persistent link for Maven used in TF jobs

### DIFF
--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -74,10 +74,8 @@ prepare:
   - name: Install mvn
     how: shell
     script: |
-      MAVEN_VERSION=3.9.10
-      MAVEN_MAJOR_VERSION=3
-      MAVEN_TGZ="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
-      MAVEN_URL="http://mirror.dkm.cz/apache/maven/maven-${MAVEN_MAJOR_VERSION}/${MAVEN_VERSION}/binaries/${MAVEN_TGZ}"
+      MAVEN_VERSION=3.9.11
+      MAVEN_URL="https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
       INSTALL_DIR="/usr/share/maven"
       INSTALL_BIN="/usr/bin/mvn"
 

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -78,12 +78,13 @@ prepare:
       MAVEN_URL="https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
       INSTALL_DIR="/usr/share/maven"
       INSTALL_BIN="/usr/bin/mvn"
-
-      mkdir -p ${INSTALL_DIR}
-      wget -q ${MAVEN_URL} -O /tmp/${MAVEN_TGZ}
-      tar -xzf /tmp/${MAVEN_TGZ} -C ${INSTALL_DIR} --strip-components=1
-      rm -f /tmp/${MAVEN_TGZ}
-      ln -sf ${INSTALL_DIR}/bin/mvn ${INSTALL_BIN}
+      
+      mkdir -p ${INSTALL_DIR} /usr/share/maven/ref
+      curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_URL}
+      tar -xzf /tmp/apache-maven.tar.gz -C ${INSTALL_DIR} --strip-components=1
+      rm -f /tmp/apache-maven.tar.gz
+      ln -s ${INSTALL_DIR}/bin/mvn ${INSTALL_BIN}
+      
 
   - name: Install kind
     how: shell


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

We use mirror for installing maven, this mirror doesn't contains all versions. This new link contains even older versions and it shouldn't break our jobs.

### Checklist

- [x] Make sure all tests pass

