### PR TITLE
docs(pdb): clarifies PodDisruptionBudget behavior

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate.adoc
@@ -1,10 +1,26 @@
-A `PodDisruptionBudget` (PDB) is a Kubernetes resource that ensures high availability by specifying the minimum number of pods that must be available during planned maintenance or upgrades.
-Strimzi creates a PDB for every new `StrimziPodSet` or `Deployment`. 
-By default, the PDB allows only one pod to be unavailable at any given time.
-You can increase the number of unavailable pods allowed by changing the default value of the `maxUnavailable` property.
+A `PodDisruptionBudget` is a Kubernetes resource that helps maintain high availability during planned maintenance or upgrades.
+It defines the minimum number of pods that must remain available at all times.
 
-`StrimziPodSet` custom resources manage pods using a custom controller that cannot use the `maxUnavailable` value directly.
-Instead, the `maxUnavailable` value is automatically converted to a `minAvailable` value when creating the PDB resource, which effectively serves the same purpose, as illustrated in the following examples:
+Strimzi creates one `PodDisruptionBudget` per component: 
+
+* Kafka cluster
+* Kafka Connect
+* MirrorMaker 2
+* Kafka Bridge
+
+Each budget applies across all pods deployed for that component.
+
+A single `PodDisruptionBudget` applies to all associated node pool pods managed by the `Kafka` resource. 
+This is true regardless of how many `StrimziPodSet` resources are created for that component.
+Disruption limits are applied at the component level, not per node pool.
+
+By default, only one pod can be unavailable at a time.
+You can modify this limit using the `maxUnavailable` property.
+
+`StrimziPodSet` custom resources are managed by a controller that does not use `maxUnavailable` directly.
+Instead, the value is automatically converted to `minAvailable`, which serves the same purpose.
+
+For example:
 
 * If there are three broker pods and the `maxUnavailable` property is set to `1` in the `Kafka` resource, the `minAvailable` setting is `2`, allowing one pod to be unavailable. 
 * If there are three broker pods and the `maxUnavailable` property is set to `0` (zero), the `minAvailable` setting is `3`, requiring all three broker pods to be available and allowing zero pods to be unavailable.
@@ -25,3 +41,11 @@ template:
     maxUnavailable: 1
 # ...
 ----
+
+.Custom disruption budget behavior
+
+To define custom disruption budget behavior, disable automatic `PodDisruptionBudget` generation. 
+Set the `STRIMZI_POD_DISRUPTION_BUDGET_GENERATION` environment variable to `false` in the Cluster Operator.
+
+You can then create your own `PodDisruptionBudget` resources. 
+For example, apply separate budgets to specific node pools using label selectors with `StrimziPodSet` resources.

--- a/documentation/modules/configuring/proc-disable-pod-disruption-budget-generation.adoc
+++ b/documentation/modules/configuring/proc-disable-pod-disruption-budget-generation.adoc
@@ -3,9 +3,18 @@
 // assembly-config.adoc
 
 [id='disable-pod-disruption-budget-generation_{context}']
-= Disabling pod disruption budget generation
+= Disabling PodDisruptionBudget generation
 
-Strimzi generates pod disruption budget resources for Kafka, Kafka Connect worker, MirrorMaker2 worker, and Kafka Bridge worker nodes.
+Strimzi automatically generates a `PodDisruptionBudget` resource for each of the following components:
 
-If you want to use custom pod disruption budget resources, you can set the `STRIMZI_POD_DISRUPTION_BUDGET_GENERATION` environment variable to `false` in the Cluster Operator configuration.
+* Kafka cluster
+* Kafka Connect
+* MirrorMaker 2
+* Kafka Bridge
+
+Each budget applies across all pods deployed for that component.
+
+The Kafka cluster's `PodDisruptionBudget` covers all associated node pool pods.
+
+To disable automatic `PodDisruptionBudget` generation, set the `STRIMZI_POD_DISRUPTION_BUDGET_GENERATION` environment variable to `false` in the Cluster Operator configuration. You can then define custom `PodDisruptionBudget` resources if needed.
 For more information, see xref:ref-operator-cluster-{context}[].

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -19,9 +19,9 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 `<kafka_cluster_name>-kafka`:: Name given to the following Kafka resources:
 +
-- StrimziPodSet for managing the Kafka broker pods.
+- StrimziPodSet for managing the Kafka pods.
 - Service account used by the Kafka pods.
-- PodDisruptionBudget configured for the Kafka brokers.
+- PodDisruptionBudget that applies to all Kafka cluster node pool pods.
 
 `<kafka_cluster_name>-kafka-<pod_id>`:: Name given to the following Kafka resources:
 +

--- a/documentation/modules/operators/con-configuring-cluster-operator.adoc
+++ b/documentation/modules/operators/con-configuring-cluster-operator.adoc
@@ -73,8 +73,9 @@ env:
     value: label1=value1,label2=value2
 ----
 
-`STRIMZI_POD_DISRUPTION_BUDGET_GENERATION`::  Optional, default `true`.
-Pod disruption budget for resources.
+`STRIMZI_POD_DISRUPTION_BUDGET_GENERATION`::  Optional. Default is `true`. 
+Controls automatic creation of `PodDisruptionBudget` resources for Kafka, Kafka Connect, MirrorMaker2, and Kafka Bridge. Each budget applies across all pods deployed for the associated component. For Kafka clusters, this includes all node pool pods.
++
 A pod disruption budget with the `maxUnavailable` value set to zero prevents Kubernetes from evicting pods automatically.
 +
 Set this environment variable to `false` to disable pod disruption budget generation. You might do this, for example, if you want to manage the pod disruption budgets yourself, or if you have a development environment where availability is not important.

--- a/documentation/modules/upgrading/con-upgrade-cluster.adoc
+++ b/documentation/modules/upgrading/con-upgrade-cluster.adoc
@@ -69,9 +69,9 @@ spec:
 # ...
 ----
 
-You need to watch the pods that need to be drained.
-You then add a pod annotation to make the update.
+The `PodDisruptionBudget` resource created for Kafka clusters covers all associated node pool pods. 
 
+Watch the node pool pods that need to be drained and add a pod annotation to make the update.
 Here, the annotation updates a Kafka pod named `my-cluster-pool-a-1`.
 
 .Performing a manual rolling update on a Kafka pod


### PR DESCRIPTION
Documentation

Clarifies in the docs how Strimzi manages PodDisruptionBudget resources 
Previous wording suggested a PDB per node pool, which does not reflect behavior.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

