### PR TITLE
fix: upgraded nimbus-jose-jwt version to 10.0.2 to resolve CVE-2025-53864

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
@@ -30,6 +30,7 @@
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
         <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
+        <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
     </properties>
 
     <repositories>
@@ -64,6 +65,13 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -29,6 +29,7 @@
         <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
         <log4j.version>2.24.3</log4j.version>
+        <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
     </properties>
 
     <repositories>
@@ -47,6 +48,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <skodjob.test-frame.version>1.0.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.4.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
+        <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
         <!--
             Currently, there are no released versions in Maven repository of this module,
             using SNAPSHOT for having the `api` module available and usable in the STs.
@@ -857,6 +858,12 @@
                 <artifactId>api</artifactId>
                 <version>${access-operator.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

Upgraded com.nimbusds:nimbus-jose-jwt from version 9.37.2 to 10.0.2 to patch [CVE-2025-53864], which fixes an uncontrolled recursion vulnerability.

nimbus-jose-jwt is a transitive dependency overridden globally to enforce the secure version across all modules.

Changes made in:
  - pom.xml
  - docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
  - docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

