### PR TITLE
Fix non-default primitive types within KafkaRebalance

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
@@ -122,6 +122,7 @@ public class KafkaRebalanceSpec extends Spec {
 
     @Description("The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.")
     @Minimum(0)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getConcurrentPartitionMovementsPerBroker() {
         return concurrentPartitionMovementsPerBroker;
     }
@@ -132,6 +133,7 @@ public class KafkaRebalanceSpec extends Spec {
 
     @Description("The upper bound of ongoing partition replica movements between disks within each broker. Default is 2.")
     @Minimum(0)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getConcurrentIntraBrokerPartitionMovements() {
         return concurrentIntraBrokerPartitionMovements;
     }
@@ -142,6 +144,7 @@ public class KafkaRebalanceSpec extends Spec {
 
     @Description("The upper bound of ongoing partition leadership movements. Default is 1000.")
     @Minimum(0)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getConcurrentLeaderMovements() {
         return concurrentLeaderMovements;
     }
@@ -152,6 +155,7 @@ public class KafkaRebalanceSpec extends Spec {
 
     @Description("The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default.")
     @Minimum(0)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public long getReplicationThrottle() {
         return replicationThrottle;
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.out.yaml
@@ -9,7 +9,5 @@ spec:
   - "DiskCapacityGoal"
   - "CpuCapacityGoal"
   skipHardGoalCheck: true
-  concurrentPartitionMovementsPerBroker: 0
-  concurrentIntraBrokerPartitionMovements: 0
-  concurrentLeaderMovements: 0
-  replicationThrottle: 0
+  concurrentPartitionMovementsPerBroker: 10
+  replicationThrottle: 5000

--- a/api/src/test/resources/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.yaml
@@ -7,3 +7,5 @@ spec:
     - DiskCapacityGoal
     - CpuCapacityGoal
   skipHardGoalCheck: true
+  concurrentPartitionMovementsPerBroker: 10
+  replicationThrottle: 5000


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The 'KafkaRebalance' custom resource allows to specify some rebalancing parameters, within the `spec` section, which are defined by primitive types within the Strimzi api module.
An example is the `concurrentPartitionMovementsPerBroker` which is defined as `int`.
When using the Strimzi api module from a Java application to create a `KafkaRebalance` custom resource, the `concurrentPartitionMovementsPerBroker` field is actually serialized as 0 (nu using the default `int` value).
The expectation would be that the field is not serialized at all so that it's not provided to the Cruise Control REST API call and Cruise Control itself would use the default value of 5 (https://github.com/linkedin/cruise-control/blob/main/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java#L145).
What's saving from using the serialized 0, is that the Cruise Control client within the operator doesn't add this parameter to the query string if it's zero (https://github.com/strimzi/strimzi-kafka-operator/blob/main/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java#L132)
Anyway the serialization should not happen, even because it confuses the user: they see 0 within a custom resource but Cruise Control is actually using 5.
Not having the field in the custom resource would make clear that a default value, within Cruise Control, would be used.
The same applies to other parameters like `concurrentIntraBrokerPartitionMovements` (default 2 in CC), `concurrentLeaderMovements` (default 1000 in CC), `replicationThrottle` (default no limit in CC), `skipHardGoalCheck` (default false in CC).

For example, when a `KafkaRebalance` is created via using the Strimzi api module but with an empty `spec`, the following is the serialized version:

```yaml
spec:
    concurrentIntraBrokerPartitionMovements: 0
    concurrentLeaderMovements: 0
    concurrentPartitionMovementsPerBroker: 0
    mode: full
    replicationThrottle: 0
    skipHardGoalCheck: false
```

which instead should be just:

```yaml
spec:
    mode: full
    skipHardGoalCheck: false
```

with Cruise Control using default values for the not provided parameters.

This PR fixes the issue by adding the `@JsonInclude(JsonInclude.Include.NON_DEFAULT)` annotation to the corresponding fields.

This fix also comes from the following discussion on Slack: https://cloud-native.slack.com/archives/C018247K8T0/p1744204117886419

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally