### PR TITLE
feat(helm-charts,helm3,strimzi-kafka-operator): add optional deploymentStrategy to CO

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -119,6 +119,7 @@ the documentation for more details.
 | `operationTimeoutMs`                        | Operation timeout in milliseconds                                               | 300000                       |
 | `operatorNamespaceLabels`                   | Labels of the namespace where the operator runs                                 | `nil`                        |
 | `podSecurityContext`                        | Cluster Operator pod's security context                                         | `nil`                        |
+| `deploymentStrategy`                        | Adjust the Kubernetes rollout strategy of the Cluster Operator Deployment       | `nil`                        |
 | `priorityClassName`                         | Cluster Operator pod's priority class name                                      | `nil`                        |
 | `securityContext`                           | Cluster Operator container's security context                                   | `nil`                        |
 | `rbac.create`                               | Whether to create RBAC related resources                                        | `yes`                        |
@@ -127,7 +128,7 @@ the documentation for more details.
 | `podDisruptionBudget.enabled`               | Whether to enable the podDisruptionBudget feature                               | `false`                      |
 | `podDisruptionBudget.minAvailable`          | Default value for how many pods must be running in a cluster                    | `1`                          |
 | `podDisruptionBudget.maxUnavailable`        | Default value for how many pods can be down                                     | `nil`                        |
-| `podDisruptionBudget.unhealthyPodEvictionPolicy` | Default value for how to respond to unheathly pods                         | `IfHealthyBudget`                |
+| `podDisruptionBudget.unhealthyPodEvictionPolicy` | Default value for how to respond to unheathly pods                              | `IfHealthyBudget`                |
 | `extraEnvs`                                 | Extra environment variables for the Cluster operator container                  | `[]`                         |
 | `kafka.image.registry`                      | Override default Kafka image registry                                           | `nil`                        |
 | `kafka.image.repository`                    | Override default Kafka image repository                                         | `nil`                        |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -97,127 +97,127 @@ The following table lists the configurable parameters of the Strimzi chart and t
 configuration of Kafka and other components are defined within their respective Custom Resource Definitions.  See
 the documentation for more details.
 
-| Parameter                                   | Description                                                                     | Default                      |
-|---------------------------------------------|---------------------------------------------------------------------------------|------------------------------|
-| `replicas`                                  | Number of replicas of the cluster operator                                      | 1                            |
-| `revisionHistoryLimit`                      | Number of replicaSet to keep of the operator deployment                         | 10                           |
-| `watchNamespaces`                           | Comma separated list of additional namespaces for the strimzi-operator to watch | []                           |
-| `watchAnyNamespace`                         | Watch the whole Kubernetes cluster (all namespaces)                             | `false`                      |
-| `defaultImageRegistry`                      | Default image registry for all the images                                       | `quay.io`                    |
-| `defaultImageRepository`                    | Default image registry for all the images                                       | `strimzi`                    |
-| `defaultImageTag`                           | Default image tag for all the images except Kafka Bridge                        | `latest`                     |
-| `deploymentAnnotations`                     | Annotations for the operator deployment                                         | `{}`                         |
-| `image.registry`                            | Override default Cluster Operator image registry                                | `nil`                        |
-| `image.repository`                          | Override default Cluster Operator image repository                              | `nil`                        |
-| `image.name`                                | Cluster Operator image name                                                     | `operator`                   |
-| `image.tag`                                 | Override default Cluster Operator image tag                                     | `nil`                        |
-| `image.digest`                              | Override Cluster Operator image tag with digest                                 | `nil`                        |
-| `image.imagePullPolicy`                     | Image pull policy for all pods deployed by Cluster Operator                     | `IfNotPresent`               |
-| `image.imagePullSecrets`                    | List of Docker registry pull secrets                                            | `[]`                         |
-| `fullReconciliationIntervalMs`              | Full reconciliation interval in milliseconds                                    | 120000                       |
-| `leaderElection.enable`                     | Whether to enable leader election                                               | `true`                       |
-| `operationTimeoutMs`                        | Operation timeout in milliseconds                                               | 300000                       |
-| `operatorNamespaceLabels`                   | Labels of the namespace where the operator runs                                 | `nil`                        |
-| `podSecurityContext`                        | Cluster Operator pod's security context                                         | `nil`                        |
-| `deploymentStrategy`                        | Adjust the Kubernetes rollout strategy of the Cluster Operator Deployment       | `nil`                        |
-| `priorityClassName`                         | Cluster Operator pod's priority class name                                      | `nil`                        |
-| `securityContext`                           | Cluster Operator container's security context                                   | `nil`                        |
-| `rbac.create`                               | Whether to create RBAC related resources                                        | `yes`                        |
-| `serviceAccountCreate`                      | Whether to create a service account                                             | `yes`                        |
-| `serviceAccount`                            | Cluster Operator's service account                                              | `strimzi-cluster-operator`   |
-| `podDisruptionBudget.enabled`               | Whether to enable the podDisruptionBudget feature                               | `false`                      |
-| `podDisruptionBudget.minAvailable`          | Default value for how many pods must be running in a cluster                    | `1`                          |
-| `podDisruptionBudget.maxUnavailable`        | Default value for how many pods can be down                                     | `nil`                        |
-| `podDisruptionBudget.unhealthyPodEvictionPolicy` | Default value for how to respond to unheathly pods                              | `IfHealthyBudget`                |
-| `extraEnvs`                                 | Extra environment variables for the Cluster operator container                  | `[]`                         |
-| `kafka.image.registry`                      | Override default Kafka image registry                                           | `nil`                        |
-| `kafka.image.repository`                    | Override default Kafka image repository                                         | `nil`                        |
-| `kafka.image.name`                          | Kafka image name                                                                | `kafka`                      |
-| `kafka.image.tagPrefix`                     | Override default Kafka image tag prefix                                         | `nil`                        |
-| `kafka.image.tag`                           | Override default Kafka image tag and ignore suffix                              | `nil`                        |
-| `kafka.image.digest`                        | Override Kafka image tag with digest                                            | `nil`                        |
-| `kafkaConnect.image.registry`               | Override default Kafka Connect image registry                                   | `nil`                        |
-| `kafkaConnect.image.repository`             | Override default Kafka Connect image repository                                 | `nil`                        |
-| `kafkaConnect.image.name`                   | Kafka Connect image name                                                        | `kafka`                      |
-| `kafkaConnect.image.tagPrefix`              | Override default Kafka Connect image tag prefix                                 | `nil`                        |
-| `kafkaConnect.image.tag`                    | Override default Kafka Connect image tag and ignore suffix                      | `nil`                        |
-| `kafkaConnect.image.digest`                 | Override Kafka Connect image tag with digest                                    | `nil`                        |
-| `cruiseControl.image.registry`              | Override default Cruise Control image registry                                  | `nil`                        |
-| `cruiseControl.image.repository`            | Override default Cruise Control image repository                                | `nil`                        |
-| `cruiseControl.image.name`                  | Cruise Control image name                                                       | `kafka`                      |
-| `cruiseControl.image.tagPrefix`             | Override default Cruise Control image tag prefix                                | `nil`                        |
-| `cruiseControl.image.tag`                   | Override default Cruise Control image tag and ignore suffix                     | `nil`                        |
-| `cruiseControl.image.digest`                | Override Cruise Control image tag with digest                                   | `nil`                        |
-| `topicOperator.image.registry`              | Override default Topic Operator image registry                                  | `nil`                        |
-| `topicOperator.image.repository`            | Override default  Topic Operator image repository                               | `nil`                        |
-| `topicOperator.image.name`                  | Topic Operator image name                                                       | `operator`                   |
-| `topicOperator.image.tag`                   | Override default Topic Operator image tag                                       | `nil`                        |
-| `topicOperator.image.digest`                | Override Topic Operator image tag with digest                                   | `nil`                        |
-| `userOperator.image.registry`               | Override default User Operator image registry                                   | `nil`                        |
-| `userOperator.image.repository`             | Override default User Operator image repository                                 | `nil`                        |
-| `userOperator.image.name`                   | User Operator image name                                                        | `operator`                   |
-| `userOperator.image.tag`                    | Override default User Operator image tag                                        | `nil`                        |
-| `userOperator.image.digest`                 | Override User Operator image tag with digest                                    | `nil`                        |
-| `kafkaInit.image.registry`                  | Override default Init Kafka image registry                                      | `nil`                        |
-| `kafkaInit.image.repository`                | Override default Init Kafka image repository                                    | `nil`                        |
-| `kafkaInit.image.name`                      | Init Kafka image name                                                           | `operator`                   |
-| `kafkaInit.image.tag`                       | Override default Init Kafka image tag                                           | `nil`                        |
-| `kafkaInit.image.digest`                    | Override Init Kafka image tag with digest                                       | `nil`                        |
-| `kafkaBridge.image.registry`                | Override default Kafka Bridge image registry                                    | `quay.io`                    |
-| `kafkaBridge.image.repository`              | Override default Kafka Bridge image repository                                  | `strimzi`                    |
-| `kafkaBridge.image.name`                    | Kafka Bridge image name                                                         | `kafka-bridge`               |
-| `kafkaBridge.image.tag`                     | Override default Kafka Bridge image tag                                         | `0.32.0`                     |
-| `kafkaBridge.image.digest`                  | Override Kafka Bridge image tag with digest                                     | `nil`                        |
-| `kafkaExporter.image.registry`              | Override default Kafka Exporter image registry                                  | `nil`                        |
-| `kafkaExporter.image.repository`            | Override default Kafka Exporter image repository                                | `nil`                        |
-| `kafkaExporter.image.name`                  | Kafka Exporter image name                                                       | `kafka`                      |
-| `kafkaExporter.image.tagPrefix`             | Override default Kafka Exporter image tag prefix                                | `nil`                        |
-| `kafkaExporter.image.tag`                   | Override default Kafka Exporter image tag and ignore suffix                     | `nil`                        |
-| `kafkaExporter.image.digest`                | Override Kafka Exporter image tag with digest                                   | `nil`                        |
-| `kafkaMirrorMaker2.image.registry`          | Override default Kafka Mirror Maker 2 image registry                            | `nil`                        |
-| `kafkaMirrorMaker2.image.repository`        | Override default Kafka Mirror Maker 2 image repository                          | `nil`                        |
-| `kafkaMirrorMaker2.image.name`              | Kafka Mirror Maker 2 image name                                                 | `kafka`                      |
-| `kafkaMirrorMaker2.image.tagPrefix`         | Override default Kafka Mirror Maker 2 image tag prefix                          | `nil`                        |
-| `kafkaMirrorMaker2.image.tag`               | Override default Kafka Mirror Maker 2 image tag and ignore suffix               | `nil`                        |
-| `kafkaMirrorMaker2.image.digest`            | Override Kafka Mirror Maker 2 image tag with digest                             | `nil`                        |
-| `kanikoExecutor.image.registry`             | Override default Kaniko Executor image registry                                 | `nil`                        |
-| `kanikoExecutor.image.repository`           | Override default Kaniko Executor image repository                               | `nil`                        |
-| `kanikoExecutor.image.name`                 | Kaniko Executor image name                                                      | `kaniko-executor`            |
-| `kanikoExecutor.image.tag`                  | Override default Kaniko Executor image tag                                      | `nil`                        |
-| `kanikoExecutor.image.digest`               | Override Kaniko Executor image tag with digest                                  | `nil`                        |
-| `resources.limits.memory`                   | Memory constraint for limits                                                    | `384Mi`                      |
-| `resources.limits.cpu`                      | CPU constraint for limits                                                       | `1000m`                      |
-| `resources.requests.memory`                 | Memory constraint for requests                                                  | `384Mi`                      |
-| `livenessProbe.initialDelaySeconds`         | Liveness probe initial delay in seconds                                         | 10                           |
-| `livenessProbe.periodSeconds`               | Liveness probe period in seconds                                                | 30                           |
-| `readinessProbe.initialDelaySeconds`        | Readiness probe initial delay in seconds                                        | 10                           |
-| `readinessProbe.periodSeconds`              | Readiness probe period in seconds                                               | 30                           |
-| `imageTagOverride`                          | Override all image tag config                                                   | `nil`                        |
-| `createGlobalResources`                     | Allow creation of cluster-scoped resources                                      | `true`                       |
-| `createAggregateRoles`                      | Create cluster roles that extend aggregated roles to use Strimzi CRDs           | `false`                      |
-| `tolerations`                               | Add tolerations to Operator Pod                                                 | `[]`                         |
-| `affinity`                                  | Add affinities to Operator Pod                                                  | `{}`                         |
-| `annotations`                               | Add annotations to Operator Pod                                                 | `{}`                         |
-| `labels`                                    | Add labels to Operator Pod                                                      | `{}`                         |
-| `nodeSelector`                              | Add a node selector to Operator Pod                                             | `{}`                         |
-| `featureGates`                              | Feature Gates configuration                                                     | `nil`                        |
-| `tmpDirSizeLimit`                           | Set the `sizeLimit` for the tmp dir volume used by the operator                 | `1Mi`                        |
-| `labelsExclusionPattern`                    | Override the exclude pattern for exclude some labels                            | `""`                         |
-| `generateNetworkPolicy`                     | Controls whether Strimzi generates network policy resources                     | `true`                       |
-| `connectBuildTimeoutMs`                     | Overrides the default timeout value for building new Kafka Connect              | `300000`                     |
-| `mavenBuilder.image.registry`               | Override default Maven Builder image registry                                   | `nil`                        |
-| `mavenBuilder.image.repository`             | Maven Builder image repository                                                  | `nil`                        |
-| `mavenBuilder.image.name`                   | Override default Maven Builder image name                                       | `maven-builder`              |
-| `mavenBuilder.image.tag`                    | Override default Maven Builder image tag                                        | `nil`                        |
-| `mavenBuilder.image.digest`                 | Override Maven Builder image tag with digest                                    | `nil`                        |
-| `logConfiguration`                          | Override default `log4j.properties` content                                     | `nil`                        |
-| `logLevel`                                  | Override default logging level                                                  | `INFO`                       |
-| `dashboards.enabled`                        | Generate configmaps containing the dashboards                                   | `false`                      |
-| `dashboards.label`                          | How should the dashboards be labeled for the sidecar                            | `grafana_dashboard`          |
-| `dashboards.labelValue`                     | What should the dashboards label value be for the sidecar                       | `"1"`                        |
-| `dashboards.extraLabels`                    | Any additional labels you would like on the dashboards                          | `{}`                         |
-| `dashboards.namespace`                      | What namespace should the dashboards be loaded into                             | `Follows toplevel Namespace` |
-| `dashboards.annotations`                    | Any custom annotations (such as folder for the sidecar)                         | `{}`                         |
+| Parameter                                        | Description                                                                     | Default                      |
+|--------------------------------------------------|---------------------------------------------------------------------------------|------------------------------|
+| `replicas`                                       | Number of replicas of the cluster operator                                      | 1                            |
+| `revisionHistoryLimit`                           | Number of replicaSet to keep of the operator deployment                         | 10                           |
+| `watchNamespaces`                                | Comma separated list of additional namespaces for the strimzi-operator to watch | []                           |
+| `watchAnyNamespace`                              | Watch the whole Kubernetes cluster (all namespaces)                             | `false`                      |
+| `defaultImageRegistry`                           | Default image registry for all the images                                       | `quay.io`                    |
+| `defaultImageRepository`                         | Default image registry for all the images                                       | `strimzi`                    |
+| `defaultImageTag`                                | Default image tag for all the images except Kafka Bridge                        | `latest`                     |
+| `deploymentAnnotations`                          | Annotations for the operator deployment                                         | `{}`                         |
+| `image.registry`                                 | Override default Cluster Operator image registry                                | `nil`                        |
+| `image.repository`                               | Override default Cluster Operator image repository                              | `nil`                        |
+| `image.name`                                     | Cluster Operator image name                                                     | `operator`                   |
+| `image.tag`                                      | Override default Cluster Operator image tag                                     | `nil`                        |
+| `image.digest`                                   | Override Cluster Operator image tag with digest                                 | `nil`                        |
+| `image.imagePullPolicy`                          | Image pull policy for all pods deployed by Cluster Operator                     | `IfNotPresent`               |
+| `image.imagePullSecrets`                         | List of Docker registry pull secrets                                            | `[]`                         |
+| `fullReconciliationIntervalMs`                   | Full reconciliation interval in milliseconds                                    | 120000                       |
+| `leaderElection.enable`                          | Whether to enable leader election                                               | `true`                       |
+| `operationTimeoutMs`                             | Operation timeout in milliseconds                                               | 300000                       |
+| `operatorNamespaceLabels`                        | Labels of the namespace where the operator runs                                 | `nil`                        |
+| `podSecurityContext`                             | Cluster Operator pod's security context                                         | `nil`                        |
+| `deploymentStrategy`                             | Adjust the Kubernetes rollout strategy of the Cluster Operator Deployment       | `nil`                        |
+| `priorityClassName`                              | Cluster Operator pod's priority class name                                      | `nil`                        |
+| `securityContext`                                | Cluster Operator container's security context                                   | `nil`                        |
+| `rbac.create`                                    | Whether to create RBAC related resources                                        | `yes`                        |
+| `serviceAccountCreate`                           | Whether to create a service account                                             | `yes`                        |
+| `serviceAccount`                                 | Cluster Operator's service account                                              | `strimzi-cluster-operator`   |
+| `podDisruptionBudget.enabled`                    | Whether to enable the podDisruptionBudget feature                               | `false`                      |
+| `podDisruptionBudget.minAvailable`               | Default value for how many pods must be running in a cluster                    | `1`                          |
+| `podDisruptionBudget.maxUnavailable`             | Default value for how many pods can be down                                     | `nil`                        |
+| `podDisruptionBudget.unhealthyPodEvictionPolicy` | Default value for how to respond to unheathly pods                              | `IfHealthyBudget`            |
+| `extraEnvs`                                      | Extra environment variables for the Cluster operator container                  | `[]`                         |
+| `kafka.image.registry`                           | Override default Kafka image registry                                           | `nil`                        |
+| `kafka.image.repository`                         | Override default Kafka image repository                                         | `nil`                        |
+| `kafka.image.name`                               | Kafka image name                                                                | `kafka`                      |
+| `kafka.image.tagPrefix`                          | Override default Kafka image tag prefix                                         | `nil`                        |
+| `kafka.image.tag`                                | Override default Kafka image tag and ignore suffix                              | `nil`                        |
+| `kafka.image.digest`                             | Override Kafka image tag with digest                                            | `nil`                        |
+| `kafkaConnect.image.registry`                    | Override default Kafka Connect image registry                                   | `nil`                        |
+| `kafkaConnect.image.repository`                  | Override default Kafka Connect image repository                                 | `nil`                        |
+| `kafkaConnect.image.name`                        | Kafka Connect image name                                                        | `kafka`                      |
+| `kafkaConnect.image.tagPrefix`                   | Override default Kafka Connect image tag prefix                                 | `nil`                        |
+| `kafkaConnect.image.tag`                         | Override default Kafka Connect image tag and ignore suffix                      | `nil`                        |
+| `kafkaConnect.image.digest`                      | Override Kafka Connect image tag with digest                                    | `nil`                        |
+| `cruiseControl.image.registry`                   | Override default Cruise Control image registry                                  | `nil`                        |
+| `cruiseControl.image.repository`                 | Override default Cruise Control image repository                                | `nil`                        |
+| `cruiseControl.image.name`                       | Cruise Control image name                                                       | `kafka`                      |
+| `cruiseControl.image.tagPrefix`                  | Override default Cruise Control image tag prefix                                | `nil`                        |
+| `cruiseControl.image.tag`                        | Override default Cruise Control image tag and ignore suffix                     | `nil`                        |
+| `cruiseControl.image.digest`                     | Override Cruise Control image tag with digest                                   | `nil`                        |
+| `topicOperator.image.registry`                   | Override default Topic Operator image registry                                  | `nil`                        |
+| `topicOperator.image.repository`                 | Override default  Topic Operator image repository                               | `nil`                        |
+| `topicOperator.image.name`                       | Topic Operator image name                                                       | `operator`                   |
+| `topicOperator.image.tag`                        | Override default Topic Operator image tag                                       | `nil`                        |
+| `topicOperator.image.digest`                     | Override Topic Operator image tag with digest                                   | `nil`                        |
+| `userOperator.image.registry`                    | Override default User Operator image registry                                   | `nil`                        |
+| `userOperator.image.repository`                  | Override default User Operator image repository                                 | `nil`                        |
+| `userOperator.image.name`                        | User Operator image name                                                        | `operator`                   |
+| `userOperator.image.tag`                         | Override default User Operator image tag                                        | `nil`                        |
+| `userOperator.image.digest`                      | Override User Operator image tag with digest                                    | `nil`                        |
+| `kafkaInit.image.registry`                       | Override default Init Kafka image registry                                      | `nil`                        |
+| `kafkaInit.image.repository`                     | Override default Init Kafka image repository                                    | `nil`                        |
+| `kafkaInit.image.name`                           | Init Kafka image name                                                           | `operator`                   |
+| `kafkaInit.image.tag`                            | Override default Init Kafka image tag                                           | `nil`                        |
+| `kafkaInit.image.digest`                         | Override Init Kafka image tag with digest                                       | `nil`                        |
+| `kafkaBridge.image.registry`                     | Override default Kafka Bridge image registry                                    | `quay.io`                    |
+| `kafkaBridge.image.repository`                   | Override default Kafka Bridge image repository                                  | `strimzi`                    |
+| `kafkaBridge.image.name`                         | Kafka Bridge image name                                                         | `kafka-bridge`               |
+| `kafkaBridge.image.tag`                          | Override default Kafka Bridge image tag                                         | `0.32.0`                     |
+| `kafkaBridge.image.digest`                       | Override Kafka Bridge image tag with digest                                     | `nil`                        |
+| `kafkaExporter.image.registry`                   | Override default Kafka Exporter image registry                                  | `nil`                        |
+| `kafkaExporter.image.repository`                 | Override default Kafka Exporter image repository                                | `nil`                        |
+| `kafkaExporter.image.name`                       | Kafka Exporter image name                                                       | `kafka`                      |
+| `kafkaExporter.image.tagPrefix`                  | Override default Kafka Exporter image tag prefix                                | `nil`                        |
+| `kafkaExporter.image.tag`                        | Override default Kafka Exporter image tag and ignore suffix                     | `nil`                        |
+| `kafkaExporter.image.digest`                     | Override Kafka Exporter image tag with digest                                   | `nil`                        |
+| `kafkaMirrorMaker2.image.registry`               | Override default Kafka Mirror Maker 2 image registry                            | `nil`                        |
+| `kafkaMirrorMaker2.image.repository`             | Override default Kafka Mirror Maker 2 image repository                          | `nil`                        |
+| `kafkaMirrorMaker2.image.name`                   | Kafka Mirror Maker 2 image name                                                 | `kafka`                      |
+| `kafkaMirrorMaker2.image.tagPrefix`              | Override default Kafka Mirror Maker 2 image tag prefix                          | `nil`                        |
+| `kafkaMirrorMaker2.image.tag`                    | Override default Kafka Mirror Maker 2 image tag and ignore suffix               | `nil`                        |
+| `kafkaMirrorMaker2.image.digest`                 | Override Kafka Mirror Maker 2 image tag with digest                             | `nil`                        |
+| `kanikoExecutor.image.registry`                  | Override default Kaniko Executor image registry                                 | `nil`                        |
+| `kanikoExecutor.image.repository`                | Override default Kaniko Executor image repository                               | `nil`                        |
+| `kanikoExecutor.image.name`                      | Kaniko Executor image name                                                      | `kaniko-executor`            |
+| `kanikoExecutor.image.tag`                       | Override default Kaniko Executor image tag                                      | `nil`                        |
+| `kanikoExecutor.image.digest`                    | Override Kaniko Executor image tag with digest                                  | `nil`                        |
+| `resources.limits.memory`                        | Memory constraint for limits                                                    | `384Mi`                      |
+| `resources.limits.cpu`                           | CPU constraint for limits                                                       | `1000m`                      |
+| `resources.requests.memory`                      | Memory constraint for requests                                                  | `384Mi`                      |
+| `livenessProbe.initialDelaySeconds`              | Liveness probe initial delay in seconds                                         | 10                           |
+| `livenessProbe.periodSeconds`                    | Liveness probe period in seconds                                                | 30                           |
+| `readinessProbe.initialDelaySeconds`             | Readiness probe initial delay in seconds                                        | 10                           |
+| `readinessProbe.periodSeconds`                   | Readiness probe period in seconds                                               | 30                           |
+| `imageTagOverride`                               | Override all image tag config                                                   | `nil`                        |
+| `createGlobalResources`                          | Allow creation of cluster-scoped resources                                      | `true`                       |
+| `createAggregateRoles`                           | Create cluster roles that extend aggregated roles to use Strimzi CRDs           | `false`                      |
+| `tolerations`                                    | Add tolerations to Operator Pod                                                 | `[]`                         |
+| `affinity`                                       | Add affinities to Operator Pod                                                  | `{}`                         |
+| `annotations`                                    | Add annotations to Operator Pod                                                 | `{}`                         |
+| `labels`                                         | Add labels to Operator Pod                                                      | `{}`                         |
+| `nodeSelector`                                   | Add a node selector to Operator Pod                                             | `{}`                         |
+| `featureGates`                                   | Feature Gates configuration                                                     | `nil`                        |
+| `tmpDirSizeLimit`                                | Set the `sizeLimit` for the tmp dir volume used by the operator                 | `1Mi`                        |
+| `labelsExclusionPattern`                         | Override the exclude pattern for exclude some labels                            | `""`                         |
+| `generateNetworkPolicy`                          | Controls whether Strimzi generates network policy resources                     | `true`                       |
+| `connectBuildTimeoutMs`                          | Overrides the default timeout value for building new Kafka Connect              | `300000`                     |
+| `mavenBuilder.image.registry`                    | Override default Maven Builder image registry                                   | `nil`                        |
+| `mavenBuilder.image.repository`                  | Maven Builder image repository                                                  | `nil`                        |
+| `mavenBuilder.image.name`                        | Override default Maven Builder image name                                       | `maven-builder`              |
+| `mavenBuilder.image.tag`                         | Override default Maven Builder image tag                                        | `nil`                        |
+| `mavenBuilder.image.digest`                      | Override Maven Builder image tag with digest                                    | `nil`                        |
+| `logConfiguration`                               | Override default `log4j.properties` content                                     | `nil`                        |
+| `logLevel`                                       | Override default logging level                                                  | `INFO`                       |
+| `dashboards.enabled`                             | Generate configmaps containing the dashboards                                   | `false`                      |
+| `dashboards.label`                               | How should the dashboards be labeled for the sidecar                            | `grafana_dashboard`          |
+| `dashboards.labelValue`                          | What should the dashboards label value be for the sidecar                       | `"1"`                        |
+| `dashboards.extraLabels`                         | Any additional labels you would like on the dashboards                          | `{}`                         |
+| `dashboards.namespace`                           | What namespace should the dashboards be loaded into                             | `Follows toplevel Namespace` |
+| `dashboards.annotations`                         | Any custom annotations (such as folder for the sidecar)                         | `{}`                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -15,6 +15,10 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -42,6 +42,7 @@ annotations: {}
 labels: {}
 nodeSelector: {}
 deploymentAnnotations: {}
+deploymentStrategy: {}
 priorityClassName: ""
 
 podSecurityContext: {}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Adds an optional `deploymentStrategy` configuration to the CO deployment. In addition the table for all Helm values was formatted in a separate commit.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

