### PR TITLE
Call kubeCmdClient clean with timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <testcontainer.version>1.20.1</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
         <junit4.version>4.13.2</junit4.version>
-        <skodjob.test-frame.version>1.0.0</skodjob.test-frame.version>
+        <skodjob.test-frame.version>1.1.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.4.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
         <!--

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
@@ -131,12 +132,19 @@ public class OlmAbstractST extends AbstractST {
 
     @AfterAll
     void teardown() {
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(KafkaRebalance.RESOURCE_KIND).toString());
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(KafkaMirrorMaker2.RESOURCE_KIND).toString());
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(KafkaBridge.RESOURCE_KIND).toString());
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(KafkaConnect.RESOURCE_KIND).toString());
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(KafkaTopic.RESOURCE_KIND).toString());
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(KafkaUser.RESOURCE_KIND).toString());
-        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).deleteContent(exampleResources.get(Kafka.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(KafkaRebalance.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(KafkaMirrorMaker2.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(KafkaBridge.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(KafkaConnect.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(KafkaTopic.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(KafkaUser.RESOURCE_KIND).toString());
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE)
+            .withTimeout(TestConstants.GLOBAL_TIMEOUT_SHORT).deleteContent(exampleResources.get(Kafka.RESOURCE_KIND).toString());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

KubeCmdClient is by default called with timeout 0 which means wait forever to end of execution of command. This can cause infinity waiting for deletion for example kafkatopic. Test suite is then stuck and do not fail. With timeout we can delegate waiting for Wait method which fails when timeout is reached. 

