### PR TITLE
Remove the KRaft and NodePool annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.48.0
 
-* n/a
+* KRaft and Kafka Node Pools are now enabled by default.
+  The `strimzi.io/node-pools` and `strimzi.io/kraft` annotations are not required anymore and will be ignored if set.
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
+++ b/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
@@ -105,6 +105,8 @@ public class ResourceAnnotations {
      * Annotation for enabling or disabling the Node Pools. This annotation is used
      * on the Kafka CR
      */
+    // This is still needed for upgrade tests. It should be remove once the upgrade tests use
+    // only Strimzi versions that do not require these annotations.
     public static final String ANNO_STRIMZI_IO_NODE_POOLS = STRIMZI_DOMAIN + "node-pools";
 
     /**
@@ -132,5 +134,7 @@ public class ResourceAnnotations {
      * This annotation is used on the Kafka CR
      * If missing or with an invalid value, the cluster is assumed to be ZooKeeper-based
      */
+    // This is still needed for upgrade tests. It should be remove once the upgrade tests use
+    // only Strimzi versions that do not require these annotations.
     public static final String ANNO_STRIMZI_IO_KRAFT = STRIMZI_DOMAIN + "kraft";
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -193,16 +193,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     public static final String ANNO_STRIMZI_CUSTOM_LISTENER_CERT_THUMBPRINTS = Annotations.STRIMZI_DOMAIN + "custom-listener-cert-thumbprints";
 
     /**
-     * The annotation value which indicates that the KRaft enabled
-     */
-    public static final String ENABLED_VALUE_STRIMZI_IO_KRAFT = "enabled";
-
-    /**
-     * The annotation value which indicates that the Node Pools are enabled
-     */
-    public static final String ENABLED_VALUE_STRIMZI_IO_NODE_POOLS = "enabled";
-
-    /**
      * Key under which the broker configuration is stored in Config Map
      */
     public static final String BROKER_CONFIGURATION_FILENAME = "server.config";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.PodRevision;
 import io.strimzi.operator.cluster.model.PodSetUtils;
@@ -36,7 +35,6 @@ import io.vertx.core.Future;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -365,28 +363,6 @@ public class ReconcilerUtils {
         var currentCertHash = Annotations.stringAnnotation(pod, ANNO_STRIMZI_SERVER_CERT_HASH, null);
         var desiredCertHash = certHashCache.get(ReconcilerUtils.getPodIndexFromPodName(pod.getMetadata().getName()));
         return currentCertHash != null && desiredCertHash != null && !currentCertHash.equals(desiredCertHash);
-    }
-
-    /**
-     * Checks whether Node pools are enabled for given Kafka custom resource using the strimzi.io/node-pools annotation.
-     *
-     * @param kafka     The Kafka custom resource which might have the node-pools annotation
-     *
-     * @return      True when the node pools are enabled. False otherwise.
-     */
-    public static boolean nodePoolsEnabled(Kafka kafka) {
-        return KafkaCluster.ENABLED_VALUE_STRIMZI_IO_NODE_POOLS.equals(Annotations.stringAnnotation(kafka, Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "disabled").toLowerCase(Locale.ENGLISH));
-    }
-
-    /**
-     * Checks whether KRaft is enabled for given Kafka custom resource using the strimzi.io/kraft annotation.
-     *
-     * @param kafka     The Kafka custom resource which might have the KRaft annotation
-     *
-     * @return      True when KRaft is enabled. False otherwise.
-     */
-    public static boolean kraftEnabled(Kafka kafka) {
-        return KafkaCluster.ENABLED_VALUE_STRIMZI_IO_KRAFT.equals(Annotations.stringAnnotation(kafka, Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled").toLowerCase(Locale.ENGLISH));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -56,7 +56,6 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
@@ -117,7 +116,6 @@ public class CruiseControlTest {
                 .withNamespace(NAMESPACE)
                 .withName(CLUSTER_NAME)
                 .withLabels(Map.of("my-user-label", "cromulent"))
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -43,7 +43,6 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -84,7 +83,6 @@ public class EntityOperatorTest {
                 .withNamespace(NAMESPACE)
                 .withName(CLUSTER_NAME)
                 .withLabels(Map.of("my-user-label", "cromulent"))
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -22,7 +22,6 @@ import io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpecBu
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -52,7 +51,6 @@ public class EntityTopicOperatorTest {
                 .withNamespace(NAMESPACE)
                 .withName(CLUSTER_NAME)
                 .withLabels(Map.of("my-user-label", "cromulent"))
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -25,7 +25,6 @@ import io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperatorSpecBui
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -48,7 +47,6 @@ public class EntityUserOperatorTest {
                 .withNamespace(NAMESPACE)
                 .withName(CLUSTER_NAME)
                 .withLabels(Map.of("my-user-label", "cromulent"))
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -19,7 +19,6 @@ import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
@@ -42,7 +41,6 @@ public class KafkaClusterOAuthValidationTest {
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -39,7 +39,6 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -71,7 +70,6 @@ public class KafkaExporterTest {
             .withNewMetadata()
                 .withNamespace(NAMESPACE)
                 .withName(CLUSTER_NAME)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPoolTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPoolTest.java
@@ -20,7 +20,6 @@ import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.cluster.model.nodepools.NodeIdAssignment;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,6 @@ public class KafkaPoolTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerTest.java
@@ -19,7 +19,6 @@ import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import org.apache.kafka.common.config.TopicConfig;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,6 @@ public class KafkaSpecCheckerTest {
             .withNewMetadata()
                 .withName(NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NodePoolUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NodePoolUtilsTest.java
@@ -43,7 +43,6 @@ public class NodePoolUtilsTest {
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
@@ -33,7 +32,6 @@ public class CruiseControlMetricsReporterTest {
             .withNewMetadata()
                 .withName(NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentialsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentialsTest.java
@@ -22,7 +22,6 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.MockSharedEnvironmentProvider;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -87,7 +86,6 @@ public class HashLoginServiceApiCredentialsTest {
                 .withNewMetadata()
                     .withName(CLUSTER)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractKafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractKafkaRebalanceAssemblyOperatorTest.java
@@ -51,7 +51,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -64,7 +63,6 @@ public abstract class AbstractKafkaRebalanceAssemblyOperatorTest {
     protected static final Kafka KAFKA = new KafkaBuilder()
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -39,7 +39,6 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.DeploymentOperat
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
@@ -115,7 +114,6 @@ public class CaReconcilerTest {
             .withNewMetadata()
                 .withName(NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -80,7 +80,6 @@ public class CruiseControlReconcilerTest {
                 .withNewMetadata()
                     .withName(NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -63,7 +62,6 @@ public class EntityOperatorReconcilerTest {
             .withNewMetadata()
                 .withName(NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -125,7 +125,6 @@ public class JbodStorageMockTest {
                 .withNewMetadata()
                     .withNamespace(namespace)
                     .withName(NAME)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -18,7 +18,6 @@ import io.strimzi.operator.cluster.model.KafkaUpgradeException;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -519,7 +517,6 @@ public class KRaftVersionChangeCreatorTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -63,10 +63,6 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
     private static final Kafka KAFKA = new KafkaBuilder()
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
-                .withAnnotations(Map.of(
-                        Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                        Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                ))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
@@ -128,10 +128,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withAnnotations(Map.of(
-                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -77,10 +77,6 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
     private static final Kafka KAFKA = new KafkaBuilder()
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
-                .withAnnotations(Map.of(
-                        Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                        Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                ))
                 .withNamespace(NAMESPACE)
             .endMetadata()
             .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNodePoolWatcherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNodePoolWatcherTest.java
@@ -22,7 +22,6 @@ import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Vertx;
@@ -45,10 +44,6 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
                 .withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
                 .withLabels(Map.of("selector", "matching"))
-                .withAnnotations(Map.of(
-                        Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                        Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                ))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()
@@ -128,24 +123,6 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(null);
 
         MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "not-matching")).build(), supplier);
-        mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
-
-        assertThat(mockKao.reconciliations.size(), is(0));
-    }
-
-    @Test
-    public void testEnqueueingResourceWithMissingAnnotation()    {
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editMetadata()
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "not-enabled"))
-                .endMetadata()
-                .build();
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
-        when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(kafka);
-
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(null, supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
 
         assertThat(mockKao.reconciliations.size(), is(0));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -20,7 +20,6 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ClusterRoleBindingOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.platform.KubernetesVersion;
@@ -105,10 +104,6 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 .withNewMetadata()
                     .withName(NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(
-                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -146,10 +146,6 @@ public class KafkaAssemblyOperatorTest {
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
-                .withAnnotations(Map.of(
-                        Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                        Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                ))
                 .withGeneration(1L)
             .endMetadata()
             .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAutoRebalancingMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAutoRebalancingMockTest.java
@@ -29,7 +29,6 @@ import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
@@ -129,10 +128,6 @@ public class KafkaAutoRebalancingMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withAnnotations(Map.of(
-                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
@@ -59,7 +59,6 @@ public class KafkaClusterCreatorTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconcilerTest.java
@@ -39,7 +39,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -70,7 +69,6 @@ public class KafkaExporterReconcilerTest {
             .withNewMetadata()
                 .withNamespace(NAMESPACE)
                 .withName(NAME)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerRoutesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerRoutesTest.java
@@ -65,10 +65,6 @@ public class KafkaListenerReconcilerRoutesTest {
     private static final Kafka KAFKA = new KafkaBuilder()
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
-                    .withAnnotations(Map.of(
-                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTest.java
@@ -70,10 +70,6 @@ public class KafkaListenerReconcilerTest {
     private static final Kafka KAFKA = new KafkaBuilder()
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
-                    .withAnnotations(Map.of(
-                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -36,7 +36,6 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.NodeOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
@@ -102,7 +101,6 @@ public class KafkaReconcilerStatusTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -24,7 +24,6 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.model.StatusUtils;
@@ -44,7 +43,6 @@ import org.mockito.ArgumentCaptor;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -83,7 +81,6 @@ public class KafkaStatusTest {
                 .withNewMetadata()
                     .withName(clusterName)
                     .withNamespace(namespace)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                     .withGeneration(2L)
                 .endMetadata()
                 .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
@@ -28,7 +28,6 @@ import io.strimzi.operator.cluster.model.KafkaUpgradeException;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
@@ -83,10 +82,6 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
     private static final Kafka KAFKA = new KafkaBuilder()
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
-                    .withAnnotations(Map.of(
-                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
-                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
-                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -149,7 +149,6 @@ public class PartialRollingUpdateMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -51,7 +51,6 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaReconciler;
 import io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AdminClientProvider;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.auth.PemAuthIdentity;
 import io.strimzi.operator.common.auth.PemTrustSet;
@@ -131,7 +130,6 @@ public class KubernetesRestartEventsMockTest {
     private final static Kafka KAFKA = new KafkaBuilder()
             .withNewMetadata()
                 .withName(CLUSTER_NAME)
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
             .endMetadata()
             .withNewSpec()
                 .withNewKafka()

--- a/documentation/assemblies/deploying/assembly-kraft-mode.adoc
+++ b/documentation/assemblies/deploying/assembly-kraft-mode.adoc
@@ -14,7 +14,6 @@ Metadata operations become more efficient as they are directly integrated.
 And by removing the need to maintain a ZooKeeper cluster, there's also a reduction in the operational and security overhead.
 
 To deploy a Kafka cluster in KRaft mode, you must use `Kafka` and `KafkaNodePool` custom resources.
-The `Kafka` resource using KRaft mode must also have the annotations `strimzi.io/kraft: enabled` and `strimzi.io/node-pools: enabled`.
 For more details and examples, see xref:deploying-kafka-cluster-kraft-{context}[].
 
 Through xref:config-node-pools-{context}[node pool configuration using `KafkaNodePool` resources], nodes are assigned the role of broker, controller, or both:

--- a/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
@@ -29,8 +29,6 @@ kind: Kafka
 metadata:
   name: my-cluster
   namespace: my-project
-  annotations:
-    strimzi.io/node-pools: enabled
 spec:
   kafka:
     # ...

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster-kraft.adoc
@@ -20,9 +20,6 @@ Strimzi provides the following xref:config-examples-{context}[example deployment
 
 In this procedure, we use the example deployment file that deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.
 
-The `Kafka` resource configuration for each example includes the `strimzi.io/node-pools: enabled` annotation, which is required when using node pools.
-`Kafka` resources using KRaft mode must also have the annotation `strimzi.io/kraft: enabled`.
-
 The example YAML files specify the latest supported Kafka version and KRaft metadata version used by the Kafka cluster.
 
 .Prerequisites

--- a/packaging/examples/cruise-control/kafka-cruise-control-auto-rebalancing.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control-auto-rebalancing.yaml
@@ -38,9 +38,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/cruise-control/kafka-cruise-control-with-goals.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control-with-goals.yaml
@@ -38,9 +38,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/cruise-control/kafka-cruise-control.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control.yaml
@@ -38,9 +38,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/kafka/kafka-ephemeral.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral.yaml
@@ -38,9 +38,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -47,9 +47,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -42,9 +42,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/kafka/kafka-single-node.yaml
+++ b/packaging/examples/kafka/kafka-single-node.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/kafka/kafka-with-dual-role-nodes.yaml
+++ b/packaging/examples/kafka/kafka-with-dual-role-nodes.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -38,9 +38,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -42,9 +42,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-metrics.yaml
@@ -40,9 +40,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: cluster-a
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: cluster-b
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -42,9 +42,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: cluster-a
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0
@@ -75,9 +72,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: cluster-b
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -42,9 +42,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -23,9 +23,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: cluster-a
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0
@@ -75,9 +72,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: cluster-b
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 4.0.0

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/types/KafkaType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/types/KafkaType.java
@@ -13,17 +13,14 @@ import io.skodjob.testframe.resources.KubeResourceManager;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaList;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.resources.CrdClients;
 import io.strimzi.systemtest.resources.ResourceConditions;
 import io.strimzi.systemtest.resources.ResourceOperation;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.platform.commons.util.Preconditions;
 
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -93,17 +90,8 @@ public class KafkaType implements ResourceType<Kafka> {
 
         // proceed only if kafka is still present as Kafka is purposefully deleted in some test cases
         if (currentKafka != null) {
-            // load current Kafka's annotations to obtain information, if KafkaNodePools are used for this Kafka
-            Map<String, String> annotations = currentKafka.getMetadata().getAnnotations();
-
             client.inNamespace(namespaceName).withName(
                 kafka.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-
-            if (annotations.get(Annotations.ANNO_STRIMZI_IO_NODE_POOLS) == null
-                || annotations.get(Annotations.ANNO_STRIMZI_IO_NODE_POOLS).equals("disabled")) {
-                // additional deletion of pvcs with specification deleteClaim set to false which were not deleted prior this method
-                PersistentVolumeClaimUtils.deletePvcsByPrefixWithWait(namespaceName, clusterName);
-            }
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -16,7 +16,6 @@ import io.strimzi.api.kafka.model.common.template.ContainerEnvVarBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.utils.FileUtils;
@@ -166,8 +165,6 @@ public class KafkaTemplates {
             .withNewMetadata()
                 .withName(kafkaClusterName)
                 .withNamespace(namespaceName)
-                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
-                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
             .endMetadata()
             .editSpec()
                 .editKafka()

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -98,7 +98,7 @@ public class KafkaNodePoolST extends AbstractST {
 
         PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaComponents.getPodSetName(testStorage.getClusterName(), nodePoolNameInitial), 2);
 
-        LOGGER.info("Testing deployment of KafkaNodePools with pre-configured annotation: {} is creating Brokers with correct IDs", Annotations.ANNO_STRIMZI_IO_NODE_POOLS);
+        LOGGER.info("Testing deployment of KafkaNodePools with pre-configured annotation: {} is creating Brokers with correct IDs", Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS);
 
         // Deploy NodePool A with only 1 replica and next ID 4, and NodePool B with 2 replica and next ID 6
         KubeResourceManager.get().createResourceWithWait(KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), nodePoolNameA, testStorage.getClusterName(), 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorScalabilityPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorScalabilityPerformance.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
@@ -109,10 +108,6 @@ public class TopicOperatorScalabilityPerformance extends AbstractST {
 
         KubeResourceManager.get().createResourceWithWait(
             KafkaTemplates.kafka(suiteTestStorage.getNamespaceName(),  suiteTestStorage.getClusterName(), 3)
-                .editMetadata()
-                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
-                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
-                .endMetadata()
                 .editSpec()
                     .editKafka()
                     .withResources(new ResourceRequirementsBuilder()

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -331,6 +331,8 @@ public class AbstractKRaftUpgradeST extends AbstractST {
                     KafkaNodePoolTemplates.brokerPoolPersistentStorage(componentsNamespaceName, BROKER_NODE_NAME, CLUSTER_NAME, 3).build(),
                     KafkaTemplates.kafka(componentsNamespaceName, CLUSTER_NAME, 3)
                         .editMetadata()
+                            // This is still needed for upgrade tests. It should be remove once the upgrade tests use
+                            // only Strimzi versions that do not require these annotations.
                             .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                             .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                         .endMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftKafkaUpgradeDowngradeST.java
@@ -129,6 +129,8 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
 
             KafkaBuilder kafka = KafkaTemplates.kafka(testStorage.getNamespaceName(), CLUSTER_NAME, brokerReplicas)
                 .editMetadata()
+                    // This is still needed for upgrade tests. It should be remove once the upgrade tests use
+                    // only Strimzi versions that do not require these annotations.
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .endMetadata()


### PR DESCRIPTION
### Type of change

- Task

### Description

As discussed in #11657, there seems to be consensus to stop enforcing the `strimzi.io/node-pools` and `strimzi.io/kraft` annotations. This PR removes them from the docs, examples, and from source code. The only place where they remain are the upgrade/downgrade system tests. They should be removed from there only once we do not use them with any Strimzi version enforcing them.

This PR - assuming it is approved and merged - should make #11657 obsolete.

There is no real need for users to remove the annotations - they will be simply ignored.

The validation for pre-existing ZooKeeper-based clusters still remains in place. So if user upgrades without migrating all their clusters to KRaft, they should get error like this:
```
2025-07-23 19:51:52 WARN  AbstractOperator:566 - Reconciliation #1(watch) Kafka(myproject/my-cluster): Failed to reconcile
io.strimzi.operator.common.InvalidConfigurationException: Strimzi 0.48.0-SNAPSHOT supports only KRaft-based Apache Kafka clusters. Please make sure your cluster is migrated to KRaft before using Strimzi 0.48.0-SNAPSHOT.
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator.reconcile(KafkaAssemblyOperator.java:228) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator.createOrUpdate(KafkaAssemblyOperator.java:141) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator.createOrUpdate(KafkaAssemblyOperator.java:71) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.AbstractOperator.reconcileResource(AbstractOperator.java:268) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.AbstractOperator.lambda$reconcile$0(AbstractOperator.java:191) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.complete(Composition.java:40) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureBase.lambda$emitResult$0(FutureBase.java:59) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:507) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:182) ~[io.netty.netty-transport-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

Similarly, the operator still validates the presence of the Node Pools. So if user tries to deploy a ZooKeeper-based cluster without node pool based on an old example, they still get this error:
```
2025-07-23 19:25:15 ERROR AbstractOperator:285 - Reconciliation #77(watch) Kafka(myproject/my-cluster): createOrUpdate failed
io.strimzi.operator.common.InvalidConfigurationException: No KafkaNodePools found for Kafka cluster my-cluster
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$kafkaReconciler$6(KafkaAssemblyOperator.java:507) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.complete(Composition.java:40) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureBase.emitResult(FutureBase.java:68) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureImpl.completeInternal(FutureImpl.java:163) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:169) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.CompositeFutureImpl.doComplete(CompositeFutureImpl.java:218) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.CompositeFutureImpl.onSuccess(CompositeFutureImpl.java:123) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.CompositeFutureImpl.complete(CompositeFutureImpl.java:85) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureBase.lambda$emitResult$0(FutureBase.java:59) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:507) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:182) ~[io.netty.netty-transport-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

We also keep validating the presence of controller nodes. So YAML for an ols Zoo-based cluster without controller nodes would also fail with the corresponding error:
```
2025-07-23 19:28:01 ERROR AbstractOperator:285 - Reconciliation #82(watch) Kafka(myproject/my-cluster): createOrUpdate failed
io.strimzi.operator.common.model.InvalidResourceException: The Kafka cluster my-cluster is invalid: [At least one KafkaNodePool with the controller role and at least one replica is required when KRaft mode is enabled]
	at io.strimzi.operator.cluster.model.nodepools.NodePoolUtils.validateNodePools(NodePoolUtils.java:107) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.nodepools.NodePoolUtils.createKafkaPools(NodePoolUtils.java:56) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaClusterCreator.createKafkaCluster(KafkaClusterCreator.java:330) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaClusterCreator.createKafkaCluster(KafkaClusterCreator.java:166) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaClusterCreator.prepareKafkaCluster(KafkaClusterCreator.java:114) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$kafkaReconciler$6(KafkaAssemblyOperator.java:522) ~[io.strimzi.cluster-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.complete(Composition.java:40) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureBase.emitResult(FutureBase.java:68) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureImpl.completeInternal(FutureImpl.java:163) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:169) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.CompositeFutureImpl.doComplete(CompositeFutureImpl.java:218) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.CompositeFutureImpl.onSuccess(CompositeFutureImpl.java:123) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.CompositeFutureImpl.complete(CompositeFutureImpl.java:85) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.vertx.core.impl.future.FutureBase.lambda$emitResult$0(FutureBase.java:59) ~[io.vertx.vertx-core-5.0.1.jar:5.0.1]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:507) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:182) ~[io.netty.netty-transport-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.2.2.Final.jar:4.2.2.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md