### PR TITLE
Server Side Apply phase 1 - ConfigMap, Ingress, Service, ServiceAccount, PVC

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
         display_name: 'feature-gates-regression-bundle VII. - logging + specific'
         profile: 'azp_logging_specific'
         cluster_operator_install_type: 'yaml'
-        strimzi_feature_gates: '+DummyFeatureGate'
+        strimzi_feature_gates: '+ServerSideApplyPhase1'
         timeout: 360
         releaseVersion: '${{ parameters.releaseVersion }}'
         kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -82,7 +82,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VIII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'yaml'
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -21,7 +21,7 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -34,7 +34,7 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -47,7 +47,7 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -60,7 +60,7 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -73,7 +73,7 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -86,6 +86,6 @@ jobs:
       cluster_operator_install_type: 'yaml'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+DummyFeatureGate'
+      strimzi_feature_gates: '+ServerSideApplyPhase1'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Make properties `broker.session.timeout.ms`, `broker.heartbeat.interval.ms` and `controller.socket.timeout.ms` configurable
 * Add monitoring of custom resources using [kubernetes-state-metrics (KSM)](https://github.com/kubernetes/kube-state-metrics) (see [Strimzi proposal 087](https://github.com/strimzi/proposals/blob/main/087-monitoring-of-custom-resources.md))
 * Added support for Strimzi Metrics Reporter to Kafka Connect, Mirror Maker 2 and Kafka Bridge.
+* Add new feature gate `ServerSideApplyPhase1` (disabled by default) that adds support for Server Side Apply for `ConfigMap`, `Ingress`, `PVC`, `Service`, and `ServiceAccount` according to [Strimzi Proposal #105](https://github.com/strimzi/proposals/blob/main/105-server-side-apply-implementation-fg-timelines.md).
 
 ### Major changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -136,13 +136,15 @@ public class Main {
      *
      * @return  Future which completes when all Cluster Operator verticles are started and running
      */
-    static CompositeFuture deployClusterOperatorVerticles(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config, ShutdownHook shutdownHook) {
+    static CompositeFuture deployClusterOperatorVerticles(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider,
+                                                          PlatformFeaturesAvailability pfa, ClusterOperatorConfig config, ShutdownHook shutdownHook) {
         ResourceOperatorSupplier resourceOperatorSupplier = new ResourceOperatorSupplier(
                 vertx,
                 client,
                 metricsProvider,
                 pfa,
-                config.getOperatorName()
+                config.getOperatorName(),
+                config.featureGates()
         );
 
         // Initialize the PodSecurityProvider factory to provide the user configured provider

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
@@ -263,6 +263,13 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
         }
     }
 
+    /**
+     * Patches the resource with the given namespace and name to match the given desired resource
+     * and completes the given future accordingly.
+     * The patch is done using Server-Side Apply, which means that the server will handle the changes
+     * to the resource.
+     * First patch attempt is done without force, however if there is a conflict, operator will try again using force.
+     */
     protected Future<ReconcileResult<T>> internalServerSideApply(Reconciliation reconciliation, String namespace, String name, T desired) {
         R resourceOp = operation().inNamespace(namespace).withName(name);
 
@@ -292,6 +299,12 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
         }
     }
 
+    /**
+     * Creates {@link PatchContext} with SSA type for the Cluster Operator.
+     *
+     * @param useForce  boolean parameter determining if the force should be used or not.
+     * @return  {@link PatchContext} with SSA type for the Cluster Operator.
+     */
     private static PatchContext serverSideApplyPatchContext(boolean useForce) {
         return new PatchContext.Builder()
             .withFieldManager("strimzi-kafka-operator")
@@ -299,7 +312,6 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
             .withPatchType(PatchType.SERVER_SIDE_APPLY)
             .build();
     }
-
 
     /**
      * Method for patching or replacing a resource. By default, is using JSON-type patch. Overriding this method can be

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
@@ -68,7 +68,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * @param vertx                 The vertx instance.
      * @param client                The kubernetes client.
      * @param resourceKind          The kind of Kubernetes resource (used for logging).
-     * @param useServerSideApply    Determines if Server Side Apply should be used
+     * @param useServerSideApply    Determines if Server Side Apply should be used.
      */
     public AbstractNamespacedResourceOperator(Vertx vertx, C client, String resourceKind, boolean useServerSideApply) {
         super(vertx, client, resourceKind);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperator.java
@@ -28,11 +28,12 @@ public class ConfigMapOperator extends AbstractNamespacedResourceOperator<Kubern
     /**
      * Constructor
      *
-     * @param vertx The Vertx instance
-     * @param client The Kubernetes client
+     * @param vertx                 The Vertx instance
+     * @param client                The Kubernetes client
+     * @param useServerSideApply    Determines if Server Side Apply should be used
      */
-    public ConfigMapOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client, "ConfigMap");
+    public ConfigMapOperator(Vertx vertx, KubernetesClient client, boolean useServerSideApply) {
+        super(vertx, client, "ConfigMap", useServerSideApply);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/IngressOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/IngressOperator.java
@@ -33,9 +33,10 @@ public class IngressOperator extends AbstractNamespacedResourceOperator<Kubernet
      * Constructor
      * @param vertx The Vertx instance
      * @param client The Kubernetes client
+     * @param useServerSideApply    Determines if Server Side Apply should be used
      */
-    public IngressOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client, "Ingress");
+    public IngressOperator(Vertx vertx, KubernetesClient client, boolean useServerSideApply) {
+        super(vertx, client, "Ingress", useServerSideApply);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/PvcOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/PvcOperator.java
@@ -40,11 +40,12 @@ public class PvcOperator extends AbstractNamespacedResourceOperator<KubernetesCl
 
     /**
      * Constructor
-     * @param vertx The Vertx instance
-     * @param client The Kubernetes client
+     * @param vertx                 The Vertx instance
+     * @param client                The Kubernetes client
+     * @param useServerSideApply    Determines if Server Side Apply should be used
      */
-    public PvcOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client, "PersistentVolumeClaim");
+    public PvcOperator(Vertx vertx, KubernetesClient client, boolean useServerSideApply) {
+        super(vertx, client, "PersistentVolumeClaim", useServerSideApply);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceAccountOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceAccountOperator.java
@@ -24,11 +24,12 @@ public class ServiceAccountOperator extends AbstractNamespacedResourceOperator<K
 
     /**
      * Constructor
-     * @param vertx The Vertx instance
-     * @param client The Kubernetes client
+     * @param vertx                 The Vertx instance
+     * @param client                The Kubernetes client
+     * @param useServerSideApply    Determines if Server Side Apply should be used
      */
-    public ServiceAccountOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client, "ServiceAccount");
+    public ServiceAccountOperator(Vertx vertx, KubernetesClient client, boolean useServerSideApply) {
+        super(vertx, client, "ServiceAccount", useServerSideApply);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperator.java
@@ -53,11 +53,12 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
     /**
      * Constructor
      *
-     * @param vertx The Vertx instance
-     * @param client The Kubernetes client
+     * @param vertx                 The Vertx instance
+     * @param client                The Kubernetes client
+     * @param useServerSideApply    Determines if Server Side Apply should be used
      */
-    public ServiceOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client, "Service");
+    public ServiceOperator(Vertx vertx, KubernetesClient client, boolean useServerSideApply) {
+        super(vertx, client, "Service", useServerSideApply);
         this.endpointOperations = new EndpointOperator(vertx, client);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -43,7 +43,7 @@ public class ClusterOperatorConfigTest {
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.OPERATOR_NAMESPACE.key(), "operator-namespace");
-        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+DummyFeatureGate");
+        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+ServerSideApplyPhase1");
         ENV_VARS.put(ClusterOperatorConfig.DNS_CACHE_TTL.key(), "10");
         ENV_VARS.put(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.key(), "my.package.CustomPodSecurityProvider");
         ENV_VARS.put(ClusterOperatorConfig.POD_DISRUPTION_BUDGET_GENERATION.key(), "false");
@@ -100,7 +100,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getOperationTimeoutMs(), is(30_000L));
         assertThat(config.getConnectBuildTimeoutMs(), is(40_000L));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
-        assertThat(config.featureGates().dummyFeatureGateEnabled(), is(true));
+        assertThat(config.featureGates().serverSideApplyPhase1Enabled(), is(true));
         assertThat(config.getDnsCacheTtlSec(), is(10));
         assertThat(config.getPodSecurityProviderClass(), is("my.package.CustomPodSecurityProvider"));
         assertThat(config.isPodDisruptionBudgetGeneration(), is(false));
@@ -118,7 +118,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getOperationTimeoutMs(), is(Long.parseLong(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.defaultValue())));
         assertThat(config.getOperatorNamespace(), is(nullValue()));
         assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
-        assertThat(config.featureGates().dummyFeatureGateEnabled(), is(false));
+        assertThat(config.featureGates().serverSideApplyPhase1Enabled(), is(false));
         assertThat(config.getDnsCacheTtlSec(), is(Integer.parseInt(ClusterOperatorConfig.DNS_CACHE_TTL.defaultValue())));
         assertThat(config.getPodSecurityProviderClass(), is(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.defaultValue()));
         assertThat(config.isPodDisruptionBudgetGeneration(), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -783,14 +783,14 @@ public class EntityOperatorTest {
     @ParallelTest
     public void testFeatureGateEnvVars() {
         ClusterOperatorConfig config = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
-                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+DummyFeatureGate")
+                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+ServerSideApplyPhase1")
                 .build();
 
         EntityOperator eo = EntityOperator.fromCrd(new Reconciliation("test", KAFKA.getKind(), KAFKA.getMetadata().getNamespace(), KAFKA.getMetadata().getName()), KAFKA, SHARED_ENV_PROVIDER, config);
         Deployment dep = eo.generateDeployment(Map.of(), false, null, null);
 
-        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("+DummyFeatureGate"));
-        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(1).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("+DummyFeatureGate"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("+ServerSideApplyPhase1"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(1).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("+ServerSideApplyPhase1"));
     }
 
     ////////////////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperatorServerSideApplyIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperatorServerSideApplyIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.strimzi.operator.cluster.operator.VertxUtil;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * The main purpose of the Integration Tests for the operators is to test them against a real Kubernetes cluster.
+ * Real Kubernetes cluster has often some quirks such as some fields being immutable, some fields in the spec section
+ * being created by the Kubernetes API etc. These things are hard to test with mocks. These IT tests make it easy to
+ * test them against real clusters.
+ */
+@ExtendWith(VertxExtension.class)
+public abstract class AbstractNamespacedResourceOperatorServerSideApplyIT<C extends KubernetesClient,
+        T extends HasMetadata,
+        L extends KubernetesResourceList<T>,
+        R extends Resource<T>> extends AbstractNamespacedResourceOperatorIT<C, T, L, R> {
+    protected static final Logger LOGGER = LogManager.getLogger(AbstractNamespacedResourceOperatorServerSideApplyIT.class);
+
+    abstract T getNonConflicting();
+    abstract T getConflicting();
+
+    @Test
+    public void testCreateModifyDelete(VertxTestContext context)    {
+        Checkpoint async = context.checkpoint();
+        AbstractNamespacedResourceOperator<C, T, L, R> op = operator();
+
+        T newResource = getOriginal();
+        T nonConfResource = getNonConflicting();
+        T modResource = getModified();
+
+        op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, newResource)
+            .onComplete(context.succeeding(rrCreated -> {
+                T created = op.get(namespace, resourceName);
+
+                context.verify(() -> assertThat(created, is(notNullValue())));
+                assertResources(context, newResource, created);
+            }))
+            .andThen(rr -> {
+                op.operation().inNamespace(namespace).resource(nonConfResource).update();
+
+                T currentResource = op.get(namespace, resourceName);
+
+                assertThat(currentResource.getMetadata().getAnnotations(), is(nonConfResource.getMetadata().getAnnotations()));
+            })
+            .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, modResource))
+            .onComplete(context.succeeding(rrModified -> {
+                T modified = op.get(namespace, resourceName);
+
+                assertThat(rrModified.getType(), is(ReconcileResult.Type.PATCHED_WITH_SERVER_SIDE_APPLY));
+                context.verify(() -> assertThat(modified, is(notNullValue())));
+                assertThat(modified.getMetadata().getAnnotations(), is(nonConfResource.getMetadata().getAnnotations()));
+                assertResources(context, modResource, modified);
+            }))
+            .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null))
+            .onComplete(context.succeeding(rrDeleted -> {
+                // it seems the resource is cached for some time, so we need wait for it to be null
+                context.verify(() ->
+                    VertxUtil.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
+                            30_000, () -> op.get(namespace, resourceName) == null)
+                            .onComplete(del -> {
+                                assertThat(op.get(namespace, resourceName), is(nullValue()));
+                                async.flag();
+                            })
+                );
+            }));
+    }
+
+    @Test
+    void testCreateModifyWithConflictAndDelete(VertxTestContext context) {
+        Checkpoint async = context.checkpoint();
+        AbstractNamespacedResourceOperator<C, T, L, R> op = operator();
+
+        T newResource = getOriginal();
+        T modResource = getModified();
+        T confResource = getConflicting();
+
+        op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, newResource)
+            .onComplete(context.succeeding(rrCreated -> {
+                T created = op.get(namespace, resourceName);
+
+                context.verify(() -> assertThat(created, is(notNullValue())));
+                assertResources(context, newResource, created);
+            }))
+            .andThen(rr -> {
+                PatchContext patchContext = new PatchContext.Builder()
+                    .withFieldManager("another-operator")
+                    .withForce(false)
+                    .withPatchType(PatchType.SERVER_SIDE_APPLY)
+                    .build();
+
+                op.operation().inNamespace(namespace).withName(resourceName).patch(patchContext, confResource);
+
+                T modified = op.get(namespace, resourceName);
+
+                assertResources(context, confResource, modified);
+            })
+            .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, modResource))
+            .onComplete(context.succeeding(rrModified -> {
+                T modified = op.get(namespace, resourceName);
+
+                assertThat(rrModified.getType(), is(ReconcileResult.Type.PATCHED_WITH_SERVER_SIDE_APPLY));
+                context.verify(() -> assertThat(modified, is(notNullValue())));
+                assertResources(context, modResource, modified);
+            }))
+            .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null))
+            .onComplete(context.succeeding(rrDeleted -> {
+                // it seems the resource is cached for some time, so we need wait for it to be null
+                context.verify(() ->
+                    VertxUtil.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
+                            30_000, () -> op.get(namespace, resourceName) == null)
+                        .onComplete(del -> {
+                            assertThat(op.get(namespace, resourceName), is(nullValue()));
+                            async.flag();
+                        })
+                );
+            }));
+    }
+}
+

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperatorServerSideApplyIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperatorServerSideApplyIT.java
@@ -27,10 +27,9 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
- * The main purpose of the Integration Tests for the operators is to test them against a real Kubernetes cluster.
- * Real Kubernetes cluster has often some quirks such as some fields being immutable, some fields in the spec section
- * being created by the Kubernetes API etc. These things are hard to test with mocks. These IT tests make it easy to
- * test them against real clusters.
+ * The primary purpose of the integration tests for the operators is to validate their behavior on a live Kubernetes cluster.
+ * Live clusters often exhibit specific behaviors, such as immutable fields or API-generated spec fields, that are difficult to simulate with mocks.
+ * These integration tests enable reliable validation of operator functionality in a production-like environment.
  */
 @ExtendWith(VertxExtension.class)
 public abstract class AbstractNamespacedResourceOperatorServerSideApplyIT<C extends KubernetesClient,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperatorTest.java
@@ -7,8 +7,10 @@ package io.strimzi.operator.cluster.operator.resource.kubernetes;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Deletable;
@@ -16,6 +18,7 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Vertx;
@@ -26,14 +29,21 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -46,6 +56,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(VertxExtension.class)
 public abstract class AbstractNamespacedResourceOperatorTest<C extends KubernetesClient, T extends HasMetadata,
         L extends KubernetesResourceList<T>, R extends Resource<T>> {
@@ -65,6 +76,36 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
     public static void after() {
         sharedWorkerExecutor.close();
         vertx.close();
+    }
+
+    /**
+     * Returns if resource supports SSA.
+     * This is used in {@link #useServerSideApplyCombinations()} and then in test cases that are only for SSA.
+     *
+     * @return  boolean value determining if resource supports SSA.
+     */
+    protected boolean supportsServerSideApply() {
+        return false;
+    }
+
+    /**
+     * Returns combinations for parameterized test cases for Server Side Apply.
+     * In case that {@link #supportsServerSideApply()} returns `true`, both of the combinations for SSA disabled
+     * and enabled is returned. Otherwise, just the disabled is returned.
+     *
+     * @return  combinations for parameterized test cases for Server Side Apply.
+     */
+    protected Stream<Arguments> useServerSideApplyCombinations() {
+        if (supportsServerSideApply()) {
+            return Stream.of(
+                Arguments.of(false),
+                Arguments.of(true)
+            );
+        } else {
+            return Stream.of(
+                Arguments.of(false)
+            );
+        }
     }
 
     /**
@@ -117,17 +158,31 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
     /** Create the subclass of ResourceOperation to be tested */
     protected abstract AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperations(Vertx vertx, C mockClient);
 
-    /** Create the subclass of ResourceOperation to be tested with mocked readiness checks*/
-    protected AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperationsWithMockedReadiness(Vertx vertx, C mockClient)    {
+    /**
+     *  Create the subclass of ResourceOperation to be tested.
+     *  The boolean parameter useServerSideApply is not used by default.
+     *  In case that resource supports SSA, the method should be overridden in resource's test class
+     */
+    protected AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperations(Vertx vertx, C mockClient, boolean useServerSideApply) {
+        if (useServerSideApply && !supportsServerSideApply()) {
+            throw new UnsupportedOperationException("This resource does not support Server Side Apply");
+        }
+
         return createResourceOperations(vertx, mockClient);
     }
 
-    @Test
-    public void testCreateWhenExistsWithChangeIsAPatch(VertxTestContext context) {
-        testCreateWhenExistsWithChangeIsAPatch(context, true);
+    /** Create the subclass of ResourceOperation to be tested with mocked readiness checks*/
+    protected AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperationsWithMockedReadiness(Vertx vertx, C mockClient, boolean useServerSideApply)    {
+        return createResourceOperations(vertx, mockClient, useServerSideApply);
     }
 
-    public void testCreateWhenExistsWithChangeIsAPatch(VertxTestContext context, boolean cascade) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testCreateWhenExistsWithChangeIsAPatch(boolean useServerSideApply, VertxTestContext context) {
+        testCreateWhenExistsWithChangeIsAPatch(context, true, useServerSideApply);
+    }
+
+    public void testCreateWhenExistsWithChangeIsAPatch(VertxTestContext context, boolean cascade, boolean useServerSideApply) {
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -143,7 +198,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, modifiedResource()).onComplete(context.succeeding(rr -> context.verify(() -> {
@@ -186,8 +241,9 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         })));
     }
 
-    @Test
-    public void testExistenceCheckThrows(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testExistenceCheckThrows(boolean useServerSideApply, VertxTestContext context) {
         T resource = resource();
         RuntimeException ex = new RuntimeException();
 
@@ -203,7 +259,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource).onComplete(context.failing(e -> context.verify(() -> {
@@ -212,13 +268,19 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         })));
     }
 
-    @Test
-    public void testSuccessfulCreation(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testSuccessfulCreation(boolean useServerSideApply, VertxTestContext context) {
         T resource = resource();
         Resource mockResource = mock(resourceType());
 
         when(mockResource.get()).thenReturn(null);
-        when(mockResource.create()).thenReturn(resource);
+
+        if (useServerSideApply) {
+            when(mockResource.patch(any(), eq(resource))).thenReturn(resource);
+        } else {
+            when(mockResource.create()).thenReturn(resource);
+        }
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
@@ -230,18 +292,26 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperationsWithMockedReadiness(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperationsWithMockedReadiness(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource).onComplete(context.succeeding(rr -> context.verify(() -> {
             verify(mockResource).get();
-            verify(mockResource).create();
+
+            if (useServerSideApply) {
+                verify(mockResource).patch(any(), eq(resource));
+                verify(mockResource, never()).create();
+            } else {
+                verify(mockResource).create();
+                verify(mockResource, never()).patch(any(), any());
+            }
             async.flag();
         })));
     }
 
-    @Test
-    public void testCreateOrUpdateThrowsWhenCreateThrows(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testCreateOrUpdateThrowsWhenCreateThrows(boolean useServerSideApply, VertxTestContext context) {
         T resource = resource();
         RuntimeException ex = new RuntimeException("Testing this exception is handled correctly");
 
@@ -254,12 +324,17 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
 
         MixedOperation mockCms = mock(MixedOperation.class);
         when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
-        when(mockResource.create()).thenThrow(ex);
+
+        if (useServerSideApply) {
+            when(mockResource.patch(any(), eq(resource))).thenThrow(ex);
+        } else {
+            when(mockResource.create()).thenThrow(ex);
+        }
 
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource).onComplete(context.failing(e -> {
@@ -268,8 +343,9 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         }));
     }
 
-    @Test
-    public void testDeleteWhenResourceDoesNotExistIsANop(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testDeleteWhenResourceDoesNotExistIsANop(boolean useServerSideApply, VertxTestContext context) {
         T resource = resource();
         Resource mockResource = mock(resourceType());
 
@@ -282,7 +358,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -293,8 +369,9 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
             })));
     }
 
-    @Test
-    public void testReconcileDeleteWhenResourceExistsStillDeletes(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testReconcileDeleteWhenResourceExistsStillDeletes(boolean useServerSideApply, VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
         AtomicBoolean resourceDeleted = new AtomicBoolean(false);
         when(mockDeletable.delete()).thenAnswer(args -> {
@@ -327,7 +404,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -337,8 +414,9 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
             })));
     }
 
-    @Test
-    public void testReconcileDeletionSuccessfullyDeletes(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testReconcileDeletionSuccessfullyDeletes(boolean useServerSideApply, VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
         AtomicBoolean resourceDeleted = new AtomicBoolean(false);
         when(mockDeletable.delete()).thenAnswer(args -> {
@@ -371,7 +449,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -381,8 +459,9 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
             })));
     }
 
-    @Test
-    public void testReconcileDeleteThrowsWhenDeletionThrows(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testReconcileDeleteThrowsWhenDeletionThrows(boolean useServerSideApply, VertxTestContext context) {
         RuntimeException ex = new RuntimeException("Testing this exception is handled correctly");
         Deletable mockDeletable = mock(Deletable.class);
         GracePeriodConfigurable mockDeletableGrace = mock(GracePeriodConfigurable.class);
@@ -411,7 +490,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -421,9 +500,10 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
             })));
     }
 
-    @Test
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
     @SuppressWarnings("unchecked")
-    public void testReconcileDeleteDoesNotThrowWhenDeletionReturnsFalse(VertxTestContext context) {
+    public void testReconcileDeleteDoesNotThrowWhenDeletionReturnsFalse(boolean useServerSideApply, VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
         AtomicBoolean resourceDeleted = new AtomicBoolean(false);
         when(mockDeletable.delete()).thenAnswer(args -> {
@@ -456,7 +536,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -468,9 +548,10 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
 
     // This tests the pre-check which should stop the self-closing-watch in case the resource is deleted before the
     // watch is opened.
-    @Test
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
     @SuppressWarnings("unchecked")
-    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(VertxTestContext context) {
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(boolean useServerSideApply, VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
         when(mockDeletable.delete()).thenReturn(List.of());
         GracePeriodConfigurable mockDeletableGrace = mock(GracePeriodConfigurable.class);
@@ -509,7 +590,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -519,8 +600,9 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
                 })));
     }
 
-    @Test
-    public void testBatchReconciliation(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testBatchReconciliation(boolean useServerSideApply, VertxTestContext context) {
         Map<String, String> selector = Map.of("labelA", "a", "labelB", "b");
 
         T resource1 = resource("resource-1");
@@ -563,7 +645,12 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
 
         Resource mockResource3 = mock(resourceType());
         when(mockResource3.get()).thenReturn(null);
-        when(mockResource3.create()).thenReturn(resource3);
+
+        if (useServerSideApply) {
+            when(mockResource3.patch(any(), eq(resource3))).thenReturn(resource3);
+        } else {
+            when(mockResource3.create()).thenReturn(resource3);
+        }
 
         KubernetesResourceList mockResourceList = mock(KubernetesResourceList.class);
         when(mockResourceList.getItems()).thenReturn(List.of(resource1, resource2));
@@ -584,7 +671,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient, useServerSideApply);
 
         Checkpoint async = context.checkpoint();
         op.batchReconcile(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, List.of(resource2Mod, resource3), Labels.fromMap(selector)).onComplete(context.succeeding(i -> context.verify(() -> {
@@ -599,11 +686,71 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
             verify(mockResource2, never()).delete();
 
             verify(mockResource3, times(1)).get();
-            verify(mockResource3, never()).patch(any(), any());
-            verify(mockResource3, times(1)).create();
+
+            if (!useServerSideApply) {
+                verify(mockResource3, times(1)).create();
+                verify(mockResource3, never()).patch(any(), any());
+            } else {
+                verify(mockResource3, times(1)).patch(any(), eq(resource3));
+                verify(mockResource3, never()).create();
+            }
+
             verify(mockResource3, never()).delete();
 
             async.flag();
         })));
+    }
+
+    /**
+     * Verifies that `force = true` is used when there is exception during resource update/creation.
+     *
+     * @param context   VertX test context
+     */
+    @Test
+    void testModifyWithForceServerSideApply(VertxTestContext context) {
+        assumeTrue(supportsServerSideApply());
+
+        T resource = resource();
+        Resource<T> mockResource = mock(resourceType());
+
+        // Simulate resource not existing initially
+        when(mockResource.get()).thenReturn(null);
+
+        // First patch attempt fails
+        when(mockResource.patch(any(), eq(resource)))
+            .thenThrow(new KubernetesClientException("conflict", 409, new Status()))
+            .thenReturn(resource); // Second attempt succeeds
+
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+        when(mockNameable.resource(eq(resource))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op =
+            createResourceOperationsWithMockedReadiness(vertx, mockClient, true);
+
+        Checkpoint async = context.checkpoint();
+        op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource)
+            .onComplete(context.succeeding(rr -> context.verify(() -> {
+                // Verify first patch attempt
+                verify(mockResource, times(2)).patch(any(), eq(resource));
+
+                // Capture arguments to see if force=true was used second time
+                ArgumentCaptor<PatchContext> patchCtxCaptor = ArgumentCaptor.forClass(PatchContext.class);
+                verify(mockResource, times(2)).patch(patchCtxCaptor.capture(), eq(resource));
+
+                PatchContext firstCtx = patchCtxCaptor.getAllValues().get(0);
+                PatchContext secondCtx = patchCtxCaptor.getAllValues().get(1);
+
+                assertThat("First patch should not be forced", firstCtx.getForce(), is(false));
+                assertThat("Second patch should be forced", secondCtx.getForce(), is(true));
+
+                async.flag();
+            })));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/BuildConfigOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/BuildConfigOperatorTest.java
@@ -14,7 +14,8 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.when;
@@ -64,14 +65,16 @@ public class BuildConfigOperatorTest extends AbstractNamespacedResourceOperatorT
     }
 
     @Override
-    @Test
-    public void testCreateWhenExistsWithChangeIsAPatch(VertxTestContext context) {
-        testCreateWhenExistsWithChangeIsAPatch(context, false);
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testCreateWhenExistsWithChangeIsAPatch(boolean useServerSideApply, VertxTestContext context) {
+        testCreateWhenExistsWithChangeIsAPatch(context, false, useServerSideApply);
     }
 
     @Override
-    @Test
-    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(boolean useServerSideApply, VertxTestContext context) {
         assumeTrue(false, "BuildConfigOperator does not use self-closing watch so this test should be skipped");
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperatorTest.java
@@ -18,13 +18,23 @@ import static org.mockito.Mockito.when;
 public class ConfigMapOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> {
 
     @Override
+    protected boolean supportsServerSideApply() {
+        return true;
+    }
+
+    @Override
     protected void  mocker(KubernetesClient mockClient, MixedOperation mockCms) {
         when(mockClient.configMaps()).thenReturn(mockCms);
     }
 
     @Override
     protected AbstractNamespacedResourceOperator<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
-        return new ConfigMapOperator(vertx, mockClient);
+        return new ConfigMapOperator(vertx, mockClient, false);
+    }
+
+    @Override
+    protected AbstractNamespacedResourceOperator<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> createResourceOperations(Vertx vertx, KubernetesClient mockClient, boolean useServerSideApply) {
+        return new ConfigMapOperator(vertx, mockClient, useServerSideApply);
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorTest.java
@@ -19,6 +19,8 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -111,8 +113,9 @@ public class KafkaCrdOperatorTest extends AbstractNamespacedResourceOperatorTest
     }
 
     @Override
-    @Test
-    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(VertxTestContext context) {
+    @ParameterizedTest(name = "{displayName} with SSA enabled: {0}")
+    @MethodSource("useServerSideApplyCombinations")
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(boolean useServerSideApply, VertxTestContext context) {
         assumeTrue(false, "CrdOperator does not use self-closing watch so this test should be skipped");
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceAccountOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceAccountOperatorIT.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class ServiceAccountOperatorIT extends AbstractNamespacedResourceOperatorIT<KubernetesClient, ServiceAccount, ServiceAccountList, ServiceAccountResource> {
     @Override
     protected AbstractNamespacedResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, ServiceAccountResource> operator() {
-        return new ServiceAccountOperator(vertx, client);
+        return new ServiceAccountOperator(vertx, client, false);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class ServiceAccountOperatorIT extends AbstractNamespacedResourceOperator
     @Override
     public void testCreateModifyDelete(VertxTestContext context)    {
         Checkpoint async = context.checkpoint();
-        ServiceAccountOperator op = new ServiceAccountOperator(vertx, client);
+        ServiceAccountOperator op = new ServiceAccountOperator(vertx, client, false);
 
         ServiceAccount newResource = getOriginal();
         ServiceAccount modResource = getModified();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceAccountOperatorServerSideApplyIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceAccountOperatorServerSideApplyIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccountList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class ServiceAccountOperatorServerSideApplyIT extends AbstractNamespacedResourceOperatorServerSideApplyIT<KubernetesClient, ServiceAccount, ServiceAccountList, ServiceAccountResource> {
+    @Override
+    protected AbstractNamespacedResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, ServiceAccountResource> operator() {
+        return new ServiceAccountOperator(vertx, client, true);
+    }
+
+    @Override
+    protected ServiceAccount getOriginal()  {
+        return new ServiceAccountBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withLabels(singletonMap("foo", "bar"))
+            .endMetadata()
+            .build();
+    }
+
+    @Override
+    protected ServiceAccount getModified() {
+        return new ServiceAccountBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withLabels(Map.of("foo", "bar", "foo2", "bar2"))
+            .endMetadata()
+            .withAutomountServiceAccountToken()
+            .build();
+    }
+
+    @Override
+    ServiceAccount getNonConflicting() {
+        return new ServiceAccountBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withAnnotations(singletonMap("my-annotation2", "my-value2"))
+            .endMetadata()
+            .withAutomountServiceAccountToken(false)
+            .build();
+    }
+
+    @Override
+    protected ServiceAccount getConflicting() {
+        return new ServiceAccountBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withLabels(singletonMap("foo", "bar"))
+            .endMetadata()
+            .withAutomountServiceAccountToken(false)
+            .build();
+    }
+
+    @Override
+    protected void assertResources(VertxTestContext context, ServiceAccount expected, ServiceAccount actual)   {
+        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
+        context.verify(() -> assertThat(actual.getMetadata().getNamespace(), is(expected.getMetadata().getNamespace())));
+        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
+        context.verify(() -> assertThat(actual.getAutomountServiceAccountToken(), is(expected.getAutomountServiceAccountToken())));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperatorIT.java
@@ -25,7 +25,7 @@ public class ServiceOperatorIT extends AbstractNamespacedResourceOperatorIT<Kube
     @Override
     protected AbstractNamespacedResourceOperator<KubernetesClient, Service, ServiceList,
                 ServiceResource<Service>> operator() {
-        return new ServiceOperator(vertx, client);
+        return new ServiceOperator(vertx, client, false);
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperatorServerSideApplyIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperatorServerSideApplyIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class ServiceOperatorServerSideApplyIT extends AbstractNamespacedResourceOperatorServerSideApplyIT<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
+
+    @Override
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Service, ServiceList,
+                ServiceResource<Service>> operator() {
+        return new ServiceOperator(vertx, client, true);
+    }
+
+    @Override
+    protected Service getOriginal()  {
+        ServicePort servicePort = new ServicePortBuilder()
+            .withName("http")
+            .withProtocol("TCP")
+            .withPort(80)
+            .withNewTargetPort(80)
+            .build();
+
+        return new ServiceBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withLabels(singletonMap("state", "new"))
+            .endMetadata()
+            .withNewSpec()
+                .withType("ClusterIP")
+                .withSelector(singletonMap("app", "kafka"))
+                .withPorts(servicePort)
+            .endSpec()
+            .build();
+    }
+
+    @Override
+    protected Service getModified()  {
+        ServicePort servicePort = new ServicePortBuilder()
+            .withName("http")
+            .withProtocol("TCP")
+            .withPort(80)
+            .withNewTargetPort(80)
+            .build();
+
+        ServicePort servicePortConflicting = new ServicePortBuilder()
+            .withName("https")
+            .withProtocol("TCP")
+            .withPort(443)
+            .withNewTargetPort(443)
+            .build();
+
+        return new ServiceBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withLabels(singletonMap("state", "modified"))
+            .endMetadata()
+            .withNewSpec()
+                .withType("ClusterIP")
+                .withSelector(singletonMap("app", "kafka"))
+                .withPorts(servicePort, servicePortConflicting)
+            .endSpec()
+            .build();
+    }
+
+    @Override
+    Service getNonConflicting() {
+        ServicePort servicePort = new ServicePortBuilder()
+            .withName("http")
+            .withProtocol("TCP")
+            .withPort(80)
+            .withNewTargetPort(80)
+            .build();
+
+        return new ServiceBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withAnnotations(singletonMap("my-annotation2", "my-value2"))
+            .endMetadata()
+            .withNewSpec()
+                .withType("ClusterIP")
+                .withSelector(singletonMap("app", "kafka"))
+                .withPorts(servicePort)
+            .endSpec()
+            .build();
+    }
+
+    @Override
+    protected Service getConflicting() {
+        ServicePort servicePort = new ServicePortBuilder()
+            .withName("http")
+            .withProtocol("TCP")
+            .withPort(80)
+            .withNewTargetPort(80)
+            .build();
+
+        ServicePort servicePortConflicting = new ServicePortBuilder()
+            .withName("https")
+            .withProtocol("TCP")
+            .withPort(443)
+            .withNewTargetPort(444)
+            .build();
+
+        return new ServiceBuilder()
+            .withNewMetadata()
+                .withName(resourceName)
+                .withNamespace(namespace)
+                .withLabels(singletonMap("state", "new"))
+            .endMetadata()
+            .withNewSpec()
+                .withType("ClusterIP")
+                .withSelector(singletonMap("app", "kafka"))
+                .withPorts(servicePort, servicePortConflicting)
+            .endSpec()
+            .build();
+    }
+
+    @Override
+    protected void assertResources(VertxTestContext context, Service expected, Service actual)   {
+        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
+        context.verify(() -> assertThat(actual.getMetadata().getNamespace(), is(expected.getMetadata().getNamespace())));
+        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
+        context.verify(() -> assertThat(actual.getSpec().getPorts().size(), is(expected.getSpec().getPorts().size())));
+        actual.getSpec().getPorts().forEach(actualPort -> {
+                context.verify(() -> assertThat(expected.getSpec().getPorts().stream().anyMatch(servicePort -> servicePort.getPort().equals(actualPort.getPort())), is(true)));
+                context.verify(() -> assertThat(expected.getSpec().getPorts().stream().anyMatch(servicePort -> servicePort.getTargetPort().equals(actualPort.getTargetPort())), is(true)));
+            }
+        );
+        context.verify(() -> assertThat(actual.getSpec().getType(), is(expected.getSpec().getType())));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ServiceOperatorTest.java
@@ -28,6 +28,11 @@ import static org.mockito.Mockito.when;
 public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
 
     @Override
+    protected boolean supportsServerSideApply() {
+        return true;
+    }
+
+    @Override
     protected Class<KubernetesClient> clientType() {
         return KubernetesClient.class;
     }
@@ -65,12 +70,17 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
     }
 
     @Override
-    protected ServiceOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
-        return new ServiceOperator(vertx, mockClient);
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Service, ServiceList, ServiceResource<Service>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new ServiceOperator(vertx, mockClient, false);
+    }
+
+    @Override
+    protected ServiceOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient, boolean useServerSideApply) {
+        return new ServiceOperator(vertx, mockClient, useServerSideApply);
     }
 
     @Test
-    public void testNodePortPatching()  {
+    public void testNodePortPatching() {
         KubernetesClient client = mock(KubernetesClient.class);
 
         Service current = new ServiceBuilder()
@@ -119,7 +129,7 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
                 .endSpec()
                 .build();
 
-        ServiceOperator op = new ServiceOperator(vertx, client);
+        ServiceOperator op = new ServiceOperator(vertx, client, false);
         op.patchNodePorts(current, desired);
 
         assertThat(current.getSpec().getPorts().get(0).getNodePort(), is(desired.getSpec().getPorts().get(1).getNodePort()));
@@ -157,7 +167,7 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
                 .endSpec()
                 .build();
 
-        ServiceOperator op = new ServiceOperator(vertx, client);
+        ServiceOperator op = new ServiceOperator(vertx, client, false);
         op.internalUpdate(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, current, desired);
 
         assertThat(desired.getMetadata().getAnnotations().get("field.cattle.io~1publicEndpoints"), equalTo("foo"));
@@ -190,7 +200,7 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
                 .endSpec()
                 .build();
 
-        ServiceOperator op = new ServiceOperator(vertx, client);
+        ServiceOperator op = new ServiceOperator(vertx, client, false);
         op.patchHealthCheckPorts(current, desired);
 
         assertThat(current.getSpec().getHealthCheckNodePort(), is(desired.getSpec().getHealthCheckNodePort()));
@@ -294,7 +304,7 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
                 .endSpec()
                 .build();
 
-        ServiceOperator op = new ServiceOperator(vertx, client);
+        ServiceOperator op = new ServiceOperator(vertx, client, false);
 
         op.patchDualStackNetworking(current, desired);
         assertThat(current.getSpec().getIpFamilyPolicy(), is(desired.getSpec().getIpFamilyPolicy()));
@@ -348,7 +358,7 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
                 .endSpec()
                 .build();
 
-        ServiceOperator op = new ServiceOperator(vertx, client);
+        ServiceOperator op = new ServiceOperator(vertx, client, false);
         op.patchLoadBalancerClass(current, desired);
 
         assertThat(current.getSpec().getLoadBalancerClass(), is(desired.getSpec().getLoadBalancerClass()));

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -133,6 +133,7 @@ env:
 The `ServerSideApplyPhase1` feature gate has a default state of _disabled_.
 
 When enabled, the Cluster Operator uses Server-Side Apply (SSA) for creating and updating certain resources.
+SSA is a Kubernetes feature that provides better tracking of field ownership and more controlled resource updates.
 In Phase 1, Server-Side Apply is used for the following resources:
 
 - `PersistentVolumeClaim`
@@ -143,10 +144,12 @@ In Phase 1, Server-Side Apply is used for the following resources:
 
 All other resources continue to be reconciled using the existing mechanism.
 
-With Server-Side Apply, the Cluster Operator modifies only the fields it manages, keeping the user changes to the other fields - in case that they do not conflict with the fields managed by Cluster Operator.
-On the first patch attempt, the operator sets `force = false`.
-If a conflict occurs in a managed field, the patch is retried with `force = true`.
+With SSA, the Cluster Operator modifies only the fields it manages.
+User changes to the other fields are preserved as long as they don't conflict.
+On the first update attempt, the Cluster Operator sets `force = false` when applying changes, respecting user changes.
+If a conflict occurs in a managed field, the update is retried with `force = true`.
 The conflict and the switch to forced apply are logged by the Cluster Operator.
 
+Ownership of individual fields is tracked through the `.metadata.managedFields` property of the resource being updated.
 .Enabling the `ServerSideApplyPhase1` feature gate
 To enable the `ServerSideApplyPhase1` feature gate, specify `+ServerSideApplyPhase1` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -88,6 +88,11 @@ The following table shows the maturity of the feature gates introduced across St
 ¦0.44
 ¦0.46
 
+¦`ServerSideApplyPhase1`
+¦0.48
+¦0.51 (planned)
+¦0.54 (planned)
+
 |===
 
 
@@ -121,3 +126,27 @@ env:
   - name: STRIMZI_FEATURE_GATES
     value: +FeatureGate1,-FeatureGate2
 ----
+
+[id='ref-operator-server-side-apply-phase-1-feature-gate-{context}']
+== `ServerSideApplyPhase1` feature gate
+
+The `ServerSideApplyPhase1` feature gate has a default state of _disabled_.
+
+When enabled, the Cluster Operator uses Server-Side Apply (SSA) for creating and updating certain resources.
+In Phase 1, Server-Side Apply is used for the following resources:
+
+- `PersistentVolumeClaim`
+- `ConfigMap`
+- `Ingress`
+- `ServiceAccount`
+- `Service`
+
+All other resources continue to be reconciled using the existing mechanism.
+
+With Server-Side Apply, the Cluster Operator modifies only the fields it manages, keeping the user changes to the other fields - in case that they do not conflict with the fields managed by Cluster Operator.
+On the first patch attempt, the operator sets `force = false`.
+If a conflict occurs in a managed field, the patch is retried with `force = true`.
+The conflict and the switch to forced apply are logged by the Cluster Operator.
+
+.Enabling the `ServerSideApplyPhase1` feature gate
+To enable the `ServerSideApplyPhase1` feature gate, specify `+ServerSideApplyPhase1` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -112,6 +112,33 @@ Early access feature gates have not yet reached the beta stage, and are disabled
 An early access feature gate provides an opportunity for assessment before its functionality is permanently incorporated into Strimzi.
 Currently, there are no alpha level feature gates.
 
+[id='ref-operator-server-side-apply-phase-1-feature-gate-{context}']
+=== `ServerSideApplyPhase1` feature gate
+
+The `ServerSideApplyPhase1` feature gate has a default state of _disabled_.
+
+When enabled, the Cluster Operator uses Server-Side Apply (SSA) for creating and updating certain resources.
+SSA is a Kubernetes feature that provides better tracking of field ownership and more controlled resource updates.
+In Phase 1, Server-Side Apply is used for the following resources:
+
+- `PersistentVolumeClaim`
+- `ConfigMap`
+- `Ingress`
+- `ServiceAccount`
+- `Service`
+
+All other resources continue to be reconciled using the existing mechanism - client-side apply.
+
+With SSA, the Cluster Operator modifies only the fields it manages.
+User changes to the other fields are preserved as long as they don't conflict.
+On the first update attempt, the Cluster Operator sets `force = false` when applying changes, respecting user changes.
+If a conflict occurs in a managed field, the update is retried with `force = true`.
+The conflict and the switch to forced apply are logged by the Cluster Operator.
+
+Ownership of individual fields is tracked through the `.metadata.managedFields` property of the resource being updated.
+.Enabling the `ServerSideApplyPhase1` feature gate
+To enable the `ServerSideApplyPhase1` feature gate, specify `+ServerSideApplyPhase1` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
 == Enabling feature gates
 
 To modify a feature gate's default state, use the `STRIMZI_FEATURE_GATES` environment variable in the operator's configuration.
@@ -126,30 +153,3 @@ env:
   - name: STRIMZI_FEATURE_GATES
     value: +FeatureGate1,-FeatureGate2
 ----
-
-[id='ref-operator-server-side-apply-phase-1-feature-gate-{context}']
-== `ServerSideApplyPhase1` feature gate
-
-The `ServerSideApplyPhase1` feature gate has a default state of _disabled_.
-
-When enabled, the Cluster Operator uses Server-Side Apply (SSA) for creating and updating certain resources.
-SSA is a Kubernetes feature that provides better tracking of field ownership and more controlled resource updates.
-In Phase 1, Server-Side Apply is used for the following resources:
-
-- `PersistentVolumeClaim`
-- `ConfigMap`
-- `Ingress`
-- `ServiceAccount`
-- `Service`
-
-All other resources continue to be reconciled using the existing mechanism.
-
-With SSA, the Cluster Operator modifies only the fields it manages.
-User changes to the other fields are preserved as long as they don't conflict.
-On the first update attempt, the Cluster Operator sets `force = false` when applying changes, respecting user changes.
-If a conflict occurs in a managed field, the update is retried with `force = true`.
-The conflict and the switch to forced apply are logged by the Cluster Operator.
-
-Ownership of individual fields is tracked through the `.metadata.managedFields` property of the resource being updated.
-.Enabling the `ServerSideApplyPhase1` feature gate
-To enable the `ServerSideApplyPhase1` feature gate, specify `+ServerSideApplyPhase1` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -128,6 +128,7 @@ In Phase 1, Server-Side Apply is used for the following resources:
 - `Service`
 
 All other resources continue to be reconciled using the existing mechanism - client-side apply.
+If users change the fields of operator-managed resources, the operator reverts these changes.
 
 With SSA, the Cluster Operator modifies only the fields it manages.
 User changes to the other fields are preserved as long as they don't conflict.

--- a/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
@@ -18,12 +18,16 @@ import static java.util.Arrays.asList;
 public class FeatureGates {
     /* test */ static final FeatureGates NONE = new FeatureGates("");
 
-    // As we currently don't have any real feature gate, this dummy feature gate is used to make it clear how to add a
-    // real feature gates in the future and allows us to test the feature gates.
-    private static final String DUMMY_FEATURE_GATE = "DummyFeatureGate";
+    // The `DummyFeatureGate` is kept as a template on how new feature gate should be added
+    // Once we don't have any other feature gate supported, code for `DummyFeatureGate` should be un-commented
+    // private static final String DUMMY_FEATURE_GATE = "DummyFeatureGate";
+
+    // Enables the usage of Server Side Apply
+    private static final String SERVER_SIDE_APPLY_PHASE_1 = "ServerSideApplyPhase1";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates(), toString(), equals(), and `hashCode() methods
-    private final FeatureGate dummyFeatureGate = new FeatureGate(DUMMY_FEATURE_GATE, false);
+    private final FeatureGate serverSideApplyPhase1 = new FeatureGate(SERVER_SIDE_APPLY_PHASE_1, false);
+    // private final FeatureGate dummyFeatureGate = new FeatureGate(DUMMY_FEATURE_GATE, false);
 
     /**
      * Constructs the feature gates configuration.
@@ -45,9 +49,13 @@ public class FeatureGates {
                 featureGate = featureGate.substring(1);
 
                 switch (featureGate) {
-                    case DUMMY_FEATURE_GATE:
-                        setValueOnlyOnce(dummyFeatureGate, value);
+    //                case DUMMY_FEATURE_GATE:
+    //                    setValueOnlyOnce(dummyFeatureGate, value);
+    //                    break;
+                    case SERVER_SIDE_APPLY_PHASE_1:
+                        setValueOnlyOnce(serverSideApplyPhase1, value);
                         break;
+
                     default:
                         throw new InvalidConfigurationException("Unknown feature gate " + featureGate + " found in the configuration");
                 }
@@ -81,11 +89,15 @@ public class FeatureGates {
         gate.setValue(value);
     }
 
+    // public boolean dummyFeatureGateEnabled() {
+    //    return dummyFeatureGate.isEnabled();
+    // }
+
     /**
-     * @return  Returns true when the DummyFeatureGate feature gate is enabled
+     * @return  Returns true when the ServerSideApplyPhase1 feature gate is enabled
      */
-    public boolean dummyFeatureGateEnabled() {
-        return dummyFeatureGate.isEnabled();
+    public boolean serverSideApplyPhase1Enabled() {
+        return serverSideApplyPhase1.isEnabled();
     }
 
     /**
@@ -94,13 +106,17 @@ public class FeatureGates {
      * @return  List of all Feature Gates
      */
     /*test*/ List<FeatureGate> allFeatureGates()  {
-        return List.of(dummyFeatureGate);
+        return List.of(
+        //  dummyFeatureGate
+            serverSideApplyPhase1
+        );
     }
 
     @Override
     public String toString() {
         return "FeatureGates(" +
-            "DummyFeatureGate=" + dummyFeatureGate.isEnabled() +
+    //      "DummyFeatureGate=" + dummyFeatureGate.isEnabled() +
+            "ServerSideApplyPhase1=" + serverSideApplyPhase1.isEnabled() +
             ")";
     }
 
@@ -132,13 +148,15 @@ public class FeatureGates {
             return false;
         } else {
             FeatureGates other = (FeatureGates) o;
-            return Objects.equals(dummyFeatureGate, other.dummyFeatureGate);
+            // return Objects.equals(dummyFeatureGate, other.dummyFeatureGate);
+            return Objects.equals(serverSideApplyPhase1, other.serverSideApplyPhase1);
         }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(dummyFeatureGate);
+        // return Objects.hashCode(dummyFeatureGate);
+        return Objects.hashCode(serverSideApplyPhase1);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
@@ -32,6 +32,11 @@ public abstract class ReconcileResult<R> {
         PATCHED,
 
         /**
+         * The resource was patched using Server Side Apply
+         */
+        PATCHED_WITH_SERVER_SIDE_APPLY,
+
+        /**
          * The resource was deleted
          */
         DELETED
@@ -102,6 +107,22 @@ public abstract class ReconcileResult<R> {
     }
 
     /**
+     * The resource was modified during the reconciliation using Server Side Apply
+     *
+     * @param <R>   Resource type for which the result is being indicated
+     */
+    public static class PatchedWithServerSideApply<R> extends ReconcileResult<R> {
+        private PatchedWithServerSideApply(R resource) {
+            super(Optional.of(resource));
+        }
+
+        @Override
+        public Type getType() {
+            return Type.PATCHED_WITH_SERVER_SIDE_APPLY;
+        }
+    }
+
+    /**
      * Return a reconciliation result that indicates the resource was patched.
      * @return a reconciliation result that indicates the resource was patched.
      * @param resource The patched resource.
@@ -109,6 +130,17 @@ public abstract class ReconcileResult<R> {
      */
     public static <D> Patched<D> patched(D resource) {
         return new Patched<>(resource);
+    }
+
+    /**
+     * Return a reconciliation result that indicates the resource was patched using Server Side Apply.
+     *
+     * @param resource  The patched resource.
+     * @return a reconciliation result that indicates the resource was patched using Server Side Apply.
+     * @param <D> The type of resource
+     */
+    public static <D> PatchedWithServerSideApply<D> patchedWithServerSideApply(D resource) {
+        return new PatchedWithServerSideApply<>(resource);
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
@@ -53,9 +53,9 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testFeatureGatesParsing() {
-        assertThat(new FeatureGates("+DummyFeatureGate").dummyFeatureGateEnabled(), is(true));
-        assertThat(new FeatureGates("-DummyFeatureGate").dummyFeatureGateEnabled(), is(false));
-        assertThat(new FeatureGates("   -DummyFeatureGate   ").dummyFeatureGateEnabled(), is(false));
+        assertThat(new FeatureGates("+ServerSideApplyPhase1").serverSideApplyPhase1Enabled(), is(true));
+        assertThat(new FeatureGates("-ServerSideApplyPhase1").serverSideApplyPhase1Enabled(), is(false));
+        assertThat(new FeatureGates("   -ServerSideApplyPhase1   ").serverSideApplyPhase1Enabled(), is(false));
         // TODO: Add more tests with various feature gate combinations once we have multiple feature gates again.
         //       The commented out code below shows the tests we used to have with multiple feature gates.
         //assertThat(new FeatureGates("-UseKRaft,-DummyFeatureGate").useKRaftEnabled(), is(false));
@@ -68,10 +68,10 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testFeatureGatesEquals() {
-        FeatureGates fg = new FeatureGates("+DummyFeatureGate");
+        FeatureGates fg = new FeatureGates("+ServerSideApplyPhase1");
         assertThat(fg, is(fg));
-        assertThat(fg, is(new FeatureGates("+DummyFeatureGate")));
-        assertThat(fg, is(not(new FeatureGates("-DummyFeatureGate"))));
+        assertThat(fg, is(new FeatureGates("+ServerSideApplyPhase1")));
+        assertThat(fg, is(not(new FeatureGates("-ServerSideApplyPhase1"))));
     }
 
     @ParallelTest
@@ -92,20 +92,20 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testDuplicateFeatureGateWithSameValue() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+DummyFeatureGate,+DummyFeatureGate"));
-        assertThat(e.getMessage(), containsString("Feature gate DummyFeatureGate is configured multiple times"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+ServerSideApplyPhase1,+ServerSideApplyPhase1"));
+        assertThat(e.getMessage(), containsString("Feature gate ServerSideApplyPhase1 is configured multiple times"));
     }
 
     @ParallelTest
     public void testDuplicateFeatureGateWithDifferentValue() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+DummyFeatureGate,-DummyFeatureGate"));
-        assertThat(e.getMessage(), containsString("Feature gate DummyFeatureGate is configured multiple times"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+ServerSideApplyPhase1,-ServerSideApplyPhase1"));
+        assertThat(e.getMessage(), containsString("Feature gate ServerSideApplyPhase1 is configured multiple times"));
     }
 
     @ParallelTest
     public void testMissingSign() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("DummyFeatureGate"));
-        assertThat(e.getMessage(), containsString("DummyFeatureGate is not a valid feature gate configuration"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("ServerSideApplyPhase1"));
+        assertThat(e.getMessage(), containsString("ServerSideApplyPhase1 is not a valid feature gate configuration"));
     }
 
     @ParallelTest
@@ -117,7 +117,7 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testEnvironmentVariable()   {
         assertThat(new FeatureGates("").toEnvironmentVariable(), is(""));
-        assertThat(new FeatureGates("+DummyFeatureGate").toEnvironmentVariable(), is("+DummyFeatureGate"));
-        assertThat(new FeatureGates("-DummyFeatureGate").toEnvironmentVariable(), is(""));
+        assertThat(new FeatureGates("+ServerSideApplyPhase1").toEnvironmentVariable(), is("+ServerSideApplyPhase1"));
+        assertThat(new FeatureGates("-ServerSideApplyPhase1").toEnvironmentVariable(), is(""));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -4,15 +4,30 @@
  */
 package io.strimzi.systemtest.operators;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.skodjob.testframe.resources.KubeResourceManager;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.operator.ClusterOperatorConfigurationBuilder;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
 import static io.strimzi.systemtest.TestTags.REGRESSION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Feature Gates should give us additional options on
@@ -20,9 +35,108 @@ import static io.strimzi.systemtest.TestTags.REGRESSION;
  * https://github.com/strimzi/proposals/blob/main/022-feature-gates.md
  */
 @Tag(REGRESSION)
-@Disabled("Currently disabled as this class doesn't contain any tests. Once there is a new test, we should remove this")
 public class FeatureGatesST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(FeatureGatesST.class);
+    private static final String SERVER_SIDE_APPLY_PHASE_1_ENABLED = "+ServerSideApplyPhase1";
+    private static final String SERVER_SIDE_APPLY_PHASE_1_DISABLED = "-ServerSideApplyPhase1";
+
+    @IsolatedTest("Creates ClusterOperator with Server Side Apply FG enabled")
+    void testServerSideApply() {
+        TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+
+        LOGGER.info("Deploying CO with SSA Phase 1 disabled");
+
+        // Firstly deploy CO without SSA enabled to check that changes to the resources will be re-written
+        setupClusterOperatorWithFeatureGate("");
+
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
+        );
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3).build());
+
+        annotateResourcesAndCheckIfPresent(testStorage, false);
+
+        LOGGER.info("Enabling Server Side Apply Phase 1");
+        changeFeatureGatesAndWaitForCoRollingUpdate(SERVER_SIDE_APPLY_PHASE_1_ENABLED);
+
+        annotateResourcesAndCheckIfPresent(testStorage, true);
+
+        LOGGER.info("Finally, changing back to SSA disabled");
+
+        changeFeatureGatesAndWaitForCoRollingUpdate(SERVER_SIDE_APPLY_PHASE_1_DISABLED);
+
+        annotateResourcesAndCheckIfPresent(testStorage, false);
+    }
+
+    private static void annotateResourcesAndCheckIfPresent(TestStorage testStorage, boolean shouldBePresent) {
+        final String annotationKey = "my-annotation";
+        final String annotationValue = "my-value";
+        final String annotationFull = String.format("%s=%s", annotationKey, annotationValue);
+
+        String brokerPodName = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
+        String controllerPodName = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getControllerSelector()).get(0).getMetadata().getName();
+
+        String bootstrapService = KafkaResources.bootstrapServiceName(testStorage.getClusterName());
+        String controllerPvc = String.format("data-%s", controllerPodName);
+        String kafkaServiceAccount = KafkaResources.kafkaComponentName(testStorage.getClusterName());
+
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName())
+            .exec("annotate", "configmap", brokerPodName, annotationFull);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName())
+            .exec("annotate", "service", bootstrapService, annotationFull);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName())
+            .exec("annotate", "pvc", controllerPvc, annotationFull);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName())
+            .exec("annotate", "serviceaccount", kafkaServiceAccount, annotationFull);
+
+        LOGGER.info("Waiting for {} for reconciliation in order to see if the annotation will stay or not.", TestConstants.RECONCILIATION_INTERVAL);
+
+        // Wait for one reconciliation interval to happen
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(TestConstants.RECONCILIATION_INTERVAL));
+
+        Map<String, String> currentAnnotations = KubeResourceManager.get().kubeClient().getClient().configMaps()
+            .inNamespace(testStorage.getNamespaceName()).withName(brokerPodName).get().getMetadata().getAnnotations();
+        assertThat(currentAnnotations.containsKey(annotationKey), is(shouldBePresent));
+
+        currentAnnotations = KubeResourceManager.get().kubeClient().getClient().services()
+            .inNamespace(testStorage.getNamespaceName()).withName(bootstrapService).get().getMetadata().getAnnotations();
+        assertThat(currentAnnotations.containsKey(annotationKey), is(shouldBePresent));
+
+        currentAnnotations = KubeResourceManager.get().kubeClient().getClient().persistentVolumeClaims()
+            .inNamespace(testStorage.getNamespaceName()).withName(controllerPvc).get().getMetadata().getAnnotations();
+        assertThat(currentAnnotations.containsKey(annotationKey), is(shouldBePresent));
+
+        currentAnnotations = KubeResourceManager.get().kubeClient().getClient().serviceAccounts()
+            .inNamespace(testStorage.getNamespaceName()).withName(kafkaServiceAccount).get().getMetadata().getAnnotations();
+        assertThat(currentAnnotations.containsKey(annotationKey), is(shouldBePresent));
+    }
+
+    /**
+     * Changes the feature gate value in `STRIMZI_FEATURE_GATES` env variable to {@param featureGatesValue}.
+     *
+     * @param featureGatesValue     value of FG that should be set in CO's `STRIMZI_FEATURE_GATES` env variable
+     */
+    private void changeFeatureGatesAndWaitForCoRollingUpdate(String featureGatesValue) {
+        LOGGER.info("Changing STRIMZI_FEATURE_GATES to {}", featureGatesValue);
+
+        Map<String, String> coPod = DeploymentUtils.depSnapshot(SetupClusterOperator.getInstance().getOperatorNamespace(), SetupClusterOperator.getInstance().getOperatorDeploymentName());
+
+        KubeResourceManager.get().kubeClient().getClient().apps().deployments().inNamespace(SetupClusterOperator.getInstance().getOperatorNamespace())
+            .withName(SetupClusterOperator.getInstance().getOperatorDeploymentName()).edit(dep -> new DeploymentBuilder(dep)
+                .editSpec()
+                    .editTemplate()
+                        .editSpec()
+                            .editFirstContainer()
+                                .addToEnv(new EnvVar("STRIMZI_FEATURE_GATES", featureGatesValue, null))
+                            .endContainer()
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build());
+
+        DeploymentUtils.waitTillDepHasRolled(SetupClusterOperator.getInstance().getOperatorNamespace(), SetupClusterOperator.getInstance().getOperatorDeploymentName(), 1, coPod);
+    }
 
     /**
      * Sets up a Cluster Operator with specified feature gates.
@@ -35,6 +149,8 @@ public class FeatureGatesST extends AbstractST {
             .getInstance()
             .withCustomConfiguration(new ClusterOperatorConfigurationBuilder()
                 .withFeatureGates(extraFeatureGates)
+                // configuring it explicitly here to be sure that we will use the correct reconciliation interval
+                .withReconciliationInterval(TestConstants.RECONCILIATION_INTERVAL)
                 .build()
             )
             .install();

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -55,3 +55,28 @@
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
+- fromVersion: HEAD
+  toVersion: 0.47.0
+  fromExamples: HEAD
+  toExamples: strimzi-0.47.0
+  fromUrl: HEAD
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.47.0/strimzi-0.47.0.zip
+  fromKafkaVersionsUrl: HEAD
+  additionalTopics: 2
+  imagesAfterOperations:
+    kafka: strimzi/kafka:0.47.0-kafka-4.0.0
+    topicOperator: strimzi/operator:0.47.0
+    userOperator: strimzi/operator:0.47.0
+  deployKafkaVersion: 4.0.0
+  client:
+    continuousClientsMessages: 400
+  environmentInfo:
+    maxK8sVersion: latest
+    status: stable
+    flakyEnvVariable: none
+    reason: Test is working on all environment used by QE.
+  fromFeatureGates: "+ServerSideApplyPhase1"
+  toFeatureGates: ""
+  filePaths:
+    fromKafka: "/examples/kafka/kafka-persistent.yaml"
+    toKafka: "/examples/kafka/kafka-persistent.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -54,3 +54,25 @@
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
+- fromVersion: 0.47.0
+  fromExamples: strimzi-0.47.0
+  deployKafkaVersion: 3.9.0
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.47.0/strimzi-0.47.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.47.0/kafka-versions.yaml
+  additionalTopics: 2
+  imagesAfterOperations:
+    kafka: strimzi/kafka:latest-kafka-4.0.0
+    topicOperator: strimzi/operator:latest
+    userOperator: strimzi/operator:latest
+  client:
+    continuousClientsMessages: 400
+  environmentInfo:
+    maxK8sVersion: latest
+    status: stable
+    flakyEnvVariable: none
+    reason: Test is working on environment, where k8s server version is < 1.22
+  fromFeatureGates: ""
+  toFeatureGates: "+ServerSideApplyPhase1"
+  filePaths:
+    fromKafka: "/examples/kafka/kafka-persistent.yaml"
+    toKafka: "/examples/kafka/kafka-persistent.yaml"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As described in https://github.com/strimzi/proposals/pull/160, this PR adds support for Server Side Apply for first five resources - `ConfigMap`, `Ingress`, `Service`, `ServiceAccount`, `PVC`.
It also adds feature gate for this phase - `ServerSideApplyPhase1`.

### Checklist

- [X] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

