### PR TITLE
Cleanup the CHANGELOG for Strimzi 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,16 @@
 
 * KRaft mode and Kafka Node Pools are now enabled by default.
   The `strimzi.io/node-pools` and `strimzi.io/kraft` annotations are not required anymore and will be ignored if set.
+* Make properties `broker.session.timeout.ms`, `broker.heartbeat.interval.ms` and `controller.socket.timeout.ms` configurable
+* Add monitoring of custom resources using [kubernetes-state-metrics (KSM)](https://github.com/kubernetes/kube-state-metrics) (see [Strimzi proposal 087](https://github.com/strimzi/proposals/blob/main/087-monitoring-of-custom-resources.md))
 
-### Changes, deprecations and removals
+### Major changes, deprecations and removals
 
-* Disable Cruise Control network resource goals when resource capacities are not set.
 * **From Strimzi 0.48.0 on, we support only Kubernetes 1.27 and newer.**
   Kubernetes 1.25 and 1.26 are not supported anymore.
-* Make properties `broker.session.timeout.ms`, `broker.heartbeat.interval.ms` and `controller.socket.timeout.ms` configurable
-* Add monitoring of custom resources (see [Strimzi proposal 087](https://github.com/strimzi/proposals/blob/main/087-monitoring-of-custom-resources.md)).
-  This deprecates Cluster Operator metrics (`strimzi_resource_state`) as described in the proposal.
-  The metrics will be removed in 4 patch releases (Strimzi 0.51.0).
-  Use kube-state-metrics based metrics from the [examples](https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/metrics/kube-state-metrics) instead.
+* Disable Cruise Control network resource goals when resource capacities are not set.
+* The `strimzi_resource_state` metric in the Cluster Operator is deprecated and is planned to be removed in Strimzi 0.51.
+  Use kube-state-metrics based metrics from the [examples](https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/metrics/kube-state-metrics) as a replacement.
 
 ## 0.47.0
 


### PR DESCRIPTION
### Type of change

- Task

### Description

The CHANGELOG for the 0.48.0 release is currently a bit of a mess, as it seems to mix new features, deprecations, removals, etc. This PR tries to clean it up, especially with the focus to make the deprecatios and breaking changes more visible.

### Checklist

- [x] Update CHANGELOG.md