### PR TITLE
Remove check for Kafka version from the `validateKRaftJbodStorage` method (but keep check for metadata version)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
@@ -167,10 +167,9 @@ public class NodePoolUtils {
         for (KafkaNodePool pool : nodePools)    {
             if (pool.getSpec().getStorage() != null
                     && pool.getSpec().getStorage() instanceof JbodStorage jbod) {
-                if (jbod.getVolumes().size() > 1
-                        && (KafkaVersion.compareDottedVersions(versionChange.from().version(), "3.7.0") < 0 || KafkaVersion.compareDottedIVVersions(versionChange.metadataVersion(), "3.7-IV2") < 0)) {
+                if (jbod.getVolumes().size() > 1 && KafkaVersion.compareDottedIVVersions(versionChange.metadataVersion(), "3.7-IV2") < 0) {
                     // When running Kafka older than 3.7.0, JBOD storage is not supported in KRaft.
-                    // This check should be removed when we remove support for Kafka 3.6.x.
+                    // This check should be removed when all the Kafka versions supported by Strimzi have minimal metadata version 3.7-IV2 and newer (kept for upgrade purposes).
                     // This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9960.
                     errors.add("Using more than one disk in a JBOD storage in KRaft mode is supported only with Apache Kafka 3.7.0 or newer and metadata version 3.7-IV2 or newer (in KafkaNodePool " + pool.getMetadata().getName() + ")");
                 }


### PR DESCRIPTION
### Type of change

- Check change

### Description

This small PR removes check for Kafka version 3.7.0 from the `validateKRaftJbodStorage` method - as we support Kafka 3.9.x and above.
But it still keeps the check for metadata version, for upgrade purposes, as the minimal supported metadata version even for Kafka 4.0.0 is 3.3.

I updated the comment in order to reflect that we are waiting for Kafka version supporting minimal version 3.7-IV2 and above - and after that we can remove the whole check (which is tracked in #9960 .

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
