### PR TITLE
Update Cluster CA secret data when removing old certificates

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -543,6 +543,7 @@ public class CaReconciler {
             clusterCa.maybeDeleteOldCerts();
 
             if (clusterCa.certsRemoved()) {
+                clusterCaCertSecret.setData(clusterCa.caCertData());
                 return secretOperator.reconcile(reconciliation, reconciliation.namespace(), AbstractModel.clusterCaCertSecretName(reconciliation.name()), clusterCaCertSecret)
                         .mapEmpty();
             } else {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Update the Cluster CA secret data with the new data that has old certs removed before calling reconcile

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

