### PR TITLE
Supports manual modification of the VolumeAttributesClassName of a PVC.

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/PvcOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/PvcOperator.java
@@ -100,6 +100,7 @@ public class PvcOperator extends AbstractNamespacedResourceOperator<KubernetesCl
     protected void revertImmutableChanges(PersistentVolumeClaim current, PersistentVolumeClaim desired)   {
         desired.getSpec().setVolumeName(current.getSpec().getVolumeName());
         desired.getSpec().setStorageClassName(current.getSpec().getStorageClassName());
+        desired.getSpec().setVolumeAttributesClassName(current.getSpec().getVolumeAttributesClassName());
         desired.getSpec().setAccessModes(current.getSpec().getAccessModes());
         desired.getSpec().setSelector(current.getSpec().getSelector());
         desired.getSpec().setDataSource(current.getSpec().getDataSource());


### PR DESCRIPTION
After manually modifying the VolumeAttributesClassName of PVC, an error is reported for updating the cluster.

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

