### PR TITLE
Added usage of Kafka Admin API to list registered brokers (and unregister them) as KIP-1073

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Add new feature gate `ServerSideApplyPhase1` (disabled by default) that adds support for Server Side Apply for `ConfigMap`, `Ingress`, `PVC`, `Service`, and `ServiceAccount` according to [Strimzi Proposal #105](https://github.com/strimzi/proposals/blob/main/105-server-side-apply-implementation-fg-timelines.md).
 * Added distinction between changes of "cluster-wide" broker properties applied dynamically at cluster level, and "per-broker" broker properties applied dynamically at broker level.
 * Extend the EntityOperator, Cruise Control and KafkaExporter deployment to support PDB via the template section in the CR spec.
+* Added support for [KIP-1073](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1073:+Return+fenced+brokers+in+DescribeCluster+response)
+  to get the list of the registered brokers by using the Kafka Admin API. It replaces the usage of the `.status.registeredNodeIds` field in Kafka.
 
 ### Major changes, deprecations and removals
 
@@ -41,6 +43,7 @@
   ```
   In case you use the standalone User Operator, you can set the environment variable in its `Deployment`.
   Please keep in mind that the ignored users will apply not only to ACLs, but also to Quotas and SCRAM-SHA credentials.
+* The field `.status.registeredNodeIds` in Kafka is now deprecated, it is not used anymore, and it will be removed in the future.
 
 ## 0.47.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
@@ -6,10 +6,12 @@ package io.strimzi.api.kafka.model.kafka;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.KafkaAutoRebalanceStatus;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -58,6 +60,9 @@ public class KafkaStatus extends Status {
         this.kafkaNodePools = kafkaNodePools;
     }
 
+    @Deprecated
+    @DeprecatedProperty(description = "The `registeredNodeIds` property is deprecated and it is not used anymore. It will be removed in the future.")
+    @PresentInVersions("v1beta2")
     @Description("Registered node IDs used by this Kafka cluster. " +
             "This field is used for internal purposes only and will be removed in the future.")
     public List<Integer> getRegisteredNodeIds() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -177,12 +177,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     status.setKafkaMetadataState(kafkaAssembly.getStatus().getKafkaMetadataState());
                 }
 
-                if (status.getRegisteredNodeIds() == null
-                        && kafkaAssembly.getStatus().getRegisteredNodeIds() != null)  {
-                    // Copy the list of registered node IDs if needed
-                    status.setRegisteredNodeIds(kafkaAssembly.getStatus().getRegisteredNodeIds());
-                }
-
                 if (status.getAutoRebalance() == null
                         && kafkaAssembly.getStatus().getAutoRebalance() != null
                         && reconcileState.isAutoRebalancingEnabled()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaNodeUnregistration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaNodeUnregistration.java
@@ -15,11 +15,14 @@ import io.strimzi.operator.common.auth.PemTrustSet;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.errors.BrokerIdNotRegisteredException;
+import org.apache.kafka.common.Node;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Contains utility methods for unregistering KRaft nodes from a Kafka cluster after scale-down
@@ -28,7 +31,7 @@ public class KafkaNodeUnregistration {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaNodeUnregistration.class.getName());
 
     /**
-     * Unregisters Kafka nodes from a KRaft-based Kafka cluster
+     * Unregisters Kafka broker nodes from a KRaft-based Kafka cluster
      *
      * @param reconciliation        Reconciliation marker
      * @param vertx                 Vert.x instance
@@ -37,15 +40,15 @@ public class KafkaNodeUnregistration {
      * @param pemAuthIdentity       Key set  for the admin client to connect to the Kafka cluster
      * @param nodeIdsToUnregister   List of node IDs that should be unregistered
      *
-     * @return  Future that completes when all nodes are unregistered
+     * @return  Future that completes when all broker nodes are unregistered
      */
-    public static Future<Void> unregisterNodes(
+    public static Future<Void> unregisterBrokerNodes(
             Reconciliation reconciliation,
             Vertx vertx,
             AdminClientProvider adminClientProvider,
             PemTrustSet pemTrustSet,
             PemAuthIdentity pemAuthIdentity,
-            List<Integer> nodeIdsToUnregister
+            Set<Integer> nodeIdsToUnregister
     ) {
         try {
             String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
@@ -53,7 +56,7 @@ public class KafkaNodeUnregistration {
 
             List<Future<Void>> futures = new ArrayList<>();
             for (Integer nodeId : nodeIdsToUnregister) {
-                futures.add(unregisterNode(reconciliation, vertx, adminClient, nodeId));
+                futures.add(unregisterBrokerNode(reconciliation, vertx, adminClient, nodeId));
             }
 
             return Future.all(futures)
@@ -69,33 +72,65 @@ public class KafkaNodeUnregistration {
     }
 
     /**
-     * Unregisters a single Kafka node using the Kafka Admin API. In case the failure is caused by the node not being
+     * List registered Kafka broker nodes within a KRaft-based cluster
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param vertx                 Vert.x instance
+     * @param adminClientProvider   Kafka Admin API client provider
+     * @param pemTrustSet           Trust set for the admin client to connect to the Kafka cluster
+     * @param pemAuthIdentity       Key set  for the admin client to connect to the Kafka cluster
+     * @param includeFencedBrokers  If listing should include fenced brokers
+     *
+     * @return  Future that completes when all registered broker nodes are listed
+     */
+    public static Future<Collection<Node>> listRegisteredBrokerNodes(
+            Reconciliation reconciliation,
+            Vertx vertx,
+            AdminClientProvider adminClientProvider,
+            PemTrustSet pemTrustSet,
+            PemAuthIdentity pemAuthIdentity,
+            boolean includeFencedBrokers) {
+
+        try {
+            String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
+            Admin adminClient = adminClientProvider.createAdminClient(bootstrapHostname, pemTrustSet, pemAuthIdentity);
+
+            DescribeClusterOptions option = new DescribeClusterOptions().includeFencedBrokers(includeFencedBrokers);
+            return VertxUtil
+                    .kafkaFutureToVertxFuture(reconciliation, vertx, adminClient.describeCluster(option).nodes())
+                    .compose(nodes -> {
+                        LOGGER.debugCr(reconciliation, "Describe cluster: nodes (fenced included) = {}", nodes);
+                        adminClient.close();
+                        return Future.succeededFuture(nodes);
+                    })
+                    .recover(throwable -> {
+                        adminClient.close();
+                        return Future.failedFuture(throwable);
+                    });
+        } catch (KafkaException e) {
+            LOGGER.warnCr(reconciliation, "Failed to list nodes", e);
+            return Future.failedFuture(e);
+        }
+    }
+
+    /**
+     * Unregisters a single Kafka broker node using the Kafka Admin API. In case the failure is caused by the node not being
      * registered, the error will be ignored.
      *
      * @param reconciliation        Reconciliation marker
      * @param vertx                 Vert.x instance
      * @param adminClient           Kafka Admin API client instance
-     * @param nodeIdToUnregister    ID of the node that should be unregistered
+     * @param nodeIdToUnregister    ID of the broker node that should be unregistered
      *
      * @return  Future that completes when the node is unregistered
      */
-    private static Future<Void> unregisterNode(Reconciliation reconciliation, Vertx vertx, Admin adminClient, Integer nodeIdToUnregister) {
+    private static Future<Void> unregisterBrokerNode(Reconciliation reconciliation, Vertx vertx, Admin adminClient, Integer nodeIdToUnregister) {
         LOGGER.debugCr(reconciliation, "Unregistering node {} from the Kafka cluster", nodeIdToUnregister);
 
         return VertxUtil
                 .kafkaFutureToVertxFuture(reconciliation, vertx, adminClient.unregisterBroker(nodeIdToUnregister).all())
-                .recover(t -> {
-                    if (t instanceof BrokerIdNotRegisteredException)    {
-                        // The broker is not registered anymore, so it does not need to be unregistered anymore and we
-                        // report success. Situation like this might happen when the operator fails before updating the
-                        // status, when the Kafka API call fails (e.g. due to network connection) but the unregistration
-                        // was done on the Kafka cluster and similar.
-                        LOGGER.warnCr(reconciliation, "Node {} is not registered and cannot be unregistered from the Kafka cluster", nodeIdToUnregister, t);
-                        return Future.succeededFuture();
-                    } else {
-                        LOGGER.warnCr(reconciliation, "Failed to unregister node {} from the Kafka cluster", nodeIdToUnregister, t);
-                        return Future.failedFuture(t);
-                    }
+                .onFailure(t -> {
+                    LOGGER.warnCr(reconciliation, "Failed to unregister node {} from the Kafka cluster", nodeIdToUnregister, t);
                 });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -62,6 +62,7 @@ import io.vertx.core.Future;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
+import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeFeaturesResult;
@@ -85,6 +86,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -244,13 +246,15 @@ public class ResourceUtils {
         try {
             Constructor<DescribeClusterResult> declaredConstructor = DescribeClusterResult.class.getDeclaredConstructor(KafkaFuture.class, KafkaFuture.class, KafkaFuture.class, KafkaFuture.class);
             declaredConstructor.setAccessible(true);
-            KafkaFuture<Node> objectKafkaFuture = KafkaFuture.completedFuture(new Node(0, "localhost", 9091));
-            KafkaFuture<String> stringKafkaFuture = KafkaFuture.completedFuture("CLUSTERID");
-            dcr = declaredConstructor.newInstance(null, objectKafkaFuture, stringKafkaFuture, null);
+            KafkaFuture<Collection<Node>> nodesKafkaFuture = KafkaFuture.completedFuture(Collections.emptyList());
+            KafkaFuture<Node> controllerKafkaFuture = KafkaFuture.completedFuture(new Node(0, "localhost", 9091));
+            KafkaFuture<String> clusterIdKafkaFuture = KafkaFuture.completedFuture("CLUSTERID");
+            dcr = declaredConstructor.newInstance(nodesKafkaFuture, controllerKafkaFuture, clusterIdKafkaFuture, null);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
         when(mock.describeCluster()).thenReturn(dcr);
+        when(mock.describeCluster(any(DescribeClusterOptions.class))).thenReturn(dcr);
 
         ListTopicsResult ltr;
         try {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
@@ -263,8 +263,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
         assertThat(k.getStatus().getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
         assertThat(k.getStatus().getKafkaMetadataState().toValue(), is("KRaft"));
         assertThat(k.getStatus().getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("brokers", "controllers")));
-        assertThat(k.getStatus().getRegisteredNodeIds().size(), is(6));
-        assertThat(k.getStatus().getRegisteredNodeIds(), hasItems(0, 1, 2, 10, 11, 12));
     }
 
     /**
@@ -568,11 +566,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
                 assertThat(brokers.getStatus().getRoles().size(), is(1));
                 assertThat(brokers.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
-                // Check the Kafka resource status
-                Kafka k = Crds.kafkaOperation(client).inNamespace(namespace).withName(CLUSTER_NAME).get();
-                assertThat(k.getStatus().getRegisteredNodeIds().size(), is(8));
-                assertThat(k.getStatus().getRegisteredNodeIds(), hasItems(0, 1, 2, 10, 11, 12, 13, 14));
-
                 // Scale down again
                 Crds.kafkaNodePoolOperation(client).inNamespace(namespace).withName("brokers").edit(p -> new KafkaNodePoolBuilder(p)
                         .editSpec()
@@ -600,11 +593,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
                 assertThat(brokers.getStatus().getNodeIds(), is(List.of(10, 11, 12)));
                 assertThat(brokers.getStatus().getRoles().size(), is(1));
                 assertThat(brokers.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
-
-                // Check the Kafka resource status
-                Kafka k = Crds.kafkaOperation(client).inNamespace(namespace).withName(CLUSTER_NAME).get();
-                assertThat(k.getStatus().getRegisteredNodeIds().size(), is(6));
-                assertThat(k.getStatus().getRegisteredNodeIds(), hasItems(0, 1, 2, 10, 11, 12));
 
                 async.flag();
             })));
@@ -674,8 +662,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
                 Kafka kafka = Crds.kafkaOperation(client).inNamespace(namespace).withName(CLUSTER_NAME).get();
                 assertThat(kafka.getStatus().getKafkaNodePools().size(), is(3));
                 assertThat(kafka.getStatus().getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), hasItems("brokers", "controllers", "new-pool"));
-                assertThat(kafka.getStatus().getRegisteredNodeIds().size(), is(9));
-                assertThat(kafka.getStatus().getRegisteredNodeIds(), hasItems(0, 1, 2, 10, 11, 12, 13, 14, 15));
 
                 KafkaNodePool controllers = Crds.kafkaNodePoolOperation(client).inNamespace(namespace).withName("controllers").get();
                 assertThat(controllers.getStatus().getReplicas(), is(3));
@@ -716,8 +702,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
                 Kafka kafka = Crds.kafkaOperation(client).inNamespace(namespace).withName(CLUSTER_NAME).get();
                 assertThat(kafka.getStatus().getKafkaNodePools().size(), is(2));
                 assertThat(kafka.getStatus().getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), hasItems("brokers", "controllers"));
-                assertThat(kafka.getStatus().getRegisteredNodeIds().size(), is(6));
-                assertThat(kafka.getStatus().getRegisteredNodeIds(), hasItems(0, 1, 2, 10, 11, 12));
 
                 KafkaNodePool controllers = Crds.kafkaNodePoolOperation(client).inNamespace(namespace).withName("controllers").get();
                 assertThat(controllers.getStatus().getReplicas(), is(3));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2307,7 +2307,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |List of the KafkaNodePools used by this Kafka cluster.
 |registeredNodeIds
 |integer array
-|Registered node IDs used by this Kafka cluster. This field is used for internal purposes only and will be removed in the future.
+|**The `registeredNodeIds` property has been deprecated.** The `registeredNodeIds` property is deprecated and it is not used anymore. It will be removed in the future. Registered node IDs used by this Kafka cluster. This field is used for internal purposes only and will be removed in the future.
 |clusterId
 |string
 |Kafka cluster Id.


### PR DESCRIPTION
### Type of change

- Enhancement/Refactoring

### Description

This PR fixes https://github.com/strimzi/strimzi-kafka-operator/issues/11667 and provides the implementation for the Strimzi proposal https://github.com/strimzi/proposals/pull/165.
It also fixes https://github.com/strimzi/strimzi-kafka-operator/issues/11477 as side effect.
It's about using the Kafka Admin API within Kafka 4.x to get the registered broker nodes in order to use them for corresponding unregistration in case of scale down or move from mixed-node to controller-only (by removing the broker role).

### Checklist

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging