### PR TITLE
Removed unused members in the RestartContext class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -303,7 +303,6 @@ public class KafkaRoller {
         final Promise<Void> promise;
         final BackOff backOff;
         RestartReasons restartReasons;
-        private long connectionErrorStart = 0L;
 
         boolean needsRestart;
         boolean needsReconfig;
@@ -317,20 +316,6 @@ public class KafkaRoller {
             promise = Promise.promise();
             backOff = backOffSupplier.get();
             backOff.delayMs();
-        }
-
-        public void clearConnectionError() {
-            connectionErrorStart = 0L;
-        }
-
-        long connectionError() {
-            return connectionErrorStart;
-        }
-
-        void noteConnectionError() {
-            if (connectionErrorStart == 0L) {
-                connectionErrorStart = System.currentTimeMillis();
-            }
         }
 
         @Override


### PR DESCRIPTION
Trivial PR to remove some unused code within the `RestartContext` in the `KafkaRoller`.