### PR TITLE
[DOC] Fix `OAUth` versus `OAuth` typos in docs

### DIFF
--- a/documentation/assemblies/oauth/assembly-oauth-security.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-security.adoc
@@ -2,7 +2,7 @@
 = Enabling OAuth 2.0 token-based access
 
 [role="_abstract"]
-Strimzi supports OAuth 2.0 for securing Kafka clusters by integrating with an OAUth 2.0 authorization server. 
+Strimzi supports OAuth 2.0 for securing Kafka clusters by integrating with an OAuth 2.0 authorization server.
 Kafka brokers and clients both need to be configured to use OAuth 2.0.
 
 OAuth 2.0 enables standardized token-based authentication and authorization between applications, using a central authorization server to issue tokens that grant limited access to resources.
@@ -12,7 +12,7 @@ Scopes correspond to different levels of access to Kafka topics or operations wi
 OAuth 2.0 also supports single sign-on and integration with identity providers. 
 
 ifdef::Section[]
-For more information on using OAUth 2.0, see the link:https://github.com/strimzi/strimzi-kafka-oauth[Strimzi OAuth 2.0 for Apache Kafka project^].
+For more information on using OAuth 2.0, see the link:https://github.com/strimzi/strimzi-kafka-oauth[Strimzi OAuth 2.0 for Apache Kafka project^].
 endif::Section[]
 
 //setting up oauth server

--- a/documentation/modules/oauth/con-oauth-authentication-broker.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-broker.adoc
@@ -6,7 +6,7 @@
 = Configuring OAuth 2.0 authentication on listeners
 
 [role="_abstract"]
-To secure Kafka brokers with OAuth 2.0 authentication, configure a listener in the `Kafka` resource to use OAUth 2.0 authentication and a client authentication mechanism, and add further configuration depending on the authentication mechanism and type of token validation used in the authentication.
+To secure Kafka brokers with OAuth 2.0 authentication, configure a listener in the `Kafka` resource to use OAuth 2.0 authentication and a client authentication mechanism, and add further configuration depending on the authentication mechanism and type of token validation used in the authentication.
 
 .Configuring listeners to use `oauth` authentication
 
@@ -264,7 +264,7 @@ For HTTP Bearer authentication, set the following property:
 Specify additional settings depending on the authentication requirements and the authorization server you are using.
 Some of these properties apply only to certain authentication mechanisms or when used in combination with other properties.
 
-For example, when using OAUth over `PLAIN`, access tokens are passed as `password` property values with or without an `$accessToken:` prefix.
+For example, when using OAuth over `PLAIN`, access tokens are passed as `password` property values with or without an `$accessToken:` prefix.
 
 * If you configure a token endpoint (`tokenEndpointUri`) in the listener configuration, you need the prefix.
 * If you don't configure a token endpoint in the listener configuration, you don't need the prefix.

--- a/documentation/modules/oauth/con-oauth-config.adoc
+++ b/documentation/modules/oauth/con-oauth-config.adoc
@@ -6,7 +6,7 @@
 = Example: Enabling OAuth 2.0 authentication
 
 [role="_abstract"]
-This example shows how to configure client access to a Kafka cluster using OAUth 2.0 authentication.
+This example shows how to configure client access to a Kafka cluster using OAuth 2.0 authentication.
 The procedures describe the configuration required to set up OAuth 2.0 authentication on Kafka listeners, Kafka Java clients, and Kafka components.
 
 include::../../modules/oauth/proc-oauth-authentication-broker-config.adoc[leveloffset=+1]

--- a/documentation/modules/oauth/proc-oauth-server-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-server-config.adoc
@@ -10,7 +10,7 @@ Before you can use OAuth 2.0 token-based access, you must configure an authoriza
 The steps are dependent on the chosen authorization server.
 Consult the product documentation for the authorization server for information on how to set up OAuth 2.0 access.
 
-Prepare the authorization server to work with Strimzi by defining _OAUth 2.0 clients_ for Kafka and each Kafka client component of your application.
+Prepare the authorization server to work with Strimzi by defining _OAuth 2.0 clients_ for Kafka and each Kafka client component of your application.
 In relation to the authorization server, the Kafka cluster and Kafka clients are both regarded as OAuth 2.0 clients.
 
 In general, configure OAuth 2.0 clients in the authorization server with the following client credentials enabled:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes the typos in the documentation where we use `OAUth` instead of `OAuth` (`U` versus `u`).

### Checklist

- [x] Update documentation