### PR TITLE
Enable storing raw yaml files from test runs

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -129,6 +129,8 @@ public abstract class AbstractST implements TestSeparator {
                 }
             }
         });
+
+        KubeResourceManager.get().setStoreYamlPath(Environment.TEST_LOG_DIR);
     }
 
     // Test-Frame integration stuff, remove everything else when not needed


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Test-frame allows to store raw yaml files of resources created by fabric8 during test runs.
This can be really handy in case you want to really show what configuration was sent to kube api and also for debugging purposes.

