### PR TITLE
Simplify ca reconciler test class

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
@@ -1,0 +1,2014 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.api.ResourceAnnotations;
+import io.strimzi.api.kafka.model.common.CertificateAuthority;
+import io.strimzi.api.kafka.model.common.CertificateAuthorityBuilder;
+import io.strimzi.api.kafka.model.common.CertificateExpirationPolicy;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.api.kafka.model.podset.StrimziPodSet;
+import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
+import io.strimzi.certs.OpenSslCertManager;
+import io.strimzi.certs.Subject;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.model.NodeRef;
+import io.strimzi.operator.cluster.model.PodSetUtils;
+import io.strimzi.operator.cluster.model.RestartReason;
+import io.strimzi.operator.cluster.model.RestartReasons;
+import io.strimzi.operator.cluster.operator.resource.KafkaRoller;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.DeploymentOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.auth.TlsPemIdentity;
+import io.strimzi.operator.common.model.Ca;
+import io.strimzi.operator.common.model.InvalidResourceException;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.PasswordGenerator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.test.ReadWriteUtils;
+import io.strimzi.test.TestUtils;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static io.strimzi.operator.common.model.Ca.CA_CRT;
+import static io.strimzi.operator.common.model.Ca.CA_KEY;
+import static io.strimzi.operator.common.model.Ca.CA_STORE;
+import static io.strimzi.operator.common.model.Ca.CA_STORE_PASSWORD;
+import static java.util.Collections.singleton;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
+@ExtendWith(VertxExtension.class)
+public class CaReconcilerReconcileCasTest {
+    private static final String NAMESPACE = "test";
+    private static final String NAME = "my-cluster";
+    private static final Kafka KAFKA = new KafkaBuilder()
+            .withNewMetadata()
+                .withName(NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withNewKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName("plain")
+                            .withPort(9092)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(false)
+                            .build())
+                .endKafka()
+            .endSpec()
+            .build();
+
+    private final static OpenSslCertManager CERT_MANAGER = new OpenSslCertManager();
+    private final static PasswordGenerator PASSWORD_GENERATOR = new PasswordGenerator(12,
+            "abcdefghijklmnopqrstuvwxyz" +
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "abcdefghijklmnopqrstuvwxyz" +
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+                    "0123456789");
+
+    private final List<Secret> secrets = new ArrayList<>();
+    private WorkerExecutor sharedWorkerExecutor;
+    private ResourceOperatorSupplier supplier;
+
+    @BeforeEach
+    public void setup(Vertx vertx) {
+        sharedWorkerExecutor = vertx.createSharedWorkerExecutor("kubernetes-ops-pool");
+        supplier = ResourceUtils.supplierWithMocks(false);
+    }
+
+    @AfterEach
+    public void teardown() {
+        sharedWorkerExecutor.close();
+    }
+
+    private Future<Void> reconcileCa(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClusterCa(clusterCa)
+                    .withClientsCa(clientsCa)
+                .endSpec()
+                .build();
+
+        return reconcileCa(vertx, kafka, Clock.systemUTC());
+    }
+
+    private Future<Void> reconcileCa(Vertx vertx, Kafka kafka, Clock clock) {
+        SecretOperator secretOps = supplier.secretOperations;
+        DeploymentOperator deploymentOps = supplier.deploymentOperations;
+        StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
+        PodOperator podOps = supplier.podOperations;
+
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenAnswer(invocation -> {
+            Map<String, String> requiredLabels = ((Labels) invocation.getArgument(1)).toMap();
+
+            List<Secret> listedSecrets = secrets.stream().filter(s -> {
+                Map<String, String> labels = s.getMetadata().getLabels();
+                labels.keySet().retainAll(requiredLabels.keySet());
+                return labels.equals(requiredLabels);
+            }).collect(Collectors.toList());
+
+            return Future.succeededFuture(listedSecrets);
+        });
+
+        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(deploymentOps.getAsync(eq(NAMESPACE), any())).thenReturn(Future.succeededFuture());
+        when(spsOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture());
+        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Promise<Void> reconcileCasComplete = Promise.promise();
+
+        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
+                .reconcile(clock)
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        reconcileCasComplete.complete();
+                    } else {
+                        reconcileCasComplete.fail(ar.cause());
+                    }
+                });
+
+        return reconcileCasComplete.future();
+    }
+
+    private CertAndKey generateCa(CertificateAuthority certificateAuthority, String commonName)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        String clusterCaStorePassword = "123456";
+
+        Path clusterCaKeyFile = Files.createTempFile("tls", "cluster-ca-key");
+        clusterCaKeyFile.toFile().deleteOnExit();
+        Path clusterCaCertFile = Files.createTempFile("tls", "cluster-ca-cert");
+        clusterCaCertFile.toFile().deleteOnExit();
+        Path clusterCaStoreFile = Files.createTempFile("tls", "cluster-ca-store");
+        clusterCaStoreFile.toFile().deleteOnExit();
+        
+        Subject sbj = new Subject.Builder()
+                .withOrganizationName("io.strimzi")
+                .withCommonName(commonName).build();
+
+        CERT_MANAGER.generateSelfSignedCert(clusterCaKeyFile.toFile(), clusterCaCertFile.toFile(), sbj, ModelUtils.getCertificateValidity(certificateAuthority));
+
+        CERT_MANAGER.addCertToTrustStore(clusterCaCertFile.toFile(), CA_CRT, clusterCaStoreFile.toFile(), clusterCaStorePassword);
+        return new CertAndKey(
+                Files.readAllBytes(clusterCaKeyFile),
+                Files.readAllBytes(clusterCaCertFile),
+                Files.readAllBytes(clusterCaStoreFile),
+                null,
+                clusterCaStorePassword);
+    }
+
+    private List<Secret> initialClusterCaSecrets(CertificateAuthority certificateAuthority)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        return initialCaSecrets(certificateAuthority, "cluster-ca",
+                AbstractModel.clusterCaKeySecretName(NAME),
+                AbstractModel.clusterCaCertSecretName(NAME));
+    }
+
+    private List<Secret> initialClientsCaSecrets(CertificateAuthority certificateAuthority)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        return initialCaSecrets(certificateAuthority, "clients-ca",
+                KafkaResources.clientsCaKeySecretName(NAME),
+                KafkaResources.clientsCaCertificateSecretName(NAME));
+    }
+
+    private List<Secret> initialCaSecrets(CertificateAuthority certificateAuthority, String commonName, String caKeySecretName, String caCertSecretName)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertAndKey result = generateCa(certificateAuthority, commonName);
+        List<Secret> secrets = new ArrayList<>();
+        secrets.add(
+                ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME, caKeySecretName, result.keyAsBase64String())
+        );
+        secrets.add(
+                ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME, caCertSecretName,
+                        result.certAsBase64String(), result.trustStoreAsBase64String(), result.storePasswordAsBase64String())
+        );
+        return secrets;
+    }
+
+    private KeyStore getTrustStore(Map<String, String> data)
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        trustStore.load(new ByteArrayInputStream(
+                Util.decodeBytesFromBase64(data.get(CA_STORE))),
+                Util.decodeFromBase64(data.get(CA_STORE_PASSWORD)).toCharArray()
+        );
+        return trustStore;
+    }
+
+    private boolean isCertInTrustStore(String alias, Map<String, String> data)
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        KeyStore trustStore = getTrustStore(data);
+        return trustStore.isCertificateEntry(alias);
+    }
+
+    private X509Certificate getCertificateFromTrustStore(String alias, Map<String, String> data)
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        KeyStore trustStore = getTrustStore(data);
+        return (X509Certificate) trustStore.getCertificate(alias);
+    }
+
+    private void assertCaptorSecretsNotNull(CaptorSecrets secrets) {
+        assertThat(secrets.clusterCaCert(), is(notNullValue()));
+        assertThat(secrets.clusterCaKey(), is(notNullValue()));
+        assertThat(secrets.clientsCaCert(), is(notNullValue()));
+        assertThat(secrets.clientsCaKey(), is(notNullValue()));
+    }
+
+    private CaptorSecrets verifyCaSecretReconcileCalls(SecretOperator secretOps) {
+        ArgumentCaptor<Secret> clusterCaCert = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clusterCaKey = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clientsCaCert = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clientsCaKey = ArgumentCaptor.forClass(Secret.class);
+        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), clusterCaCert.capture());
+        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), clusterCaKey.capture());
+        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture());
+        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture());
+
+        return new CaptorSecrets(clusterCaCert.getValue(), clusterCaKey.getValue(), clientsCaCert.getValue(), clientsCaKey.getValue());
+    }
+
+    private void assertCertDataNotNull(Map<String, String> certData) {
+        assertThat(certData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(certData.get(CA_CRT), is(notNullValue()));
+        assertThat(certData.get(CA_STORE), is(notNullValue()));
+        assertThat(certData.get(CA_STORE_PASSWORD), is(notNullValue()));
+    }
+
+    private void assertKeyDataNotNull(Map<String, String> keyData) {
+        assertThat(keyData.keySet(), is(singleton(CA_KEY)));
+        assertThat(keyData.get(CA_KEY), is(notNullValue()));
+    }
+
+    @Test
+    public void testReconcileCasGeneratesCertsInitially(Vertx vertx, VertxTestContext context) {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+
+        // Delete secrets to emulate secrets not pre-existing
+        secrets.clear();
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                assertThat(captorSecrets.clusterCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(isCertInTrustStore(CA_CRT, captorSecrets.clusterCaCert.getData()), is(true));
+
+                assertThat(captorSecrets.clusterCaKey().getData().keySet(), is(singleton(CA_KEY)));
+
+                assertThat(captorSecrets.clientsCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(isCertInTrustStore(CA_CRT, captorSecrets.clientsCaCert().getData()), is(true));
+
+                assertThat(captorSecrets.clientsCaKey().getData().keySet(), is(singleton(CA_KEY)));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testReconcileCasWhenCustomCertsAreMissingThrows(Vertx vertx, VertxTestContext context) {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(false)
+                .build();
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(InvalidResourceException.class));
+                assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testReconcileCasNoCertsGetGeneratedOutsideRenewalPeriod(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                assertThat(captorSecrets.clusterCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(captorSecrets.clusterCaCert().getData().get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(x509Certificate(initialClusterCaCertSecret.getData().get(CA_CRT)), is(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData())));
+
+                assertThat(captorSecrets.clusterCaKey().getData().keySet(), is(Set.of(CA_KEY)));
+                assertThat(captorSecrets.clusterCaKey().getData().get(CA_KEY), is(initialClusterCaKeySecret.getData().get(CA_KEY)));
+
+                assertThat(captorSecrets.clientsCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(captorSecrets.clientsCaCert().getData().get(CA_CRT), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(x509Certificate(initialClientsCaCertSecret.getData().get(CA_CRT)), is(getCertificateFromTrustStore(CA_CRT, captorSecrets.clientsCaCert().getData())));
+
+                assertThat(captorSecrets.clientsCaKey().getData().keySet(), is(Set.of(CA_KEY)));
+                assertThat(captorSecrets.clientsCaKey().getData().get(CA_KEY), is(initialClientsCaKeySecret.getData().get(CA_KEY)));
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testGenerateTruststoreFromOldSecrets(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+        // remove truststore and password to simulate Secrets coming from an older version
+        initialClusterCaCertSecret.getData().remove(CA_STORE);
+        initialClusterCaCertSecret.getData().remove(CA_STORE_PASSWORD);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+        // remove truststore and password to simulate Secrets coming from an older version
+        initialClientsCaCertSecret.getData().remove(CA_STORE);
+        initialClientsCaCertSecret.getData().remove(CA_STORE_PASSWORD);
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                String newClusterCaCert = captorSecrets.clusterCaCert().getData().get(CA_CRT);
+                assertThat(newClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData()), is(x509Certificate(newClusterCaCert)));
+
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertThat(clusterCaKeyData, aMapWithSize(1));
+                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertCertDataNotNull(clientsCaCertData);
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                assertThat(newClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertThat(clientsCaKeyData, aMapWithSize(1));
+                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testNewCertsGetGeneratedWhenInRenewalPeriodAuto(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .build();
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                String newClusterCaCert = captorSecrets.clusterCaCert().getData().get(CA_CRT);
+                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
+                assertThat(captorSecrets.clusterCaCert().getData().get(CA_STORE_PASSWORD), is(not(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD))));
+                assertThat(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData()), is(x509Certificate(newClusterCaCert)));
+
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertThat(clusterCaKeyData, aMapWithSize(1));
+                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertCertDataNotNull(clientsCaCertData);
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(not(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD))));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertThat(clientsCaKeyData, aMapWithSize(1));
+                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoOutsideOfMaintenanceWindow(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .build();
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClusterCa(certificateAuthority)
+                    .withClientsCa(certificateAuthority)
+                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
+                .endSpec()
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                String newClusterCaCert = captorSecrets.clusterCaCert().getData().get(CA_CRT);
+                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("0"));
+                assertThat(newClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(captorSecrets.clusterCaCert().getData().get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData()), is(x509Certificate(newClusterCaCert)));
+
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertThat(clusterCaKeyData, aMapWithSize(1));
+                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
+                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION), is("0"));
+
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertCertDataNotNull(clientsCaCertData);
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("0"));
+                assertThat(newClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertThat(clientsCaKeyData, aMapWithSize(1));
+                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
+                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION), is("0"));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoWithinMaintenanceWindow(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .build();
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClusterCa(certificateAuthority)
+                    .withClientsCa(certificateAuthority)
+                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
+                .endSpec()
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T10:12:00Z"), Clock.systemUTC().getZone()))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
+                assertCertDataNotNull(clusterCaCertData);
+
+                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
+                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
+                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(not(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD))));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
+
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertThat(clusterCaKeyData, aMapWithSize(1));
+                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
+                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertCertDataNotNull(clientsCaCertData);
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
+                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(not(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD))));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertThat(clientsCaKeyData, aMapWithSize(1));
+                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
+                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testNewKeyGetGeneratedWhenInRenewalPeriodAuto(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .withCertificateExpirationPolicy(CertificateExpirationPolicy.REPLACE_KEY)
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
+                assertThat(clusterCaCertData, aMapWithSize(4));
+
+                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
+                String oldClusterCaCertKey = clusterCaCertData.keySet()
+                        .stream()
+                        .filter(alias -> alias.startsWith("ca-"))
+                        .findAny()
+                        .orElseThrow();
+                String oldClusterCaCert = clusterCaCertData.get(oldClusterCaCertKey);
+
+                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
+
+                assertThat(oldClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(getCertificateFromTrustStore(oldClusterCaCertKey, clusterCaCertData), is(x509Certificate(oldClusterCaCert)));
+                assertThat(x509Certificate(newClusterCaCert).getSubjectX500Principal().getName(), is("CN=cluster-ca v1,O=io.strimzi"));
+
+                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertKeyDataNotNull(clusterCaKeyData);
+                assertThat(clusterCaKeyData.get(CA_KEY), is(not(initialClusterCaKeySecret.getData().get(CA_KEY))));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertThat(clientsCaCertData, aMapWithSize(4));
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                String oldClientsCaCertKey = clientsCaCertData.keySet()
+                        .stream()
+                        .filter(alias -> alias.startsWith("ca-"))
+                        .findAny()
+                        .orElseThrow();
+                String oldClientsCaCert = clientsCaCertData.get(oldClientsCaCertKey);
+
+                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+
+                assertThat(oldClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(getCertificateFromTrustStore(oldClientsCaCertKey, clientsCaCertData), is(x509Certificate(oldClientsCaCert)));
+                assertThat(x509Certificate(newClientsCaCert).getSubjectX500Principal().getName(), is("CN=clients-ca v1,O=io.strimzi"));
+
+                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertKeyDataNotNull(clientsCaKeyData);
+                assertThat(clientsCaKeyData.get(CA_KEY), is(not(initialClientsCaKeySecret.getData().get(CA_KEY))));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testNewKeyGeneratedWhenInRenewalPeriodAutoOutsideOfTimeWindow(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .withCertificateExpirationPolicy(CertificateExpirationPolicy.REPLACE_KEY)
+                .build();
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClusterCa(certificateAuthority)
+                    .withClientsCa(certificateAuthority)
+                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
+                .endSpec()
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
+                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "0"));
+                assertThat(clusterCaCertData, aMapWithSize(3));
+
+                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
+                assertThat(newClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
+                assertThat(x509Certificate(newClusterCaCert).getSubjectX500Principal().getName(), is("CN=cluster-ca,O=io.strimzi"));
+
+                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertThat(clusterCaKeyData, aMapWithSize(1));
+                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "0"));
+                assertThat(clientsCaCertData, aMapWithSize(3));
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                assertThat(newClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+                assertThat(x509Certificate(newClientsCaCert).getSubjectX500Principal().getName(), is("CN=clients-ca,O=io.strimzi"));
+
+                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertThat(clientsCaKeyData, aMapWithSize(1));
+                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
+
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testNewKeyGeneratedWhenInRenewalPeriodAutoWithinTimeWindow(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .withCertificateExpirationPolicy(CertificateExpirationPolicy.REPLACE_KEY)
+                .build();
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClusterCa(certificateAuthority)
+                    .withClientsCa(certificateAuthority)
+                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
+                .endSpec()
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:12:00Z"), Clock.systemUTC().getZone()))
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
+                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
+                assertThat(clusterCaCertData, aMapWithSize(4));
+
+                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
+                String oldClusterCaCertKey = clusterCaCertData.keySet()
+                        .stream()
+                        .filter(alias -> alias.startsWith("ca-"))
+                        .findAny()
+                        .orElseThrow();
+                String oldClusterCaCert = clusterCaCertData.get(oldClusterCaCertKey);
+
+                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
+
+                assertThat(oldClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(getCertificateFromTrustStore(oldClusterCaCertKey, clusterCaCertData), is(x509Certificate(oldClusterCaCert)));
+                assertThat(x509Certificate(newClusterCaCert).getSubjectX500Principal().getName(), is("CN=cluster-ca v1,O=io.strimzi"));
+
+                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
+                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
+                assertKeyDataNotNull(clusterCaKeyData);
+                assertThat(clusterCaKeyData.get(CA_KEY), is(not(initialClusterCaKeySecret.getData().get(CA_KEY))));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
+                assertThat(clientsCaCertData, aMapWithSize(4));
+
+                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
+                String oldClientsCaCertKey = clientsCaCertData.keySet()
+                        .stream()
+                        .filter(alias -> alias.startsWith("ca-"))
+                        .findAny()
+                        .orElseThrow();
+                String oldClientsCaCert = clientsCaCertData.get(oldClientsCaCertKey);
+
+                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
+
+                assertThat(oldClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(getCertificateFromTrustStore(oldClientsCaCertKey, clientsCaCertData), is(x509Certificate(oldClientsCaCert)));
+                assertThat(x509Certificate(newClientsCaCert).getSubjectX500Principal().getName(), is("CN=clients-ca v1,O=io.strimzi"));
+
+                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
+                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
+                assertKeyDataNotNull(clientsCaKeyData);
+                assertThat(clientsCaKeyData.get(CA_KEY), is(not(initialClientsCaKeySecret.getData().get(CA_KEY))));
+
+                async.flag();
+            })));
+    }
+
+    private X509Certificate x509Certificate(String newClusterCaCert) throws CertificateException {
+        return (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(Util.decodeBytesFromBase64(newClusterCaCert)));
+    }
+
+    @Test
+    public void testExpiredCertsGetRemovedAuto(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        // add an expired certificate to the secret ...
+        String clusterCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "cluster-ca.crt"));
+        String encodedClusterCert = Base64.getEncoder().encodeToString(clusterCert.getBytes(StandardCharsets.UTF_8));
+        initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClusterCert);
+
+        assertThat(initialClusterCaKeySecret.getData().keySet(), is(singleton(CA_KEY)));
+        assertThat(initialClusterCaKeySecret.getData().get(CA_KEY), is(notNullValue()));
+        // ... and to the related truststore
+        Path certFile = Files.createTempFile("tls", "-cert");
+        certFile.toFile().deleteOnExit();
+        Path trustStoreFile = Files.createTempFile("tls", "-truststore");
+        trustStoreFile.toFile().deleteOnExit();
+        Files.write(certFile, Util.decodeBytesFromBase64(initialClusterCaCertSecret.getData().get("ca-2018-07-01T09-00-00.crt")));
+        Files.write(trustStoreFile, Util.decodeBytesFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE)));
+        String trustStorePassword = Util.decodeFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD));
+        CERT_MANAGER.addCertToTrustStore(certFile.toFile(), "ca-2018-07-01T09-00-00.crt", trustStoreFile.toFile(), trustStorePassword);
+        initialClusterCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
+        assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", initialClusterCaCertSecret.getData()), is(true));
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        // add an expired certificate to the secret ...
+        String clientCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "clients-ca.crt"));
+        String encodedClientCert = Base64.getEncoder().encodeToString(clientCert.getBytes(StandardCharsets.UTF_8));
+        initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClientCert);
+
+        assertThat(initialClientsCaKeySecret.getData().keySet(), is(singleton(CA_KEY)));
+        assertThat(initialClientsCaKeySecret.getData().get(CA_KEY), is(notNullValue()));
+
+        // ... and to the related truststore
+        certFile = Files.createTempFile("tls", "-cert");
+        certFile.toFile().deleteOnExit();
+        Files.write(certFile, Util.decodeBytesFromBase64(initialClientsCaCertSecret.getData().get("ca-2018-07-01T09-00-00.crt")));
+        trustStoreFile = Files.createTempFile("tls", "-truststore");
+        trustStoreFile.toFile().deleteOnExit();
+        Files.write(trustStoreFile, Util.decodeBytesFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE)));
+        trustStorePassword = Util.decodeFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD));
+        CERT_MANAGER.addCertToTrustStore(certFile.toFile(), "ca-2018-07-01T09-00-00.crt", trustStoreFile.toFile(), trustStorePassword);
+        initialClientsCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
+        assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", initialClientsCaCertSecret.getData()), is(true));
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
+                assertCaptorSecretsNotNull(captorSecrets);
+
+                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
+                assertThat(clusterCaCertData, aMapWithSize(3));
+                assertThat(clusterCaCertData.get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(clusterCaCertData.get(CA_CRT))));
+                assertThat(captorSecrets.clusterCaKey().getData().get(CA_KEY), is(initialClusterCaKeySecret.getData().get(CA_KEY)));
+                assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", clusterCaCertData), is(false));
+
+                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
+                assertThat(clientsCaCertData, aMapWithSize(3));
+                assertThat(clientsCaCertData.get(CA_CRT), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
+                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(clientsCaCertData.get(CA_CRT))));
+                assertThat(captorSecrets.clientsCaKey().getData().get(CA_KEY), is(initialClientsCaKeySecret.getData().get(CA_KEY)));
+                assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", clientsCaCertData), is(false));
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testCustomCertsNotReconciled(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(false)
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClusterCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        assertCertDataNotNull(initialClientsCaCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
+        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), any(Secret.class));
+                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), any(Secret.class));
+                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), any(Secret.class));
+                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), any(Secret.class));
+                async.flag();
+            })));
+    }
+
+    @Test
+    public void testCustomLabelsAndAnnotations(Vertx vertx, VertxTestContext context) {
+        Map<String, String> labels = new HashMap<>(2);
+        labels.put("label1", "value1");
+        labels.put("label2", "value2");
+
+        Map<String, String> annos = new HashMap<>(2);
+        annos.put("anno1", "value3");
+        annos.put("anno2", "value4");
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withNewTemplate()
+                            .withNewClusterCaCert()
+                                .withNewMetadata()
+                                    .withAnnotations(annos)
+                                    .withLabels(labels)
+                                .endMetadata()
+                            .endClusterCaCert()
+                        .endTemplate()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        SecretOperator secretOps = supplier.secretOperations;
+        PodOperator podOps = supplier.podOperations;
+
+        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Checkpoint async = context.checkpoint();
+
+        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
+                    assertCaptorSecretsNotNull(captorSecrets);
+
+                    Secret clusterCaCertSecret = captorSecrets.clusterCaCert();
+                    Secret clusterCaKeySecret = captorSecrets.clusterCaKey();
+                    Secret clientsCaCertSecret = captorSecrets.clientsCaCert();
+                    Secret clientsCaKeySecret = captorSecrets.clientsCaKey();
+
+                    for (Map.Entry<String, String> entry : annos.entrySet()) {
+                        assertThat(clusterCaCertSecret.getMetadata().getAnnotations(), hasEntry(entry.getKey(), entry.getValue()));
+                        assertThat(clusterCaKeySecret.getMetadata().getAnnotations(), not(hasEntry(entry.getKey(), entry.getValue())));
+                        assertThat(clientsCaCertSecret.getMetadata().getAnnotations(), not(hasEntry(entry.getKey(), entry.getValue())));
+                        assertThat(clientsCaKeySecret.getMetadata().getAnnotations(), not(hasEntry(entry.getKey(), entry.getValue())));
+                    }
+
+                    for (Map.Entry<String, String> entry : labels.entrySet()) {
+                        assertThat(clusterCaCertSecret.getMetadata().getLabels(), hasEntry(entry.getKey(), entry.getValue()));
+                        assertThat(clusterCaKeySecret.getMetadata().getLabels(), not(hasEntry(entry.getKey(), entry.getValue())));
+                        assertThat(clientsCaCertSecret.getMetadata().getLabels(), not(hasEntry(entry.getKey(), entry.getValue())));
+                        assertThat(clientsCaKeySecret.getMetadata().getLabels(), not(hasEntry(entry.getKey(), entry.getValue())));
+                    }
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testClusterCASecretsWithoutOwnerReference(Vertx vertx, VertxTestContext context) {
+        CertificateAuthority caConfig = new CertificateAuthority();
+        caConfig.setGenerateSecretOwnerReference(false);
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClusterCa(caConfig)
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        SecretOperator secretOps = supplier.secretOperations;
+        PodOperator podOps = supplier.podOperations;
+
+        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Checkpoint async = context.checkpoint();
+
+        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
+                    assertCaptorSecretsNotNull(captorSecrets);
+
+                    Secret clusterCaCertSecret = captorSecrets.clusterCaCert();
+                    Secret clusterCaKeySecret = captorSecrets.clusterCaKey();
+                    Secret clientsCaCertSecret = captorSecrets.clientsCaCert();
+                    Secret clientsCaKeySecret = captorSecrets.clientsCaKey();
+
+                    assertThat(clusterCaCertSecret.getMetadata().getOwnerReferences(), hasSize(0));
+                    assertThat(clusterCaKeySecret.getMetadata().getOwnerReferences(), hasSize(0));
+                    assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences(), hasSize(1));
+                    assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences(), hasSize(1));
+
+                    TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
+                    TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testClientsCASecretsWithoutOwnerReference(Vertx vertx, VertxTestContext context) {
+        CertificateAuthority caConfig = new CertificateAuthority();
+        caConfig.setGenerateSecretOwnerReference(false);
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withClientsCa(caConfig)
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        SecretOperator secretOps = supplier.secretOperations;
+        PodOperator podOps = supplier.podOperations;
+
+        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Checkpoint async = context.checkpoint();
+
+        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
+
+                    assertThat(captorSecrets.clusterCaCert().getMetadata().getOwnerReferences(), hasSize(1));
+                    assertThat(captorSecrets.clusterCaKey().getMetadata().getOwnerReferences(), hasSize(1));
+                    assertThat(captorSecrets.clientsCaCert().getMetadata().getOwnerReferences(), hasSize(0));
+                    assertThat(captorSecrets.clientsCaKey().getMetadata().getOwnerReferences(), hasSize(0));
+
+                    TestUtils.checkOwnerReference(captorSecrets.clusterCaCert(), kafka);
+                    TestUtils.checkOwnerReference(captorSecrets.clusterCaKey(), kafka);
+
+                    async.flag();
+                })));
+    }
+
+    //////////
+    // Tests for trust rollout
+    //////////
+
+    @Test
+    public void testStrimziManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        //Annotate Cluster CA key to force replacement
+        Secret clusterCaKeySecret = clusterCaSecrets.get(0).edit()
+                .editMetadata()
+                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE, "true")
+                .endMetadata()
+                .build();
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaKeySecret, clusterCaSecrets.get(1),
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint(2);
+        when(supplier.strimziPodSetOperator.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenAnswer(i -> {
+            List<StrimziPodSet> podSets = i.getArgument(2);
+            context.verify(() -> {
+                assertThat(podSets, hasSize(2));
+                List<Pod> returnedPods = podSets
+                        .stream()
+                        .flatMap(podSet -> PodSetUtils.podSetToPods(podSet).stream())
+                        .toList();
+                for (Pod pod : returnedPods) {
+                    Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
+                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
+                }
+            });
+            async.flag();
+            return Future.succeededFuture();
+        });
+
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
+                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
+                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
+                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
+                    });
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, aMapWithSize(3));
+                    mockCaReconciler.deploymentRestartReasons.forEach((deploymentName, restartReason) ->
+                            assertThat("Deployment restart reason for " + deploymentName, restartReason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true)));
+                    async.flag();
+                })));
+    }
+
+    // Strimzi Cluster CA key replaced in previous reconcile and some pods already rolled
+    @Test
+    public void testStrimziManagedClusterCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        // Edit Cluster CA key and cert to increment generation as though replacement happened in previous reconcile
+        Secret clusterCaKeySecret = clusterCaSecrets.get(0).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
+                .endMetadata()
+                .build();
+        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
+                .endMetadata()
+                .build();
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+        Map<String, String> updatedGenerationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, updatedGenerationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, updatedGenerationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaKeySecret, clusterCaCertSecret,
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
+                controllerPods,
+                brokerPods
+        );
+
+        Checkpoint async = context.checkpoint(2);
+        when(supplier.strimziPodSetOperator.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenAnswer(i -> {
+            List<StrimziPodSet> podSets = i.getArgument(2);
+            context.verify(() -> {
+                assertThat(podSets, hasSize(2));
+                List<Pod> returnedPods = podSets
+                        .stream()
+                        .flatMap(podSet -> PodSetUtils.podSetToPods(podSet).stream())
+                        .toList();
+                for (Pod pod : returnedPods) {
+                    Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
+                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
+                }
+            });
+            async.flag();
+            return Future.succeededFuture();
+        });
+
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
+                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
+                        if ("my-cluster-controllers-4".equals(podName) || "my-cluster-brokers-0".equals(podName)) {
+                            assertThat("Pod " + podName + " should not be restarted", restartReasons.getReasons(), empty());
+                        } else {
+                            assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
+                            assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
+                        }
+                    });
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, aMapWithSize(3));
+                    mockCaReconciler.deploymentRestartReasons.forEach((deploymentName, restartReason) ->
+                            assertThat("Deployment restart reason for " + deploymentName, restartReason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true)));
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testStrimziManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        //Annotate Cluster CA cert to force renewal
+        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
+                .endMetadata()
+                .build();
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaCertSecret,
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUserManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        // Edit Cluster CA key and cert to increment generation as though user has replaced CA key
+        Secret clusterCaKeySecret = clusterCaSecrets.get(0).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
+                .endMetadata()
+                .build();
+        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
+                .endMetadata()
+                .build();
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaKeySecret, clusterCaCertSecret,
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint(2);
+        when(supplier.strimziPodSetOperator.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenAnswer(i -> {
+            List<StrimziPodSet> podSets = i.getArgument(2);
+            context.verify(() -> {
+                assertThat(podSets, hasSize(2));
+                List<Pod> returnedPods = podSets
+                        .stream()
+                        .flatMap(podSet -> PodSetUtils.podSetToPods(podSet).stream())
+                        .toList();
+                for (Pod pod : returnedPods) {
+                    Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
+                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
+                }
+            });
+            async.flag();
+            return Future.succeededFuture();
+        });
+
+        // Disable CA generation
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editClusterCa()
+                        .withGenerateCertificateAuthority(false)
+                    .endClusterCa()
+                .endSpec()
+                .build();
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
+                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
+                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
+                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
+                    });
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, aMapWithSize(3));
+                    mockCaReconciler.deploymentRestartReasons.forEach((deploymentName, restartReason) ->
+                            assertThat("Deployment restart reason for " + deploymentName, restartReason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true)));
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUserManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        // Edit Cluster CA cert to increment generation as though user has renewed CA cert
+        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
+                .endMetadata()
+                .build();
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaCertSecret,
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        // Disable CA generation
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editClusterCa()
+                        .withGenerateCertificateAuthority(false)
+                    .endClusterCa()
+                .endSpec()
+                .build();
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testStrimziManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        //Annotate Clients CA key to force replacement
+        Secret clientsCaKeySecret = clientsCaSecrets.get(0).edit()
+                .editMetadata()
+                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE, "true")
+                .endMetadata()
+                .build();
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
+                        clientsCaKeySecret, clientsCaSecrets.get(1)),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    // We rely on KafkaReconciler to roll pods for ClientsCa renewal
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    // Strimzi Clients CA key replaced in previous reconcile and some pods already rolled
+    @Test
+    public void testStrimziManagedClientsCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        // Edit Clients CA key and cert to increment generation as though replacement happened in previous reconcile
+        Secret clientsCaKeySecret = clientsCaSecrets.get(0).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
+                .endMetadata()
+                .build();
+        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
+                .endMetadata()
+                .build();
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
+                        clientsCaKeySecret, clientsCaCertSecret),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    // We don't handle this currently and rely on the rolling update later in the reconcile loop for Kafka
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testStrimziManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        //Annotate Clients CA cert to force renewal
+        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
+                .endMetadata()
+                .build();
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
+                        clientsCaSecrets.get(0), clientsCaCertSecret),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUserManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        // Edit Clients CA key and cert to increment generation as though user has replaced CA key
+        Secret clientsCaKeySecret = clientsCaSecrets.get(0).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
+                .endMetadata()
+                .build();
+        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
+                .endMetadata()
+                .build();
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
+                        clientsCaKeySecret, clientsCaCertSecret),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        // Disable CA generation
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editClientsCa()
+                        .withGenerateCertificateAuthority(false)
+                    .endClientsCa()
+                .endSpec()
+                .build();
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    // We rely on KafkaReconciler to roll pods for ClientsCa renewal
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUserManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        CertificateAuthority certificateAuthority = getCertificateAuthority();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        // Edit Clients CA cert to increment generation as though user has renewed CA cert
+        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
+                .editMetadata()
+                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
+                .endMetadata()
+                .build();
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
+                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+
+        // Kafka pods with old CA cert and key generation
+        List<Pod> controllerPods = new ArrayList<>();
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
+        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
+        List<Pod> brokerPods = new ArrayList<>();
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
+        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
+
+        initTrustRolloutTestMocks(supplier,
+                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
+                        clientsCaSecrets.get(0), clientsCaCertSecret),
+                controllerPods,
+                brokerPods);
+
+        Checkpoint async = context.checkpoint();
+
+        // Disable CA generation
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editClientsCa()
+                        .withGenerateCertificateAuthority(false)
+                    .endClientsCa()
+                .endSpec()
+                .build();
+        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
+                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
+                    async.flag();
+                })));
+    }
+
+    private void initTrustRolloutTestMocks(ResourceOperatorSupplier supplier,
+                                           List<Secret> secrets,
+                                           List<Pod> controllerPods,
+                                           List<Pod> brokerPods) {
+        SecretOperator secretOps = supplier.secretOperations;
+
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(secrets));
+        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any(Secret.class))).thenReturn(Future.succeededFuture());
+
+        PodOperator mockPodOps = supplier.podOperations;
+        List<Pod> pods = new ArrayList<>(controllerPods);
+        pods.addAll(brokerPods);
+        when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
+
+        StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
+        StrimziPodSet controllerPodSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName(NAME + "-controller")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podsToMaps(controllerPods))
+                .endSpec()
+                .build();
+
+        StrimziPodSet brokerPodSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName(NAME + "-broker")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podsToMaps(brokerPods))
+                .endSpec()
+                .build();
+
+        when(spsOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of(controllerPodSet, brokerPodSet)));
+
+        Map<String, Deployment> deps = new HashMap<>();
+        deps.put("my-cluster-entity-operator", deploymentWithName("my-cluster-entity-operator"));
+        deps.put("my-cluster-cruise-control", deploymentWithName("my-cluster-cruise-control"));
+        deps.put("my-cluster-kafka-exporter", deploymentWithName("my-cluster-kafka-exporter"));
+        DeploymentOperator depsOperator = supplier.deploymentOperations;
+        when(depsOperator.getAsync(any(), any())).thenAnswer(i -> Future.succeededFuture(deps.get(i.getArgument(1, String.class))));
+    }
+
+    static class NewMockCaReconciler extends CaReconciler {
+        Map<String, RestartReasons> kafkaRestartReasons = new HashMap<>();
+        Map<String, String> deploymentRestartReasons = new HashMap<>();
+
+        public NewMockCaReconciler(Reconciliation reconciliation, Kafka kafkaCr, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, Vertx vertx, CertManager certManager, PasswordGenerator passwordGenerator) {
+            super(reconciliation, kafkaCr, config, supplier, vertx, certManager, passwordGenerator);
+        }
+
+        @Override
+        KafkaRoller createKafkaRoller(Set<NodeRef> nodes, TlsPemIdentity coTlsPemIdentity) {
+            KafkaRoller mockKafkaRoller = mock(KafkaRoller.class);
+            when(mockKafkaRoller.rollingRestart(any())).thenAnswer(i -> podOperator.listAsync(NAMESPACE, Labels.EMPTY)
+                    .onSuccess(pods -> kafkaRestartReasons = pods.stream().collect(Collectors.toMap(
+                            pod -> pod.getMetadata().getName(),
+                            pod -> (RestartReasons) i.getArgument(0, Function.class).apply(pod))))
+                    .mapEmpty());
+            return mockKafkaRoller;
+        }
+
+        @Override
+        Future<Void> rollDeploymentIfExists(String deploymentName, RestartReason reason) {
+            return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
+                    .compose(dep -> {
+                        if (dep != null) {
+                            this.deploymentRestartReasons.put(deploymentName, reason.getDefaultNote());
+                        }
+                        return Future.succeededFuture();
+                    });
+        }
+    }
+
+    private static Pod podWithNameAndAnnotations(String name, boolean broker, boolean controller, Map<String, String> annotations) {
+        return new PodBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withAnnotations(annotations)
+                    .withLabels(Map.of(
+                            Labels.STRIMZI_CLUSTER_LABEL, NAME,
+                            Labels.STRIMZI_CONTROLLER_ROLE_LABEL, Boolean.toString(controller),
+                            Labels.STRIMZI_BROKER_ROLE_LABEL, Boolean.toString(broker)
+                            ))
+                .endMetadata()
+                .build();
+    }
+
+    private static Deployment deploymentWithName(String name) {
+        return new DeploymentBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                .endMetadata()
+                .build();
+    }
+
+    private static CertificateAuthority getCertificateAuthority() {
+        return new CertificateAuthorityBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+    }
+
+    private record CaptorSecrets(
+            Secret clusterCaCert,
+            Secret clusterCaKey,
+            Secret clientsCaCert,
+            Secret clientsCaKey
+    ) { }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
@@ -86,6 +86,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests the reconcileCas method of CaReconciler in isolation.
+ * <p>
+ * Use CaReconcilerTest for testing all steps in CaReconciler.
+ */
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerReconcileCasTest {
     private static final String NAMESPACE = "test";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
@@ -4,12 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.common.CertificateAuthority;
 import io.strimzi.api.kafka.model.common.CertificateAuthorityBuilder;
 import io.strimzi.api.kafka.model.common.CertificateExpirationPolicy;
@@ -18,10 +13,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
-import io.strimzi.api.kafka.model.podset.StrimziPodSet;
-import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -29,19 +21,10 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.ModelUtils;
-import io.strimzi.operator.cluster.model.NodeRef;
-import io.strimzi.operator.cluster.model.PodSetUtils;
-import io.strimzi.operator.cluster.model.RestartReason;
-import io.strimzi.operator.cluster.model.RestartReasons;
-import io.strimzi.operator.cluster.operator.resource.KafkaRoller;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
-import io.strimzi.operator.cluster.operator.resource.kubernetes.DeploymentOperator;
-import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
-import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
-import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
@@ -82,7 +65,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.model.Ca.CA_CRT;
@@ -96,18 +78,14 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerReconcileCasTest {
     private static final String NAMESPACE = "test";
@@ -149,10 +127,11 @@ public class CaReconcilerReconcileCasTest {
 
     @AfterEach
     public void teardown() {
+        secrets.clear();
         sharedWorkerExecutor.close();
     }
 
-    private Future<Void> reconcileCa(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
+    private Future<Void> reconcileCas(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .withClusterCa(clusterCa)
@@ -160,14 +139,11 @@ public class CaReconcilerReconcileCasTest {
                 .endSpec()
                 .build();
 
-        return reconcileCa(vertx, kafka, Clock.systemUTC());
+        return reconcileCas(vertx, kafka, Clock.systemUTC());
     }
 
-    private Future<Void> reconcileCa(Vertx vertx, Kafka kafka, Clock clock) {
+    private Future<Void> reconcileCas(Vertx vertx, Kafka kafka, Clock clock) {
         SecretOperator secretOps = supplier.secretOperations;
-        DeploymentOperator deploymentOps = supplier.deploymentOperations;
-        StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
-        PodOperator podOps = supplier.podOperations;
 
         when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenAnswer(invocation -> {
             Map<String, String> requiredLabels = ((Labels) invocation.getArgument(1)).toMap();
@@ -182,9 +158,6 @@ public class CaReconcilerReconcileCasTest {
         });
 
         when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(deploymentOps.getAsync(eq(NAMESPACE), any())).thenReturn(Future.succeededFuture());
-        when(spsOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture());
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 
@@ -192,7 +165,7 @@ public class CaReconcilerReconcileCasTest {
 
         new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
                 supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(clock)
+                .reconcileCas(clock)
                 .onComplete(ar -> {
                     if (ar.succeeded()) {
                         reconcileCasComplete.complete();
@@ -247,15 +220,14 @@ public class CaReconcilerReconcileCasTest {
     private List<Secret> initialCaSecrets(CertificateAuthority certificateAuthority, String commonName, String caKeySecretName, String caCertSecretName)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertAndKey result = generateCa(certificateAuthority, commonName);
-        List<Secret> secrets = new ArrayList<>();
-        secrets.add(
-                ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME, caKeySecretName, result.keyAsBase64String())
-        );
-        secrets.add(
-                ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME, caCertSecretName,
-                        result.certAsBase64String(), result.trustStoreAsBase64String(), result.storePasswordAsBase64String())
-        );
-        return secrets;
+        Secret caKeySecret = ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME, caKeySecretName, result.keyAsBase64String());
+        Secret caCertSecret = ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME, caCertSecretName,
+                        result.certAsBase64String(), result.trustStoreAsBase64String(), result.storePasswordAsBase64String());
+
+        assertCertDataNotNull(caCertSecret.getData());
+        assertThat(isCertInTrustStore(CA_CRT, caCertSecret.getData()), is(true));
+        assertKeyDataNotNull(caKeySecret.getData());
+        return List.of(caKeySecret, caCertSecret);
     }
 
     private KeyStore getTrustStore(Map<String, String> data)
@@ -312,6 +284,17 @@ public class CaReconcilerReconcileCasTest {
         assertThat(keyData.get(CA_KEY), is(notNullValue()));
     }
 
+    private record CaptorSecrets(
+            Secret clusterCaCert,
+            Secret clusterCaKey,
+            Secret clientsCaCert,
+            Secret clientsCaKey
+    ) { }
+
+    //////////
+    // Tests Strimzi managed CA
+    //////////
+
     @Test
     public void testReconcileCasGeneratesCertsInitially(Vertx vertx, VertxTestContext context) {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -320,11 +303,8 @@ public class CaReconcilerReconcileCasTest {
                 .withGenerateCertificateAuthority(true)
                 .build();
 
-        // Delete secrets to emulate secrets not pre-existing
-        secrets.clear();
-
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -344,23 +324,6 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testReconcileCasWhenCustomCertsAreMissingThrows(Vertx vertx, VertxTestContext context) {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
-                .withGenerateCertificateAuthority(false)
-                .build();
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.failing(e -> context.verify(() -> {
-                assertThat(e, instanceOf(InvalidResourceException.class));
-                assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
-                async.flag();
-            })));
-    }
-
-    @Test
     public void testReconcileCasNoCertsGetGeneratedOutsideRenewalPeriod(Vertx vertx, VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -373,17 +336,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -392,7 +347,7 @@ public class CaReconcilerReconcileCasTest {
 
         Checkpoint async = context.checkpoint();
 
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -443,7 +398,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -483,17 +438,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -501,7 +448,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -552,17 +499,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -570,7 +509,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -626,17 +565,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -644,7 +575,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T10:12:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T10:12:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -695,17 +626,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -713,7 +636,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -792,17 +715,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -810,7 +725,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -871,17 +786,9 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
 
         secrets.add(initialClusterCaCertSecret);
         secrets.add(initialClusterCaKeySecret);
@@ -889,7 +796,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:12:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:12:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -966,17 +873,11 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
         // add an expired certificate to the secret ...
         String clusterCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "cluster-ca.crt"));
         String encodedClusterCert = Base64.getEncoder().encodeToString(clusterCert.getBytes(StandardCharsets.UTF_8));
         initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClusterCert);
 
-        assertThat(initialClusterCaKeySecret.getData().keySet(), is(singleton(CA_KEY)));
-        assertThat(initialClusterCaKeySecret.getData().get(CA_KEY), is(notNullValue()));
         // ... and to the related truststore
         Path certFile = Files.createTempFile("tls", "-cert");
         certFile.toFile().deleteOnExit();
@@ -993,17 +894,10 @@ public class CaReconcilerReconcileCasTest {
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
 
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
         // add an expired certificate to the secret ...
         String clientCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "clients-ca.crt"));
         String encodedClientCert = Base64.getEncoder().encodeToString(clientCert.getBytes(StandardCharsets.UTF_8));
         initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClientCert);
-
-        assertThat(initialClientsCaKeySecret.getData().keySet(), is(singleton(CA_KEY)));
-        assertThat(initialClientsCaKeySecret.getData().get(CA_KEY), is(notNullValue()));
 
         // ... and to the related truststore
         certFile = Files.createTempFile("tls", "-cert");
@@ -1023,7 +917,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -1043,47 +937,6 @@ public class CaReconcilerReconcileCasTest {
                 assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(clientsCaCertData.get(CA_CRT))));
                 assertThat(captorSecrets.clientsCaKey().getData().get(CA_KEY), is(initialClientsCaKeySecret.getData().get(CA_KEY)));
                 assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", clientsCaCertData), is(false));
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testCustomCertsNotReconciled(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(false)
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), any(Secret.class));
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), any(Secret.class));
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), any(Secret.class));
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), any(Secret.class));
                 async.flag();
             })));
     }
@@ -1113,24 +966,10 @@ public class CaReconcilerReconcileCasTest {
                 .endSpec()
                 .build();
 
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        SecretOperator secretOps = supplier.secretOperations;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
         Checkpoint async = context.checkpoint();
-
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
+        reconcileCas(vertx, kafka, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                     assertCaptorSecretsNotNull(captorSecrets);
 
                     Secret clusterCaCertSecret = captorSecrets.clusterCaCert();
@@ -1167,24 +1006,11 @@ public class CaReconcilerReconcileCasTest {
                 .endSpec()
                 .build();
 
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        SecretOperator secretOps = supplier.secretOperations;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
         Checkpoint async = context.checkpoint();
 
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
+        reconcileCas(vertx, kafka, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                     assertCaptorSecretsNotNull(captorSecrets);
 
                     Secret clusterCaCertSecret = captorSecrets.clusterCaCert();
@@ -1215,24 +1041,11 @@ public class CaReconcilerReconcileCasTest {
                 .endSpec()
                 .build();
 
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        SecretOperator secretOps = supplier.secretOperations;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
         Checkpoint async = context.checkpoint();
 
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
+        reconcileCas(vertx, kafka, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
 
                     assertThat(captorSecrets.clusterCaCert().getMetadata().getOwnerReferences(), hasSize(1));
                     assertThat(captorSecrets.clusterCaKey().getMetadata().getOwnerReferences(), hasSize(1));
@@ -1247,768 +1060,56 @@ public class CaReconcilerReconcileCasTest {
     }
 
     //////////
-    // Tests for trust rollout
+    // Tests user managed CA
     //////////
 
     @Test
-    public void testStrimziManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        //Annotate Cluster CA key to force replacement
-        Secret clusterCaKeySecret = clusterCaSecrets.get(0).edit()
-                .editMetadata()
-                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE, "true")
-                .endMetadata()
-                .build();
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaKeySecret, clusterCaSecrets.get(1),
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint(2);
-        when(supplier.strimziPodSetOperator.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenAnswer(i -> {
-            List<StrimziPodSet> podSets = i.getArgument(2);
-            context.verify(() -> {
-                assertThat(podSets, hasSize(2));
-                List<Pod> returnedPods = podSets
-                        .stream()
-                        .flatMap(podSet -> PodSetUtils.podSetToPods(podSet).stream())
-                        .toList();
-                for (Pod pod : returnedPods) {
-                    Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
-                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-                }
-            });
-            async.flag();
-            return Future.succeededFuture();
-        });
-
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
-                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
-                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
-                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-                    });
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, aMapWithSize(3));
-                    mockCaReconciler.deploymentRestartReasons.forEach((deploymentName, restartReason) ->
-                            assertThat("Deployment restart reason for " + deploymentName, restartReason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true)));
-                    async.flag();
-                })));
-    }
-
-    // Strimzi Cluster CA key replaced in previous reconcile and some pods already rolled
-    @Test
-    public void testStrimziManagedClusterCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        // Edit Cluster CA key and cert to increment generation as though replacement happened in previous reconcile
-        Secret clusterCaKeySecret = clusterCaSecrets.get(0).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
-                .endMetadata()
-                .build();
-        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
-                .endMetadata()
-                .build();
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-        Map<String, String> updatedGenerationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, updatedGenerationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, updatedGenerationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaKeySecret, clusterCaCertSecret,
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
-                controllerPods,
-                brokerPods
-        );
-
-        Checkpoint async = context.checkpoint(2);
-        when(supplier.strimziPodSetOperator.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenAnswer(i -> {
-            List<StrimziPodSet> podSets = i.getArgument(2);
-            context.verify(() -> {
-                assertThat(podSets, hasSize(2));
-                List<Pod> returnedPods = podSets
-                        .stream()
-                        .flatMap(podSet -> PodSetUtils.podSetToPods(podSet).stream())
-                        .toList();
-                for (Pod pod : returnedPods) {
-                    Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
-                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-                }
-            });
-            async.flag();
-            return Future.succeededFuture();
-        });
-
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
-                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
-                        if ("my-cluster-controllers-4".equals(podName) || "my-cluster-brokers-0".equals(podName)) {
-                            assertThat("Pod " + podName + " should not be restarted", restartReasons.getReasons(), empty());
-                        } else {
-                            assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
-                            assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-                        }
-                    });
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, aMapWithSize(3));
-                    mockCaReconciler.deploymentRestartReasons.forEach((deploymentName, restartReason) ->
-                            assertThat("Deployment restart reason for " + deploymentName, restartReason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true)));
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testStrimziManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        //Annotate Cluster CA cert to force renewal
-        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
-                .endMetadata()
-                .build();
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaCertSecret,
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testUserManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        // Edit Cluster CA key and cert to increment generation as though user has replaced CA key
-        Secret clusterCaKeySecret = clusterCaSecrets.get(0).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
-                .endMetadata()
-                .build();
-        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
-                .endMetadata()
-                .build();
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaKeySecret, clusterCaCertSecret,
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint(2);
-        when(supplier.strimziPodSetOperator.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenAnswer(i -> {
-            List<StrimziPodSet> podSets = i.getArgument(2);
-            context.verify(() -> {
-                assertThat(podSets, hasSize(2));
-                List<Pod> returnedPods = podSets
-                        .stream()
-                        .flatMap(podSet -> PodSetUtils.podSetToPods(podSet).stream())
-                        .toList();
-                for (Pod pod : returnedPods) {
-                    Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
-                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-                }
-            });
-            async.flag();
-            return Future.succeededFuture();
-        });
-
-        // Disable CA generation
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editClusterCa()
-                        .withGenerateCertificateAuthority(false)
-                    .endClusterCa()
-                .endSpec()
-                .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
-                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
-                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
-                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-                    });
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, aMapWithSize(3));
-                    mockCaReconciler.deploymentRestartReasons.forEach((deploymentName, restartReason) ->
-                            assertThat("Deployment restart reason for " + deploymentName, restartReason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true)));
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testUserManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        // Edit Cluster CA cert to increment generation as though user has renewed CA cert
-        Secret clusterCaCertSecret = clusterCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
-                .endMetadata()
-                .build();
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaCertSecret,
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        // Disable CA generation
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editClusterCa()
-                        .withGenerateCertificateAuthority(false)
-                    .endClusterCa()
-                .endSpec()
-                .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testStrimziManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        //Annotate Clients CA key to force replacement
-        Secret clientsCaKeySecret = clientsCaSecrets.get(0).edit()
-                .editMetadata()
-                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE, "true")
-                .endMetadata()
-                .build();
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaKeySecret, clientsCaSecrets.get(1)),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    // We rely on KafkaReconciler to roll pods for ClientsCa renewal
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    // Strimzi Clients CA key replaced in previous reconcile and some pods already rolled
-    @Test
-    public void testStrimziManagedClientsCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        // Edit Clients CA key and cert to increment generation as though replacement happened in previous reconcile
-        Secret clientsCaKeySecret = clientsCaSecrets.get(0).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
-                .endMetadata()
-                .build();
-        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
-                .endMetadata()
-                .build();
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaKeySecret, clientsCaCertSecret),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    // We don't handle this currently and rely on the rolling update later in the reconcile loop for Kafka
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testStrimziManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        //Annotate Clients CA cert to force renewal
-        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
-                .endMetadata()
-                .build();
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaSecrets.get(0), clientsCaCertSecret),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testUserManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        // Edit Clients CA key and cert to increment generation as though user has replaced CA key
-        Secret clientsCaKeySecret = clientsCaSecrets.get(0).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1")
-                .endMetadata()
-                .build();
-        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
-                .endMetadata()
-                .build();
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaKeySecret, clientsCaCertSecret),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        // Disable CA generation
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editClientsCa()
-                        .withGenerateCertificateAuthority(false)
-                    .endClientsCa()
-                .endSpec()
-                .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    // We rely on KafkaReconciler to roll pods for ClientsCa renewal
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testUserManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        CertificateAuthority certificateAuthority = getCertificateAuthority();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        // Edit Clients CA cert to increment generation as though user has renewed CA cert
-        Secret clientsCaCertSecret = clientsCaSecrets.get(1).edit()
-                .editMetadata()
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1")
-                .endMetadata()
-                .build();
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
-                        Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
-
-        // Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-
-        initTrustRolloutTestMocks(supplier,
-                List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaSecrets.get(0), clientsCaCertSecret),
-                controllerPods,
-                brokerPods);
-
-        Checkpoint async = context.checkpoint();
-
-        // Disable CA generation
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editClientsCa()
-                        .withGenerateCertificateAuthority(false)
-                    .endClientsCa()
-                .endSpec()
-                .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
-                    assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
-                    async.flag();
-                })));
-    }
-
-    private void initTrustRolloutTestMocks(ResourceOperatorSupplier supplier,
-                                           List<Secret> secrets,
-                                           List<Pod> controllerPods,
-                                           List<Pod> brokerPods) {
-        SecretOperator secretOps = supplier.secretOperations;
-
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(secrets));
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any(Secret.class))).thenReturn(Future.succeededFuture());
-
-        PodOperator mockPodOps = supplier.podOperations;
-        List<Pod> pods = new ArrayList<>(controllerPods);
-        pods.addAll(brokerPods);
-        when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
-
-        StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
-        StrimziPodSet controllerPodSet = new StrimziPodSetBuilder()
-                .withNewMetadata()
-                    .withName(NAME + "-controller")
-                .endMetadata()
-                .withNewSpec()
-                    .withPods(PodSetUtils.podsToMaps(controllerPods))
-                .endSpec()
-                .build();
-
-        StrimziPodSet brokerPodSet = new StrimziPodSetBuilder()
-                .withNewMetadata()
-                    .withName(NAME + "-broker")
-                .endMetadata()
-                .withNewSpec()
-                    .withPods(PodSetUtils.podsToMaps(brokerPods))
-                .endSpec()
-                .build();
-
-        when(spsOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of(controllerPodSet, brokerPodSet)));
-
-        Map<String, Deployment> deps = new HashMap<>();
-        deps.put("my-cluster-entity-operator", deploymentWithName("my-cluster-entity-operator"));
-        deps.put("my-cluster-cruise-control", deploymentWithName("my-cluster-cruise-control"));
-        deps.put("my-cluster-kafka-exporter", deploymentWithName("my-cluster-kafka-exporter"));
-        DeploymentOperator depsOperator = supplier.deploymentOperations;
-        when(depsOperator.getAsync(any(), any())).thenAnswer(i -> Future.succeededFuture(deps.get(i.getArgument(1, String.class))));
-    }
-
-    static class NewMockCaReconciler extends CaReconciler {
-        Map<String, RestartReasons> kafkaRestartReasons = new HashMap<>();
-        Map<String, String> deploymentRestartReasons = new HashMap<>();
-
-        public NewMockCaReconciler(Reconciliation reconciliation, Kafka kafkaCr, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, Vertx vertx, CertManager certManager, PasswordGenerator passwordGenerator) {
-            super(reconciliation, kafkaCr, config, supplier, vertx, certManager, passwordGenerator);
-        }
-
-        @Override
-        KafkaRoller createKafkaRoller(Set<NodeRef> nodes, TlsPemIdentity coTlsPemIdentity) {
-            KafkaRoller mockKafkaRoller = mock(KafkaRoller.class);
-            when(mockKafkaRoller.rollingRestart(any())).thenAnswer(i -> podOperator.listAsync(NAMESPACE, Labels.EMPTY)
-                    .onSuccess(pods -> kafkaRestartReasons = pods.stream().collect(Collectors.toMap(
-                            pod -> pod.getMetadata().getName(),
-                            pod -> (RestartReasons) i.getArgument(0, Function.class).apply(pod))))
-                    .mapEmpty());
-            return mockKafkaRoller;
-        }
-
-        @Override
-        Future<Void> rollDeploymentIfExists(String deploymentName, RestartReason reason) {
-            return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
-                    .compose(dep -> {
-                        if (dep != null) {
-                            this.deploymentRestartReasons.put(deploymentName, reason.getDefaultNote());
-                        }
-                        return Future.succeededFuture();
-                    });
-        }
-    }
-
-    private static Pod podWithNameAndAnnotations(String name, boolean broker, boolean controller, Map<String, String> annotations) {
-        return new PodBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                    .withAnnotations(annotations)
-                    .withLabels(Map.of(
-                            Labels.STRIMZI_CLUSTER_LABEL, NAME,
-                            Labels.STRIMZI_CONTROLLER_ROLE_LABEL, Boolean.toString(controller),
-                            Labels.STRIMZI_BROKER_ROLE_LABEL, Boolean.toString(broker)
-                            ))
-                .endMetadata()
-                .build();
-    }
-
-    private static Deployment deploymentWithName(String name) {
-        return new DeploymentBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                .endMetadata()
-                .build();
-    }
-
-    private static CertificateAuthority getCertificateAuthority() {
-        return new CertificateAuthorityBuilder()
+    public void testReconcileCasWhenUserManagedCertsAreMissingThrows(Vertx vertx, VertxTestContext context) {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
                 .withRenewalDays(10)
-                .withGenerateCertificateAuthority(true)
+                .withGenerateCertificateAuthority(false)
                 .build();
+
+        Checkpoint async = context.checkpoint();
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+                .onComplete(context.failing(e -> context.verify(() -> {
+                    assertThat(e, instanceOf(InvalidResourceException.class));
+                    assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
+                    async.flag();
+                })));
     }
 
-    private record CaptorSecrets(
-            Secret clusterCaCert,
-            Secret clusterCaKey,
-            Secret clientsCaCert,
-            Secret clientsCaKey
-    ) { }
+    @Test
+    public void testUserManagedCertsNotReconciled(Vertx vertx, VertxTestContext context)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(false)
+                .build();
+
+        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
+        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
+        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
+
+        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
+        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
+        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        Checkpoint async = context.checkpoint();
+        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), any(Secret.class));
+                    verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), any(Secret.class));
+                    verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), any(Secret.class));
+                    verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), any(Secret.class));
+                    async.flag();
+                })));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -92,6 +92,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests for actions taken by CaReconciler after the CA Secrets are reconciled,
+ * particularly the rolling updates for trust.
+ * The test cases use a mock CaReconciler class to capture when Kafka pods and
+ * other deployment (Kafka Exporter etc) are rolled.
+ * <p>
+ * Use CaReconcilerReconcileCasTest for testing the reconcileCas method in isolation.
+ */
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerTest {
     private static final String NAMESPACE = "test";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.common.CertificateAuthority;
 import io.strimzi.api.kafka.model.common.CertificateAuthorityBuilder;
-import io.strimzi.api.kafka.model.common.CertificateExpirationPolicy;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -21,7 +20,6 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -43,14 +41,9 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Ca;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
-import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.test.ReadWriteUtils;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.junit5.Checkpoint;
@@ -64,7 +57,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
@@ -74,26 +66,19 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.model.Ca.CA_CRT;
-import static io.strimzi.operator.common.model.Ca.CA_KEY;
 import static io.strimzi.operator.common.model.Ca.CA_STORE;
 import static io.strimzi.operator.common.model.Ca.CA_STORE_PASSWORD;
-import static java.util.Collections.singleton;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -107,7 +92,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerTest {
     private static final String NAMESPACE = "test";
@@ -137,7 +121,6 @@ public class CaReconcilerTest {
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
                     "0123456789");
 
-    private final List<Secret> secrets = new ArrayList<>();
     private WorkerExecutor sharedWorkerExecutor;
     private ResourceOperatorSupplier supplier;
 
@@ -152,57 +135,6 @@ public class CaReconcilerTest {
         sharedWorkerExecutor.close();
     }
 
-    private Future<Void> reconcileCa(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClusterCa(clusterCa)
-                    .withClientsCa(clientsCa)
-                .endSpec()
-                .build();
-
-        return reconcileCa(vertx, kafka, Clock.systemUTC());
-    }
-
-    private Future<Void> reconcileCa(Vertx vertx, Kafka kafka, Clock clock) {
-        SecretOperator secretOps = supplier.secretOperations;
-        DeploymentOperator deploymentOps = supplier.deploymentOperations;
-        StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenAnswer(invocation -> {
-            Map<String, String> requiredLabels = ((Labels) invocation.getArgument(1)).toMap();
-
-            List<Secret> listedSecrets = secrets.stream().filter(s -> {
-                Map<String, String> labels = s.getMetadata().getLabels();
-                labels.keySet().retainAll(requiredLabels.keySet());
-                return labels.equals(requiredLabels);
-            }).collect(Collectors.toList());
-
-            return Future.succeededFuture(listedSecrets);
-        });
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(deploymentOps.getAsync(eq(NAMESPACE), any())).thenReturn(Future.succeededFuture());
-        when(spsOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture());
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
-        Promise<Void> reconcileCasComplete = Promise.promise();
-
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(clock)
-                .onComplete(ar -> {
-                    if (ar.succeeded()) {
-                        reconcileCasComplete.complete();
-                    } else {
-                        reconcileCasComplete.fail(ar.cause());
-                    }
-                });
-
-        return reconcileCasComplete.future();
-    }
 
     private CertAndKey generateCa(CertificateAuthority certificateAuthority, String commonName)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
@@ -258,795 +190,6 @@ public class CaReconcilerTest {
         return secrets;
     }
 
-    private KeyStore getTrustStore(Map<String, String> data)
-            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
-        KeyStore trustStore = KeyStore.getInstance("PKCS12");
-        trustStore.load(new ByteArrayInputStream(
-                Util.decodeBytesFromBase64(data.get(CA_STORE))),
-                Util.decodeFromBase64(data.get(CA_STORE_PASSWORD)).toCharArray()
-        );
-        return trustStore;
-    }
-
-    private boolean isCertInTrustStore(String alias, Map<String, String> data)
-            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
-        KeyStore trustStore = getTrustStore(data);
-        return trustStore.isCertificateEntry(alias);
-    }
-
-    private X509Certificate getCertificateFromTrustStore(String alias, Map<String, String> data)
-            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
-        KeyStore trustStore = getTrustStore(data);
-        return (X509Certificate) trustStore.getCertificate(alias);
-    }
-
-    private void assertCaptorSecretsNotNull(CaptorSecrets secrets) {
-        assertThat(secrets.clusterCaCert(), is(notNullValue()));
-        assertThat(secrets.clusterCaKey(), is(notNullValue()));
-        assertThat(secrets.clientsCaCert(), is(notNullValue()));
-        assertThat(secrets.clientsCaKey(), is(notNullValue()));
-    }
-
-    private CaptorSecrets verifyCaSecretReconcileCalls(SecretOperator secretOps) {
-        ArgumentCaptor<Secret> clusterCaCert = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clusterCaKey = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clientsCaCert = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clientsCaKey = ArgumentCaptor.forClass(Secret.class);
-        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), clusterCaCert.capture());
-        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), clusterCaKey.capture());
-        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture());
-        verify(secretOps).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture());
-
-        return new CaptorSecrets(clusterCaCert.getValue(), clusterCaKey.getValue(), clientsCaCert.getValue(), clientsCaKey.getValue());
-    }
-
-    private void assertCertDataNotNull(Map<String, String> certData) {
-        assertThat(certData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
-        assertThat(certData.get(CA_CRT), is(notNullValue()));
-        assertThat(certData.get(CA_STORE), is(notNullValue()));
-        assertThat(certData.get(CA_STORE_PASSWORD), is(notNullValue()));
-    }
-
-    private void assertKeyDataNotNull(Map<String, String> keyData) {
-        assertThat(keyData.keySet(), is(singleton(CA_KEY)));
-        assertThat(keyData.get(CA_KEY), is(notNullValue()));
-    }
-
-    @Test
-    public void testReconcileCasGeneratesCertsInitially(Vertx vertx, VertxTestContext context) {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
-                .withGenerateCertificateAuthority(true)
-                .build();
-
-        // Delete secrets to emulate secrets not pre-existing
-        secrets.clear();
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                assertThat(captorSecrets.clusterCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
-                assertThat(isCertInTrustStore(CA_CRT, captorSecrets.clusterCaCert.getData()), is(true));
-
-                assertThat(captorSecrets.clusterCaKey().getData().keySet(), is(singleton(CA_KEY)));
-
-                assertThat(captorSecrets.clientsCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
-                assertThat(isCertInTrustStore(CA_CRT, captorSecrets.clientsCaCert().getData()), is(true));
-
-                assertThat(captorSecrets.clientsCaKey().getData().keySet(), is(singleton(CA_KEY)));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testReconcileCasWhenCustomCertsAreMissingThrows(Vertx vertx, VertxTestContext context) {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
-                .withGenerateCertificateAuthority(false)
-                .build();
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.failing(e -> context.verify(() -> {
-                assertThat(e, instanceOf(InvalidResourceException.class));
-                assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testReconcileCasNoCertsGetGeneratedOutsideRenewalPeriod(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
-                .withGenerateCertificateAuthority(true)
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                assertThat(captorSecrets.clusterCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
-                assertThat(captorSecrets.clusterCaCert().getData().get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(x509Certificate(initialClusterCaCertSecret.getData().get(CA_CRT)), is(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData())));
-
-                assertThat(captorSecrets.clusterCaKey().getData().keySet(), is(Set.of(CA_KEY)));
-                assertThat(captorSecrets.clusterCaKey().getData().get(CA_KEY), is(initialClusterCaKeySecret.getData().get(CA_KEY)));
-
-                assertThat(captorSecrets.clientsCaCert().getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
-                assertThat(captorSecrets.clientsCaCert().getData().get(CA_CRT), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(x509Certificate(initialClientsCaCertSecret.getData().get(CA_CRT)), is(getCertificateFromTrustStore(CA_CRT, captorSecrets.clientsCaCert().getData())));
-
-                assertThat(captorSecrets.clientsCaKey().getData().keySet(), is(Set.of(CA_KEY)));
-                assertThat(captorSecrets.clientsCaKey().getData().get(CA_KEY), is(initialClientsCaKeySecret.getData().get(CA_KEY)));
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testGenerateTruststoreFromOldSecrets(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
-                .withGenerateCertificateAuthority(true)
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        // remove truststore and password to simulate Secrets coming from an older version
-        initialClusterCaCertSecret.getData().remove(CA_STORE);
-        initialClusterCaCertSecret.getData().remove(CA_STORE_PASSWORD);
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        // remove truststore and password to simulate Secrets coming from an older version
-        initialClientsCaCertSecret.getData().remove(CA_STORE);
-        initialClientsCaCertSecret.getData().remove(CA_STORE_PASSWORD);
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                String newClusterCaCert = captorSecrets.clusterCaCert().getData().get(CA_CRT);
-                assertThat(newClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData()), is(x509Certificate(newClusterCaCert)));
-
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertThat(clusterCaKeyData, aMapWithSize(1));
-                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertCertDataNotNull(clientsCaCertData);
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                assertThat(newClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertThat(clientsCaKeyData, aMapWithSize(1));
-                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testNewCertsGetGeneratedWhenInRenewalPeriodAuto(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(true)
-                .build();
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                String newClusterCaCert = captorSecrets.clusterCaCert().getData().get(CA_CRT);
-                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
-                assertThat(captorSecrets.clusterCaCert().getData().get(CA_STORE_PASSWORD), is(not(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD))));
-                assertThat(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData()), is(x509Certificate(newClusterCaCert)));
-
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertThat(clusterCaKeyData, aMapWithSize(1));
-                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertCertDataNotNull(clientsCaCertData);
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(not(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD))));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertThat(clientsCaKeyData, aMapWithSize(1));
-                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoOutsideOfMaintenanceWindow(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(true)
-                .build();
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClusterCa(certificateAuthority)
-                    .withClientsCa(certificateAuthority)
-                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
-                .endSpec()
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                String newClusterCaCert = captorSecrets.clusterCaCert().getData().get(CA_CRT);
-                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("0"));
-                assertThat(newClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(captorSecrets.clusterCaCert().getData().get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, captorSecrets.clusterCaCert().getData()), is(x509Certificate(newClusterCaCert)));
-
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertThat(clusterCaKeyData, aMapWithSize(1));
-                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
-                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION), is("0"));
-
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertCertDataNotNull(clientsCaCertData);
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("0"));
-                assertThat(newClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertThat(clientsCaKeyData, aMapWithSize(1));
-                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
-                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION), is("0"));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoWithinMaintenanceWindow(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(true)
-                .build();
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClusterCa(certificateAuthority)
-                    .withClientsCa(certificateAuthority)
-                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
-                .endSpec()
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T10:12:00Z"), Clock.systemUTC().getZone()))
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
-                assertCertDataNotNull(clusterCaCertData);
-
-                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
-                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
-                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(not(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD))));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
-
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertThat(clusterCaKeyData, aMapWithSize(1));
-                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
-                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertCertDataNotNull(clientsCaCertData);
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
-                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(not(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD))));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertThat(clientsCaKeyData, aMapWithSize(1));
-                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
-                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testNewKeyGetGeneratedWhenInRenewalPeriodAuto(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(true)
-                .withCertificateExpirationPolicy(CertificateExpirationPolicy.REPLACE_KEY)
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
-                assertThat(clusterCaCertData, aMapWithSize(4));
-
-                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
-                String oldClusterCaCertKey = clusterCaCertData.keySet()
-                        .stream()
-                        .filter(alias -> alias.startsWith("ca-"))
-                        .findAny()
-                        .orElseThrow();
-                String oldClusterCaCert = clusterCaCertData.get(oldClusterCaCertKey);
-
-                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
-
-                assertThat(oldClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(getCertificateFromTrustStore(oldClusterCaCertKey, clusterCaCertData), is(x509Certificate(oldClusterCaCert)));
-                assertThat(x509Certificate(newClusterCaCert).getSubjectX500Principal().getName(), is("CN=cluster-ca v1,O=io.strimzi"));
-
-                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertKeyDataNotNull(clusterCaKeyData);
-                assertThat(clusterCaKeyData.get(CA_KEY), is(not(initialClusterCaKeySecret.getData().get(CA_KEY))));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertThat(clientsCaCertData, aMapWithSize(4));
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                String oldClientsCaCertKey = clientsCaCertData.keySet()
-                        .stream()
-                        .filter(alias -> alias.startsWith("ca-"))
-                        .findAny()
-                        .orElseThrow();
-                String oldClientsCaCert = clientsCaCertData.get(oldClientsCaCertKey);
-
-                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-
-                assertThat(oldClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(getCertificateFromTrustStore(oldClientsCaCertKey, clientsCaCertData), is(x509Certificate(oldClientsCaCert)));
-                assertThat(x509Certificate(newClientsCaCert).getSubjectX500Principal().getName(), is("CN=clients-ca v1,O=io.strimzi"));
-
-                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertKeyDataNotNull(clientsCaKeyData);
-                assertThat(clientsCaKeyData.get(CA_KEY), is(not(initialClientsCaKeySecret.getData().get(CA_KEY))));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testNewKeyGeneratedWhenInRenewalPeriodAutoOutsideOfTimeWindow(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(true)
-                .withCertificateExpirationPolicy(CertificateExpirationPolicy.REPLACE_KEY)
-                .build();
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClusterCa(certificateAuthority)
-                    .withClientsCa(certificateAuthority)
-                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
-                .endSpec()
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
-                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "0"));
-                assertThat(clusterCaCertData, aMapWithSize(3));
-
-                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
-                assertThat(newClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
-                assertThat(x509Certificate(newClusterCaCert).getSubjectX500Principal().getName(), is("CN=cluster-ca,O=io.strimzi"));
-
-                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertThat(clusterCaKeyData, aMapWithSize(1));
-                assertThat(clusterCaKeyData, hasEntry(CA_KEY, initialClusterCaKeySecret.getData().get(CA_KEY)));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "0"));
-                assertThat(clientsCaCertData, aMapWithSize(3));
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                assertThat(newClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-                assertThat(x509Certificate(newClientsCaCert).getSubjectX500Principal().getName(), is("CN=clients-ca,O=io.strimzi"));
-
-                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "0"));
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertThat(clientsCaKeyData, aMapWithSize(1));
-                assertThat(clientsCaKeyData, hasEntry(CA_KEY, initialClientsCaKeySecret.getData().get(CA_KEY)));
-
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testNewKeyGeneratedWhenInRenewalPeriodAutoWithinTimeWindow(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(true)
-                .withCertificateExpirationPolicy(CertificateExpirationPolicy.REPLACE_KEY)
-                .build();
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClusterCa(certificateAuthority)
-                    .withClientsCa(certificateAuthority)
-                    .withMaintenanceTimeWindows("* 10-14 * * * ? *")
-                .endSpec()
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:12:00Z"), Clock.systemUTC().getZone()))
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
-                assertThat(captorSecrets.clusterCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
-                assertThat(clusterCaCertData, aMapWithSize(4));
-
-                String newClusterCaCert = clusterCaCertData.get(CA_CRT);
-                String oldClusterCaCertKey = clusterCaCertData.keySet()
-                        .stream()
-                        .filter(alias -> alias.startsWith("ca-"))
-                        .findAny()
-                        .orElseThrow();
-                String oldClusterCaCert = clusterCaCertData.get(oldClusterCaCertKey);
-
-                assertThat(newClusterCaCert, is(not(initialClusterCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(newClusterCaCert)));
-
-                assertThat(oldClusterCaCert, is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(getCertificateFromTrustStore(oldClusterCaCertKey, clusterCaCertData), is(x509Certificate(oldClusterCaCert)));
-                assertThat(x509Certificate(newClusterCaCert).getSubjectX500Principal().getName(), is("CN=cluster-ca v1,O=io.strimzi"));
-
-                assertThat(captorSecrets.clusterCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
-                Map<String, String> clusterCaKeyData = captorSecrets.clusterCaKey().getData();
-                assertKeyDataNotNull(clusterCaKeyData);
-                assertThat(clusterCaKeyData.get(CA_KEY), is(not(initialClusterCaKeySecret.getData().get(CA_KEY))));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertThat(captorSecrets.clientsCaCert().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
-                assertThat(clientsCaCertData, aMapWithSize(4));
-
-                String newClientsCaCert = clientsCaCertData.get(CA_CRT);
-                String oldClientsCaCertKey = clientsCaCertData.keySet()
-                        .stream()
-                        .filter(alias -> alias.startsWith("ca-"))
-                        .findAny()
-                        .orElseThrow();
-                String oldClientsCaCert = clientsCaCertData.get(oldClientsCaCertKey);
-
-                assertThat(newClientsCaCert, is(not(initialClientsCaCertSecret.getData().get(CA_CRT))));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(newClientsCaCert)));
-
-                assertThat(oldClientsCaCert, is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(getCertificateFromTrustStore(oldClientsCaCertKey, clientsCaCertData), is(x509Certificate(oldClientsCaCert)));
-                assertThat(x509Certificate(newClientsCaCert).getSubjectX500Principal().getName(), is("CN=clients-ca v1,O=io.strimzi"));
-
-                assertThat(captorSecrets.clientsCaKey().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
-                Map<String, String> clientsCaKeyData = captorSecrets.clientsCaKey().getData();
-                assertKeyDataNotNull(clientsCaKeyData);
-                assertThat(clientsCaKeyData.get(CA_KEY), is(not(initialClientsCaKeySecret.getData().get(CA_KEY))));
-
-                async.flag();
-            })));
-    }
-
-    private X509Certificate x509Certificate(String newClusterCaCert) throws CertificateException {
-        return (X509Certificate) CertificateFactory.getInstance("X.509")
-                .generateCertificate(new ByteArrayInputStream(Util.decodeBytesFromBase64(newClusterCaCert)));
-    }
-
-    @Test
-    public void testExpiredCertsGetRemovedAuto(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
-                .withGenerateCertificateAuthority(true)
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        // add an expired certificate to the secret ...
-        String clusterCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "cluster-ca.crt"));
-        String encodedClusterCert = Base64.getEncoder().encodeToString(clusterCert.getBytes(StandardCharsets.UTF_8));
-        initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClusterCert);
-
-        assertThat(initialClusterCaKeySecret.getData().keySet(), is(singleton(CA_KEY)));
-        assertThat(initialClusterCaKeySecret.getData().get(CA_KEY), is(notNullValue()));
-        // ... and to the related truststore
-        Path certFile = Files.createTempFile("tls", "-cert");
-        certFile.toFile().deleteOnExit();
-        Path trustStoreFile = Files.createTempFile("tls", "-truststore");
-        trustStoreFile.toFile().deleteOnExit();
-        Files.write(certFile, Util.decodeBytesFromBase64(initialClusterCaCertSecret.getData().get("ca-2018-07-01T09-00-00.crt")));
-        Files.write(trustStoreFile, Util.decodeBytesFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE)));
-        String trustStorePassword = Util.decodeFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD));
-        CERT_MANAGER.addCertToTrustStore(certFile.toFile(), "ca-2018-07-01T09-00-00.crt", trustStoreFile.toFile(), trustStorePassword);
-        initialClusterCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
-        assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", initialClusterCaCertSecret.getData()), is(true));
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        // add an expired certificate to the secret ...
-        String clientCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "clients-ca.crt"));
-        String encodedClientCert = Base64.getEncoder().encodeToString(clientCert.getBytes(StandardCharsets.UTF_8));
-        initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClientCert);
-
-        assertThat(initialClientsCaKeySecret.getData().keySet(), is(singleton(CA_KEY)));
-        assertThat(initialClientsCaKeySecret.getData().get(CA_KEY), is(notNullValue()));
-
-        // ... and to the related truststore
-        certFile = Files.createTempFile("tls", "-cert");
-        certFile.toFile().deleteOnExit();
-        Files.write(certFile, Util.decodeBytesFromBase64(initialClientsCaCertSecret.getData().get("ca-2018-07-01T09-00-00.crt")));
-        trustStoreFile = Files.createTempFile("tls", "-truststore");
-        trustStoreFile.toFile().deleteOnExit();
-        Files.write(trustStoreFile, Util.decodeBytesFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE)));
-        trustStorePassword = Util.decodeFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD));
-        CERT_MANAGER.addCertToTrustStore(certFile.toFile(), "ca-2018-07-01T09-00-00.crt", trustStoreFile.toFile(), trustStorePassword);
-        initialClientsCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
-        assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", initialClientsCaCertSecret.getData()), is(true));
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
-                assertCaptorSecretsNotNull(captorSecrets);
-
-                Map<String, String> clusterCaCertData = captorSecrets.clusterCaCert().getData();
-                assertThat(clusterCaCertData, aMapWithSize(3));
-                assertThat(clusterCaCertData.get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-                assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(clusterCaCertData.get(CA_CRT))));
-                assertThat(captorSecrets.clusterCaKey().getData().get(CA_KEY), is(initialClusterCaKeySecret.getData().get(CA_KEY)));
-                assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", clusterCaCertData), is(false));
-
-                Map<String, String> clientsCaCertData = captorSecrets.clientsCaCert().getData();
-                assertThat(clientsCaCertData, aMapWithSize(3));
-                assertThat(clientsCaCertData.get(CA_CRT), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(clientsCaCertData.get(CA_CRT))));
-                assertThat(captorSecrets.clientsCaKey().getData().get(CA_KEY), is(initialClientsCaKeySecret.getData().get(CA_KEY)));
-                assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", clientsCaCertData), is(false));
-                async.flag();
-            })));
-    }
-
     @Test
     public void testOldClusterCaCertsGetsRemovedAuto(Vertx vertx, VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
@@ -1072,7 +215,13 @@ public class CaReconcilerTest {
         String trustStorePassword = Util.decodeFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD));
         CERT_MANAGER.addCertToTrustStore(certFile.toFile(), oldCertAlias, trustStoreFile.toFile(), trustStorePassword);
         initialClusterCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
-        assertThat(isCertInTrustStore(oldCertAlias, initialClusterCaCertSecret.getData()), is(true));
+
+        // Check it was added correctly
+        KeyStore initialClusterCaTrustStore = KeyStore.getInstance("PKCS12");
+        initialClusterCaTrustStore.load(new ByteArrayInputStream(Util.decodeBytesFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE))),
+                Util.decodeFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)).toCharArray()
+        );
+        assertThat(initialClusterCaTrustStore.isCertificateEntry(oldCertAlias), is(true));
 
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
@@ -1092,7 +241,13 @@ public class CaReconcilerTest {
         trustStorePassword = Util.decodeFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD));
         CERT_MANAGER.addCertToTrustStore(certFile.toFile(), oldCertAlias, trustStoreFile.toFile(), trustStorePassword);
         initialClientsCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
-        assertThat(isCertInTrustStore(oldCertAlias, initialClientsCaCertSecret.getData()), is(true));
+
+        // Check it was added correctly
+        KeyStore initialClientsCaTrustStore = KeyStore.getInstance("PKCS12");
+        initialClientsCaTrustStore.load(new ByteArrayInputStream(Util.decodeBytesFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE))),
+                Util.decodeFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)).toCharArray()
+        );
+        assertThat(initialClientsCaTrustStore.isCertificateEntry(oldCertAlias), is(true));
 
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
@@ -1108,8 +263,7 @@ public class CaReconcilerTest {
                 List.of(brokerPod));
 
         Checkpoint async = context.checkpoint();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1125,8 +279,15 @@ public class CaReconcilerTest {
                     assertThat(clusterCaCertData, aMapWithSize(3));
                     assertThat(clusterCaCertData.get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
                     assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)));
-                    assertThat(getCertificateFromTrustStore(CA_CRT, clusterCaCertData), is(x509Certificate(clusterCaCertData.get(CA_CRT))));
-                    assertThat(isCertInTrustStore(oldCertAlias, clusterCaCertData), is(false));
+
+                    X509Certificate x509clusterCaCert = (X509Certificate) CertificateFactory.getInstance("X.509")
+                            .generateCertificate(new ByteArrayInputStream(Util.decodeBytesFromBase64(clusterCaCertData.get(CA_CRT))));
+                    KeyStore clusterCaTrustStore = KeyStore.getInstance("PKCS12");
+                    clusterCaTrustStore.load(new ByteArrayInputStream(Util.decodeBytesFromBase64(clusterCaCertData.get(CA_STORE))),
+                            Util.decodeFromBase64(clusterCaCertData.get(CA_STORE_PASSWORD)).toCharArray()
+                    );
+                    assertThat((X509Certificate) clusterCaTrustStore.getCertificate(CA_CRT), is(x509clusterCaCert));
+                    assertThat(clusterCaTrustStore.isCertificateEntry(oldCertAlias), is(false));
 
                     // Clients CA cert doesn't have old CA certs removed automatically
                     Map<String, String> clientsCaCertData = clientsCaCert.getValue().getData();
@@ -1134,220 +295,21 @@ public class CaReconcilerTest {
                     assertThat(clientsCaCertData.get(CA_CRT), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
                     assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)));
                     assertThat(clientsCaCertData.get(oldCertAlias), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-                    assertThat(getCertificateFromTrustStore(CA_CRT, clientsCaCertData), is(x509Certificate(clientsCaCertData.get(CA_CRT))));
-                    assertThat(isCertInTrustStore(oldCertAlias, clientsCaCertData), is(true));
+
+                    X509Certificate x509clientsCaCert = (X509Certificate) CertificateFactory.getInstance("X.509")
+                            .generateCertificate(new ByteArrayInputStream(Util.decodeBytesFromBase64(clientsCaCertData.get(CA_CRT))));
+                    KeyStore clientsCaTrustStore = KeyStore.getInstance("PKCS12");
+                    clientsCaTrustStore.load(new ByteArrayInputStream(Util.decodeBytesFromBase64(clientsCaCertData.get(CA_STORE))),
+                            Util.decodeFromBase64(clientsCaCertData.get(CA_STORE_PASSWORD)).toCharArray()
+                    );
+                    assertThat((X509Certificate) clientsCaTrustStore.getCertificate(CA_CRT), is(x509clientsCaCert));
+                    assertThat(clientsCaTrustStore.isCertificateEntry(oldCertAlias), is(true));
                     async.flag();
                 })));
     }
-
-    @Test
-    public void testCustomCertsNotReconciled(Vertx vertx, VertxTestContext context)
-            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(false)
-                .build();
-
-        List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
-        Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
-        Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClusterCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClusterCaKeySecret.getData());
-
-        List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
-        Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
-        Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-
-        assertCertDataNotNull(initialClientsCaCertSecret.getData());
-        assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
-        assertKeyDataNotNull(initialClientsCaKeySecret.getData());
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        Checkpoint async = context.checkpoint();
-        reconcileCa(vertx, certificateAuthority, certificateAuthority)
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), any(Secret.class));
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), any(Secret.class));
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), any(Secret.class));
-                verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), any(Secret.class));
-                async.flag();
-            })));
-    }
-
-    @Test
-    public void testCustomLabelsAndAnnotations(Vertx vertx, VertxTestContext context) {
-        Map<String, String> labels = new HashMap<>(2);
-        labels.put("label1", "value1");
-        labels.put("label2", "value2");
-
-        Map<String, String> annos = new HashMap<>(2);
-        annos.put("anno1", "value3");
-        annos.put("anno2", "value4");
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editKafka()
-                        .withNewTemplate()
-                            .withNewClusterCaCert()
-                                .withNewMetadata()
-                                    .withAnnotations(annos)
-                                    .withLabels(labels)
-                                .endMetadata()
-                            .endClusterCaCert()
-                        .endTemplate()
-                    .endKafka()
-                .endSpec()
-                .build();
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        SecretOperator secretOps = supplier.secretOperations;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
-        Checkpoint async = context.checkpoint();
-
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
-                    assertCaptorSecretsNotNull(captorSecrets);
-
-                    Secret clusterCaCertSecret = captorSecrets.clusterCaCert();
-                    Secret clusterCaKeySecret = captorSecrets.clusterCaKey();
-                    Secret clientsCaCertSecret = captorSecrets.clientsCaCert();
-                    Secret clientsCaKeySecret = captorSecrets.clientsCaKey();
-
-                    for (Map.Entry<String, String> entry : annos.entrySet()) {
-                        assertThat(clusterCaCertSecret.getMetadata().getAnnotations(), hasEntry(entry.getKey(), entry.getValue()));
-                        assertThat(clusterCaKeySecret.getMetadata().getAnnotations(), not(hasEntry(entry.getKey(), entry.getValue())));
-                        assertThat(clientsCaCertSecret.getMetadata().getAnnotations(), not(hasEntry(entry.getKey(), entry.getValue())));
-                        assertThat(clientsCaKeySecret.getMetadata().getAnnotations(), not(hasEntry(entry.getKey(), entry.getValue())));
-                    }
-
-                    for (Map.Entry<String, String> entry : labels.entrySet()) {
-                        assertThat(clusterCaCertSecret.getMetadata().getLabels(), hasEntry(entry.getKey(), entry.getValue()));
-                        assertThat(clusterCaKeySecret.getMetadata().getLabels(), not(hasEntry(entry.getKey(), entry.getValue())));
-                        assertThat(clientsCaCertSecret.getMetadata().getLabels(), not(hasEntry(entry.getKey(), entry.getValue())));
-                        assertThat(clientsCaKeySecret.getMetadata().getLabels(), not(hasEntry(entry.getKey(), entry.getValue())));
-                    }
-
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testClusterCASecretsWithoutOwnerReference(Vertx vertx, VertxTestContext context) {
-        CertificateAuthority caConfig = new CertificateAuthority();
-        caConfig.setGenerateSecretOwnerReference(false);
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClusterCa(caConfig)
-                .endSpec()
-                .build();
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        SecretOperator secretOps = supplier.secretOperations;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
-        Checkpoint async = context.checkpoint();
-
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
-                    assertCaptorSecretsNotNull(captorSecrets);
-
-                    Secret clusterCaCertSecret = captorSecrets.clusterCaCert();
-                    Secret clusterCaKeySecret = captorSecrets.clusterCaKey();
-                    Secret clientsCaCertSecret = captorSecrets.clientsCaCert();
-                    Secret clientsCaKeySecret = captorSecrets.clientsCaKey();
-
-                    assertThat(clusterCaCertSecret.getMetadata().getOwnerReferences(), hasSize(0));
-                    assertThat(clusterCaKeySecret.getMetadata().getOwnerReferences(), hasSize(0));
-                    assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences(), hasSize(1));
-                    assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences(), hasSize(1));
-
-                    TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
-                    TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
-
-                    async.flag();
-                })));
-    }
-
-    @Test
-    public void testClientsCASecretsWithoutOwnerReference(Vertx vertx, VertxTestContext context) {
-        CertificateAuthority caConfig = new CertificateAuthority();
-        caConfig.setGenerateSecretOwnerReference(false);
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withClientsCa(caConfig)
-                .endSpec()
-                .build();
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        SecretOperator secretOps = supplier.secretOperations;
-        PodOperator podOps = supplier.podOperations;
-
-        when(secretOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
-        Checkpoint async = context.checkpoint();
-
-        new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(secretOps);
-
-                    assertThat(captorSecrets.clusterCaCert().getMetadata().getOwnerReferences(), hasSize(1));
-                    assertThat(captorSecrets.clusterCaKey().getMetadata().getOwnerReferences(), hasSize(1));
-                    assertThat(captorSecrets.clientsCaCert().getMetadata().getOwnerReferences(), hasSize(0));
-                    assertThat(captorSecrets.clientsCaKey().getMetadata().getOwnerReferences(), hasSize(0));
-
-                    TestUtils.checkOwnerReference(captorSecrets.clusterCaCert(), kafka);
-                    TestUtils.checkOwnerReference(captorSecrets.clusterCaKey(), kafka);
-
-                    async.flag();
-                })));
-    }
-
-    //////////
-    // Tests for trust rollout
-    //////////
 
     @Test
     public void testStrimziManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1402,8 +364,7 @@ public class CaReconcilerTest {
             return Future.succeededFuture();
         });
 
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1422,9 +383,6 @@ public class CaReconcilerTest {
     // Strimzi Cluster CA key replaced in previous reconcile and some pods already rolled
     @Test
     public void testStrimziManagedClusterCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1489,8 +447,7 @@ public class CaReconcilerTest {
             return Future.succeededFuture();
         });
 
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1512,9 +469,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testStrimziManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1550,8 +504,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1563,9 +516,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testUserManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1633,8 +583,7 @@ public class CaReconcilerTest {
                     .endClusterCa()
                 .endSpec()
                 .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1652,9 +601,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testUserManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1698,8 +644,7 @@ public class CaReconcilerTest {
                     .endClusterCa()
                 .endSpec()
                 .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1711,9 +656,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testStrimziManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1749,8 +691,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1764,9 +705,6 @@ public class CaReconcilerTest {
     // Strimzi Clients CA key replaced in previous reconcile and some pods already rolled
     @Test
     public void testStrimziManagedClientsCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1807,8 +745,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1821,9 +758,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testStrimziManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1859,8 +793,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1872,9 +805,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testUserManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1923,8 +853,7 @@ public class CaReconcilerTest {
                     .endClientsCa()
                 .endSpec()
                 .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -1937,9 +866,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testUserManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -1983,8 +909,7 @@ public class CaReconcilerTest {
                     .endClientsCa()
                 .endSpec()
                 .build();
-        NewMockCaReconciler mockCaReconciler = new NewMockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -2037,12 +962,19 @@ public class CaReconcilerTest {
         when(depsOperator.getAsync(any(), any())).thenAnswer(i -> Future.succeededFuture(deps.get(i.getArgument(1, String.class))));
     }
 
-    static class NewMockCaReconciler extends CaReconciler {
+    static class MockCaReconciler extends CaReconciler {
         Map<String, RestartReasons> kafkaRestartReasons = new HashMap<>();
         Map<String, String> deploymentRestartReasons = new HashMap<>();
 
-        public NewMockCaReconciler(Reconciliation reconciliation, Kafka kafkaCr, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, Vertx vertx, CertManager certManager, PasswordGenerator passwordGenerator) {
-            super(reconciliation, kafkaCr, config, supplier, vertx, certManager, passwordGenerator);
+        public MockCaReconciler(Kafka kafkaCr, ResourceOperatorSupplier supplier, Vertx vertx) {
+            super(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME),
+                    kafkaCr,
+                    new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                    supplier,
+                    vertx,
+                    CERT_MANAGER,
+                    PASSWORD_GENERATOR
+            );
         }
 
         @Override
@@ -2097,11 +1029,4 @@ public class CaReconcilerTest {
                 .withGenerateCertificateAuthority(true)
                 .build();
     }
-
-    private record CaptorSecrets(
-            Secret clusterCaCert,
-            Secret clusterCaKey,
-            Secret clientsCaCert,
-            Secret clientsCaKey
-    ) { }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

#### Motivation

In main today the CaReconcilerTest has two distinct ways the tests are run:
1. Tests that call a `CaReconcilerTest.reconcileCa` method which sets up lots of Mockito mocks and then creates an actual CaReconciler instance and calls `reconcile` on it
2. Tests that call `CaReconcilerTest.initTrustRolloutTestMocks` which sets up different Mockito mocks and then create a MockCaReconciler instance to call `reconcile` on

The reason for the separation is that tests of type 1 are actually only concerned about the behaviour of reconciling the CA secrets (so `CaReconciler.reconcileCas` method), and do not care about rolling updates or any other changes later in the reconciliation.

Tests of type 2 are focused on checking that Kafka pods are rolled correctly, or other updates occur, such as removing old Ca certificates from the cluster CA.

This means when adding new tests (for example in future when adding tests for Cert Manager integration) it's difficult to understand the best approach without first reviewing every single test and understanding the two distinct ways that the tests work. The class is also very long so it's hard to get an overview of the test cases and find specific test cases.

#### Changes

To simplify the test classes for developers I have separated the tests into two distinct classes:
- CaReconcilerReconcileCasTest to test the reconcileCas method in CaReconciler in isolation
- CaReconcilerTest to test all steps in CaReconciler, particularly the rolling updates for trust

I have then gone through each class and made some further simplifications, for example asserting that secrets were created correctly in the method used to create them, rather than in each test method. In CaReconcilerReconcileCasTest the tests now also call `CaReconciler.reconcileCas` directly, rather than the `CaReconciler.reconcile` method, which allowed me to remove additional Mockito calls that weren't relevant to the tests.

I created the PR with two commits, one to just duplicate CaReconciler, and the second to take out the tests that are in the other test class and simplify the remaining tests. Hopefully this helps with reviews as in the second commit it's easier to see what changed

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

