### PR TITLE
Clean-up the `Util` class in `operator-common`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -22,7 +22,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.TimeoutException;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.metrics.MetricsHolder;
 import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
 import io.strimzi.operator.common.model.InvalidConfigParameterException;
@@ -213,7 +212,7 @@ public abstract class AbstractOperator<
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();
 
-        if (!Util.matchesSelector(selector(), cr))  {
+        if (!ReconcilerUtils.matchesSelector(selector(), cr))  {
             // When the labels matching the selector are removed from the custom resource, a DELETE event is
             // triggered by the watch even through the custom resource might not match the watch labels anymore
             // and might not be really deleted. We have to filter these situations out and ignore the
@@ -608,7 +607,7 @@ public abstract class AbstractOperator<
         }
 
         return resourceOperator.getAsync(reconciliation.namespace(), reconciliation.name()).map(cr -> {
-            if (cr != null && Util.matchesSelector(selector(), cr)) {
+            if (cr != null && ReconcilerUtils.matchesSelector(selector(), cr)) {
                 resourcesStateCounter.computeIfAbsent(key, tags ->
                         metrics().metricsProvider().gauge(MetricsHolder.METRICS_RESOURCE_STATE, "Current state of the resource: 1 ready, 0 fail", metricTags)
                 );

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -40,7 +40,6 @@ import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.config.ConfigParameter;
 import io.strimzi.operator.common.model.ClientsCa;
 import io.strimzi.operator.common.model.Labels;
@@ -774,7 +773,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             Kafka kafka = kafkaOperator.get(resource.getMetadata().getNamespace(), kafkaName);
 
             if (kafka != null
-                    && Util.matchesSelector(selector(), kafka)) {
+                    && ReconcilerUtils.matchesSelector(selector(), kafka)) {
                 Reconciliation reconciliation = new Reconciliation("watch", kind(), kafka.getMetadata().getNamespace(), kafkaName);
                 LOGGER.infoCr(reconciliation, "{} {} in namespace {} was {}", resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace(), action);
                 enqueueReconciliation(reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -13,10 +13,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
+import io.strimzi.operator.cluster.model.logging.LoggingUtils;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.vertx.core.json.JsonObject;
 
@@ -62,7 +62,6 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public CompletableFuture<Map<String, Object>> createOrUpdatePutRequest(
             Reconciliation reconciliation,
             String host, int port,
@@ -434,7 +433,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
             }
             return k1.compareTo(k2);
         });
-        Map<String, String> desiredMap = new OrderedProperties().addStringPairs(Util.expandVars(desiredLogging)).asMap();
+        Map<String, String> desiredMap = new OrderedProperties().addStringPairs(LoggingUtils.expandVars(desiredLogging)).asMap();
 
         updateLoggers.putAll(fetchedLoggers.keySet().stream().collect(Collectors.toMap(
             Function.identity(),
@@ -478,15 +477,15 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         }
 
         //nothing found, use root level
-        return getLoggerLevelFromAppenderCouple(Util.expandVar(desired.get("log4j.rootLogger"), desired));
+        return getLoggerLevelFromAppenderCouple(LoggingUtils.expandVar(desired.get("log4j.rootLogger"), desired));
     }
 
     private void addToLoggers(Map<String, String> entries, Map<String, String> updateLoggers) {
         for (Map.Entry<String, String> e : entries.entrySet()) { // set desired loggers to desired levels
             if (e.getKey().equals("log4j.rootLogger")) {
-                updateLoggers.put("root", getLoggerLevelFromAppenderCouple(Util.expandVar(e.getValue(), entries)));
+                updateLoggers.put("root", getLoggerLevelFromAppenderCouple(LoggingUtils.expandVar(e.getValue(), entries)));
             } else if (e.getKey().startsWith("log4j.logger.")) {
-                updateLoggers.put(e.getKey().substring("log4j.logger.".length()), getLoggerLevelFromAppenderCouple(Util.expandVar(e.getValue(), entries)));
+                updateLoggers.put(e.getKey().substring("log4j.logger.".length()), getLoggerLevelFromAppenderCouple(LoggingUtils.expandVar(e.getValue(), entries)));
             }
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -191,7 +191,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                         if (useConnectorResources) {
                             // When connector resources are used, we do dynamic configuration update, and we need the hash to
                             // contain only settings that cannot be updated dynamically
-                            podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                            podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(ReconcilerUtils.getLoggingDynamicallyUnmodifiableEntries(logging)));
                         } else {
                             // When connector resources are not used, we do not do dynamic logging updates, and we need the
                             // hash to cover complete logging configuration
@@ -528,7 +528,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                                     // (i.e. short circuit doing a whole KafkaConnect reconciliation).
                                     Reconciliation reconciliation = new Reconciliation("connector-watch", kind(), resource.getMetadata().getNamespace(), connectName);
 
-                                    if (!Util.matchesSelector(selector(), connect)) {
+                                    if (!ReconcilerUtils.matchesSelector(selector(), connect)) {
                                         LOGGER.debugCr(reconciliation, "{} {} in namespace {} was {}, but Connect cluster {} does not match label selector {} and will be ignored", connectorKind, connectorName, namespace, action, connectName, selector());
                                         return Future.succeededFuture();
                                     } else if (connect.getSpec() != null && connect.getSpec().getReplicas() == 0 && !Annotations.isReconciliationPausedWithAnnotation(resource)) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -134,7 +134,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
 
                     if (!mirrorMaker2Cluster.logging().isLog4j2()) {
                         // Logging annotation is set only for Log4j1
-                        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(ReconcilerUtils.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     }
 
                     desiredLogging.set(logging);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -54,7 +54,6 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.StatusUtils;
@@ -1152,7 +1151,7 @@ public class KafkaRebalanceAssemblyOperator
                                 new NoSuchResourceException("Kafka resource '" + clusterName
                                         + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL
                                         + "' does not exist in namespace " + clusterNamespace + ".")));
-                    } else if (!Util.matchesSelector(kafkaSelector, kafka)) {
+                    } else if (!ReconcilerUtils.matchesSelector(kafkaSelector, kafka)) {
                         LOGGER.debugCr(reconciliation, "{} {} in namespace {} belongs to a Kafka cluster {} which does not match label selector {} and will be ignored", kind(), kafkaRebalance.getMetadata().getName(), clusterNamespace, clusterName, kafkaSelector.getMatchLabels());
                         return Future.succeededFuture(null);
                     } else if (!isKafkaClusterReady(kafka) && KafkaRebalanceUtils.rebalanceState(kafkaRebalance.getStatus()) != KafkaRebalanceState.Ready) {
@@ -1194,12 +1193,12 @@ public class KafkaRebalanceAssemblyOperator
                             .compose(compositeFuture -> {
                                 Secret ccSecret = compositeFuture.resultAt(1);
                                 if (ccSecret == null) {
-                                    return Future.failedFuture(Util.missingSecretException(clusterNamespace, ccSecretName));
+                                    return Future.failedFuture(ReconcilerUtils.missingSecretException(clusterNamespace, ccSecretName));
                                 }
 
                                 Secret ccApiSecret = compositeFuture.resultAt(2);
                                 if (ccApiSecret == null) {
-                                    return Future.failedFuture(Util.missingSecretException(clusterNamespace, ccApiSecretName));
+                                    return Future.failedFuture(ReconcilerUtils.missingSecretException(clusterNamespace, ccApiSecretName));
                                 }
 
                                 CruiseControlConfiguration ccConfig = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet(), Map.of());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -699,7 +699,7 @@ public class KafkaReconciler {
                             // For controllers only, we use the full logging configuration in the logging annotation
                             this.brokerLoggingHash.put(nodeId, Util.hashStub(logging));
                         } else {
-                            this.brokerLoggingHash.put(nodeId, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                            this.brokerLoggingHash.put(nodeId, Util.hashStub(ReconcilerUtils.getLoggingDynamicallyUnmodifiableEntries(logging)));
                         }
 
                         // We store hash of the broker configurations for later use in Pod and in rolling updates

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -37,7 +37,6 @@ import io.strimzi.operator.common.InformerUtils;
 import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.metrics.ControllerMetricsHolder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.StatusDiff;
@@ -233,7 +232,7 @@ public class StrimziPodSetController implements Runnable {
                 .list(pod.getMetadata().getNamespace())
                 .stream()
                 .filter(podSet -> podSet.getSpec() != null
-                        && Util.matchesSelector(podSet.getSpec().getSelector(), pod))
+                        && ReconcilerUtils.matchesSelector(podSet.getSpec().getSelector(), pod))
                 .findFirst().orElse(null);
     }
 
@@ -281,7 +280,7 @@ public class StrimziPodSetController implements Runnable {
             HasMetadata cr = findCustomResource(podSet);
 
             if (cr != null
-                    && Util.matchesSelector(crSelector, cr)) {
+                    && ReconcilerUtils.matchesSelector(crSelector, cr)) {
                 return true;
             } else {
                 LOGGER.debugOp("StrimziPodSet {} in namespace {} does not belong to a custom resource matching the selector", podSet.getMetadata().getName(), podSet.getMetadata().getNamespace());
@@ -486,7 +485,7 @@ public class StrimziPodSetController implements Runnable {
         Set<String> toBeDeleted = podInformer
                 .list(reconciliation.namespace())
                 .stream()
-                .filter(pod -> Util.matchesSelector(selector, pod))
+                .filter(pod -> ReconcilerUtils.matchesSelector(selector, pod))
                 .map(pod -> pod.getMetadata().getName())
                 .collect(Collectors.toSet());
         toBeDeleted.removeAll(desiredPodNames);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -5,9 +5,9 @@
 
 package io.strimzi.operator.cluster.operator.resource;
 
+import io.strimzi.operator.cluster.model.logging.LoggingUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.AbstractJsonDiff;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
@@ -159,12 +159,12 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
                     String name = line.substring(startIdx, endIdx).trim();
                     String value = line.substring(endIdx + 1).split(",")[0].trim();
 
-                    value = Util.expandVar(value, env);
+                    value = LoggingUtils.expandVar(value, env);
                     parsed.put(name, value);
 
                 } else if (line.startsWith("log4j.rootLogger=")) {
                     int startIdx = "log4j.rootLogger=".length();
-                    parsed.put("root", Util.expandVar(line.substring(startIdx).split(",")[0].trim(), env));
+                    parsed.put("root", LoggingUtils.expandVar(line.substring(startIdx).split(",")[0].trim(), env));
 
                 } else {
                     LOGGER.debugCr(reconciliation, "Skipping log4j line: {}", line);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -132,7 +132,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
     protected static HTTPHeader getAuthHttpHeader(boolean apiAuthEnabled, Secret apiSecret) {
         if (apiAuthEnabled) {
-            String password = Util.asciiFieldFromSecret(apiSecret, CruiseControlApiProperties.REBALANCE_OPERATOR_PASSWORD_KEY);
+            String password = Util.fromAsciiBytes(Util.decodeBase64FieldFromSecret(apiSecret, CruiseControlApiProperties.REBALANCE_OPERATOR_PASSWORD_KEY));
             return generateAuthHttpHeader(CruiseControlApiProperties.REBALANCE_OPERATOR_USERNAME, password);
         } else {
             return null;
@@ -437,7 +437,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public CompletableFuture<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port) {
         String path = new PathBuilder(CruiseControlEndpoints.STOP)
                         .withParameter(CruiseControlParameters.JSON, "true").build();

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -4,20 +4,11 @@
  */
 package io.strimzi.operator.common;
 
-import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.strimzi.operator.common.model.InvalidResourceException;
-import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import static io.strimzi.operator.common.Util.matchesSelector;
 import static io.strimzi.operator.common.Util.parseMap;
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
@@ -92,101 +83,5 @@ public class UtilTest {
         assertThat(Util.maskPassword(noPassword, "123456"), is("123456"));
         assertThat(Util.maskPassword(passwordAtTheEnd, "123456"), is("********"));
         assertThat(Util.maskPassword(passwordInTheMiddle, "123456"), is("********"));
-    }
-
-    @Test
-    public void testMergeLabelsOrAnnotations()  {
-        Map<String, String> base = new HashMap<>();
-        base.put("label1", "value1");
-        base.put(Labels.STRIMZI_DOMAIN + "label2", "value2");
-
-        Map<String, String> overrides1 = new HashMap<>();
-        overrides1.put("override1", "value1");
-        overrides1.put(Labels.KUBERNETES_DOMAIN + "override2", "value2");
-
-        Map<String, String> overrides2 = new HashMap<>();
-        overrides2.put("override3", "value3");
-
-        Map<String, String> forbiddenOverrides = new HashMap<>();
-        forbiddenOverrides.put(Labels.STRIMZI_DOMAIN + "override4", "value4");
-
-        Map<String, String> expected = new HashMap<>();
-        expected.put("label1", "value1");
-        expected.put(Labels.STRIMZI_DOMAIN + "label2", "value2");
-        expected.put("override1", "value1");
-        expected.put("override3", "value3");
-
-        assertThat(Util.mergeLabelsOrAnnotations(base, overrides1, overrides2), is(expected));
-        assertThat(Util.mergeLabelsOrAnnotations(base, overrides1, null, overrides2), is(expected));
-        assertThat(Util.mergeLabelsOrAnnotations(base, (Map<String, String>) null), is(base));
-        assertThat(Util.mergeLabelsOrAnnotations(base, (Map<String, String>[]) null), is(base));
-        assertThat(Util.mergeLabelsOrAnnotations(base), is(base));
-        assertThat(Util.mergeLabelsOrAnnotations(null, overrides2), is(overrides2));
-        assertThrows(InvalidResourceException.class, () -> Util.mergeLabelsOrAnnotations(base, forbiddenOverrides));
-    }
-
-    @Test
-    public void testVarExpansion() {
-        String input = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-                "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n\n" +
-                "connect.root.logger.level=INFO\n" +
-                "log4j.rootLogger=${connect.root.logger.level}, CONSOLE\n" +
-                "log4j.logger.org.reflections=ERROR";
-
-        String expectedOutput = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-                "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-                "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n\n" +
-                "connect.root.logger.level=INFO\n" +
-                "log4j.rootLogger=INFO, CONSOLE\n" +
-                "log4j.logger.org.reflections=ERROR\n";
-
-        String result = Util.expandVars(input);
-        assertThat(result, is(expectedOutput));
-    }
-
-    @Test
-    public void testMatchesSelector()   {
-        Pod testResource = new PodBuilder()
-                .withNewMetadata()
-                    .withName("test-pod")
-                .endMetadata()
-                .withNewSpec()
-                .endSpec()
-                .build();
-
-        // Resources without any labels
-        LabelSelector selector = null;
-        assertThat(matchesSelector(selector, testResource), is(true));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(emptyMap()).build();
-        assertThat(matchesSelector(selector, testResource), is(true));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2")).build();
-        assertThat(matchesSelector(selector, testResource), is(false));
-
-        // Resources with Labels
-        testResource.getMetadata().setLabels(Map.of("label1", "value1", "label2", "value2"));
-
-        selector = null;
-        assertThat(matchesSelector(selector, testResource), is(true));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(emptyMap()).build();
-        assertThat(matchesSelector(selector, testResource), is(true));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2")).build();
-        assertThat(matchesSelector(selector, testResource), is(true));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1")).build();
-        assertThat(matchesSelector(selector, testResource), is(true));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value1")).build();
-        assertThat(matchesSelector(selector, testResource), is(false));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label3", "value3")).build();
-        assertThat(matchesSelector(selector, testResource), is(false));
-
-        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1", "label3", "value3")).build();
-        assertThat(matchesSelector(selector, testResource), is(false));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

While reviewing #11742, I notices that the `Util` class in the `operator-common` seems to have many methods that are not really shared between the other modules but used only in the Cluster Operator. This PR moves them to thee `cluster-operator` module to the classes that seem best fitting for them. Some which are used only by one class are moved there directly. Others are moved to various utils classes used by the assembly operators / reconcilers, models, etc.

This PR also removes some unused methods and addresses some IDE warnings in the `Util` class. Apart from moving the methods, there should be no real change their code.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally