### PR TITLE
Integrate OAuth 0.17.0 `grantType` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * Extend the EntityOperator, Cruise Control and KafkaExporter deployment to support PDB via the template section in the CR spec.
 * Added support for [KIP-1073](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1073:+Return+fenced+brokers+in+DescribeCluster+response)
   to get the list of the registered brokers by using the Kafka Admin API. It replaces the usage of the `.status.registeredNodeIds` field in Kafka.
+* Update OAuth library to 0.17.0.
+* Additional OAuth configuration options have been added for 'oauth' authentication on the listener and the client.
+  On the listener `clientGrantType` has been added.
+  On the client `grantType` has been added.
 
 ### Major changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -81,7 +81,8 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
         this.clientId = clientId;
     }
 
-    @Description("OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.")
+    @Description("A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. "
+            + "The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getGrantType() {
         return grantType;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -32,13 +32,14 @@ import java.util.Map;
     "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientSecret", "passwordSecret", "accessToken",
     "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",
     "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader", "accessTokenLocation",
-    "clientAssertion", "clientAssertionLocation", "clientAssertionType", "saslExtensions"})
+    "clientAssertion", "clientAssertionLocation", "clientAssertionType", "saslExtensions", "grantType"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
     public static final String TYPE_OAUTH = "oauth";
 
     private String clientId;
+    private String grantType;
     private String username;
     private String scope;
     private String audience;
@@ -78,6 +79,16 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
 
     public void setClientId(String clientId) {
         this.clientId = clientId;
+    }
+
+    @Description("OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getGrantType() {
+        return grantType;
+    }
+
+    public void setGrantType(String grantType) {
+        this.grantType = grantType;
     }
 
     @Description("OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. "

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -218,7 +218,9 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
         this.clientAudience = audience;
     }
 
-    @Description("The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.")
+    @Description("The grant type to use when making requests to the authorization server's token endpoint. " +
+            "Used for `OAuth over PLAIN` when `username` and `password` passed via SASL_PLAIN client authentication " +
+            "are passed on to the authorization server as `clientId` and `secret`.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getClientGrantType() {
         return clientGrantType;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -35,7 +35,7 @@ import java.util.List;
     "accessTokenIsJwt", "tlsTrustedCertificates", "disableTlsHostnameVerification", "enableECDSA",
     "maxSecondsWithoutReauthentication", "enablePlain", "tokenEndpointUri", "enableOauthBearer", "customClaimCheck",
     "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientScope", "clientAudience",
-    "enableMetrics", "failFast", "includeAcceptHeader", "serverBearerTokenLocation", "userNamePrefix"})
+    "clientGrantType", "enableMetrics", "failFast", "includeAcceptHeader", "serverBearerTokenLocation", "userNamePrefix"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {
@@ -81,6 +81,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private Integer httpRetryPauseMs;
     private String clientScope = null;
     private String clientAudience = null;
+    private String clientGrantType = null;
     private boolean enableMetrics = false;
     private boolean failFast = true;
     private boolean includeAcceptHeader = true;
@@ -215,6 +216,16 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     public void setClientAudience(String audience) {
         this.clientAudience = audience;
+    }
+
+    @Description("The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getClientGrantType() {
+        return clientGrantType;
+    }
+
+    public void setClientGrantType(String grantType) {
+        this.clientGrantType = grantType;
     }
 
     @Description("URI of the JWKS certificate endpoint, which can be used for local JWT validation.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -374,6 +374,7 @@ public class AuthenticationUtils {
         addOption(options, ClientConfig.OAUTH_CLIENT_ID, oauth.getClientId());
         addOption(options, ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME, oauth.getUsername());
         addOption(options, ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, oauth.getTokenEndpointUri());
+        addOption(options, ClientConfig.OAUTH_CLIENT_CREDENTIALS_GRANT_TYPE, oauth.getGrantType());
         addOption(options, ClientConfig.OAUTH_SCOPE, oauth.getScope());
         addOption(options, ClientConfig.OAUTH_AUDIENCE, oauth.getAudience());
         if (oauth.isDisableTlsHostnameVerification()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -530,6 +530,7 @@ public class KafkaBrokerConfigurationBuilder {
         addBooleanOptionIfFalse(options, ServerConfig.OAUTH_CHECK_ISSUER, oauth.isCheckIssuer());
         addBooleanOptionIfTrue(options, ServerConfig.OAUTH_CHECK_AUDIENCE, oauth.isCheckAudience());
         addOptionIfNotNull(options, ServerConfig.OAUTH_CUSTOM_CLAIM_CHECK, oauth.getCustomClaimCheck());
+        addOptionIfNotNull(options, ServerConfig.OAUTH_CLIENT_CREDENTIALS_GRANT_TYPE, oauth.getClientGrantType());
         addOptionIfNotNull(options, ServerConfig.OAUTH_SCOPE, oauth.getClientScope());
         addOptionIfNotNull(options, ServerConfig.OAUTH_AUDIENCE, oauth.getClientAudience());
         addOptionIfNotNull(options, ServerConfig.OAUTH_JWKS_ENDPOINT_URI, oauth.getJwksEndpointUri());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -1062,6 +1062,7 @@ public class KafkaBridgeClusterTest {
                                 .withTokenEndpointUri("http://my-oauth-server")
                                 .withAudience("kafka")
                                 .withScope("all")
+                                .withGrantType("custom_client_credentials")
                                 .withNewClientSecret()
                                     .withSecretName("my-secret-secret")
                                     .withKey("my-secret-key")
@@ -1077,6 +1078,7 @@ public class KafkaBridgeClusterTest {
         assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " +
                 "oauth.client.id=\"my-client-id\" " +
                 "oauth.token.endpoint.uri=\"http://my-oauth-server\" " +
+                "oauth.client.credentials.grant.type=\"custom_client_credentials\" " +
                 "oauth.scope=\"all\" " +
                 "oauth.audience=\"kafka\" " +
                 "oauth.client.secret=\"${strimzidir:/opt/strimzi/oauth/my-secret-secret:my-secret-key}\";"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -1977,6 +1977,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                     .withMaxSecondsWithoutReauthentication(3600)
                     .withJwksMinRefreshPauseSeconds(5)
                     .withEnablePlain(true)
+                    .withClientGrantType("custom_client_credentials")
                     .withTokenEndpointUri("http://token")
                     .withConnectTimeoutSeconds(30)
                     .withReadTimeoutSeconds(30)
@@ -2012,9 +2013,9 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder",
                 "listener.name.plain-9092.oauthbearer.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
-                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.server.bearer.token.location=\"/var/run/secrets/kubernetes.io/serviceaccount/token\" oauth.username.claim=\"preferred_username\" oauth.username.prefix=\"user-\" oauth.fallback.username.claim=\"client_id\" oauth.fallback.username.prefix=\"service-account-\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\";",
+                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.client.credentials.grant.type=\"custom_client_credentials\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.server.bearer.token.location=\"/var/run/secrets/kubernetes.io/serviceaccount/token\" oauth.username.claim=\"preferred_username\" oauth.username.prefix=\"user-\" oauth.fallback.username.claim=\"client_id\" oauth.fallback.username.prefix=\"service-account-\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\";",
                 "listener.name.plain-9092.plain.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler",
-                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.server.bearer.token.location=\"/var/run/secrets/kubernetes.io/serviceaccount/token\" oauth.username.claim=\"preferred_username\" oauth.username.prefix=\"user-\" oauth.fallback.username.claim=\"client_id\" oauth.fallback.username.prefix=\"service-account-\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\" oauth.token.endpoint.uri=\"http://token\";",
+                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.client.credentials.grant.type=\"custom_client_credentials\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.server.bearer.token.location=\"/var/run/secrets/kubernetes.io/serviceaccount/token\" oauth.username.claim=\"preferred_username\" oauth.username.prefix=\"user-\" oauth.fallback.username.claim=\"client_id\" oauth.fallback.username.prefix=\"service-account-\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\" oauth.token.endpoint.uri=\"http://token\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=OAUTHBEARER,PLAIN",
                 "listener.name.plain-9092.connections.max.reauth.ms=3600000"));
     }
@@ -2037,6 +2038,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withTokenEndpointUri("http://token")
                 .withClientAudience("kafka")
                 .withClientScope("messaging")
+                .withClientGrantType("custom_client_credentials")
                 .withConnectTimeoutSeconds(30)
                 .withEnableMetrics(true)
                 .endKafkaListenerAuthenticationOAuth()
@@ -2069,7 +2071,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder",
                 "listener.name.plain-9092.plain.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler",
-                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.scope=\"messaging\" oauth.audience=\"kafka\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.connect.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.config.id=\"PLAIN-9092\" oauth.token.endpoint.uri=\"http://token\";",
+                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.client.credentials.grant.type=\"custom_client_credentials\" oauth.scope=\"messaging\" oauth.audience=\"kafka\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.connect.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.config.id=\"PLAIN-9092\" oauth.token.endpoint.uri=\"http://token\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=PLAIN",
                 "listener.name.plain-9092.connections.max.reauth.ms=3600000"));
     }
@@ -2252,6 +2254,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withReadTimeoutSeconds(60)
                 .withHttpRetries(2)
                 .withHttpRetryPauseMs(500)
+                .withClientGrantType("custom_client_credentials")
                 .withClientAudience("kafka")
                 .withClientScope("messaging")
                 .withEnableMetrics(true)
@@ -2265,6 +2268,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         expectedOptions.put(ServerConfig.OAUTH_CHECK_ISSUER, String.valueOf(false));
         expectedOptions.put(ServerConfig.OAUTH_CHECK_AUDIENCE, String.valueOf(true));
         expectedOptions.put(ServerConfig.OAUTH_CUSTOM_CLAIM_CHECK, "@.aud && @.aud == 'something'");
+        expectedOptions.put(ServerConfig.OAUTH_CLIENT_CREDENTIALS_GRANT_TYPE, "custom_client_credentials");
         expectedOptions.put(ServerConfig.OAUTH_SCOPE, "messaging");
         expectedOptions.put(ServerConfig.OAUTH_AUDIENCE, "kafka");
         expectedOptions.put(ServerConfig.OAUTH_JWKS_ENDPOINT_URI, "http://jwks-endpoint");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1725,6 +1725,7 @@ public class KafkaConnectClusterTest {
                                 .withTokenEndpointUri("http://my-oauth-server")
                                 .withAudience("kafka")
                                 .withScope("all")
+                                .withGrantType("custom-client-credentials")
                                 .withNewClientSecret()
                                     .withSecretName("my-secret-secret")
                                     .withKey("my-secret-key")
@@ -1740,7 +1741,7 @@ public class KafkaConnectClusterTest {
         String connectConfigurations = configMap.getData().get(KafkaConnectCluster.KAFKA_CONNECT_CONFIGURATION_FILENAME);
         assertThat(connectConfigurations, containsString("security.protocol=SASL_PLAINTEXT"));
         assertThat(connectConfigurations, containsString("sasl.mechanism=OAUTHBEARER"));
-        assertThat(connectConfigurations, containsString("sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required oauth.client.id=\"my-client-id\" oauth.token.endpoint.uri=\"http://my-oauth-server\" oauth.scope=\"all\" oauth.audience=\"kafka\" oauth.client.secret=\"${strimzidir:/opt/kafka/oauth/my-secret-secret:my-secret-key}\";"));
+        assertThat(connectConfigurations, containsString("sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required oauth.client.id=\"my-client-id\" oauth.token.endpoint.uri=\"http://my-oauth-server\" oauth.client.credentials.grant.type=\"custom-client-credentials\" oauth.scope=\"all\" oauth.audience=\"kafka\" oauth.client.secret=\"${strimzidir:/opt/kafka/oauth/my-secret-secret:my-secret-key}\";"));
         assertThat(connectConfigurations, containsString("sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1816,6 +1816,8 @@ public class KafkaMirrorMaker2ClusterTest {
                     new KafkaClientAuthenticationOAuthBuilder()
                             .withClientId("my-client-id")
                             .withTokenEndpointUri("http://my-oauth-server")
+                            .withScope("all")
+                            .withGrantType("custom_client_credentials")
                             .withNewClientSecret()
                                 .withSecretName("my-secret-secret")
                                 .withKey("my-secret-key")
@@ -1837,6 +1839,8 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(connectConfigurations, containsString("sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " +
                 "oauth.client.id=\"my-client-id\" " +
                 "oauth.token.endpoint.uri=\"http://my-oauth-server\" " +
+                "oauth.client.credentials.grant.type=\"custom_client_credentials\" " +
+                "oauth.scope=\"all\" " +
                 "oauth.client.secret=\"${strimzidir:/opt/kafka/oauth/my-secret-secret:my-secret-key}\";"));
 
         // Check PodSet

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -755,6 +755,8 @@ public class KafkaMirrorMaker2ConnectorsTest {
                         .withKey("clientAssertionKey")
                         .withSecretName("clientAssertionSecretName")
                     .endClientAssertion()
+                    .withScope("all")
+                    .withGrantType("custom_client_credentials")
                     .withTlsTrustedCertificates(new CertSecretSourceBuilder().withCertificate("ca.crt").withSecretName("my-oauth-secret").build())
                 .endKafkaClientAuthenticationOAuth()
                 .build();
@@ -770,6 +772,8 @@ public class KafkaMirrorMaker2ConnectorsTest {
                         "oauth.refresh.token", "${strimzidir:/opt/kafka/mm2-oauth/sourceClusterAlias/refreshTokenSecretName:refreshTokenKey}",
                         "oauth.password.grant.password", "${strimzidir:/opt/kafka/mm2-oauth/sourceClusterAlias/passwordSecretSecretName:passwordSecretPassword}",
                         "oauth.client.assertion", "${strimzidir:/opt/kafka/mm2-oauth/sourceClusterAlias/clientAssertionSecretName:clientAssertionKey}",
+                        "oauth.scope", "all",
+                        "oauth.client.credentials.grant.type", "custom_client_credentials",
                         "oauth.ssl.truststore.location", "/tmp/kafka/clusters/sourceClusterAlias-oauth.truststore.p12",
                         "oauth.ssl.truststore.type", "PKCS12",
                         "oauth.ssl.truststore.password", PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR)));

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.0-RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.143</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.16.2</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0-pre</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.143</cruise-control.version>
@@ -35,6 +35,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-pre</id>
+            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.0-pre</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0-RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.143</cruise-control.version>
@@ -35,10 +35,6 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
-        </repository>
-        <repository>
-            <id>oauth-pre</id>
-            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.0-RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.142</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.16.2</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0-pre</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.142</cruise-control.version>
@@ -35,6 +35,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-pre</id>
+            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.0-pre</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0-RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.142</cruise-control.version>
@@ -35,10 +35,6 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
-        </repository>
-        <repository>
-            <id>oauth-pre</id>
-            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth.adoc
@@ -25,7 +25,7 @@ authentication:
     key: client-secret
 ----
 
-Optionally, `scope` and `audience` can be specified if needed.
+Optionally, `scope` and `audience` can be specified if needed. `grantType` can also be specified for custom client credentials implementations.
 
 .Client ID and refresh token
 You can configure the address of your OAuth server in the `tokenEndpointUri` property together with the OAuth client ID and refresh token.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -327,6 +327,9 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |clientAudience
 |string
 |The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|clientGrantType
+|string
+|The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
 |enableMetrics
 |boolean
 |Enable or disable OAuth metrics. Default value is `false`.
@@ -2797,6 +2800,9 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 |saslExtensions
 |map
 |SASL extensions parameters.
+|grantType
+|string
+|OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
 |====
 
 [id='type-KafkaClientAuthenticationCustom-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -329,7 +329,7 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
 |clientGrantType
 |string
-|The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|The grant type to use when making requests to the authorization server's token endpoint. Used for `OAuth over PLAIN` when `username` and `password` passed via SASL_PLAIN client authentication are passed on to the authorization server as `clientId` and `secret`.
 |enableMetrics
 |boolean
 |Enable or disable OAuth metrics. Default value is `false`.
@@ -2802,7 +2802,7 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 |SASL extensions parameters.
 |grantType
 |string
-|OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+|A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations.
 |====
 
 [id='type-KafkaClientAuthenticationCustom-{context}']

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -53,7 +53,7 @@
 :keycloak-server-install-doc: link:https://www.keycloak.org/operator/installation[Installing the Keycloak Operator^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services^]
 :keycloak-admin-guide: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Server Administration^]
-:OAuthVersion: 0.16.2
+:OAuthVersion: 0.17.0
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples[Using Keycloak as the OAuth 2.0 authorization server^]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples/docker#running-with-hydra-using-ssl-and-opaque-tokens[Using Hydra as the OAuth 2.0 authorization server^]
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -116,6 +116,9 @@ spec:
                               clientAudience:
                                 type: string
                                 description: The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+                              clientGrantType:
+                                type: string
+                                description: The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
                               clientId:
                                 type: string
                                 description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -118,7 +118,7 @@ spec:
                                 description: The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
                               clientGrantType:
                                 type: string
-                                description: The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+                                description: The grant type to use when making requests to the authorization server's token endpoint. Used for `OAuth over PLAIN` when `username` and `password` passed via SASL_PLAIN client authentication are passed on to the authorization server as `clientId` and `secret`.
                               clientId:
                                 type: string
                                 description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -187,6 +187,9 @@ spec:
                     enableMetrics:
                       type: boolean
                       description: Enable or disable OAuth metrics. Default value is `false`.
+                    grantType:
+                      type: string
+                      description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
                     httpRetries:
                       type: integer
                       description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -189,7 +189,7 @@ spec:
                       description: Enable or disable OAuth metrics. Default value is `false`.
                     grantType:
                       type: string
-                      description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+                      description: "A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations."
                     httpRetries:
                       type: integer
                       description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -190,6 +190,9 @@ spec:
                     enableMetrics:
                       type: boolean
                       description: Enable or disable OAuth metrics. Default value is `false`.
+                    grantType:
+                      type: string
+                      description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
                     httpRetries:
                       type: integer
                       description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -192,7 +192,7 @@ spec:
                       description: Enable or disable OAuth metrics. Default value is `false`.
                     grantType:
                       type: string
-                      description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+                      description: "A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations."
                     httpRetries:
                       type: integer
                       description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -199,6 +199,9 @@ spec:
                           enableMetrics:
                             type: boolean
                             description: Enable or disable OAuth metrics. Default value is `false`.
+                          grantType:
+                            type: string
+                            description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
                           httpRetries:
                             type: integer
                             description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -201,7 +201,7 @@ spec:
                             description: Enable or disable OAuth metrics. Default value is `false`.
                           grantType:
                             type: string
-                            description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+                            description: "A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations."
                           httpRetries:
                             type: integer
                             description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -115,6 +115,9 @@ spec:
                             clientAudience:
                               type: string
                               description: The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+                            clientGrantType:
+                              type: string
+                              description: The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
                             clientId:
                               type: string
                               description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -117,7 +117,7 @@ spec:
                               description: The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
                             clientGrantType:
                               type: string
-                              description: The grant type to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+                              description: The grant type to use when making requests to the authorization server's token endpoint. Used for `OAuth over PLAIN` when `username` and `password` passed via SASL_PLAIN client authentication are passed on to the authorization server as `clientId` and `secret`.
                             clientId:
                               type: string
                               description: OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -188,7 +188,7 @@ spec:
                     description: Enable or disable OAuth metrics. Default value is `false`.
                   grantType:
                     type: string
-                    description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+                    description: "A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations."
                   httpRetries:
                     type: integer
                     description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -186,6 +186,9 @@ spec:
                   enableMetrics:
                     type: boolean
                     description: Enable or disable OAuth metrics. Default value is `false`.
+                  grantType:
+                    type: string
+                    description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
                   httpRetries:
                     type: integer
                     description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -191,7 +191,7 @@ spec:
                     description: Enable or disable OAuth metrics. Default value is `false`.
                   grantType:
                     type: string
-                    description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+                    description: "A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations."
                   httpRetries:
                     type: integer
                     description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -189,6 +189,9 @@ spec:
                   enableMetrics:
                     type: boolean
                     description: Enable or disable OAuth metrics. Default value is `false`.
+                  grantType:
+                    type: string
+                    description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
                   httpRetries:
                     type: integer
                     description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -198,6 +198,9 @@ spec:
                         enableMetrics:
                           type: boolean
                           description: Enable or disable OAuth metrics. Default value is `false`.
+                        grantType:
+                          type: string
+                          description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
                         httpRetries:
                           type: integer
                           description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -200,7 +200,7 @@ spec:
                           description: Enable or disable OAuth metrics. Default value is `false`.
                         grantType:
                           type: string
-                          description: OAuth grant type to use when authenticating against the authorization server. This value defaults to `client_credentials` when `clientId` and `clientSecret` are specified.
+                          description: "A custom OAuth grant type to use when authenticating against the authorization server with `clientId` and one of `clientSecret` or `clientAssertion`. The value defaults to `client_credentials` in these cases. This is optional configuration, only used with custom authorization server implementations."
                         httpRetries:
                           type: integer
                           description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>12.0.22</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
-        <strimzi-oauth.version>0.17.0-RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0</strimzi-oauth.version>
         <netty.version>4.2.5.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>12.0.22</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
-        <strimzi-oauth.version>0.16.2</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0-RC1</strimzi-oauth.version>
         <netty.version>4.2.5.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

A new configuration option `grantType` is added to client OAuth authentication configuration
A new configuration option `clientGrantType` is added to listener OAuth authentication configuration

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

