### PR TITLE
Attemp to fix flakiness CoreFeaturesIT

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -32,7 +32,7 @@ stages:
           artifactRunVersion: ''
           artifactRunId: ''
     variables:
-      STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: false
+      STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: true
 
   # Builds Strimzi docs
   - stage: build_docs

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -32,6 +32,7 @@ stages:
           artifactRunVersion: ''
           artifactRunId: ''
     variables:
+      # set to false when none error occurs during 2 weeks - https://github.com/strimzi/strimzi-kafka-operator/issues/11839
       STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: true
 
   # Builds Strimzi docs

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -93,7 +93,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
             throw new IllegalStateException();
         }
 
-        shutdownHook = new Thread(this::shutdown, "TopicOperator-shutdown-hook");
+        shutdownHook = new Thread(this::stop,"TopicOperator-shutdown-hook");
         LOGGER.infoOp("Installing shutdown hook");
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         LOGGER.infoOp("Starting health and metrics");
@@ -120,10 +120,6 @@ public class TopicOperatorMain implements Liveness, Readiness {
 
     synchronized void stop() {
         // Execute the actual shutdown sequence (idempotent).
-        shutdown();
-    }
-
-    private void shutdown() {
         if (shutdownHook == null) {
             LOGGER.debugOp("Already shut down.");
             return;
@@ -145,6 +141,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
             this.healthAndMetricsServer.stop();
             LOGGER.infoOp("Shutdown completed normally");
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             LOGGER.infoOp("Interrupted during shutdown");
             throw new RuntimeException(e);
         }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -118,12 +118,12 @@ public class TopicOperatorMain implements Liveness, Readiness {
         LOGGER.infoOp("TopicOperator started");
     }
 
-    void stop() {
+    synchronized void stop() {
         // Execute the actual shutdown sequence (idempotent).
         shutdown();
     }
 
-    private synchronized void shutdown() {
+    private void shutdown() {
         if (shutdownHook == null) {
             LOGGER.debugOp("Already shut down.");
             return;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -93,7 +93,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
             throw new IllegalStateException();
         }
 
-        shutdownHook = new Thread(this::stop,"TopicOperator-shutdown-hook");
+        shutdownHook = new Thread(this::stop, "TopicOperator-shutdown-hook");
         LOGGER.infoOp("Installing shutdown hook");
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         LOGGER.infoOp("Starting health and metrics");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -145,14 +145,14 @@ public class TopicOperatorMain implements Liveness, Readiness {
 
     private synchronized void shutdown() {
         if (shutdownHook == null) {
-            LOGGER.infoOp("Already shutting down");
-            return; // already shut down
+            LOGGER.infoOp("Already shut down.");
+            return;
         }
+
+        LOGGER.infoOp("Shutdown initiated");
         shutdownHook = null;
         // Note: This method can be invoked on either via the shutdown hook thread or
         // on the thread(s) on which stop()/start() are called
-        LOGGER.infoOp("Shutdown initiated");
-
         try {
             // Idempotent resource teardown.
             if (informer != null) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -144,11 +144,16 @@ public class TopicOperatorMain implements Liveness, Readiness {
     }
 
     private synchronized void shutdown() {
+        if (shutdownHook == null) {
+            LOGGER.infoOp("Already shutting down");
+            return; // already shut down
+        }
+        shutdownHook = null;
         // Note: This method can be invoked on either via the shutdown hook thread or
         // on the thread(s) on which stop()/start() are called
         LOGGER.infoOp("Shutdown initiated");
+
         try {
-            shutdownHook = null;
             // Idempotent resource teardown.
             if (informer != null) {
                 informer.stop();


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR resolves a race condition issue during tests in `CoreFeaturesIT`. It was caused by the `shouldTerminateIfQueueFull` test case, which left the overall test suite in a bad state (i.e., the Shutdown hook thread was still present `Thread[TopicOperator-shutdown-hook,5,main]` even though it should be null). This eventually led to failing `shouldAccountForReassigningPartitionsNoRfChange` test case. 

I have made the `shutdownHook` instance variable volatile, so there are always correct reads from the threats (i.e., not inconsistent between threads). 

### Checklist

- [x] Make sure all tests pass