### PR TITLE
[DOC] Improve the examples of MM2 connector and connector task restart annotations

### DIFF
--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -36,11 +36,11 @@ Task IDs are non-negative integers, starting from 0.
 kubectl annotate KafkaMirrorMaker2 <mirrormaker_cluster_name> "strimzi.io/restart-connector-task=<mirrormaker_connector_name>:<task_id>"
 ----
 +
-In this example, task `0` for connector `my-connector` in the `my-mirror-maker-2` cluster is restarted:
+In this example, task `0` for connector `source-cluster->target-cluster.MirrorSourceConnector` in the `my-mirror-maker-2` cluster is restarted:
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl annotate KafkaMirrorMaker2 my-mirror-maker-2 "strimzi.io/restart-connector-task=my-connector:0"
+kubectl annotate KafkaMirrorMaker2 my-mirror-maker-2 "strimzi.io/restart-connector-task=source-cluster->target-cluster.MirrorSourceConnector:2"
 ----
 
 . Wait for the next reconciliation to occur (every two minutes by default).

--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector.adoc
@@ -34,11 +34,11 @@ kubectl describe KafkaMirrorMaker2 <mirrormaker_cluster_name>
 kubectl annotate KafkaMirrorMaker2 <mirrormaker_cluster_name> "strimzi.io/restart-connector=<mirrormaker_connector_name>"
 ----
 +
-In this example, connector `my-connector` in the `my-mirror-maker-2` cluster is restarted:
+In this example, connector `source-cluster->target-cluster.MirrorCheckpointConnector` in the `my-mirror-maker-2` cluster is restarted:
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl annotate KafkaMirrorMaker2 my-mirror-maker-2 "strimzi.io/restart-connector=my-connector"
+kubectl annotate KafkaMirrorMaker2 my-mirror-maker-2 "strimzi.io/restart-connector=source-cluster->target-cluster.MirrorCheckpointConnector"
 ----
 
 . Wait for the next reconciliation to occur (every two minutes by default).


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

Currenty, the dcs for Mirror Maker 2 on restarting connector / connector task use very bad example connector name `my-connector` which is not suitable for MM2 and does not give the user the correct idea what to look for. This Pr updates the docs to use an example connector name based on the real names as users would see in their MM2 deployments.

### Checklist

- [x] Update documentation