### PR TITLE
Add `RequiredInVersions` annotation to our CRD generator

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -31,6 +31,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.strimzi.crdgenerator.annotations.Type;
 
 import java.io.File;
@@ -741,6 +742,9 @@ class CrdGenerator {
             if (property.isAnnotationPresent(JsonProperty.class)
                     && property.getAnnotation(JsonProperty.class).required()
                 || property.isDiscriminator()) {
+                result.add(property.getName());
+            } else if (property.isAnnotationPresent(RequiredInVersions.class)
+                    && ApiVersion.parseRange(property.getAnnotation(RequiredInVersions.class).value()).contains(crApiVersion)) {
                 result.add(property.getName());
             }
         }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/RequiredInVersions.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/RequiredInVersions.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used when a property is required from or until a particular CR API version
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface RequiredInVersions {
+    /**
+     * @return The versions in which the annotated property is required
+     */
+    String value();
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -23,6 +23,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 
 import java.util.List;
 import java.util.Map;
@@ -290,6 +291,7 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         this.longProperty = longProperty;
     }
 
+    @RequiredInVersions("v1alpha1")
     public boolean isBooleanProperty() {
         return booleanProperty;
     }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -626,6 +626,7 @@ spec:
           - mapStringObject
         required:
         - stringProperty
+        - booleanProperty
   - name: v1beta1
     served: true
     storage: false

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -632,6 +632,7 @@ spec:
           - mapStringObject
         required:
         - stringProperty
+        - booleanProperty
   - name: v1beta1
     served: true
     storage: false

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -619,6 +619,7 @@ spec:
           - mapStringObject
         required:
         - stringProperty
+        - booleanProperty
   - name: v1beta1
     served: true
     storage: false


### PR DESCRIPTION
### Type of change

- Task

### Description

As part of introducing the new Strimzi `v1` CRD API, we will need to make fields required in the new API version. If nothing else, the `.spec` sections of some of our resources (see #10074). That is not possible now, as for required fields we use the `@JsonProperty(required = true)` annotation from FasterXML Jackson which always applies to all CRD versions (as well as to Jackson when instantiating the API classes).

This PR adds new Strimzi CRD annotation named `RequiredInVersions`, which allows us to mark fields required only in some API versions and not in all of them. Thanks to that, we can for example male the `.spec` sections required in `v1` API without breaking the `v1beta2` API.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging