### PR TITLE
Update the Prometheus JMX Exporter and the Maven Builder image

### DIFF
--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -81,8 +81,8 @@ COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 # Add Prometheus JMX Exporter
 #####
 ENV JMX_EXPORTER_HOME=/opt/prometheus-jmx-exporter
-ENV JMX_EXPORTER_VERSION=1.3.0
-ENV JMX_EXPORTER_CHECKSUM="58b87e0c7f14cdbd3cdac3408e377be0bf0b30b3cd878669e94bf48181e878e3e4d30b2c2219c74da7f694fe85bcf81014520d84294da44e302247126bd92753  jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
+ENV JMX_EXPORTER_VERSION=1.4.0
+ENV JMX_EXPORTER_CHECKSUM="896852fe1be41a61785d325bc2bec3cbc63a3a4d3e0f21380cda3bf4eaa0050e58f9681a101bc56e2869c42b3e85a7222602a95e223ccd5c3886d6aac4d97ca4  jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
 
 RUN set -ex; \
     curl -LO https://github.com/prometheus/jmx_exporter/releases/download/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar; \

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Prometheus JMX Exporter to 1.4.0 and the Maven Builder container image to 1.23.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally