### PR TITLE
Fix OAuth version in docs (to 0.16.2)

### DIFF
--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -53,7 +53,7 @@
 :keycloak-server-install-doc: link:https://www.keycloak.org/operator/installation[Installing the Keycloak Operator^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services^]
 :keycloak-admin-guide: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Server Administration^]
-:OAuthVersion: 0.15.0
+:OAuthVersion: 0.16.2
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples[Using Keycloak as the OAuth 2.0 authorization server^]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples/docker#running-with-hydra-using-ssl-and-opaque-tokens[Using Hydra as the OAuth 2.0 authorization server^]
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

#11351 updated OAuth to 0.16.2, but did not update the version in docs. This PR fixes it.

### Checklist

- [x] Update documentation