### PR TITLE
Add support for Kafka 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.48.0
 
-* Add support for Kafka 4.1.0.
+* Add support for Kafka 4.0.1 and 4.1.0.
   Remove support for Kafka 3.9.0 and 3.9.1.
 * KRaft mode and Kafka Node Pools are now enabled by default.
   The `strimzi.io/node-pools` and `strimzi.io/kraft` annotations are not required anymore and will be ignored if set.

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -7,6 +7,7 @@
 |Kafka
 a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-4.0.0
+* {DockerOrg}/kafka:{DockerTag}-kafka-4.0.1
 * {DockerOrg}/kafka:{DockerTag}-kafka-4.1.0
 
 a|

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -259,6 +259,13 @@
   third-party-libs: 4.0.x
   supported: true
   default: false
+- version: 4.0.1
+  metadata: 4.0
+  url: https://dist.apache.org/repos/dist/dev/kafka/4.0.1-rc2/kafka_2.13-4.0.1.tgz
+  checksum: 23B241098672D828CA86A6DD1DD99102FCDB9DE8680ECF213B47251A7AE7A342343CF41ADF6FEE9F920D171AE13F94C39475165F5A246E1A46609A7D9D5A6811
+  third-party-libs: 4.0.x
+  supported: true
+  default: false
 - version: 4.1.0
   metadata: 4.1
   url: https://archive.apache.org/dist/kafka/4.1.0/kafka_2.13-4.1.0.tgz

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -12,13 +12,16 @@
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
                 4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.0.0")) }}
+                4.0.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.0.1")) }}
                 4.1.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.1.0")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
                 4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.0.0")) }}
+                4.0.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.0.1")) }}
                 4.1.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.1.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
                 4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.0.0")) }}
+                4.0.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.0.1")) }}
                 4.1.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.1.0")) }}
 {{- end -}}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -54,14 +54,17 @@ spec:
             - name: STRIMZI_KAFKA_IMAGES
               value: |
                 4.0.0=quay.io/strimzi/kafka:latest-kafka-4.0.0
+                4.0.1=quay.io/strimzi/kafka:latest-kafka-4.0.1
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 4.0.0=quay.io/strimzi/kafka:latest-kafka-4.0.0
+                4.0.1=quay.io/strimzi/kafka:latest-kafka-4.0.1
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 4.0.0=quay.io/strimzi/kafka:latest-kafka-4.0.0
+                4.0.1=quay.io/strimzi/kafka:latest-kafka-4.0.1
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: quay.io/strimzi/operator:latest

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>apache-staging</id>
+            <url>https://repository.apache.org/content/groups/staging/</url>
+        </repository>
     </repositories>
 
     <properties>

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -195,7 +195,8 @@ public class Environment {
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "4.0.0";
     public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.11.0";
-    public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
+    public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repository.apache.org/content/groups/staging/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
+    //public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";
     public static final String IP_FAMILY_VERSION_6 = "ipv6";


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for Kafka 4.0.1. It is currently a draft based on the RC1 used for testing purposes only.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

