### PR TITLE
docs(affinity): updates the pod scheduling section to use node pools

### DIFF
--- a/documentation/assemblies/configuring/assembly-scheduling.adoc
+++ b/documentation/assemblies/configuring/assembly-scheduling.adoc
@@ -6,8 +6,12 @@
 = Configuring pod scheduling
 
 [role="_abstract"]
-To avoid performance degradation caused by resource conflicts between applications scheduled on the same Kubernetes node, you can schedule Kafka pods separately from critical workloads. 
-This can be achieved by either selecting specific nodes or dedicating a set of nodes exclusively for Kafka.
+To optimize the resilience and performance of your Kafka cluster, you can control how its pods are scheduled across Kubernetes nodes.
+Pod scheduling strategies can help you to achieve the following:
+
+* Increase fault tolerance by spreading Kafka pods across different nodes.
+* Avoid resource contention by separating pods from critical workloads.
+* Maintain resource availability by assigning Kafka pods to nodes with sufficient capacity.
 
 include::../../modules/configuring/ref-affinity.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/configuring/assembly-storage.adoc
+++ b/documentation/assemblies/configuring/assembly-storage.adoc
@@ -37,7 +37,8 @@ include::../../modules/configuring/con-considerations-for-data-storage.adoc[leve
 
 //KRaft storage
 include::../../modules/configuring/con-config-storage-kraft.adoc[leveloffset=+1]
-include::../../modules/configuring/proc-managing-storage-node-pools.adoc[leveloffset=+2]
-include::../../modules/configuring/proc-managing-storage-affinity-node-pools.adoc[leveloffset=+2]
+include::../../modules/configuring/con-config-storage-kraft-metadata.adoc[leveloffset=+1]
+include::../../modules/configuring/proc-managing-storage-node-pools.adoc[leveloffset=+1]
+include::../../modules/configuring/proc-managing-storage-affinity-node-pools.adoc[leveloffset=+1]
 //tiered storage
 include::../../modules/configuring/ref-storage-tiered.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-config-storage-kraft-metadata.adoc
+++ b/documentation/modules/configuring/con-config-storage-kraft-metadata.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// assembly-storage.adoc
+
+[id='con-storing-metadata-log-{context}']
+= Configuring KRaft metadata log storage
+
+In KRaft mode, each node (including brokers and controllers) stores a copy of the Kafka cluster's metadata log on one of its data volumes. 
+By default, the log is stored on the volume with the lowest ID, but you can specify a different volume using the `kraftMetadata` property.
+
+For controller-only nodes, storage is exclusively for the metadata log. 
+Since the log is always stored on a single volume, using JBOD storage with multiple volumes does not improve performance or increase available disk space.
+
+In contrast, broker nodes or nodes that combine broker and controller roles can share the same volume for both the metadata log and partition replica data, optimizing disk utilization. 
+They can also use JBOD storage, where one volume is shared for the metadata log and partition replica data, while additional volumes are used solely for partition replica data.
+
+Changing the volume that stores the metadata log triggers a rolling update of the cluster nodes, involving the deletion of the old log and the creation of a new one in the specified location. 
+If `kraftMetadata` isn't specified, adding a new volume with a lower ID also prompts an update and relocation of the metadata log.
+
+.Example JBOD storage configuration using volume with ID 1 to store the KRaft metadata
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  # ...
+spec:
+  storage:
+    type: jbod
+    volumes:
+    - id: 0
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+    - id: 1
+      type: persistent-claim
+      size: 100Gi
+      kraftMetadata: shared
+      deleteClaim: false
+  # ...
+----

--- a/documentation/modules/configuring/con-config-storage-kraft.adoc
+++ b/documentation/modules/configuring/con-config-storage-kraft.adoc
@@ -3,7 +3,7 @@
 // assembly-storage.adoc
 
 [id='con-config-storage-kraft-{context}']
-= Configuring Kafka storage in KRaft mode
+= Configuring storage types
 
 [role="_abstract"]
 Use the `storage` properties of the `KafkaNodePool` custom resource to configure storage for a deployment of Kafka in KRaft mode.
@@ -209,42 +209,3 @@ When adding a new volume to the to the `volumes` array under an `id` which was a
 
 Use Cruise Control to reassign partitions when adding or removing volumes. 
 For information on intra-broker disk balancing, see xref:con-rebalance-{context}[].
-
-[id='con-storing-metadata-log-{context}']
-== Configuring KRaft metadata log storage
-
-In KRaft mode, each node (including brokers and controllers) stores a copy of the Kafka cluster's metadata log on one of its data volumes. 
-By default, the log is stored on the volume with the lowest ID, but you can specify a different volume using the `kraftMetadata` property.
-
-For controller-only nodes, storage is exclusively for the metadata log. 
-Since the log is always stored on a single volume, using JBOD storage with multiple volumes does not improve performance or increase available disk space.
-
-In contrast, broker nodes or nodes that combine broker and controller roles can share the same volume for both the metadata log and partition replica data, optimizing disk utilization. 
-They can also use JBOD storage, where one volume is shared for the metadata log and partition replica data, while additional volumes are used solely for partition replica data.
-
-Changing the volume that stores the metadata log triggers a rolling update of the cluster nodes, involving the deletion of the old log and the creation of a new one in the specified location. 
-If `kraftMetadata` isn't specified, adding a new volume with a lower ID also prompts an update and relocation of the metadata log.
-
-.Example JBOD storage configuration using volume with ID 1 to store the KRaft metadata
-[source,yaml,subs="attributes+"]
-----
-apiVersion: {KafkaApiVersion}
-kind: KafkaNodePool
-metadata:
-  name: pool-a
-  # ...
-spec:
-  storage:
-    type: jbod
-    volumes:
-    - id: 0
-      type: persistent-claim
-      size: 100Gi
-      deleteClaim: false
-    - id: 1
-      type: persistent-claim
-      size: 100Gi
-      kraftMetadata: shared
-      deleteClaim: false
-  # ...
-----

--- a/documentation/modules/configuring/proc-dedicated-nodes.adoc
+++ b/documentation/modules/configuring/proc-dedicated-nodes.adoc
@@ -3,61 +3,78 @@
 // assembly-scheduling.adoc
 
 [id='proc-dedicated-nodes-{context}']
-= Setting up dedicated nodes and scheduling pods on them
+= Configuring pod affinity for dedicated nodes
+
+[role="_abstract"]
+You can dedicate a set of worker nodes exclusively to your Kafka brokers so that no other applications can compete with Kafka for resources on those nodes.
+
+To configure dedicated worker nodes for Kafka pods in a specific pool, set taints on the worker nodes, and configure `tolerations`` and `nodeAffinity` in your `KafkaNodePool` resource.
 
 .Prerequisites
 
 * A Kubernetes cluster
 * A running Cluster Operator
+* Dedicated worker nodes without scheduled workloads
 
 .Procedure
 
-. Select the nodes which should be used as dedicated.
-. Make sure there are no workloads scheduled on these nodes.
-. Set the taints on the selected nodes:
+. Taint the dedicated worker nodes to prevent other pods from being scheduled on them:
 +
-This can be done using `kubectl taint`:
-[source,shell,subs=+quotes]
-kubectl taint node _NAME-OF-NODE_ dedicated=Kafka:NoSchedule
-+
-. Additionally, add a label to the selected nodes as well.
-+
-This can be done using `kubectl label`:
-[source,shell,subs=+quotes]
-kubectl label node _NAME-OF-NODE_ dedicated=Kafka
-+
-. Edit the `affinity` and `tolerations` properties in the resource specifying the cluster deployment.
-+
-For example:
-+
-[source,yaml,subs=attributes+]
+[source,shell]
 ----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
-spec:
-  kafka:
-    # ...
-    template:
-      pod:
-        tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "Kafka"
-            effect: "NoSchedule"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: dedicated
-                  operator: In
-                  values:
-                  - Kafka
-    # ...
+kubectl taint node <name_of_node> dedicated=Kafka:NoSchedule
+----
++
+This command marks the node so that only pods with a corresponding toleration can use it.
+
+. Label the dedicated nodes where you want to schedule your Kafka pods. 
++
+If the nodes aren't already labeled, apply labels using `kubectl label`:
++
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl label node <name_of_node> dedicated=kafka
 ----
 
-. Create or update the resource.
+. In your `KafkaNodePool` custom resource, edit the `tolerations` and `affinity` properties in the `spec.template.pod` section.
 +
-This can be done using `kubectl apply`:
-[source,shell,subs=+quotes]
-kubectl apply -f _<kafka_configuration_file>_
+To assign Kafka pods from the same node pool to a worker node, add a `nodeAffinity` rule. 
++
+* Add a toleration that exactly matches the taint you applied to the node.
+The Kafka pods are only scheduled on the dedicated nodes.
+* Use `nodeSelectorTerms` with `matchExpressions` to specify the key (label name) and values of the nodes you want to schedule pods on. 
+Pods are only scheduled on nodes that match these expressions.
++
+.Example affinity configuration for dedicated nodes
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  template:
+    pod:
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "kafka"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - kafka
+  # ...
+----
+
+. Apply the changes to the `KafkaNodePool` configuration.

--- a/documentation/modules/configuring/proc-dedicated-nodes.adoc
+++ b/documentation/modules/configuring/proc-dedicated-nodes.adoc
@@ -14,12 +14,11 @@ Taints:: Apply taints to worker nodes to prevent other pods from being scheduled
 Tolerations:: Apply tolerations to Kafka pods to allow them to be scheduled on tainted nodes.
 Affinity:: Apply affinity to Kafka pods to schedule them on specifically labeled nodes.
 
-The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
-For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
-This procedure shows example configurations for both.
+This procedure provides configuration examples for the cluster-wide `Kafka` resource and the pool-specific `KafkaNodePool` resource.
 
-IMPORTANT: A `nodeAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
-The rules are not merged.
+NOTE: If you configure `KafkaNodePool.spec.template`, its settings replace `Kafka.spec.kafka.template` for that node pool.
+Properties are not merged. 
+For more information, see xref:affinity-{context}[Scheduling strategies].
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-dedicated-nodes.adoc
+++ b/documentation/modules/configuring/proc-dedicated-nodes.adoc
@@ -3,49 +3,82 @@
 // assembly-scheduling.adoc
 
 [id='proc-dedicated-nodes-{context}']
-= Configuring pod affinity for dedicated nodes
+= Configuring pod scheduling for dedicated nodes
 
 [role="_abstract"]
 You can dedicate a set of worker nodes exclusively to your Kafka brokers so that no other applications can compete with Kafka for resources on those nodes.
 
-To configure dedicated worker nodes for Kafka pods in a specific pool, set taints on the worker nodes, and configure `tolerations`` and `nodeAffinity` in your `KafkaNodePool` resource.
+To configure dedicated worker nodes for Kafka pods in a specific pool, combine the following:
+
+Taints:: Apply taints to worker nodes to prevent other pods from being scheduled on them.
+Tolerations:: Apply tolerations to Kafka pods to allow them to be scheduled on tainted nodes.
+Affinity:: Apply affinity to Kafka pods to schedule them on specifically labeled nodes.
+
+The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
+For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
+This procedure shows example configurations for both.
+
+IMPORTANT: A `nodeAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
+The rules are not merged.
 
 .Prerequisites
 
-* A Kubernetes cluster
-* A running Cluster Operator
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.] 
 * Dedicated worker nodes without scheduled workloads
 
 .Procedure
 
-. Taint the dedicated worker nodes to prevent other pods from being scheduled on them:
+. Taint and label the dedicated worker nodes to prevent other pods from being scheduled on them and to identify them when scheduling the Kafka pods:
 +
 [source,shell]
 ----
-kubectl taint node <name_of_node> dedicated=Kafka:NoSchedule
-----
-+
-This command marks the node so that only pods with a corresponding toleration can use it.
-
-. Label the dedicated nodes where you want to schedule your Kafka pods. 
-+
-If the nodes aren't already labeled, apply labels using `kubectl label`:
-+
-[source,shell,subs="+quotes,attributes+"]
-----
+kubectl taint node <name_of_node> dedicated=kafka:NoSchedule
 kubectl label node <name_of_node> dedicated=kafka
 ----
 
-. In your `KafkaNodePool` custom resource, edit the `tolerations` and `affinity` properties in the `spec.template.pod` section.
+. Configure `tolerations` and `nodeAffinity` in either your `Kafka` or `KafkaNodePool` custom resource to match the taint and label.
 +
-To assign Kafka pods from the same node pool to a worker node, add a `nodeAffinity` rule. 
+--
+* To set a cluster-wide rule, edit the `affinity` property in `spec.kafka.template.pod` of your `Kafka` resource.
+* To set a pool-specific rule, edit the `affinity` property in `spec.template.pod` of your `KafkaNodePool` resource.
+--
 +
-* Add a toleration that exactly matches the taint you applied to the node.
-The Kafka pods are only scheduled on the dedicated nodes.
-* Use `nodeSelectorTerms` with `matchExpressions` to specify the key (label name) and values of the nodes you want to schedule pods on. 
-Pods are only scheduled on nodes that match these expressions.
+In both cases, use `nodeSelectorTerms` with `matchExpressions` to specify the key-value label of the nodes you want to schedule pods on.
 +
-.Example affinity configuration for dedicated nodes
+This example applies a rule to a `Kafka` resource that assigns all its broker pods to run only on nodes that have been tainted and labeled with `dedicated=kafka`.
++
+.Example cluster-wide affinity configuration for dedicated nodes
+[source,yaml,subs=attributes+]
+----
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "kafka"
+            effect: "NoSchedule"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - kafka
+  # ...
+----
++
+This example applies a rule to a `KafkaNodePool` resource named `broker` that assigns its pods to run on dedicated nodes marked with `dedicated=broker-kafka`.
++
+.Example node pool-specific affinity configuration for dedicated nodes
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaNodePoolApiVersion}
@@ -73,8 +106,8 @@ spec:
               - key: dedicated
                 operator: In
                 values:
-                - kafka
+                - broker-kafka
   # ...
 ----
 
-. Apply the changes to the `KafkaNodePool` configuration.
+. Apply the changes to your custom resource configuration.

--- a/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
@@ -9,12 +9,11 @@
 To improve stability and performance, you can prevent Kafka pods from running on the same worker nodes as other resource-intensive applications, such as databases. 
 Configure `podAntiAffinity` so that these workloads are scheduled on separate nodes.
 
-The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
-For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
-This procedure shows example configurations for both.
+This procedure provides configuration examples for the cluster-wide `Kafka` resource and the pool-specific `KafkaNodePool` resource.
 
-IMPORTANT: A `podAntiAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
-The rules are not merged.
+NOTE: If you configure `KafkaNodePool.spec.template`, its settings replace `Kafka.spec.kafka.template` for that node pool.
+Properties are not merged. 
+For more information, see xref:affinity-{context}[Scheduling strategies].
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
@@ -6,26 +6,63 @@
 = Configuring pod anti-affinity against other workloads
 
 [role="_abstract"]
-To improve the stability and performance of your Kafka cluster, you can prevent its pods from running on the same worker nodes as other resource-intensive applications. 
+To improve stability and performance, you can prevent Kafka pods from running on the same worker nodes as other resource-intensive applications, such as databases. 
+Configure `podAntiAffinity` so that these workloads are scheduled on separate nodes.
 
-Using `podAntiAffinity` in your `KafkaNodePool` resource tells Kubernetes to avoid scheduling Kafka nodes from the same pool alongside specific workloads, such as databases or other messaging systems.
+The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
+For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
+This procedure shows example configurations for both.
+
+IMPORTANT: A `podAntiAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
+The rules are not merged.
 
 .Prerequisites
 
-* A Kubernetes cluster
-* A running Cluster Operator
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.] 
+* The other workloads in your cluster use consistent labels.
 
 .Procedure
 
-. In your `KafkaNodePool` custom resource, edit the `affinity` property in the `spec.template.pod` section.
+. Configure `podAntiAffinity` in either the `Kafka` or `KafkaNodePool` resource.
 +
-To prevent Kafka pods from the same node pool sharing a worker node with other application pods, add a `podAntiAffinity` rule.
+--
+* To set a cluster-wide rule, edit the `affinity` property in `spec.kafka.template.pod` of your `Kafka` resource. 
+* To set a pool-specific rule, edit the `affinity` property in `spec.template.pod` of your `KafkaNodePool` resource. 
+--
 +
-* Use a `labelSelector` to identify the pods to keep separate from your Kafka nodes.
-* Set the `topologyKey` to `"kubernetes.io/hostname"`. 
-This defines each worker node as a separate domain for the scheduling rule, preventing the targeted pods from being placed on the same host.
+In both cases, use a `labelSelector` to identify the application pods you want to keep separate from your Kafka pods and set the `topologyKey` to `"kubernetes.io/hostname"` to prevent pods from being placed on the same host.
 +
-.Example anti-affinity configuration against other workloads
+This example applies a rule to a `Kafka` resource named `my-cluster` that prevents any of its broker pods from running on the same node as pods labeled `postgresql` and `mongodb`.
++
+.Example cluster-wide anti-affinity configuration
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: application
+                      operator: In
+                      values:
+                      - postgresql
+                      - mongodb
+                topologyKey: "kubernetes.io/hostname"
+  # ...
+----
++
+This example applies a rule to a `KafkaNodePool` resource named `broker` that prevents pods from that pool from running on the same node as pods labeled `postgresql` and `mongodb`.
++
+.Example node pool-specific anti-affinity configuration
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaNodePoolApiVersion}
@@ -54,4 +91,4 @@ spec:
   # ...
 ----
 
-. Apply the changes to the `KafkaNodePool` configuration.
+. Apply the changes to your custom resource configuration.

--- a/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
@@ -3,10 +3,12 @@
 // assembly-scheduling.adoc
 
 [id='configuring-pod-anti-affinity-in-kafka-components-{context}']
-= Configuring pod anti-affinity in Kafka components
+= Configuring pod anti-affinity against other workloads
 
-Pod anti-affinity configuration helps with the stability and performance of Kafka brokers. By using `podAntiAffinity`, Kubernetes will not schedule Kafka brokers on the same nodes as other workloads. 
-Typically, you want to avoid Kafka running on the same worker node as other network or storage intensive applications such as databases, storage or other messaging platforms.
+[role="_abstract"]
+To improve the stability and performance of your Kafka cluster, you can prevent its pods from running on the same worker nodes as other resource-intensive applications. 
+
+Using `podAntiAffinity` in your `KafkaNodePool` resource tells Kubernetes to avoid scheduling Kafka nodes from the same pool alongside specific workloads, such as databases or other messaging systems.
 
 .Prerequisites
 
@@ -15,36 +17,41 @@ Typically, you want to avoid Kafka running on the same worker node as other netw
 
 .Procedure
 
-. Edit the `affinity` property in the resource specifying the cluster deployment.
-Use labels to specify the pods which should not be scheduled on the same nodes.
-The `topologyKey` should be set to `kubernetes.io/hostname` to specify that the selected pods should not be scheduled on nodes with the same hostname.
-For example:
+. In your `KafkaNodePool` custom resource, edit the `affinity` property in the `spec.template.pod` section.
 +
+To prevent Kafka pods from the same node pool sharing a worker node with other application pods, add a `podAntiAffinity` rule.
++
+* Use a `labelSelector` to identify the pods to keep separate from your Kafka nodes.
+* Set the `topologyKey` to `"kubernetes.io/hostname"`. 
+This defines each worker node as a separate domain for the scheduling rule, preventing the targeted pods from being placed on the same host.
++
+.Example anti-affinity configuration against other workloads
 [source,yaml,subs=attributes+]
 ----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
 spec:
-  kafka:
-    # ...
-    template:
-      pod:
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpressions:
-                    - key: application
-                      operator: In
-                      values:
-                        - postgresql
-                        - mongodb
-                topologyKey: "kubernetes.io/hostname"
-    # ...
+  replicas: 3
+  roles:
+    - broker
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: application
+                    operator: In
+                    values:
+                      - postgresql
+                      - mongodb
+              topologyKey: "kubernetes.io/hostname"
+  # ...
 ----
 
-. Create or update the resource.
-+
-This can be done using `kubectl apply`:
-[source,shell,subs=+quotes]
-kubectl apply -f _<kafka_configuration_file>_
+. Apply the changes to the `KafkaNodePool` configuration.

--- a/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
+++ b/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
@@ -6,29 +6,64 @@
 = Configuring pod anti-affinity for Kafka nodes
 
 [role="_abstract"]
-By default, multiple Kafka nodes from the same pool can run on the same worker node in your Kubernetes cluster.
-If that worker node fails, all Kafka nodes hosted on it become unavailable, impacting the reliability of your cluster.
+To improve fault tolerance, you can prevent multiple Kafka broker pods from running on the same worker node.
+Configure `podAntiAffinity` so that the pods are scheduled on different worker nodes. 
 
-To improve fault tolerance, configure `podAntiAffinity` in your `KafkaNodePool` resource so that Kafka nodes within a pool are scheduled on different worker nodes. 
+The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
+For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
+This procedure shows example configurations for both.
+
+IMPORTANT: A `podAntiAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
+The rules are not merged.
 
 .Prerequisites
 
-* A Kubernetes cluster
-* A running Cluster Operator
-* Other workloads in the cluster are labelled
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]  
 
 .Procedure
 
-. In your `KafkaNodePool` custom resource, edit the `affinity` property in the `spec.template.pod` section.
+. Configure `podAntiAffinity` in either the `Kafka` or `KafkaNodePool` resource.
 +
-To prevent Kafka pods from the same node pool from sharing a worker node, add a `podAntiAffinity` rule.
+--
+* To set a cluster-wide rule, edit the `affinity` property in `spec.kafka.template.pod` of your `Kafka` resource. 
+Use the `strimzi.io/name` label to select all broker pods.
+* To set a pool-specific rule, edit the `affinity` property in `spec.template.pod` of your `KafkaNodePool` resource. 
+Use the `strimzi.io/pool-name` label to select only the pods in that pool.
+--
 +
-* Use a `labelSelector` to identify the pods using the node pool name.
-* Set the `topologyKey` to `"kubernetes.io/hostname"`. 
-This defines each worker node as a separate domain for the scheduling rule, preventing the targeted pods from being placed on the same host.
+In both cases, set the `topologyKey` to `"kubernetes.io/hostname"` to prevent pods from being placed on the same host.
 +
-.Example anti-affinity configuration for a node pool
-[source,yaml,subs="+quotes,attributes+"]
+This example applies a rule to a `Kafka` resource named `my-cluster` that prevents any of its broker pods from running on the same node.
++
+.Example cluster-wide anti-affinity configuration
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: strimzi.io/name
+                      operator: In
+                      values:
+                        - my-cluster-kafka
+                topologyKey: "kubernetes.io/hostname"
+  # ...
+----
++
+This example applies a rule to a `KafkaNodePool` resource named `broker` that prevents pods from that specific pool from running on the same node.
++
+.Example node pool-specific anti-affinity configuration
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaNodePoolApiVersion}
 kind: KafkaNodePool
@@ -54,8 +89,5 @@ spec:
               topologyKey: "kubernetes.io/hostname"
   # ...
 ----
-+
-NOTE: For a stricter, cluster-wide anti-affinity rule, use the `strimzi.io/cluster` label with your cluster name as the value. 
-This prevents a pod from running on the same node as any other pod from the same Kafka cluster (such as controllers or brokers from a different pool).
 
-. Apply the changes to the `KafkaNodePool` configuration.
+. Apply the changes to your custom resource configuration.

--- a/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
+++ b/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
@@ -9,12 +9,11 @@
 To improve fault tolerance, you can prevent multiple Kafka broker pods from running on the same worker node.
 Configure `podAntiAffinity` so that the pods are scheduled on different worker nodes. 
 
-The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
-For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
-This procedure shows example configurations for both.
+This procedure provides configuration examples for the cluster-wide `Kafka` resource and the pool-specific `KafkaNodePool` resource.
 
-IMPORTANT: A `podAntiAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
-The rules are not merged.
+NOTE: If you configure `KafkaNodePool.spec.template`, its settings replace `Kafka.spec.kafka.template` for that node pool.
+Properties are not merged. 
+For more information, see xref:affinity-{context}[Scheduling strategies].
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
+++ b/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
@@ -2,78 +2,60 @@
 //
 // assembly-scheduling.adoc
 
-[id='configuring-pod-anti-affinity-to-schedule-each-kafka-broker-on-a-different-worker-node-{context}']
-= Configuring pod anti-affinity to schedule each Kafka broker on a different worker node
+[id='proc-scheduling-brokers-on-different-worker-nodes-{context}']
+= Configuring pod anti-affinity for Kafka nodes
 
-Many Kafka nodes can run on the same Kubernetes worker node.
-If the worker node fails, they will all become unavailable at the same time. 
-To improve reliability, you can use `podAntiAffinity` configuration to schedule each Kafka node on a different Kubernetes worker node.
+[role="_abstract"]
+By default, multiple Kafka nodes from the same pool can run on the same worker node in your Kubernetes cluster.
+If that worker node fails, all Kafka nodes hosted on it become unavailable, impacting the reliability of your cluster.
+
+To improve fault tolerance, configure `podAntiAffinity` in your `KafkaNodePool` resource so that Kafka nodes within a pool are scheduled on different worker nodes. 
 
 .Prerequisites
 
 * A Kubernetes cluster
 * A running Cluster Operator
+* Other workloads in the cluster are labelled
 
 .Procedure
 
-. Edit the `affinity` property in the resource specifying the cluster deployment.
-To make sure that no worker nodes are shared by Kafka nodes, use the `strimzi.io/name` label.
-Set the `topologyKey` to `kubernetes.io/hostname` to specify that the selected pods are not scheduled on nodes with the same hostname.
-This will still allow the same worker node to be shared by a single Kafka node.
-For example:
+. In your `KafkaNodePool` custom resource, edit the `affinity` property in the `spec.template.pod` section.
 +
+To prevent Kafka pods from the same node pool from sharing a worker node, add a `podAntiAffinity` rule.
++
+* Use a `labelSelector` to identify the pods using the node pool name.
+* Set the `topologyKey` to `"kubernetes.io/hostname"`. 
+This defines each worker node as a separate domain for the scheduling rule, preventing the targeted pods from being placed on the same host.
++
+.Example anti-affinity configuration for a node pool
 [source,yaml,subs="+quotes,attributes+"]
 ----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
 spec:
-  kafka:
-    # ...
-    template:
-      pod:
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpressions:
-                    - key: strimzi.io/name
-                      operator: In
-                      values:
-                        - _CLUSTER-NAME_-kafka
-                topologyKey: "kubernetes.io/hostname"
-    # ...
+  replicas: 3
+  roles:
+    - broker
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: strimzi.io/pool-name
+                    operator: In
+                    values:
+                      - broker
+              topologyKey: "kubernetes.io/hostname"
+  # ...
 ----
 +
-Where `_CLUSTER-NAME_` is the name of your Kafka custom resource.
+NOTE: For a stricter, cluster-wide anti-affinity rule, use the `strimzi.io/cluster` label with your cluster name as the value. 
+This prevents a pod from running on the same node as any other pod from the same Kafka cluster (such as controllers or brokers from a different pool).
 
-. If you even want to make sure that a Kafka node do not share the same worker node, use the `strimzi.io/cluster` label.
-For example:
-+
-[source,yaml,subs="+quotes,attributes+"]
-----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
-spec:
-  kafka:
-    # ...
-    template:
-      pod:
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpressions:
-                    - key: strimzi.io/cluster
-                      operator: In
-                      values:
-                        - _CLUSTER-NAME_
-                topologyKey: "kubernetes.io/hostname"
-    # ...
-----
-+
-Where `_CLUSTER-NAME_` is the name of your Kafka custom resource.
-
-. Create or update the resource.
-+
-[source,shell,subs=+quotes]
-kubectl apply -f _<kafka_configuration_file>_
+. Apply the changes to the `KafkaNodePool` configuration.

--- a/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
+++ b/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
@@ -3,62 +3,71 @@
 // assembly-scheduling.adoc
 
 [id='proc-configuring-node-affinity-{context}']
-= Configuring pod affinity for specific nodes
+= Configuring pod scheduling for specific nodes
 
 [role="_abstract"]
-Your Kubernetes cluster might have different types of worker nodes, some with specialized hardware like fast SSD storage, powerful CPUs, or high-speed network cards. 
+Your Kubernetes cluster might have different types of worker nodes, some with specialized hardware (fast SSDs, powerful CPUs) or a particular location (a specific availability zone). 
+To optimize performance and resource usage, configure `nodeAffinity` so that Kafka pods are scheduled only on the nodes that match your requirements.
 
-To optimize performance and resource usage, configure `nodeAffinity` in your `KafkaNodePool` resource so that Kafka pods in a specific pool are scheduled only on the nodes that meet their requirements.
+The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
+For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
+For example, you can tie different pools to different availability zones.
+This procedure shows example configurations for both.
+
+IMPORTANT: A `nodeAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
+The rules are not merged.
 
 .Prerequisites
 
-* A Kubernetes cluster
-* A running Cluster Operator
-* Worker nodes are labelled
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]  
+* Worker nodes are labeled to identify their specific characteristics (such as `disk:sdd`).
 
 .Procedure
 
-. Label the worker nodes where you want to schedule your Kafka pods. 
-+
-If the nodes aren't already labeled, apply labels using `kubectl label`:
+. Label the worker nodes to identify them when scheduling the kafka pods.
 +
 [source,shell,subs="+quotes,attributes+"]
 ----
-kubectl label node <name_of_node> node-type=fast-network
+kubectl label node <name_of_node> disk=sdd
 ----
 
-. In your `KafkaNodePool` custom resource, edit the `affinity` property in the `spec.template.pod` section.
+. Configure `nodeAffinity` in either the `Kafka` or `KafkaNodePool` resource to match the label.
 +
-To assign Kafka pods from the same node pool to a worker node, add a `nodeAffinity` rule.
+--
+* To set a cluster-wide rule, edit the `affinity` property in `spec.kafka.template.pod` of your `Kafka` resource.
+* To set a pool-specific rule, edit the `affinity` property in `spec.template.pod` of your `KafkaNodePool` resource.
+--
 +
-* Use `nodeSelectorTerms` with `matchExpressions` to specify the key (label name) and values of the nodes you want to schedule pods on. 
-Pods are only scheduled on nodes that match these expressions.
+In both cases, use `nodeSelectorTerms` with `matchExpressions` to specify the key-value label of the nodes you want to schedule pods on.
 +
-.Example affinity configuration for specific nodes
-[source,yaml,subs=attributes+]
+This example applies a rule to a `Kafka` resource that assigns all its broker pods to run only on nodes with the label `disk: ssd`.
++
+.Example cluster-wide affinity configuration for specific nodes
+[source,yaml,subs="+attributes"]
 ----
-apiVersion: {KafkaNodePoolApiVersion}
-kind: KafkaNodePool
+apiVersion: {KafkaApiVersion}
+kind: Kafka
 metadata:
-  name: broker
-  labels:
-    strimzi.io/cluster: my-cluster
+  name: my-cluster
 spec:
-  replicas: 3
-  roles:
-    - broker
-  template:
+  kafka:
+    # ...
+    template:
       pod:
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
                 - matchExpressions:
-                  - key: node-type
+                  - key: disk
                     operator: In
                     values:
-                    - fast-network
+                    - sdd
   # ...
 ----
++
+.Example availability zone scheduling for node pools
+For node pools, a common production scenario is to configure node pools so that pods are scheduled only on nodes within a specified availability zone. 
+For more information, see xref:proc-managing-storage-affinity-node-pools-str[Managing storage affinity using node pools]
 
-. Apply the changes to the `KafkaNodePool` configuration.
+. Apply the changes to your custom resource configuration.

--- a/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
+++ b/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
@@ -3,33 +3,51 @@
 // assembly-scheduling.adoc
 
 [id='proc-configuring-node-affinity-{context}']
-= Configuring node affinity in Kafka components
+= Configuring pod affinity for specific nodes
+
+[role="_abstract"]
+Your Kubernetes cluster might have different types of worker nodes, some with specialized hardware like fast SSD storage, powerful CPUs, or high-speed network cards. 
+
+To optimize performance and resource usage, configure `nodeAffinity` in your `KafkaNodePool` resource so that Kafka pods in a specific pool are scheduled only on the nodes that meet their requirements.
 
 .Prerequisites
 
 * A Kubernetes cluster
 * A running Cluster Operator
+* Worker nodes are labelled
 
 .Procedure
 
-. Label the nodes where Strimzi components should be scheduled.
+. Label the worker nodes where you want to schedule your Kafka pods. 
 +
-This can be done using `kubectl label`:
+If the nodes aren't already labeled, apply labels using `kubectl label`:
++
 [source,shell,subs="+quotes,attributes+"]
-kubectl label node _NAME-OF-NODE_ node-type=fast-network
+----
+kubectl label node <name_of_node> node-type=fast-network
+----
+
+. In your `KafkaNodePool` custom resource, edit the `affinity` property in the `spec.template.pod` section.
 +
-Alternatively, some of the existing labels might be reused.
-. Edit the `affinity` property in the resource specifying the cluster deployment.
-For example:
+To assign Kafka pods from the same node pool to a worker node, add a `nodeAffinity` rule.
 +
+* Use `nodeSelectorTerms` with `matchExpressions` to specify the key (label name) and values of the nodes you want to schedule pods on. 
+Pods are only scheduled on nodes that match these expressions.
++
+.Example affinity configuration for specific nodes
 [source,yaml,subs=attributes+]
 ----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
 spec:
-  kafka:
-    # ...
-    template:
+  replicas: 3
+  roles:
+    - broker
+  template:
       pod:
         affinity:
           nodeAffinity:
@@ -40,11 +58,7 @@ spec:
                     operator: In
                     values:
                     - fast-network
-    # ...
+  # ...
 ----
 
-. Create or update the resource.
-+
-This can be done using `kubectl apply`:
-[source,shell,subs="+quotes,attributes+"]
-kubectl apply -f _<kafka_configuration_file>_
+. Apply the changes to the `KafkaNodePool` configuration.

--- a/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
+++ b/documentation/modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc
@@ -9,13 +9,11 @@
 Your Kubernetes cluster might have different types of worker nodes, some with specialized hardware (fast SSDs, powerful CPUs) or a particular location (a specific availability zone). 
 To optimize performance and resource usage, configure `nodeAffinity` so that Kafka pods are scheduled only on the nodes that match your requirements.
 
-The simplest way to configure this is to set a cluster-wide policy in the `Kafka` resource.
-For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
-For example, you can tie different pools to different availability zones.
-This procedure shows example configurations for both.
+This procedure provides configuration examples for the cluster-wide `Kafka` resource and the pool-specific `KafkaNodePool` resource.
 
-IMPORTANT: A `nodeAffinity` rule defined in a `KafkaNodePool` resource overrides any rule in the `Kafka` resource. 
-The rules are not merged.
+NOTE: If you configure `KafkaNodePool.spec.template`, its settings replace `Kafka.spec.kafka.template` for that node pool.
+Properties are not merged. 
+For more information, see xref:affinity-{context}[Scheduling strategies].
 
 .Prerequisites
 

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -3,59 +3,33 @@
 // assembly-scheduling.adoc
 
 [id='affinity-{context}']
-= Specifying affinity, tolerations, and topology spread constraints
+= Scheduling strategies
 
-Use affinity, tolerations and topology spread constraints to schedule the pods of kafka resources onto nodes.
-Affinity, tolerations and topology spread constraints are configured using the `affinity`, `tolerations`, and `topologySpreadConstraints` properties in following resources:
+Kafka components can be scheduled onto Kubernetes nodes using affinity rules, tolerations, and topology constraints.  
+These strategies help isolate workloads, optimize resource usage, and improve overall cluster performance.
 
-* `Kafka.spec.kafka.template.pod`
+The following scheduling techniques support different deployment goals:
+
+Use pod anti-affinity to avoid critical applications sharing nodes::
+Use pod anti-affinity to prevent critical applications from being scheduled on the same disk.  
+In Kafka deployments, configure pod anti-affinity to ensure that Kafka brokers do not share nodes with other workloads, such as databases.
+
+Use node affinity to schedule workloads onto specific nodes::
+Kubernetes clusters often include nodes optimized for different workloads, such as CPU, memory, storage, or network.  
+Node affinity enables scheduling Kafka components onto nodes that match specific labels, such as `beta.kubernetes.io/instance-type` or custom labels, to optimize performance and cost.
+
+Use node affinity and tolerations for dedicated nodes::
+Cluster administrators can taint nodes to exclude them from general scheduling.  
+Kafka pods can be scheduled onto these dedicated nodes by configuring both node affinity and tolerations.  
+This approach isolates Kafka from other workloads, reducing resource contention and improving stability.
+
+To apply scheduling strategies, use `template.pod` properties in the `spec` section of the following resources
+
+* `KafkaNodePool.spec.template.pod`
 * `Kafka.spec.entityOperator.template.pod`
+* `Kafka.spec.cruiseControl.template.pod`
 * `KafkaConnect.spec.template.pod`
 * `KafkaBridge.spec.template.pod`
 * `KafkaMirrorMaker2.spec.template.pod`
 
-The format of the `affinity`, `tolerations`, and `topologySpreadConstraints` properties follows the Kubernetes specification.
-The affinity configuration can include different types of affinity:
-
-* Pod affinity and anti-affinity
-* Node affinity
-
-[role="_additional-resources"]
-.Additional resources
-
-* {K8sAffinity}
-* {K8sTolerations}
-* {K8sTopologySpreadConstraints}
-
-[id='con-scheduling-based-on-other-pods-{context}']
-== Use pod anti-affinity to avoid critical applications sharing nodes
-
-Use pod anti-affinity to ensure that critical applications are never scheduled on the same disk.
-When running a Kafka cluster, it is recommended to use pod anti-affinity to ensure that the Kafka brokers do not share nodes with other workloads, such as databases.
-
-[id='con-scheduling-to-specific-nodes-{context}']
-== Use node affinity to schedule workloads onto specific nodes
-
-The Kubernetes cluster usually consists of many different types of worker nodes.
-Some are optimized for CPU heavy workloads, some for memory, while other might be optimized for storage (fast local SSDs) or network.
-Using different nodes helps to optimize both costs and performance.
-To achieve the best possible performance, it is important to allow scheduling of Strimzi components to use the right nodes.
-
-Kubernetes uses node affinity to schedule workloads onto specific nodes.
-Node affinity allows you to create a scheduling constraint for the node on which the pod will be scheduled.
-The constraint is specified as a label selector.
-You can specify the label using either the built-in node label like `beta.kubernetes.io/instance-type` or custom labels to select the right node.
-
-[id='con-dedicated-nodes-{context}']
-== Use node affinity and tolerations for dedicated nodes
-
-Use taints to create dedicated nodes, then schedule Kafka pods on the dedicated nodes by configuring node affinity and tolerations.
-
-Cluster administrators can mark selected Kubernetes nodes as tainted.
-Nodes with taints are excluded from regular scheduling and normal pods will not be scheduled to run on them.
-Only services which can tolerate the taint set on the node can be scheduled on it.
-The only other services running on such nodes will be system services such as log collectors or software defined networks.
-
-Running Kafka and its components on dedicated nodes can have many advantages.
-There will be no other applications running on the same nodes which could cause disturbance or consume the resources needed for Kafka.
-That can lead to improved performance and stability.
+Scheduling properties follow the Kubernetes specification.

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -30,14 +30,23 @@ Kafka pods can still be scheduled onto these nodes by configuring:
 These settings direct Kafka pods to dedicated nodes while preventing other workloads from being scheduled there
 This approach isolates Kafka from other workloads, reducing resource contention and improving stability.
 
+Use topology spread constraints to balance pods across zones or nodes::
+Topology spread constraints help distribute pods evenly across specified topology domains, such as zones, regions, or nodes.
+For Kafka, this strategy reduces the risk of scheduling too many brokers on the same zone or node, improving availability and resilience.
+
 You can apply these scheduling strategies in the `template.pod` property within the `spec` of a Strimzi custom resource. 
+
 For Kafka brokers specifically, Strimzi provides a two-level configuration:
 
 * `Kafka.spec.kafka.template.pod` +
 Use this to set a cluster-wide default scheduling policy for all Kafka broker and controller pods.
 * `KafkaNodePool.spec.template.pod` + 
-Use this to set scheduling policy for a specific node pool. 
-Any scheduling rules defined here override the cluster-wide default for the pods managed by that specific node pool.
+For more granular control, if needed, you can override the default policy for specific node pools using the `KafkaNodePool` resource.
+
+IMPORTANT: If any property is defined under `KafkaNodePool.spec.template`, *all* `Kafka.spec.kafka.template` settings are ignored for pods in that node pool. 
+Properties are not merged. 
+In other words, node pools using `KafkaNodePool.spec.template` settings do not inherit any settings from the cluster-wide template. 
+Every required setting must be specified in the pool’s template.
 
 Other Strimzi components have their own template properties for scheduling:
 
@@ -49,7 +58,13 @@ Other Strimzi components have their own template properties for scheduling:
 * `KafkaBridge.spec.template.pod`
 * `KafkaMirrorMaker2.spec.template.pod`
 
-The following procedures provide configuration examples for the `Kafka` and `KafkaNodePool` resources. 
-The same affinity and tolerations configurations shown in these examples can be applied to the `template.pod` property of any other component.
+The following procedures provide scheduling configuration examples for the `Kafka` and `KafkaNodePool` resources. 
+The same configurations shown in these examples can be applied to the `template.pod` property of any other component.
 
 Scheduling properties follow the Kubernetes specification.
+
+.Additional resources
+
+* {K8sAffinity}
+* {K8sTolerations}
+* {K8sTopologySpreadConstraints}

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -16,7 +16,7 @@ In Kafka deployments, configure pod anti-affinity to ensure that Kafka brokers d
 
 Use node affinity to schedule workloads onto specific nodes::
 Kubernetes clusters often include nodes optimized for different workloads, such as CPU, memory, storage, or network.  
-Node affinity enables scheduling Kafka components onto nodes that match specific labels, such as `beta.kubernetes.io/instance-type` or custom labels, to optimize performance and cost.
+Node affinity enables scheduling Kafka components onto nodes that match specific labels, such as `node.kubernetes.io/instance-type` or custom labels, to optimize performance and cost.
 
 Use node affinity, taints, and tolerations for dedicated nodes::
 To reserve nodes for Kafka, you can taint them to exclude them from general workloads. 

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -18,18 +18,38 @@ Use node affinity to schedule workloads onto specific nodes::
 Kubernetes clusters often include nodes optimized for different workloads, such as CPU, memory, storage, or network.  
 Node affinity enables scheduling Kafka components onto nodes that match specific labels, such as `beta.kubernetes.io/instance-type` or custom labels, to optimize performance and cost.
 
-Use node affinity and tolerations for dedicated nodes::
-Cluster administrators can taint nodes to exclude them from general scheduling.  
-Kafka pods can be scheduled onto these dedicated nodes by configuring both node affinity and tolerations.  
+Use node affinity, taints, and tolerations for dedicated nodes::
+To reserve nodes for Kafka, you can taint them to exclude them from general workloads. 
+Kafka pods can still be scheduled onto these nodes by configuring:
++
+--
+* Tolerations, which allow the pods to bypass the taint.
+* Node affinity, for the pods to run on those specific nodes.
+--
++  
+These settings direct Kafka pods to dedicated nodes while preventing other workloads from being scheduled there
 This approach isolates Kafka from other workloads, reducing resource contention and improving stability.
 
-To apply scheduling strategies, use `template.pod` properties in the `spec` section of the following resources
+You can apply these scheduling strategies in the `template.pod` property within the `spec` of a Strimzi custom resource. 
+For Kafka brokers specifically, Strimzi provides a two-level configuration:
 
+* `Kafka.spec.kafka.template.pod` +
+Use this to set a cluster-wide default scheduling policy for all Kafka broker and controller pods.
+* `KafkaNodePool.spec.template.pod` + 
+Use this to set scheduling policy for a specific node pool. 
+Any scheduling rules defined here override the cluster-wide default for the pods managed by that specific node pool.
+
+Other Strimzi components have their own template properties for scheduling:
+
+* `Kafka.spec.kafka.template.pod`
 * `KafkaNodePool.spec.template.pod`
 * `Kafka.spec.entityOperator.template.pod`
 * `Kafka.spec.cruiseControl.template.pod`
 * `KafkaConnect.spec.template.pod`
 * `KafkaBridge.spec.template.pod`
 * `KafkaMirrorMaker2.spec.template.pod`
+
+The following procedures provide configuration examples for the `Kafka` and `KafkaNodePool` resources. 
+The same affinity and tolerations configurations shown in these examples can be applied to the `template.pod` property of any other component.
 
 Scheduling properties follow the Kubernetes specification.


### PR DESCRIPTION
**Documentation**

- Updates pod scheduling concepts and procedures
- Procedures now use node pools as examples
- Concepts streamlined and made more concise
- Kafka config option dropped and cruise control config added to concepts
- Minor restructure of storage section to make storage affinity and metadata storage more visible in the ToC 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

