### PR TITLE
Add support for deprecated versions to our CRD Generator

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -353,6 +353,12 @@ class CrdGenerator {
             versionNode.put("served", servedVersion != null ? servedVersion.contains(crApiVersion) : version.served());
             versionNode.put("storage", storageVersion != null ? crApiVersion.equals(storageVersion) : version.storage());
 
+            // Deprecation
+            versionNode.put("deprecated", version.deprecated());
+            if (version.deprecationWarning() != null && !version.deprecationWarning().isEmpty()) {
+                versionNode.put("deprecationWarning", version.deprecationWarning());
+            }
+
             // Subresources
             ObjectNode subresourcesForVersion = subresources.get(crApiVersion);
             if (!subresourcesForVersion.isEmpty()) {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -105,6 +105,16 @@ public @interface Crd {
              * @return  Specifies if this version is stored
              */
             boolean storage();
+
+            /**
+             * @return  Specifies if this version is deprecated
+             */
+            boolean deprecated() default false;
+
+            /**
+             * @return  Specifies the deprecation warning. Should be used only for deprecated resource versions.
+             */
+            String deprecationWarning() default "";
         }
 
         /**

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -37,7 +37,7 @@ import java.util.Map;
             categories = {"strimzi"}),
         scope = "Namespaced",
         versions = {
-            @Crd.Spec.Version(name = "v1alpha1", served = true, storage = true),
+            @Crd.Spec.Version(name = "v1alpha1", served = true, storage = true, deprecated = true, deprecationWarning = "This version is deprecated"),
             @Crd.Spec.Version(name = "v1beta1", served = true, storage = false)
         },
         additionalPrinterColumns = {

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -18,6 +18,8 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    deprecated: true
+    deprecationWarning: This version is deprecated
     additionalPrinterColumns:
     - name: Foo
       description: The foo
@@ -630,6 +632,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     additionalPrinterColumns:
     - name: Foo
       description: The foo

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -24,6 +24,8 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    deprecated: true
+    deprecationWarning: This version is deprecated
     additionalPrinterColumns:
     - name: Foo
       description: The foo
@@ -636,6 +638,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     additionalPrinterColumns:
     - name: Foo
       description: The foo

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithSubresources.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithSubresources.yaml
@@ -18,6 +18,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:
@@ -52,6 +53,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -18,6 +18,8 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    deprecated: true
+    deprecationWarning: This version is deprecated
     additionalPrinterColumns:
     - name: Foo
       description: The foo
@@ -623,6 +625,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     additionalPrinterColumns:
     - name: Foo
       description: The foo

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
@@ -18,6 +18,7 @@ spec:
   - name: v1
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:
@@ -63,6 +64,7 @@ spec:
   - name: v2
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -131,6 +132,7 @@ spec:
     - name: v1beta1
       served: true
       storage: false
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -238,6 +240,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -255,6 +256,7 @@ spec:
     - name: v1beta1
       served: true
       storage: false
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -486,6 +488,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -24,6 +24,7 @@ spec:
     - name: v1beta2
       served: true
       storage: true
+      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
+++ b/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -130,6 +131,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -237,6 +239,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -254,6 +255,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -485,6 +487,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -130,6 +131,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -237,6 +239,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -23,6 +23,7 @@ spec:
   - name: v1beta2
     served: true
     storage: true
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -254,6 +255,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -485,6 +487,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

For the Strimzi `v1` CRD API, we will at some point need to deprecate the old versions. This PR adds support for that to the CRD Generator so that it can be set through annotations. (For the time being, it keeps all versions as undeprecated)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally