### PR TITLE
Cleanup of API CRD classes

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
@@ -32,21 +32,20 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaBridge.RESOURCE_KIND,
             plural = KafkaBridge.RESOURCE_PLURAL,
-            shortNames = {KafkaBridge.SHORT_NAME},
+            shortNames = {"kb"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaBridge.RESOURCE_GROUP,
         scope = KafkaBridge.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaBridge.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaBridge.V1ALPHA1, served = true, storage = true)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status(),
             scale = @Crd.Spec.Subresources.Scale(
-                specReplicasPath = KafkaBridge.SPEC_REPLICAS_PATH,
-                statusReplicasPath = KafkaBridge.STATUS_REPLICAS_PATH,
-                labelSelectorPath = KafkaBridge.LABEL_SELECTOR_PATH
+                specReplicasPath = ".spec.replicas",
+                statusReplicasPath = ".status.replicas",
+                labelSelectorPath = ".status.labelSelector"
             )
         ),
         additionalPrinterColumns = {
@@ -76,32 +75,25 @@ import java.util.function.Predicate;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
-@ToString
+@ToString(callSuper = true)
 public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1ALPHA1);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "KafkaBridge";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkabridges";
     public static final String RESOURCE_SINGULAR = "kafkabridge";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "kb";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
-    public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
-    public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Constants.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Constants.java
@@ -16,6 +16,8 @@ public class Constants {
 
     public static final String STRIMZI_CATEGORY = "strimzi";
 
+    public static final String SCOPE_NAMESPACED = "Namespaced";
+
     public static final String FABRIC8_KUBERNETES_API = "io.fabric8.kubernetes.api.builder";
 
     public static final String MEMORY_REGEX = "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$";

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
@@ -32,22 +32,20 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaConnect.RESOURCE_KIND,
             plural = KafkaConnect.RESOURCE_PLURAL,
-            shortNames = {KafkaConnect.SHORT_NAME},
+            shortNames = {"kc"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaConnect.RESOURCE_GROUP,
         scope = KafkaConnect.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaConnect.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaConnect.V1BETA1, served = true, storage = true),
-            @Crd.Spec.Version(name = KafkaConnect.V1ALPHA1, served = true, storage = false)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status(),
             scale = @Crd.Spec.Subresources.Scale(
-                specReplicasPath = KafkaConnect.SPEC_REPLICAS_PATH,
-                statusReplicasPath = KafkaConnect.STATUS_REPLICAS_PATH,
-                labelSelectorPath = KafkaConnect.LABEL_SELECTOR_PATH
+                specReplicasPath = ".spec.replicas",
+                statusReplicasPath = ".status.replicas",
+                labelSelectorPath = ".status.labelSelector"
             )
         ),
         additionalPrinterColumns = {
@@ -78,28 +76,20 @@ import java.util.function.Predicate;
 public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String V1BETA1 = Constants.V1BETA1;
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1BETA1, V1ALPHA1);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "KafkaConnect";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkaconnects";
     public static final String RESOURCE_SINGULAR = "kafkaconnect";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "kc";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
-    public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
-    public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaConnect() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
@@ -30,20 +30,19 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaConnector.RESOURCE_KIND,
             plural = KafkaConnector.RESOURCE_PLURAL,
-            shortNames = {KafkaConnector.SHORT_NAME},
+            shortNames = {"kctr"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaConnector.RESOURCE_GROUP,
         scope = KafkaConnector.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaConnector.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaConnector.V1ALPHA1, served = true, storage = true)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status(),
             scale = @Crd.Spec.Subresources.Scale(
-                specReplicasPath = KafkaConnector.SPEC_REPLICAS_PATH,
-                statusReplicasPath = KafkaConnector.STATUS_REPLICAS_PATH
+                specReplicasPath = ".spec.tasksMax",
+                statusReplicasPath = ".status.tasksMax"
             )
         ),
         additionalPrinterColumns = {
@@ -84,25 +83,20 @@ import java.util.function.Predicate;
 public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1ALPHA1);
-    public static final String SCOPE = "Namespaced";
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
     public static final String RESOURCE_PLURAL = "kafkaconnectors";
     public static final String RESOURCE_SINGULAR = "kafkaconnector";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_KIND = "KafkaConnector";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "kctr";
-    public static final String SPEC_REPLICAS_PATH = ".spec.tasksMax";
-    public static final String STATUS_REPLICAS_PATH = ".status.tasksMax";
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaConnector() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
@@ -32,15 +32,13 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = Kafka.RESOURCE_KIND,
             plural = Kafka.RESOURCE_PLURAL,
-            shortNames = {Kafka.SHORT_NAME},
+            shortNames = {"k"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = Kafka.RESOURCE_GROUP,
         scope = Kafka.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = Kafka.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = Kafka.V1BETA1, served = true, storage = true),
-            @Crd.Spec.Version(name = Kafka.V1ALPHA1, served = true, storage = false)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status()
@@ -76,27 +74,22 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Namespaced, UnknownPropertyPreserving {
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String V1BETA1 = Constants.V1BETA1;
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1BETA1, V1ALPHA1);
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "Kafka";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkas";
     public static final String RESOURCE_SINGULAR = "kafka";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "k";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public Kafka() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
@@ -32,21 +32,20 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaMirrorMaker2.RESOURCE_KIND,
             plural = KafkaMirrorMaker2.RESOURCE_PLURAL,
-            shortNames = {KafkaMirrorMaker2.SHORT_NAME},
+            shortNames = {"kmm2"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaMirrorMaker2.RESOURCE_GROUP,
         scope = KafkaMirrorMaker2.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaMirrorMaker2.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaMirrorMaker2.V1ALPHA1, served = true, storage = true)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status(),
             scale = @Crd.Spec.Subresources.Scale(
-                specReplicasPath = KafkaMirrorMaker2.SPEC_REPLICAS_PATH,
-                statusReplicasPath = KafkaMirrorMaker2.STATUS_REPLICAS_PATH,
-                labelSelectorPath = KafkaMirrorMaker2.LABEL_SELECTOR_PATH
+                specReplicasPath = ".spec.replicas",
+                statusReplicasPath = ".status.replicas",
+                labelSelectorPath = ".status.labelSelector"
             )
         ),
         additionalPrinterColumns = {
@@ -65,7 +64,6 @@ import java.util.function.Predicate;
 )
 @Buildable(
         editableEnabled = false,
-        generateBuilderPackage = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API,
         refs = {@BuildableReference(CustomResource.class), @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class)}
 )
@@ -78,27 +76,20 @@ import java.util.function.Predicate;
 public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1ALPHA1);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "KafkaMirrorMaker2";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkamirrormaker2s";
     public static final String RESOURCE_SINGULAR = "kafkamirrormaker2";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "kmm2";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
-    public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
-    public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaMirrorMaker2() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -33,20 +33,20 @@ import java.util.Map;
                 names = @Crd.Spec.Names(
                         kind = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.RESOURCE_KIND,
                         plural = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.RESOURCE_PLURAL,
-                        shortNames = {io.strimzi.api.kafka.model.nodepool.KafkaNodePool.SHORT_NAME},
+                        shortNames = {"knp"},
                         categories = {Constants.STRIMZI_CATEGORY}
                 ),
                 group = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.RESOURCE_GROUP,
                 scope = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.SCOPE,
                 versions = {
-                    @Crd.Spec.Version(name = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.V1BETA2, served = true, storage = true)
+                    @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                         status = @Crd.Spec.Subresources.Status(),
                         scale = @Crd.Spec.Subresources.Scale(
-                                specReplicasPath = KafkaNodePool.SPEC_REPLICAS_PATH,
-                                statusReplicasPath = KafkaNodePool.STATUS_REPLICAS_PATH,
-                                labelSelectorPath = KafkaNodePool.LABEL_SELECTOR_PATH
+                                specReplicasPath = ".spec.replicas",
+                                statusReplicasPath = ".status.replicas",
+                                labelSelectorPath = ".status.labelSelector"
                         )
                 ),
                 additionalPrinterColumns = {
@@ -82,24 +82,20 @@ import java.util.Map;
 public class KafkaNodePool extends CustomResource<KafkaNodePoolSpec, KafkaNodePoolStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "KafkaNodePool";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkanodepools";
     public static final String RESOURCE_SINGULAR = "kafkanodepool";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "knp";
-    public static final String SPEC_REPLICAS_PATH = ".spec.replicas";
-    public static final String STATUS_REPLICAS_PATH = ".status.replicas";
-    public static final String LABEL_SELECTOR_PATH = ".status.labelSelector";
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaNodePool() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
@@ -31,13 +31,13 @@ import java.util.Map;
                 names = @Crd.Spec.Names(
                         kind = StrimziPodSet.RESOURCE_KIND,
                         plural = StrimziPodSet.RESOURCE_PLURAL,
-                        shortNames = {StrimziPodSet.SHORT_NAME},
+                        shortNames = {"sps"},
                         categories = {Constants.STRIMZI_CATEGORY}
                 ),
                 group = StrimziPodSet.RESOURCE_GROUP,
                 scope = StrimziPodSet.SCOPE,
                 versions = {
-                    @Crd.Spec.Version(name = StrimziPodSet.V1BETA2, served = true, storage = true)
+                    @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
                 },
                 subresources = @Crd.Spec.Subresources(
                     status = @Crd.Spec.Subresources.Status()
@@ -85,21 +85,20 @@ import java.util.Map;
 public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodSetStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "StrimziPodSet";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_CORE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "strimzipodsets";
     public static final String RESOURCE_SINGULAR = "strimzipodset";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "sps";
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public StrimziPodSet() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -32,14 +32,13 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaRebalance.RESOURCE_KIND,
             plural = KafkaRebalance.RESOURCE_PLURAL,
-            shortNames = {KafkaRebalance.SHORT_NAME},
+            shortNames = {"kr"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaRebalance.RESOURCE_GROUP,
         scope = KafkaRebalance.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaRebalance.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaRebalance.V1ALPHA1, served = true, storage = true)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status()
@@ -65,7 +64,6 @@ import java.util.function.Predicate;
 )
 @Buildable(
         editableEnabled = false,
-        generateBuilderPackage = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API,
         refs = {@BuildableReference(CustomResource.class)}
 )
@@ -78,24 +76,20 @@ import java.util.function.Predicate;
 public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1ALPHA1);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2);
     public static final String RESOURCE_KIND = "KafkaRebalance";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkarebalances";
     public static final String RESOURCE_SINGULAR = "kafkarebalance";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "kr";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaRebalance() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
@@ -32,15 +32,15 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaTopic.RESOURCE_KIND,
             plural = KafkaTopic.RESOURCE_PLURAL,
-            shortNames = {KafkaTopic.SHORT_NAME},
+            shortNames = "kt",
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaTopic.RESOURCE_GROUP,
         scope = KafkaTopic.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaTopic.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaTopic.V1BETA1, served = true, storage = true),
-            @Crd.Spec.Version(name = KafkaTopic.V1ALPHA1, served = true, storage = false)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true),
+            @Crd.Spec.Version(name = Constants.V1BETA1, served = true, storage = false),
+            @Crd.Spec.Version(name = Constants.V1ALPHA1, served = true, storage = false)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status()
@@ -83,25 +83,20 @@ import java.util.function.Predicate;
 public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String V1BETA1 = Constants.V1BETA1;
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1BETA1, V1ALPHA1);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2, Constants.V1BETA1, Constants.V1ALPHA1);
     public static final String RESOURCE_KIND = "KafkaTopic";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkatopics";
     public static final String RESOURCE_SINGULAR = "kafkatopic";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "kt";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaTopic() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
@@ -32,15 +32,15 @@ import java.util.function.Predicate;
         names = @Crd.Spec.Names(
             kind = KafkaUser.RESOURCE_KIND,
             plural = KafkaUser.RESOURCE_PLURAL,
-            shortNames = {KafkaUser.SHORT_NAME},
+            shortNames = {"ku"},
             categories = {Constants.STRIMZI_CATEGORY}
         ),
         group = KafkaUser.RESOURCE_GROUP,
         scope = KafkaUser.SCOPE,
         versions = {
-            @Crd.Spec.Version(name = KafkaUser.V1BETA2, served = true, storage = false),
-            @Crd.Spec.Version(name = KafkaUser.V1BETA1, served = true, storage = true),
-            @Crd.Spec.Version(name = KafkaUser.V1ALPHA1, served = true, storage = false)
+            @Crd.Spec.Version(name = Constants.V1BETA2, served = true, storage = true),
+            @Crd.Spec.Version(name = Constants.V1BETA1, served = true, storage = false),
+            @Crd.Spec.Version(name = Constants.V1ALPHA1, served = true, storage = false)
         },
         subresources = @Crd.Spec.Subresources(
             status = @Crd.Spec.Subresources.Status()
@@ -83,25 +83,20 @@ import java.util.function.Predicate;
 public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    public static final String SCOPE = "Namespaced";
-    public static final String V1ALPHA1 = Constants.V1ALPHA1;
-    public static final String V1BETA1 = Constants.V1BETA1;
-    public static final String V1BETA2 = Constants.V1BETA2;
-    public static final String CONSUMED_VERSION = V1BETA2;
-    public static final List<String> VERSIONS = List.of(V1BETA2, V1BETA1, V1ALPHA1);
+    public static final String SCOPE = Constants.SCOPE_NAMESPACED;
+    public static final List<String> VERSIONS = List.of(Constants.V1BETA2, Constants.V1BETA1, Constants.V1ALPHA1);
     public static final String RESOURCE_KIND = "KafkaUser";
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = Constants.RESOURCE_GROUP_NAME;
     public static final String RESOURCE_PLURAL = "kafkausers";
     public static final String RESOURCE_SINGULAR = "kafkauser";
-    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
-    public static final String SHORT_NAME = "ku";
-    public static final List<String> RESOURCE_SHORTNAMES = List.of(SHORT_NAME);
 
     private Map<String, Object> additionalProperties;
 
-    // Added to avoid duplication during Json serialization
+    // Added to avoid duplication during JSON serialization
+    @SuppressWarnings({"UnusedDeclaration"})
     private String apiVersion;
+    @SuppressWarnings({"UnusedDeclaration"})
     private String kind;
 
     public KafkaUser() {

--- a/api/src/test/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeCrdIT.java
@@ -121,13 +121,13 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaBridge.CRD_NAME, CrdUtils.CRD_KAFKA_BRIDGE);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_BRIDGE_NAME, CrdUtils.CRD_KAFKA_BRIDGE);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaBridge.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_BRIDGE_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/connect/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/connect/KafkaConnectCrdIT.java
@@ -106,13 +106,13 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaConnect.CRD_NAME, CrdUtils.CRD_KAFKA_CONNECT);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_CONNECT_NAME, CrdUtils.CRD_KAFKA_CONNECT);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaConnect.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_CONNECT_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/connector/KafkaConnectorCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/connector/KafkaConnectorCrdIT.java
@@ -35,13 +35,13 @@ public class KafkaConnectorCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaConnector.CRD_NAME, CrdUtils.CRD_KAFKA_CONNECTOR);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_CONNECTOR_NAME, CrdUtils.CRD_KAFKA_CONNECTOR);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaConnector.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_CONNECTOR_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaCrdIT.java
@@ -127,13 +127,13 @@ public class KafkaCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, Kafka.CRD_NAME, CrdUtils.CRD_KAFKA);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_NAME, CrdUtils.CRD_KAFKA);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, Kafka.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2CrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2CrdIT.java
@@ -106,13 +106,13 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaMirrorMaker2.CRD_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaMirrorMaker2.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolCrdIT.java
@@ -49,13 +49,13 @@ public class KafkaNodePoolCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaNodePool.CRD_NAME, CrdUtils.CRD_KAFKA_NODE_POOL);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_NODE_POOL_NAME, CrdUtils.CRD_KAFKA_NODE_POOL);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaNodePool.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_NODE_POOL_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/podset/StrimziPodSetCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/podset/StrimziPodSetCrdIT.java
@@ -72,13 +72,13 @@ public class StrimziPodSetCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, StrimziPodSet.CRD_NAME, CrdUtils.CRD_STRIMZI_POD_SET);
+        CrdUtils.createCrd(client, CrdUtils.CRD_STRIMZI_POD_SET_NAME, CrdUtils.CRD_STRIMZI_POD_SET);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, StrimziPodSet.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_STRIMZI_POD_SET_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceCrdIT.java
@@ -106,13 +106,13 @@ public class KafkaRebalanceCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaRebalance.CRD_NAME, CrdUtils.CRD_KAFKA_REBALANCE);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_REBALANCE_NAME, CrdUtils.CRD_KAFKA_REBALANCE);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaRebalance.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_REBALANCE_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/topic/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/topic/KafkaTopicCrdIT.java
@@ -48,13 +48,13 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaTopic.CRD_NAME, CrdUtils.CRD_TOPIC);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_TOPIC_NAME, CrdUtils.CRD_TOPIC);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaTopic.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_TOPIC_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/user/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/user/KafkaUserCrdIT.java
@@ -48,13 +48,13 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        CrdUtils.createCrd(client, KafkaUser.CRD_NAME, CrdUtils.CRD_KAFKA_USER);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_USER_NAME, CrdUtils.CRD_KAFKA_USER);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        CrdUtils.deleteCrd(client, KafkaUser.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_USER_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectList;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -88,10 +89,10 @@ public class StrimziPodSetControllerIT {
         LOGGER.info("Created namespace");
 
         LOGGER.info("Creating CRDs");
-        CrdUtils.createCrd(client, Kafka.CRD_NAME, CrdUtils.CRD_KAFKA);
-        CrdUtils.createCrd(client, KafkaConnect.CRD_NAME, CrdUtils.CRD_KAFKA_CONNECT);
-        CrdUtils.createCrd(client, KafkaMirrorMaker2.CRD_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
-        CrdUtils.createCrd(client, StrimziPodSet.CRD_NAME, CrdUtils.CRD_STRIMZI_POD_SET);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_NAME, CrdUtils.CRD_KAFKA);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_CONNECT_NAME, CrdUtils.CRD_KAFKA_CONNECT);
+        CrdUtils.createCrd(client, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        CrdUtils.createCrd(client, CrdUtils.CRD_STRIMZI_POD_SET_NAME, CrdUtils.CRD_STRIMZI_POD_SET);
         LOGGER.info("Created CRDs");
 
         vertx = Vertx.vertx();
@@ -114,10 +115,10 @@ public class StrimziPodSetControllerIT {
         kafkaOp().inNamespace(NAMESPACE).withName(KAFKA_NAME).delete();
         kafkaOp().inNamespace(NAMESPACE).withName(OTHER_KAFKA_NAME).delete();
 
-        CrdUtils.deleteCrd(client, Kafka.CRD_NAME);
-        CrdUtils.deleteCrd(client, KafkaConnect.CRD_NAME);
-        CrdUtils.deleteCrd(client, KafkaMirrorMaker2.CRD_NAME);
-        CrdUtils.deleteCrd(client, StrimziPodSet.CRD_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_CONNECT_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2_NAME);
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_STRIMZI_POD_SET_NAME);
 
         TestUtils.deleteNamespace(client, NAMESPACE);
 
@@ -207,7 +208,7 @@ public class StrimziPodSetControllerIT {
 
         assertThat(owner, is(notNullValue()));
         assertThat(owner.getKind(), is("StrimziPodSet"));
-        assertThat(owner.getApiVersion(), is(StrimziPodSet.RESOURCE_GROUP + "/" + StrimziPodSet.V1BETA2));
+        assertThat(owner.getApiVersion(), is(StrimziPodSet.RESOURCE_GROUP + "/" + Constants.V1BETA2));
         assertThat(owner.getName(), is(podSetName));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectList;
@@ -240,7 +241,7 @@ public class StrimziPodSetControllerMockTest {
 
         assertThat(owner, is(notNullValue()));
         assertThat(owner.getKind(), is("StrimziPodSet"));
-        assertThat(owner.getApiVersion(), is(StrimziPodSet.RESOURCE_GROUP + "/" + StrimziPodSet.V1BETA2));
+        assertThat(owner.getApiVersion(), is(StrimziPodSet.RESOURCE_GROUP + "/" + Constants.V1BETA2));
         assertThat(owner.getName(), is(podSetName));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaBridgeCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaBridgeCrdOperatorIT.java
@@ -42,7 +42,7 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
 
     @Override
     protected String getCrdName() {
-        return KafkaBridge.CRD_NAME;
+        return CrdUtils.CRD_KAFKA_BRIDGE_NAME;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectCrdOperatorIT.java
@@ -40,7 +40,7 @@ public class KafkaConnectCrdOperatorIT extends AbstractCustomResourceOperatorIT<
 
     @Override
     protected String getCrdName() {
-        return KafkaConnect.CRD_NAME;
+        return CrdUtils.CRD_KAFKA_CONNECT_NAME;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectorCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectorCrdOperatorIT.java
@@ -40,7 +40,7 @@ public class KafkaConnectorCrdOperatorIT extends AbstractCustomResourceOperatorI
 
     @Override
     protected String getCrdName() {
-        return KafkaConnector.CRD_NAME;
+        return CrdUtils.CRD_KAFKA_CONNECTOR_NAME;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorIT.java
@@ -42,7 +42,7 @@ public class KafkaCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kuberne
 
     @Override
     protected String getCrdName() {
-        return Kafka.CRD_NAME;
+        return CrdUtils.CRD_KAFKA_NAME;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorTest.java
@@ -44,7 +44,6 @@ public class KafkaCrdOperatorTest extends AbstractNamespacedResourceOperatorTest
     @Override
     protected Kafka resource(String name) {
         return new KafkaBuilder()
-                .withApiVersion(Kafka.RESOURCE_GROUP + "/" + Kafka.V1BETA1)
                 .withNewMetadata()
                     .withName(name)
                     .withNamespace(NAMESPACE)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaMirrorMaker2CrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaMirrorMaker2CrdOperatorIT.java
@@ -40,7 +40,7 @@ public class KafkaMirrorMaker2CrdOperatorIT extends AbstractCustomResourceOperat
 
     @Override
     protected String getCrdName() {
-        return KafkaMirrorMaker2.CRD_NAME;
+        return CrdUtils.CRD_KAFKA_MIRROR_MAKER_2_NAME;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/StrimziPodSetCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/StrimziPodSetCrdOperatorIT.java
@@ -60,7 +60,7 @@ public class StrimziPodSetCrdOperatorIT extends AbstractCustomResourceOperatorIT
 
     @Override
     protected String getCrdName() {
-        return StrimziPodSet.CRD_NAME;
+        return CrdUtils.CRD_STRIMZI_POD_SET_NAME;
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/KafkaUserCrdOperatorIT.java
@@ -38,7 +38,7 @@ public class KafkaUserCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kub
 
     @Override
     protected String getCrdName() {
-        return KafkaUser.CRD_NAME;
+        return CrdUtils.CRD_KAFKA_USER_NAME;
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/CrdUtils.java
+++ b/test/src/main/java/io/strimzi/test/CrdUtils.java
@@ -21,9 +21,19 @@ public final class CrdUtils {
     public static final String CRD_TOPIC = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/043-Crd-kafkatopic.yaml";
 
     /**
+     * Name of the KafkaTopic CRD
+     */
+    public static final String CRD_KAFKA_TOPIC_NAME = "kafkatopics.kafka.strimzi.io";
+
+    /**
      * Path to the Kafka CRD definition YAML
      */
     public static final String CRD_KAFKA = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/040-Crd-kafka.yaml";
+
+    /**
+     * Name of the Kafka CRD
+     */
+    public static final String CRD_KAFKA_NAME = "kafkas.kafka.strimzi.io";
 
     /**
      * Path to the KafkaConnect CRD definition YAML
@@ -31,9 +41,19 @@ public final class CrdUtils {
     public static final String CRD_KAFKA_CONNECT = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml";
 
     /**
+     * Name of the KafkaConnect CRD
+     */
+    public static final String CRD_KAFKA_CONNECT_NAME = "kafkaconnects.kafka.strimzi.io";
+
+    /**
      * Path to the KafkaUser CRD definition YAML
      */
     public static final String CRD_KAFKA_USER = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/044-Crd-kafkauser.yaml";
+
+    /**
+     * Name of the KafkaUser CRD
+     */
+    public static final String CRD_KAFKA_USER_NAME = "kafkausers.kafka.strimzi.io";
 
     /**
      * Path to the KafkaBridge CRD definition YAML
@@ -41,9 +61,19 @@ public final class CrdUtils {
     public static final String CRD_KAFKA_BRIDGE = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/046-Crd-kafkabridge.yaml";
 
     /**
+     * Name of the KafkaBridge CRD
+     */
+    public static final String CRD_KAFKA_BRIDGE_NAME = "kafkabridges.kafka.strimzi.io";
+
+    /**
      * Path to the KafkaMirrorMaker2 CRD definition YAML
      */
     public static final String CRD_KAFKA_MIRROR_MAKER_2 = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml";
+
+    /**
+     * Name of the KafkaMirrorMaker2 CRD
+     */
+    public static final String CRD_KAFKA_MIRROR_MAKER_2_NAME = "kafkamirrormaker2s.kafka.strimzi.io";
 
     /**
      * Path to the KafkaConnector CRD definition YAML
@@ -51,9 +81,19 @@ public final class CrdUtils {
     public static final String CRD_KAFKA_CONNECTOR = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml";
 
     /**
+     * Name of the KafkaConnector CRD
+     */
+    public static final String CRD_KAFKA_CONNECTOR_NAME = "kafkaconnectors.kafka.strimzi.io";
+
+    /**
      * Path to the KafkaRebalance CRD definition YAML
      */
     public static final String CRD_KAFKA_REBALANCE = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml";
+
+    /**
+     * Name of the KafkaRebalance CRD
+     */
+    public static final String CRD_KAFKA_REBALANCE_NAME = "kafkarebalances.kafka.strimzi.io";
 
     /**
      * Path to the KafkaNodePool CRD definition YAML
@@ -61,9 +101,19 @@ public final class CrdUtils {
     public static final String CRD_KAFKA_NODE_POOL = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml";
 
     /**
+     * Name of the KafkaNodePool CRD
+     */
+    public static final String CRD_KAFKA_NODE_POOL_NAME = "kafkanodepools.kafka.strimzi.io";
+
+    /**
      * Path to the StrimziPodSet CRD definition YAML
      */
     public static final String CRD_STRIMZI_POD_SET = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/042-Crd-strimzipodset.yaml";
+
+    /**
+     * Name of the StrimziPodSet CRD
+     */
+    public static final String CRD_STRIMZI_POD_SET_NAME = "strimzipodsets.core.strimzi.io";
 
     private CrdUtils() { }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR does some cleanup of the API CRD classes.
* It removes some unused constants
* Constants used only in the annotations are set directly in the annotations instead of being defined as public constants (Java annotations cannot refer to private constants)
* Constants used only in tests are moved to the `CrdUtils` class, where some similar constants used in testing already exist
* Some other IDE warnings are addressed (or suppressed where we cannot address them, such as the unused fields)

### Checklist

- [x] Make sure all tests pass