### PR TITLE
[ST] Configure `KAFKA_TIERED_STORAGE_BASE_IMAGE` env in TestingFarm pipeline

### DIFF
--- a/systemtest/tmt/tests/strimzi/test.sh
+++ b/systemtest/tmt/tests/strimzi/test.sh
@@ -22,6 +22,12 @@ if [[ ${RELEASE:-False} == True ]]; then
 	export DOCKER_TAG="${PACKIT_TAG_NAME}"
 fi
 
+# Get latest Kafka version from kafka-versions.yaml
+KAFKA_VERSION=$(cat kafka-versions.yaml | yq eval '.[] | select(.default) | .version' -)
+
+# Configure the `KAFKA_TIERED_STORAGE_BASE_IMAGE` needed for the TieredStorageST
+export KAFKA_TIERED_STORAGE_BASE_IMAGE="${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka:${DOCKER_TAG}-kafka-${KAFKA_VERSION}"
+
 echo "Using container registry '$DOCKER_REGISTRY'"
 echo "Using container org '$DOCKER_ORG'"
 echo "Using container tag '$DOCKER_TAG'"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds configuration of `KAFKA_TIERED_STORAGE_BASE_IMAGE` env variable inside the `test.sh` for Testing Farm.
Because currently, when we run TF tests on PR adding new version of Kafka - that is not yet pushed in Quay - they will fail - because it cannot pull image that doesn't exist.

### Checklist

- [ ] Make sure all tests pass
