### PR TITLE
Use proper ref for load images and fix results notification

### DIFF
--- a/.github/actions/log-variables/action.yml
+++ b/.github/actions/log-variables/action.yml
@@ -7,16 +7,16 @@ runs:
     - name: Print environment variables
       shell: bash
       run: |
-        echo "BRANCH: ${{ github.ref_name }}"
-        echo "TAG: ${{ env.TAG }}"
+        echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
+        echo "REPO_SLUG: ${{ github.repository }}"
+        echo "REASON (event_name): ${{ github.event_name }}"
+        echo "REF (determined): ${{ env.REF }}"
         echo "COMMIT: ${{ github.sha }}"
+        echo "TAG: ${{ env.TAG }}"
         echo "PULL_REQUEST: ${{ env.PULL_REQUEST }}"
         echo "DOCKER_ORG: ${{ env.DOCKER_ORG }}"
         echo "DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}"
         echo "DOCKER_TAG: ${{ env.DOCKER_TAG }}"
-        echo "REASON: ${{ github.event_name }}"
-        echo "REPO_SLUG: ${{ github.repository }}"
-        echo "PATH: $PATH"
         echo "OPERATOR_IMAGE_PULL_POLICY: ${{ env.OPERATOR_IMAGE_PULL_POLICY }}"
         echo "ST_KAFKA_VERSION: ${{ env.ST_KAFKA_VERSION }}"
         echo "KAFKA_VERSION: ${{ env.KAFKA_VERSION }}"

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -207,7 +207,7 @@ jobs:
 
       # Load Strimzi images
       - name: Load Strimzi images
-        if: ${{ env.DOCKER_TAG == 'latest' && github.ref_name != 'main' }}
+        if: ${{ env.DOCKER_TAG == 'latest' && inputs.ref != 'main' }}
         uses: ./.github/actions/containers-load
         with:
           architecture: ${{ matrix.config.arch }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -180,7 +180,11 @@ jobs:
         uses: ./.github/actions/add-comment
         with:
           commentMessage: |
-            ${{ needs.run-tests.result == 'success' && ':tada: System test verification **passed**' || needs.run-tests.result == 'failure' && ':x: System test verification **failed**' || ':warning: System test verification **skipped**' }}: [link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            ${{
+              (needs.run-tests.result == 'success' && ':tada: System test verification **passed**') ||
+              (needs.run-tests.result == 'failure' && ':x: System test verification **failed**') ||
+              ':warning: System test verification **skipped**'
+            }}: [link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
       - name: Set check & commit status
         uses: ./.github/actions/check-and-status
         with:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Use proper ref - `inputs.ref` which points to real repository ref instead of `github.ref_name` that always points to default branch in case of `issue_comment` trigger.

Also fix comment notification for failed workflows.

### Checklist

- [ ] Make sure all tests pass


