### PR TITLE
Remove invalid warning about JVM Options being not supported in `KafkaBridge`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
@@ -120,7 +120,7 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @Description("**Currently not supported** JVM Options for pods")
+    @Description("JVM Options for pods")
     public JvmOptions getJvmOptions() {
         return jvmOptions;
     }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3807,7 +3807,7 @@ include::../api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc[leveloffs
 |CPU and memory resources to reserve.
 |jvmOptions
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|**Currently not supported** JVM Options for pods.
+|JVM Options for pods.
 |logging
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |Logging configuration for Kafka Bridge.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -405,7 +405,7 @@ spec:
                             type: string
                             description: The system property value.
                       description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                  description: '**Currently not supported** JVM Options for pods.'
+                  description: JVM Options for pods.
                 logging:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -404,7 +404,7 @@ spec:
                           type: string
                           description: The system property value.
                     description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                description: '**Currently not supported** JVM Options for pods.'
+                description: JVM Options for pods.
               logging:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The docs for `KafkaBridge` currently state that the `jvmOptions` field is `Currently not supported`. That seems to be just something we forgot to remove. This PR addresses it.

### Checklist

- [x] Update documentation