### PR TITLE
Update Vert.x to 5.0.4 and Netty to 4.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
         <fasterxml.jackson-annotations.version>2.18.3</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.18.3</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.18.3</fasterxml.jackson-jaxrs.version>
-        <vertx.version>5.0.3</vertx.version>
-        <vertx-junit5.version>5.0.3</vertx-junit5.version>
+        <vertx.version>5.0.4</vertx.version>
+        <vertx-junit5.version>5.0.4</vertx-junit5.version>
         <kafka.version>4.0.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>
@@ -122,7 +122,7 @@
         <jetty-old-kafka.version>9.4.56.v20240826</jetty-old-kafka.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.16.2</strimzi-oauth.version>
-        <netty.version>4.2.4.Final</netty.version>
+        <netty.version>4.2.5.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Vert.x and Netty to new patch releases that address some CVEs. It would nice to have it addressed given the upcoming release.