### PR TITLE
Improve UO error when no operation is specified in ACL rule

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -145,6 +145,8 @@ public class SimpleAclRule {
     public static List<SimpleAclRule> fromCrd(AclRule rule) {
         if (rule.getOperations() != null && rule.getOperation() != null) {
             throw new InvalidResourceException("Both fields `operations` and `operation` cannot be filled in at the same time");
+        } else if (rule.getOperations() == null && rule.getOperation() == null) {
+            throw new InvalidResourceException("Both fields `operations` and `operation` are null. At least one of them must be specified!");
         } else if (rule.getOperations() != null) {
             List<SimpleAclRule> simpleAclRules = new ArrayList<>();
             for (AclOperation operation : rule.getOperations()) {

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
@@ -74,6 +74,21 @@ public class SimpleAclRuleTest {
     }
 
     @Test
+    public void testFromCrdWithNoOperationsAndOperationSet()   {
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
+            AclRule rule = new AclRuleBuilder()
+                .withType(AclRuleType.ALLOW)
+                .withResource(ACL_RULE_TOPIC_RESOURCE)
+                .withHost("127.0.0.1")
+                .build();
+
+            SimpleAclRule.fromCrd(rule);
+        });
+
+        assertThat(ex.getMessage(), is("Both fields `operations` and `operation` are null. At least one of them must be specified!"));
+    }
+
+    @Test
     public void testFromCrdWithThreeOperationsPerRule()   {
         AclRule rule = new AclRuleBuilder()
             .withType(AclRuleType.ALLOW)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When a user creates a `KafkaUser` resource with ACL rules without any operation specified (the operation can be specified as deprecated `operation` field or `operations` list - so they cannot be required in the CRD), the User Operator currently throws a very hard-to-understand error (an NPE in a `hashCode` method):
```
2025-09-04 08:31:49 ERROR UserControllerLoop:127 - Reconciliation #15(timer) KafkaUser(myproject/my-user): KafkaUser my-user in namespace myproject reconciliation failed
java.util.concurrent.ExecutionException: io.strimzi.operator.common.ReconciliationException: java.lang.NullPointerException: Cannot invoke "io.strimzi.api.kafka.model.user.acl.AclOperation.hashCode()" because "this.operation" is null
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?]
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096) ~[?:?]
	at io.strimzi.operator.user.UserControllerLoop.reconcile(UserControllerLoop.java:122) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.common.controller.AbstractControllerLoop.reconcileWrapper(AbstractControllerLoop.java:158) ~[io.strimzi.operator-common-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.common.controller.AbstractControllerLoop.reconcileWithLock(AbstractControllerLoop.java:118) ~[io.strimzi.operator-common-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.common.controller.AbstractControllerLoop$Runner.run(AbstractControllerLoop.java:183) ~[io.strimzi.operator-common-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
Caused by: io.strimzi.operator.common.ReconciliationException: java.lang.NullPointerException: Cannot invoke "io.strimzi.api.kafka.model.user.acl.AclOperation.hashCode()" because "this.operation" is null
	at io.strimzi.operator.user.operator.KafkaUserOperator.createOrUpdate(KafkaUserOperator.java:242) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.KafkaUserOperator.reconcile(KafkaUserOperator.java:189) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.user.UserControllerLoop.reconcile(UserControllerLoop.java:115) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	... 4 more
Caused by: java.lang.NullPointerException: Cannot invoke "io.strimzi.api.kafka.model.user.acl.AclOperation.hashCode()" because "this.operation" is null
	at io.strimzi.operator.user.model.acl.SimpleAclRule.hashCode(SimpleAclRule.java:99) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at java.util.HashMap.hash(HashMap.java:338) ~[?:?]
	at java.util.HashMap.put(HashMap.java:610) ~[?:?]
	at java.util.HashSet.add(HashSet.java:221) ~[?:?]
	at java.util.AbstractCollection.addAll(AbstractCollection.java:336) ~[?:?]
	at io.strimzi.operator.user.model.KafkaUserModel.setSimpleAclRules(KafkaUserModel.java:569) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.user.model.KafkaUserModel.fromCrd(KafkaUserModel.java:132) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.KafkaUserOperator.createOrUpdate(KafkaUserOperator.java:237) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.KafkaUserOperator.reconcile(KafkaUserOperator.java:189) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	at io.strimzi.operator.user.UserControllerLoop.reconcile(UserControllerLoop.java:115) ~[io.strimzi.user-operator-0.48.0-SNAPSHOT.jar:0.48.0-SNAPSHOT]
	... 4 more
```

This PR catches the situation when no operation is set and prodce proper explanatory error.

### Checklist

- [x] Write tests
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally