### PR TITLE
[AZP] Add cleanup phase to UTs/ITs job for build

### DIFF
--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -14,6 +14,9 @@ jobs:
       vmImage: Ubuntu-22.04
     # Pipeline steps
     steps:
+      # Clean up unnecessary tools
+      - template: "clean_up_workspace.yaml"
+
       # Get cached Maven repository
       - template: "../../steps/maven_cache.yaml"
 

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -15,7 +15,7 @@ jobs:
     # Pipeline steps
     steps:
       # Clean up unnecessary tools
-      - template: "clean_up_workspace.yaml"
+      - template: "../../steps/clean_up_workspace.yaml"
 
       # Get cached Maven repository
       - template: "../../steps/maven_cache.yaml"


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

As it seems that we have some issues with disk space - which was previously a little bit fixed in STs pipeline - this PR adds cleanup_workspace YAML to the UTs/ITs job in AZPs.
This should help to not fill the disk fully, however it still doesn't fix it completely - a lot of space is taken by the Maven Cache, which needs to be somehow resolved in a different PR.

### Checklist

- [ ] Make sure all tests pass