### PR TITLE
Fix two leftover examples to Kafka 4.1.0

### DIFF
--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-connect-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-connect-metrics.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: my-connect-cluster
 spec:
-  version: 4.0.0
+  version: 4.1.0
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9092
   metricsConfig:

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-mirror-maker-2-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-mirror-maker-2-metrics.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: my-mm2-cluster
 spec:
-  version: 4.0.0
+  version: 4.1.0
   replicas: 1
   connectCluster: "my-cluster-target"
   clusters:

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -61,7 +61,7 @@
   fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.47.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
-    kafka: strimzi/kafka:latest-kafka-4.0.0
+    kafka: strimzi/kafka:latest-kafka-4.1.0
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seem to be two leftover examples that were not updated to Kafka 4.1.0. This PR fixes it.