### PR TITLE
Removed use of AccessController

### DIFF
--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -25,8 +25,6 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -237,18 +235,13 @@ public class KafkaConfigModelGenerator {
     }
 
     private static Field getField(Class<?> cls, String fieldName) {
-        return AccessController.doPrivileged(new PrivilegedAction<Field>() {
-                @Override
-                public Field run() {
-                    try {
-                        Field f1 = cls.getDeclaredField(fieldName);
-                        f1.setAccessible(true);
-                        return f1;
-                    } catch (ReflectiveOperationException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            });
+        try {
+            Field f1 = cls.getDeclaredField(fieldName);
+            f1.setAccessible(true);
+            return f1;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static ConfigModel range(ConfigDef.ConfigKey key, ConfigModel descriptor) {


### PR DESCRIPTION
This PR fixes #11650 
As mentioned by @katheris in the issue, the `getDeclaredField` method is already used in other places without the need for the `AccessController`. It is anyway used at build time and not runtime. I removed it and ran the build and the model generator works fine (the models are ok and the same as the current ones).