### PR TITLE
Allow typed APIs to be present only in some API versions

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -615,7 +615,7 @@ class CrdGenerator {
             checkClassOverrides(crdClass, "hashCode");
             hasAnyGetterAndAnySetter(crdClass);
         } else {
-            for (Class<?> c : subtypes(crdClass)) {
+            for (Class<?> c : subtypes(null, crdClass)) {
                 hasAnyGetterAndAnySetter(c);
                 checkDiscriminatorIsIncluded(crdClass, c);
                 checkJsonPropertyOrder(c);
@@ -711,7 +711,7 @@ class CrdGenerator {
         JsonPropertyOrder order = crdClass.getAnnotation(JsonPropertyOrder.class);
 
         TreeMap<String, Property> result = new TreeMap<>();
-        for (Class<?> subtype : Property.subtypes(crdClass)) {
+        for (Class<?> subtype : Property.subtypes(crApiVersion, crdClass)) {
             Map<String, Property> properties = properties(crApiVersion, subtype);
             checkPropertiesInJsonPropertyOrder(subtype, properties.keySet());
             result.putAll(properties);
@@ -1003,7 +1003,7 @@ class CrdGenerator {
 
         if (property.getDeclaringClass().isAnnotationPresent(JsonTypeInfo.class)
             && property.getName().equals(property.getDeclaringClass().getAnnotation(JsonTypeInfo.class).property())) {
-            result.set("enum", stringArray(Property.subtypeNames(property.getDeclaringClass())));
+            result.set("enum", stringArray(Property.subtypeNames(crApiVersion, property.getDeclaringClass())));
         }
 
         return result;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -287,8 +287,10 @@ class Property implements AnnotatedElement {
      * This method is used to provide the typed classes that are part of a typed API. This method is used to generate
      * the CRDs and the API reference docs.
      *
-     * @param crApiVersion  Strimzi API version for which the type classes should be returned (some types might be present only in some versions)
-     * @param crdClass      The parent class for which the type identifiers should be returned
+     * @param crApiVersion  Strimzi API version for which the type classes should be returned (some types might be present
+     *                      only in some versions). If null, all types are returned. This might be used in places where
+     *                      we want all subtypes regardless of their versions, for example, for generating the docs.
+     * @param crdClass      The parent class for which the type identifiers should be returned.
      *
      * @return  List of the available subtype classes
      */
@@ -315,8 +317,9 @@ class Property implements AnnotatedElement {
     /**
      * This method is used to provide the type identifiers for typed APIs. This method is used to generate the CRDs.
      *
-     * @param crApiVersion  Strimzi API version for which the identifiers should be returned (some types might be present only in some versions)
-     * @param crdClass      The parent class for which the type identifiers should be returned
+     * @param crApiVersion  Strimzi API version for which the identifiers should be returned (some types might be present
+     *                      only in some versions). It should always contain a specific version and not be null.
+     * @param crdClass      The parent class for which the type identifiers should be returned.
      *
      * @return  List of the available types
      */

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/PresentInVersions.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/PresentInVersions.java
@@ -10,10 +10,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used when a property is present from or until a particular CR API version
+ * Used when a property is present from or until a particular CR API version. It can be also used on a type definition,
+ * in which case the type will be included only in some API versions when it is used in some typed APIs (based on the
+ * "type: xxx" differentiator).
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.TYPE})
 public @interface PresentInVersions {
     /**
      * @return The versions in which the annotated property is present

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -23,6 +23,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 
 import java.util.List;
@@ -229,6 +230,7 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonPropertyOrder({"discrim", "commonProperty", "rightProperty"})
+    @PresentInVersions("v1alpha1")
     public static class PolymorphicRight extends PolymorphicTop {
         private String rightProperty;
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -176,6 +176,8 @@ It must have the value `left` for the type `PolymorphicLeft`.
 Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 
 
+The type PolymorphicRight is supported only in the Strimzi API version(s) v1alpha1.
+
 The `discrim` property is a discriminator that distinguishes use of the `PolymorphicRight` type from xref:type-PolymorphicLeft-{context}[`PolymorphicLeft`].
 It must have the value `right` for the type `PolymorphicRight`.
 [cols="2,2,3a",options="header"]

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -723,13 +723,9 @@ spec:
                 type: string
                 enum:
                 - left
-                - right
               leftProperty:
                 type: string
                 description: "when descrim=left, the left-hand property."
-              rightProperty:
-                type: string
-                description: "when descrim=right, the right-hand property."
             required:
             - discrim
           affinity:
@@ -1104,13 +1100,9 @@ spec:
                   type: string
                   enum:
                   - left
-                  - right
                 leftProperty:
                   type: string
                   description: "when descrim=left, the left-hand property."
-                rightProperty:
-                  type: string
-                  description: "when descrim=right, the right-hand property."
               required:
               - discrim
           rawList:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -729,13 +729,9 @@ spec:
                 type: string
                 enum:
                 - left
-                - right
               leftProperty:
                 type: string
                 description: "when descrim=left, the left-hand property."
-              rightProperty:
-                type: string
-                description: "when descrim=right, the right-hand property."
             required:
             - discrim
           affinity:
@@ -1110,13 +1106,9 @@ spec:
                   type: string
                   enum:
                   - left
-                  - right
                 leftProperty:
                   type: string
                   description: "when descrim=left, the left-hand property."
-                rightProperty:
-                  type: string
-                  description: "when descrim=right, the right-hand property."
               required:
               - discrim
           rawList:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -714,10 +714,7 @@ spec:
                 type: string
                 enum:
                 - left
-                - right
               leftProperty:
-                type: string
-              rightProperty:
                 type: string
             required:
             - discrim
@@ -1092,10 +1089,7 @@ spec:
                   type: string
                   enum:
                   - left
-                  - right
                 leftProperty:
-                  type: string
-                rightProperty:
                   type: string
               required:
               - discrim


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

For the `v1` CRD API, we will need to make sure some types in typed APIs will be available only in some versions. For example, the `type: opa` authorization should be available in `v1beta2`. But as it is deprecated and should be removed in `v1`, it should be not present there.

We cannot add it to the annotations for the typed API (`@JsonSubTypes`) as they are part of Jackson. This PR adds support for that by extending the `@PresentInVersions` annotation also to types. And when the subtype has the `@PresentInVersions` annotation set, it will be added only to those versions. It also updates the Docs generator to add a note about where the type is support to the API reference as well.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally