### PR TITLE
Allow KafkaRoller connect to controllers

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -155,7 +155,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     protected static final String REPLICATION_PORT_NAME = "tcp-replication";
     protected static final int KAFKA_AGENT_PORT = 8443;
     protected static final String KAFKA_AGENT_PORT_NAME = "tcp-kafkaagent";
-    protected static final int CONTROLPLANE_PORT = 9090;
+    /**
+     * Port number used for control plane
+     */
+    public static final int CONTROLPLANE_PORT = 9090;
     protected static final String CONTROLPLANE_PORT_NAME = "tcp-ctrlplane"; // port name is up to 15 characters
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -892,7 +892,7 @@ public class KafkaRoller {
                 return adminClientProvider.createAdminClient(bootstrapHostnames, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
             }
         } catch (RuntimeException e) {
-            throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
+            throw new ForceableProblem("An error while try to create an admin client with bootstrap " + bootstrapHostnames, e);
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -362,7 +362,17 @@ public class ResourceUtils {
             }
 
             @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
+                return createControllerAdminClient(controllerBootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
+            }
+
+            @Override
             public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
+                return mockAdminClient;
+            }
+
+            @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
                 return mockAdminClient;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -998,7 +998,7 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected KafkaQuorumCheck quorumCheck(Admin ac, long controllerQuorumFetchTimeoutMs) {
+        protected KafkaQuorumCheck quorumCheck(Admin ac, NodeRef ref) {
             Admin admin = mock(Admin.class);
             DescribeMetadataQuorumResult qrmResult = mock(DescribeMetadataQuorumResult.class);
             when(admin.describeMetadataQuorum()).thenReturn(qrmResult);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -589,7 +589,17 @@ public class KubernetesRestartEventsMockTest {
             }
 
             @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
+                return adminClientSupplier.get();
+            }
+
+            @Override
             public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
+                return adminClientSupplier.get();
+            }
+
+            @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
                 return adminClientSupplier.get();
             }
         };

--- a/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 public interface AdminClientProvider {
 
     /**
-     * Create a Kafka Admin interface instance
+     * Create a Kafka Admin interface instance for brokers
      *
      * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param kafkaCaTrustSet Trust set for connecting to Kafka
@@ -26,7 +26,17 @@ public interface AdminClientProvider {
     Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity);
 
     /**
-     * Create a Kafka Admin interface instance
+     * Create a Kafka Admin interface instance for controllers
+     *
+     * @param controllerBootstrapHostnames Kafka controller hostname to connect to for administration operations
+     * @param kafkaCaTrustSet Trust set for connecting to Kafka
+     * @param authIdentity Identity for TLS client authentication for connecting to Kafka
+     * @return Instance of Kafka Admin interface
+     */
+    Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity);
+
+    /**
+     * Create a Kafka Admin interface instance for brokers
      *
      * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param kafkaCaTrustSet Trust set for connecting to Kafka
@@ -36,4 +46,16 @@ public interface AdminClientProvider {
      * @return Instance of Kafka Admin interface
      */
     Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config);
+
+    /**
+     * Create a Kafka Admin interface instance for controllers
+     *
+     * @param controllerBootstrapHostnames Kafka hostname to connect to for administration operations
+     * @param kafkaCaTrustSet Trust set for connecting to Kafka
+     * @param authIdentity Identity for TLS client authentication for connecting to Kafka
+     * @param config Additional configuration for the Kafka Admin Client
+     *
+     * @return Instance of Kafka Admin interface
+     */
+    Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config);
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -21,6 +21,11 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
         return createAdminClient(bootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
     }
 
+    @Override
+    public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
+        return createControllerAdminClient(controllerBootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
+    }
+
     /**
      * Create a Kafka Admin interface instance handling the following different scenarios:
      *
@@ -44,25 +49,29 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
      */
     @Override
     public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
-        return Admin.create(adminClientConfiguration(bootstrapHostnames, kafkaCaTrustSet, authIdentity, config));
+        config.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
+        return Admin.create(adminClientConfiguration(kafkaCaTrustSet, authIdentity, config));
+    }
+
+    @Override
+    public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
+        config.setProperty(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG, controllerBootstrapHostnames);
+        return Admin.create(adminClientConfiguration(kafkaCaTrustSet, authIdentity, config));
     }
 
     /**
      * Utility method for preparing the Admin client configuration
      *
-     * @param bootstrapHostnames    Kafka bootstrap address
      * @param kafkaCaTrustSet       Trust set for connecting to Kafka
      * @param authIdentity          Identity for TLS client authentication for connecting to Kafka
      * @param config                Custom Admin client configuration or empty properties instance
      *
      * @return  Admin client configuration
      */
-    /* test */ static Properties adminClientConfiguration(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
+    /* test */ Properties adminClientConfiguration(PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
         if (config == null) {
             throw new InvalidConfigurationException("The config parameter should not be null");
         }
-
-        config.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
 
         // configuring TLS encryption if requested
         if (kafkaCaTrustSet != null) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/DefaultAdminClientProviderTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/DefaultAdminClientProviderTest.java
@@ -9,6 +9,7 @@ import io.strimzi.operator.common.auth.PemTrustSet;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Properties;
 
@@ -16,7 +17,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultAdminClientProviderTest {
@@ -26,7 +30,6 @@ public class DefaultAdminClientProviderTest {
     private static final String USER_KEY = "user-key";
 
     private void assertDefaultConfigs(Properties config) {
-        assertThat(config.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), is("my-kafka:9092"));
         assertThat(config.get(AdminClientConfig.METADATA_MAX_AGE_CONFIG), is("30000"));
         assertThat(config.get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG), is("10000"));
         assertThat(config.get(AdminClientConfig.RETRIES_CONFIG), is("3"));
@@ -35,9 +38,10 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testPlainConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, null, new Properties());
+        DefaultAdminClientProvider defaultAdminClientProvider = new DefaultAdminClientProvider();
+        Properties config = defaultAdminClientProvider.adminClientConfiguration(null, null, new Properties());
 
-        assertThat(config.size(), is(5));
+        assertThat(config.size(), is(4));
         assertDefaultConfigs(config);
     }
 
@@ -47,10 +51,10 @@ public class DefaultAdminClientProviderTest {
         customConfig.setProperty(AdminClientConfig.RETRIES_CONFIG, "5"); // Override a value we have default for
         customConfig.setProperty(AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG, "13000"); // Override a value we do not use
 
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, null, customConfig);
+        DefaultAdminClientProvider defaultAdminClientProvider = new DefaultAdminClientProvider();
+        Properties config = defaultAdminClientProvider.adminClientConfiguration(null, null, customConfig);
 
-        assertThat(config.size(), is(6));
-        assertThat(config.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), is("my-kafka:9092"));
+        assertThat(config.size(), is(5));
         assertThat(config.get(AdminClientConfig.METADATA_MAX_AGE_CONFIG), is("30000"));
         assertThat(config.get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG), is("10000"));
         assertThat(config.get(AdminClientConfig.RETRIES_CONFIG), is("5"));
@@ -60,9 +64,10 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testTlsConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", mockPemTrustSet(), null, new Properties());
+        DefaultAdminClientProvider defaultAdminClientProvider = new DefaultAdminClientProvider();
+        Properties config = defaultAdminClientProvider.adminClientConfiguration(mockPemTrustSet(), null, new Properties());
 
-        assertThat(config.size(), is(8));
+        assertThat(config.size(), is(7));
         assertDefaultConfigs(config);
         assertThat(config.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
         assertThat(config.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), is("PEM"));
@@ -72,9 +77,10 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testMTlsConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", mockPemTrustSet(), mockPemAuthIdentity(), new Properties());
+        DefaultAdminClientProvider defaultAdminClientProvider = new DefaultAdminClientProvider();
+        Properties config = defaultAdminClientProvider.adminClientConfiguration(mockPemTrustSet(), mockPemAuthIdentity(), new Properties());
 
-        assertThat(config.size(), is(11));
+        assertThat(config.size(), is(10));
         assertDefaultConfigs(config);
         assertThat(config.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
         assertThat(config.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), is("PEM"));
@@ -87,9 +93,10 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testMTlsWithPublicCAConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, mockPemAuthIdentity(), new Properties());
+        DefaultAdminClientProvider defaultAdminClientProvider = new DefaultAdminClientProvider();
+        Properties config = defaultAdminClientProvider.adminClientConfiguration(null, mockPemAuthIdentity(), new Properties());
 
-        assertThat(config.size(), is(9));
+        assertThat(config.size(), is(8));
         assertDefaultConfigs(config);
         assertThat(config.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
         assertThat(config.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG).toString(), is("PEM"));
@@ -99,8 +106,39 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testNullConfig() {
-        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, mockPemAuthIdentity(), null));
+        DefaultAdminClientProvider defaultAdminClientProvider = new DefaultAdminClientProvider();
+        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> defaultAdminClientProvider.adminClientConfiguration(null, mockPemAuthIdentity(), null));
         assertThat(ex.getMessage(), is("The config parameter should not be null"));
+    }
+
+    @Test
+    public void tesCreateControllerAdminClientConfig() {
+        DefaultAdminClientProvider defaultAdminClientProvider = spy(DefaultAdminClientProvider.class);
+        // We expect a failure from creating an actual admin client since the bootstrap is not real
+        assertThrows(RuntimeException.class, () -> defaultAdminClientProvider.createControllerAdminClient("my-kafka-controller:9090", null, null));
+
+        ArgumentCaptor<Properties> configsCapture = ArgumentCaptor.forClass(Properties.class);
+        verify(defaultAdminClientProvider).adminClientConfiguration(eq(null), eq(null), configsCapture.capture());
+        Properties configs = configsCapture.getValue();
+
+        assertThat(configs.size(), is(5));
+        assertThat(configs.getProperty(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG), is("my-kafka-controller:9090"));
+        assertDefaultConfigs(configs);
+    }
+
+    @Test
+    public void testCreateBrokerAdminClient() {
+        DefaultAdminClientProvider defaultAdminClientProvider = spy(DefaultAdminClientProvider.class);
+        // We expect a failure from creating an actual admin client since the bootstrap is not real
+        assertThrows(RuntimeException.class, () -> defaultAdminClientProvider.createAdminClient("my-kafka-broker:9092", null, null));
+
+        ArgumentCaptor<Properties> configsCapture = ArgumentCaptor.forClass(Properties.class);
+        verify(defaultAdminClientProvider).adminClientConfiguration(eq(null), eq(null), configsCapture.capture());
+        Properties configs = configsCapture.getValue();
+
+        assertThat(configs.size(), is(5));
+        assertThat(configs.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), is("my-kafka-broker:9092"));
+        assertDefaultConfigs(configs);
     }
 
     public static PemTrustSet mockPemTrustSet() {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

- Add a method for creating admin client for controllers with BOOTSTRAP_CONTROLLERS_CONFIG set.
- Make KafkaRoller create admin client against controllers nodes before attempting to roll a controller node
- Tidy up: remove ceShouldBeFatal option as it's never set to true.

There will be a follow up PR to dynamically apply configurations for controllers using the admin client instead of how we currently restart controllers when any config changes.

Closes https://github.com/strimzi/strimzi-kafka-operator/issues/9692

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

