### PR TITLE
chore(monitoring): fix alerts grouping

### DIFF
--- a/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-connect-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-connect-rules.yaml
@@ -18,18 +18,18 @@ spec:
         summary: 'All Kafka Connect containers down or in CrashLookBackOff status'
         description: 'All Kafka Connect containers have been down or in CrashLookBackOff status for 3 minutes'
     - alert: ConnectFailedConnector
-      expr: sum(kafka_connect_connector_status{status="failed"}) by (namespace) > 0
+      expr: sum(kafka_connect_connector_status{status="failed"}) by (namespace, pod) > 0
       for: 5m
       labels:
         severity: major
       annotations:
         summary: 'Kafka Connect Connector Failure'
-        description: 'One or more connectors have been in failed state for 5 minutes,'
+        description: 'Kafka instance on pod {{ $labels.namespace }}/{{ $labels.pod }} has {{ $value }} connector(s) in failed state during last 5 minutes'
     - alert: ConnectFailedTask
-      expr: sum(kafka_connect_worker_connector_failed_task_count) by (namespace) > 0
+      expr: sum(kafka_connect_worker_connector_failed_task_count) by (namespace, pod) > 0
       for: 5m
       labels:
         severity: major
       annotations:
         summary: 'Kafka Connect Task Failure'
-        description: 'One or more tasks have been in failed state for 5 minutes.'
+        description: 'Kafka instance on pod {{ $labels.namespace }}/{{ $labels.pod }} has {{ $value }} task(s) in failed state during last 5 minutes'

--- a/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-rules.yaml
@@ -26,21 +26,21 @@ spec:
         summary: 'Kafka under replicated partitions'
         description: 'There are {{ $value }} under replicated partitions on {{ $labels.kubernetes_pod_name }}'
     - alert: AbnormalControllerState
-      expr: sum(kafka_controller_kafkacontroller_activecontrollercount) by (strimzi_io_name, namespace) != 1
+      expr: sum(kafka_controller_kafkacontroller_activecontrollercount) by (strimzi_io_name, namespace, pod) != 1
       for: 10s
       labels:
         severity: warning
       annotations:
         summary: 'Kafka abnormal controller state'
-        description: 'There are {{ $value }} active controllers in the cluster'
+        description: 'Kafka instance on pod {{ $labels.namespace }}/{{ $labels.pod }} has {{ $value }} active controllers'
     - alert: OfflinePartitions
-      expr: sum(kafka_controller_kafkacontroller_offlinepartitionscount) by (namespace) > 0
+      expr: sum(kafka_controller_kafkacontroller_offlinepartitionscount) by (namespace, pod) > 0
       for: 10s
       labels:
         severity: warning
       annotations:
         summary: 'Kafka offline partitions'
-        description: 'One or more partitions have no leader'
+        description: 'Kafka instance on pod {{ $labels.namespace }}/{{ $labels.pod }} has {{ $value }} partition(s) with no leader'
     - alert: UnderMinIsrPartitionCount
       expr: kafka_server_replicamanager_underminisrpartitioncount > 0
       for: 10s


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Current approach with `sum()` operator usage produces cumulative metric without any labels. Labels are very important in alert routing. Short example:

```text
http_requests_total{handler="/health", method="GET",namespace="admin"} 10
http_requests_total{handler="/api", method="GET",namespace="admin"} 5
http_requests_total{handler="/", method="GET",namespace="portal-dev"} 20
```
query `sum(http_requests_total)` returns `35` - a sum of all available metrics. But maybe admin team doesn't want to receive alerts of portal-dev team. The most often case - splitting alertmanager routes based on Kubernetes `namespace` label value.

So, query `sum(http_requests_total) by (namespace)` solves current problem:
```text
{namespace="admin"} 15
{namespace="portal-dev"} 20
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

