### PR TITLE
[ST] Change `testChangingInternalToExternalLoggingTriggerRollingUpdate` after removal of Kafka 3.9.x

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.log.LoggingChangeST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.log.LoggingChangeST.md
@@ -15,17 +15,17 @@
 
 <hr style="border:1px solid">
 
-## testChangingInternalToExternalLoggingTriggerRollingUpdate
+## testChangingInternalToExternalLoggingDoesNotTriggerRollingUpdate
 
-**Description:** This test case checks that changing Logging configuration from internal to external triggers Rolling Update.
+**Description:** This test case checks that changing Logging configuration from internal to external will not trigger Rolling Update.
 
 **Steps:**
 
 | Step | Action | Result |
 | - | - | - |
 | 1. | Deploy Kafka cluster, without any logging related configuration. | Cluster is deployed. |
-| 2. | Modify Kafka by changing specification of logging to new external value. | Change in logging specification triggers Rolling Update. |
-| 3. | Modify ConfigMap to new logging format. | Change in logging specification triggers Rolling Update. |
+| 2. | Modify Kafka by changing specification of logging to new external value. | Change in logging specification doesn't trigger Rolling Update. |
+| 3. | Modify ConfigMap to new logging format. | Change in logging specification doesn't trigger Rolling Update. |
 
 **Labels:**
 

--- a/development-docs/systemtests/labels/kafka.md
+++ b/development-docs/systemtests/labels/kafka.md
@@ -12,7 +12,7 @@ These tests are crucial to ensure that Kafka clusters can handle production work
 - [testAdvertisedHostNamesAppearsInBrokerCerts](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testCertificateWithNonExistingDataCrt](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testCertificateWithNonExistingDataKey](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
-- [testChangingInternalToExternalLoggingTriggerRollingUpdate](../io.strimzi.systemtest.log.LoggingChangeST.md)
+- [testChangingInternalToExternalLoggingDoesNotTriggerRollingUpdate](../io.strimzi.systemtest.log.LoggingChangeST.md)
 - [testClusterIp](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testClusterIpTls](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testClusterOperatorMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)

--- a/development-docs/systemtests/labels/logging.md
+++ b/development-docs/systemtests/labels/logging.md
@@ -13,7 +13,7 @@ and stability of Kafka deployments in production environments.
 <!-- generated part -->
 **Tests:**
 - [testBridgeLogSetting](../io.strimzi.systemtest.log.LogSettingST.md)
-- [testChangingInternalToExternalLoggingTriggerRollingUpdate](../io.strimzi.systemtest.log.LoggingChangeST.md)
+- [testChangingInternalToExternalLoggingDoesNotTriggerRollingUpdate](../io.strimzi.systemtest.log.LoggingChangeST.md)
 - [testConnectLogSetting](../io.strimzi.systemtest.log.LogSettingST.md)
 - [testCruiseControlLogChange](../io.strimzi.systemtest.log.LogSettingST.md)
 - [testDynamicallyAndNonDynamicSetConnectLoggingLevels](../io.strimzi.systemtest.log.LoggingChangeST.md)


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR changes the `LoggingChangeST#testChangingInternalToExternalLoggingTriggerRollingUpdate` after removal of Kafka 3.9.x from supported matrix of Strimzi. Before, when we had only Kafka 3.x (which used the Log4j1), change from internal to external logging cause rolling update of the controllers and brokers. However, with Kafka 4.x (and upgrade of Log4j2), this is done dynamically, so no rolling update is triggered.

As part of the PR I changed the name to `testChangingInternalToExternalLoggingDoesNotTriggerRollingUpdate` and also the overall test to check the configuration that we are configuring + checking that there is no actual rolling update.

Finally, this test was disabled for Kafka 4.x until now - we can finally enable it.

Fixes #11312 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

