### PR TITLE
Allow having CEL validation rules only for specific CRD API versions

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/CelValidation.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/CelValidation.java
@@ -55,5 +55,10 @@ public @interface CelValidation {
          * @return  Return fieldPath
          */
         String fieldPath() default "";
+
+        /**
+         * @return The versions in which this validation rule is used
+         */
+        String versions() default "";
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -148,7 +148,7 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     @JsonPropertyOrder({"foo", "bar"})
     @CelValidation(rules = {
         @CelValidation.CelValidationRule(rule = "size(self.foo) >= 5", message = "foo needs to be at least 5 characters long", fieldPath = ".foo", reason = "FieldValueInvalid"),
-        @CelValidation.CelValidationRule(rule = "size(self.bar) >= 5", message = "bar needs to be at least 5 characters long", fieldPath = ".bar", reason = "FieldValueInvalid")
+        @CelValidation.CelValidationRule(rule = "size(self.bar) >= 5", message = "bar needs to be at least 5 characters long", fieldPath = ".bar", reason = "FieldValueInvalid", versions = "v1beta1")
     })
     public static class ObjectProperty {
         private String foo;
@@ -285,6 +285,9 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     @Description("An example long property")
     @Example("42")
     @Minimum(42)
+    @CelValidation(rules = {
+        @CelValidation.CelValidationRule(rule = "self >= 1874", message = "long property needs to be 1874 or higher", versions = "v1beta1")
+    })
     public long getLongProperty() {
         return longProperty;
     }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -82,10 +82,6 @@ spec:
               message: foo needs to be at least 5 characters long
               fieldPath: .foo
               reason: FieldValueInvalid
-            - rule: size(self.bar) >= 5
-              message: bar needs to be at least 5 characters long
-              fieldPath: .bar
-              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -671,6 +667,9 @@ spec:
             example: 42
             minimum: 42
             description: An example long property.
+            x-kubernetes-validations:
+            - rule: self >= 1874
+              message: long property needs to be 1874 or higher
           booleanProperty:
             type: boolean
           normalEnum:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -88,10 +88,6 @@ spec:
               message: foo needs to be at least 5 characters long
               fieldPath: .foo
               reason: FieldValueInvalid
-            - rule: size(self.bar) >= 5
-              message: bar needs to be at least 5 characters long
-              fieldPath: .bar
-              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -677,6 +673,9 @@ spec:
             example: 42
             minimum: 42
             description: An example long property.
+            x-kubernetes-validations:
+            - rule: self >= 1874
+              message: long property needs to be 1874 or higher
           booleanProperty:
             type: boolean
           normalEnum:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -80,10 +80,6 @@ spec:
               message: foo needs to be at least 5 characters long
               fieldPath: .foo
               reason: FieldValueInvalid
-            - rule: size(self.bar) >= 5
-              message: bar needs to be at least 5 characters long
-              fieldPath: .bar
-              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -662,6 +658,9 @@ spec:
             type: integer
             example: 42
             minimum: 42
+            x-kubernetes-validations:
+            - rule: self >= 1874
+              message: long property needs to be 1874 or higher
           booleanProperty:
             type: boolean
           normalEnum:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Right now, we can configure CEL validation rules in our CRDs using the `CelValidation` annotation. But right now, the validation rules are the same for all CRD API versions. This PR extends the annotation to allow specifying the versions in which the validation is present. That allows us to add new additional validations, for example, based on the #11765 issue, only in the `v1` version.

This PR itself does not add any new validations, just the support for them.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally