### PR TITLE
Handling `min.insync.replicas` deletion operation when possible based on ELR version

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -83,11 +83,6 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
         this.brokerConfigDiff = diff(brokerNodeRef, desired, brokerConfigs, configModel);
     }
 
-    // TODO: to be removed. Having this ctor to avoid changes in all tests for now, until the solution is approved
-    protected KafkaBrokerConfigurationDiff(Reconciliation reconciliation, Config brokerConfigs, String desired, KafkaVersion kafkaVersion, NodeRef brokerNodeRef) {
-        this(reconciliation, brokerConfigs, desired, kafkaVersion, brokerNodeRef, (short) 0);
-    }
-
     /**
      * @return  Returns true if the configuration can be updated dynamically
      */
@@ -223,7 +218,6 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
         } else {
             // entry is in current, is not in desired, is not default -> it was using non-default value and was removed
             // if the entry was custom, it should be deleted
-            // TODO: to evaluate if we want a list of such properties or leaving the single one involved
             if ("min.insync.replicas".equals(entry.name()) && elrVersion >= 1) {
                 LOGGER.infoCr(reconciliation, "min.insync.replicas cannot be deleted when ELR is enabled");
             } else if (!isIgnorableProperty(pathValueWithoutSlash, nodeIsController)) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -206,7 +206,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
         if (KafkaConfiguration.isCustomConfigurationOption(entry.name(), configModel)) {
             // we are deleting custom option
             LOGGER.traceCr(reconciliation, "removing custom property {}", entry.name());
-        } else if (entry.isDefault()) {
+        } else if (entry.isDefault() || ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG.equals(entry.source())) {
             // entry is in current, is not in desired, is default -> it uses default value, skip.
             // Some default properties do not have set ConfigEntry.ConfigSource.DEFAULT_CONFIG and thus
             // we are removing property. That might cause redundant RU. To fix this we would have to add defaultValue

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -219,7 +219,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
             // entry is in current, is not in desired, is not default -> it was using non-default value and was removed
             // if the entry was custom, it should be deleted
             if ("min.insync.replicas".equals(entry.name()) && elrVersion >= 1) {
-                LOGGER.infoCr(reconciliation, "min.insync.replicas cannot be deleted when ELR is enabled");
+                LOGGER.traceCr(reconciliation, "min.insync.replicas cannot be deleted when ELR is enabled");
             } else if (!isIgnorableProperty(pathValueWithoutSlash, nodeIsController)) {
                 updatedCE.add(new AlterConfigOp(new ConfigEntry(pathValueWithoutSlash, null), AlterConfigOp.OpType.DELETE));
                 LOGGER.infoCr(reconciliation, "{} not set in desired, unsetting back to default {}", entry.name(), "deleted entry");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -224,8 +224,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
             // entry is in current, is not in desired, is not default -> it was using non-default value and was removed
             // if the entry was custom, it should be deleted
             // TODO: to evaluate if we want a list of such properties or leaving the single one involved
-            //       also if the elrVersion could be even higher than 1 in the future so condition should be > 1
-            if ("min.insync.replicas".equals(entry.name()) && elrVersion == 1) {
+            if ("min.insync.replicas".equals(entry.name()) && elrVersion >= 1) {
                 LOGGER.infoCr(reconciliation, "min.insync.replicas cannot be deleted when ELR is enabled");
             } else if (!isIgnorableProperty(pathValueWithoutSlash, nodeIsController)) {
                 updatedCE.add(new AlterConfigOp(new ConfigEntry(pathValueWithoutSlash, null), AlterConfigOp.OpType.DELETE));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -666,7 +666,7 @@ public class KafkaRoller {
      * Returns the information about the features within the Kafka Cluster
      * @return information about the features
      */
-    FeatureMetadata featureMetadata() throws ForceableProblem, InterruptedException {
+    /* test */ FeatureMetadata featureMetadata() throws ForceableProblem, InterruptedException {
         return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerAdminClient.describeFeatures().featureMetadata()),
                 30, TimeUnit.SECONDS,
                 error -> new ForceableProblem("Error getting feature metadata", error)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.FeatureMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigException;
@@ -623,8 +624,12 @@ public class KafkaRoller {
             // Always get the broker config. This request gets sent to that specific broker, so it's a proof that we can
             // connect to the broker and that it's capable of responding.
             Config brokerConfig;
+            short elrVersion = 0;
             try {
                 brokerConfig = brokerConfig(nodeRef);
+                FeatureMetadata featureMetadata = featureMetadata();
+                elrVersion = featureMetadata.finalizedFeatures().get("eligible.leader.replicas.version") == null ?
+                        0 : featureMetadata.finalizedFeatures().get("eligible.leader.replicas.version").maxVersionLevel();
             } catch (ForceableProblem e) {
                 if (restartContext.backOff.done()) {
                     needsRestart = true;
@@ -636,7 +641,7 @@ public class KafkaRoller {
 
             if (!needsRestart && allowReconfiguration) {
                 LOGGER.traceCr(reconciliation, "Pod {}: description {}", nodeRef, brokerConfig);
-                brokerConfigDiff = new KafkaBrokerConfigurationDiff(reconciliation, brokerConfig, kafkaConfigProvider.apply(nodeRef.nodeId()), kafkaVersion, nodeRef);
+                brokerConfigDiff = new KafkaBrokerConfigurationDiff(reconciliation, brokerConfig, kafkaConfigProvider.apply(nodeRef.nodeId()), kafkaVersion, nodeRef, elrVersion);
 
                 if (brokerConfigDiff.getDiffSize() > 0) {
                     if (brokerConfigDiff.canBeUpdatedDynamically()) {
@@ -655,6 +660,17 @@ public class KafkaRoller {
         restartContext.needsReconfig = needsReconfig;
         restartContext.forceRestart = false;
         restartContext.brokerConfigDiff = brokerConfigDiff;
+    }
+
+    /**
+     * Returns the information about the features within the Kafka Cluster
+     * @return information about the features
+     */
+    FeatureMetadata featureMetadata() throws ForceableProblem, InterruptedException {
+        return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerAdminClient.describeFeatures().featureMetadata()),
+                30, TimeUnit.SECONDS,
+                error -> new ForceableProblem("Error getting feature metadata", error)
+        );
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -1036,11 +1036,11 @@ public class KafkaRollerTest {
 
             Map<String, SupportedVersionRange> supportedVersionRanges = Map.of(
                     "eligible.leader.replicas.version",
-                    new SupportedVersionRange((short)0, (short)1)
+                    new SupportedVersionRange((short) 0, (short) 1)
             );
             Map<String, FinalizedVersionRange> finalizedVersionRanges = Map.of(
                     "eligible.leader.replicas.version",
-                    new FinalizedVersionRange((short)0, (short)1)
+                    new FinalizedVersionRange((short) 0, (short) 1)
             );
             when(mockFeatureMetadata.supportedFeatures()).thenReturn(supportedVersionRanges);
             when(mockFeatureMetadata.finalizedFeatures()).thenReturn(finalizedVersionRanges);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -28,7 +28,10 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeMetadataQuorumResult;
+import org.apache.kafka.clients.admin.FeatureMetadata;
+import org.apache.kafka.clients.admin.FinalizedVersionRange;
 import org.apache.kafka.clients.admin.QuorumInfo;
+import org.apache.kafka.clients.admin.SupportedVersionRange;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.junit.jupiter.api.AfterAll;
@@ -46,6 +49,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
@@ -1024,6 +1028,26 @@ public class KafkaRollerTest {
             } else {
                 return super.deferController(nodeRef, restartContext);
             }
+        }
+
+        @Override
+        FeatureMetadata featureMetadata() throws ForceableProblem, InterruptedException {
+            FeatureMetadata mockFeatureMetadata = mock(FeatureMetadata.class);
+
+            Map<String, SupportedVersionRange> supportedVersionRanges = Map.of(
+                    "eligible.leader.replicas.version",
+                    new SupportedVersionRange((short)0, (short)1)
+            );
+            Map<String, FinalizedVersionRange> finalizedVersionRanges = Map.of(
+                    "eligible.leader.replicas.version",
+                    new FinalizedVersionRange((short)0, (short)1)
+            );
+            when(mockFeatureMetadata.supportedFeatures()).thenReturn(supportedVersionRanges);
+            when(mockFeatureMetadata.finalizedFeatures()).thenReturn(finalizedVersionRanges);
+            when(mockFeatureMetadata.finalizedFeaturesEpoch()).thenReturn(Optional.of(1L));
+
+            return mockFeatureMetadata;
+
         }
 
         @Override

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -181,3 +181,8 @@ spec:
 <24> Specified User Operator loggers and log levels.
 <25> Kafka Exporter configuration. Kafka Exporter is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use.
 <26> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
+
+WARNING: If you remove the `min.insync.replicas` property from `.spec.kafka.config` within the `Kafka` resource, behavior depends on the ELR (Eligible Leader Replicas) setting.
+When ELR is enabled (default from Kafka 4.1.0), Kafka retains the last known value of `min.insync.replicas` defined in the `Kafka` resource.
+When ELR is disabled, Kafka falls back to the `min.insync.replicas` default (`1`).
+To ensure durability of the cluster, define `min.insync.replicas` explicitly.


### PR DESCRIPTION
This PR fixes #11854.
More details about the rationale behind this fix are described in the issue. 