### PR TITLE
Add deployment strategy configuration to Helm chart

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -107,6 +107,7 @@ the documentation for more details.
 | `defaultImageRepository`                    | Default image registry for all the images                                       | `strimzi`                    |
 | `defaultImageTag`                           | Default image tag for all the images except Kafka Bridge                        | `0.47.0`                     |
 | `deploymentAnnotations`                     | Annotations for the operator deployment                                         | `{}`                         |
+| `deploymentStrategy`                        | Adjust the Kubernetes rollout strategy of the cluster operator deployment       | `{}`                         |
 | `image.registry`                            | Override default Cluster Operator image registry                                | `nil`                        |
 | `image.repository`                          | Override default Cluster Operator image repository                              | `nil`                        |
 | `image.name`                                | Cluster Operator image name                                                     | `operator`                   |

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -22,6 +22,10 @@ spec:
     matchLabels:
       name: strimzi-cluster-operator
       strimzi.io/kind: cluster-operator
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -41,6 +41,7 @@ affinity: {}
 annotations: {}
 labels: {}
 nodeSelector: {}
+deploymentStrategy: {}
 deploymentAnnotations: {}
 priorityClassName: ""
 


### PR DESCRIPTION
Type of change

- Enhancement / New Feature

Description
By default, when installing the strimzi-kafka-operator via Helm chart, the update strategy applied to the K8S deployment is:

- StrategyType: RollingUpdate
- RollingUpdateStrategy: 25% maxUnavailable, 25% maxSurge

This default setting causes manual intervention when upgrading the Helm release, especially for deployments with multiple pods (e.g., 3 pods). Currently, running pods need to be managed manually to restart them during upgrades.

This change introduces the ability to configure the update strategy via Helm values, which simplifies pod restarts during upgrades.

Additionally, this modification aligns the Strimzi operator Helm chart behavior with the approach used in the Strimzi Drain Cleaner Helm chart.