### PR TITLE
Convert long numeric values to int64 in Helm templates, preventing 1.8e+06 formatting and operator crashes

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -92,9 +92,9 @@ spec:
               {{- end }}
               {{- end }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
-              value: {{ .Values.fullReconciliationIntervalMs | quote }}
+              value: {{ .Values.fullReconciliationIntervalMs | int64 | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS
-              value: {{ .Values.operationTimeoutMs | quote }}
+              value: {{ .Values.operationTimeoutMs | int64 | quote }}
             {{- template "strimzi.kafka.image.map" . }}
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: {{ template "strimzi.image" (set . "key" "topicOperator") }}
@@ -142,7 +142,7 @@ spec:
             {{- end }}
             {{- if ne (int .Values.connectBuildTimeoutMs) 300000 }}
             - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
-              value: {{ .Values.connectBuildTimeoutMs | quote }}
+              value: {{ .Values.connectBuildTimeoutMs | int64 | quote }}
             {{- end }}
             {{- if ne .Values.generatePodDisruptionBudget true}}
             - name: STRIMZI_POD_DISRUPTION_BUDGET_GENERATION

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -92,9 +92,9 @@ spec:
               {{- end }}
               {{- end }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
-              value: {{ .Values.fullReconciliationIntervalMs | int64 | quote }}
+              value: {{ .Values.fullReconciliationIntervalMs | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS
-              value: {{ .Values.operationTimeoutMs | int64 | quote }}
+              value: {{ .Values.operationTimeoutMs | quote }}
             {{- template "strimzi.kafka.image.map" . }}
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: {{ template "strimzi.image" (set . "key" "topicOperator") }}
@@ -142,7 +142,7 @@ spec:
             {{- end }}
             {{- if ne (int .Values.connectBuildTimeoutMs) 300000 }}
             - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
-              value: {{ .Values.connectBuildTimeoutMs | int64 | quote }}
+              value: {{ .Values.connectBuildTimeoutMs | quote }}
             {{- end }}
             {{- if ne .Values.generatePodDisruptionBudget true}}
             - name: STRIMZI_POD_DISRUPTION_BUDGET_GENERATION

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -96,9 +96,9 @@ spec:
               {{- end }}
               {{- end }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
-              value: {{ .Values.fullReconciliationIntervalMs | quote }}
+              value: {{ .Values.fullReconciliationIntervalMs | int64 | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS
-              value: {{ .Values.operationTimeoutMs | quote }}
+              value: {{ .Values.operationTimeoutMs | int64 | quote }}
             {{- template "strimzi.kafka.image.map" . }}
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: {{ template "strimzi.image" (set . "key" "topicOperator") }}
@@ -146,7 +146,7 @@ spec:
             {{- end }}
             {{- if ne (int .Values.connectBuildTimeoutMs) 300000 }}
             - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
-              value: {{ .Values.connectBuildTimeoutMs | quote }}
+              value: {{ .Values.connectBuildTimeoutMs | int64 | quote }}
             {{- end }}
             {{- if ne .Values.generatePodDisruptionBudget true}}
             - name: STRIMZI_POD_DISRUPTION_BUDGET_GENERATION

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
@@ -203,3 +203,27 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'executing "strimzi.listPluck" at <.>: wrong type for value; expected map[string]interface {}; got string'
+
+  - it: large numeric values should be properly formatted without scientific notation
+    set:
+      fullReconciliationIntervalMs: 999999999999
+      operationTimeoutMs: 999999999999
+      connectBuildTimeoutMs: 999999999999
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "999999999999"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: STRIMZI_OPERATION_TIMEOUT_MS
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "999999999999"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
+            value: "999999999999"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Convert long numeric values to int64 in Helm templates, preventing 1.8e+06 formatting and operator crashes

Closes #11714
### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x]  Write tests