### PR TITLE
fix(kafka_connect): cleanup /tmp on container restart

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -31,6 +31,10 @@ export CERTS_STORE_PASSWORD
 # Create dir where keystores and truststores will be stored
 mkdir -p /tmp/kafka
 
+# Clean-up /tmp directory from files which might have remained from previous container restart
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/* || true
+
 # Import certificates into keystore and truststore
 ./kafka_connect_tls_prepare_certificates.sh
 


### PR DESCRIPTION
Problem:
After Kafka Connect container restarts, old extracted snappy native libraries remain in /tmp. These leftover files may become stale or corrupted, causing issues when a new version of the library is loaded.

Solution:
Added a cleanup step in kafka_connect_run.sh to remove temporary files in /tmp before Kafka Connect starts. This ensures only fresh snappy libraries are loaded.


Like https://github.com/strimzi/strimzi-kafka-operator/pull/6966/files