### PR TITLE
Deprecate OAuth authentication and Keycloak authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 ### Major changes, deprecations, and removals
 
 * The `.status.kafkaMetadataState` field in the `Kafka` custom resource is deprecated and not used anymore.
+* The `type: oauth` authentication in Kafka brokers and Kafka clients (Kafka Connect, MirrorMaker 2, and Strimzi HTTP Bridge) has been deprecated.
+  Please use the `type: custom` authentication instead.
+  The Strimzi OAuth library continues to be packaged with the Strimzi container images.
+  Follow the documentation for the examples and migration details.
+* The Keycloak authorization (`type: keycloak`) has been deprecated and will be removed in the future.
+  To use the Keycloak authorizer, you can use the `type: custom` authorization.
+  The Strimzi OAuth library with the Keycloak authorizer continues to be packaged with the Strimzi container images.
+  Follow the documentation for the examples and migration details.
 
 ## 0.48.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -41,7 +41,9 @@ public abstract class KafkaClientAuthentication implements UnknownPropertyPreser
             "`scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. " +
             "`plain` uses SASL PLAIN authentication. " +
             "`oauth` uses SASL OAUTHBEARER authentication. " +
-            "`custom` allows you to configure a custom authentication mechanism.")
+            "`custom` allows you to configure a custom authentication mechanism. " +
+            "As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. " +
+            "Please use `custom` type instead.")
     public abstract String getType();
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -6,12 +6,14 @@ package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
 import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -35,6 +37,9 @@ import java.util.Map;
     "clientAssertion", "clientAssertionLocation", "clientAssertionType", "saslExtensions", "grantType"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
+@DeprecatedType(replacedWithType = KafkaClientAuthenticationCustom.class)
+@PresentInVersions("v1beta2")
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
     public static final String TYPE_OAUTH = "oauth";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
@@ -40,7 +40,7 @@ public abstract class KafkaAuthorization implements UnknownPropertyPreserving {
             "`keycloak` authorization type uses Keycloak Authorization Services for authorization. " +
             "`opa` authorization type uses Open Policy Agent based authorization. " +
             "`custom` authorization type uses user-provided implementation for authorization. " +
-            "As of Strimzi 0.49.0, `opa` and `keycloak` types are deprecated and will be removed in the `v1` API version. " +
+            "`opa` (as of Strimzi 0.46.0) and `keycloak` (as of Strimzi 0.49.0) types are deprecated and will be removed in the `v1` API version. " +
             "Please use `custom` type instead.")
     public abstract String getType();
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "type")
-@SuppressWarnings("deprecation") // OPA Authorization is deprecated
+@SuppressWarnings("deprecation") // OPA and Keycloak Authorization is deprecated
 @JsonSubTypes({
     @JsonSubTypes.Type(name = KafkaAuthorizationSimple.TYPE_SIMPLE, value = KafkaAuthorizationSimple.class),
     @JsonSubTypes.Type(name = KafkaAuthorizationOpa.TYPE_OPA, value = KafkaAuthorizationOpa.class),
@@ -40,7 +40,7 @@ public abstract class KafkaAuthorization implements UnknownPropertyPreserving {
             "`keycloak` authorization type uses Keycloak Authorization Services for authorization. " +
             "`opa` authorization type uses Open Policy Agent based authorization. " +
             "`custom` authorization type uses user-provided implementation for authorization. " +
-            "As of Strimzi 0.46.0, `opa` type is deprecated and will be removed in the future. " +
+            "As of Strimzi 0.49.0, `opa` and `keycloak` types are deprecated and will be removed in the `v1` API version. " +
             "Please use `custom` type instead.")
     public abstract String getType();
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -7,11 +7,13 @@ package io.strimzi.api.kafka.model.kafka;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -32,6 +34,9 @@ import java.util.List;
     "httpRetries", "enableMetrics", "includeAcceptHeader"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
+@DeprecatedType(replacedWithType = KafkaAuthorizationCustom.class)
+@PresentInVersions("v1beta2")
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     public static final String TYPE_KEYCLOAK = "keycloak";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -20,6 +20,7 @@ import java.util.Map;
 /**
  * Configures listener authentication.
  */
+@SuppressWarnings("deprecation") // OAuth authentication is deprecated
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "type")
@@ -43,8 +44,10 @@ public abstract class KafkaListenerAuthentication implements UnknownPropertyPres
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`tls` type uses TLS Client Authentication. " +
-            "`tls` type is supported only on TLS listeners." +
-            "`custom` type allows for any authentication type to be used.")
+            "`tls` type is supported only on TLS listeners. " +
+            "`custom` type allows for any authentication type to be used. " +
+            "As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. " +
+            "Please use `custom` type instead.")
     public abstract String getType();
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.annotations.DeprecatedProperty;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
@@ -38,6 +39,9 @@ import java.util.List;
     "clientGrantType", "enableMetrics", "failFast", "includeAcceptHeader", "serverBearerTokenLocation", "userNamePrefix"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
+@DeprecatedType(replacedWithType = KafkaListenerAuthenticationCustom.class)
+@PresentInVersions("v1beta2")
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {
     public static final String TYPE_OAUTH = "oauth";
     public static final int DEFAULT_JWKS_EXPIRY_SECONDS = 360;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -55,7 +55,7 @@ public class AuthenticationUtils {
      *
      * @return  A warning message
      */
-    @SuppressWarnings("BooleanExpressionComplexity")
+    @SuppressWarnings({"BooleanExpressionComplexity", "deprecation"}) // OAuth authentication is deprecated
     public static String validateClientAuthentication(KafkaClientAuthentication authentication, boolean tls) {
         String warnMsg = "";
         if (authentication != null)   {
@@ -82,6 +82,7 @@ public class AuthenticationUtils {
         return warnMsg;
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     private static void validateClientAuthenticationOAuth(KafkaClientAuthenticationOAuth auth) {
         boolean accessTokenCase = auth.getAccessToken() != null || auth.getAccessTokenLocation() != null;
         boolean accessTokenLocationCase = auth.getAccessTokenLocation() != null;
@@ -129,6 +130,7 @@ public class AuthenticationUtils {
      * @param volumeNamePrefix Prefix used for volume names
      * @param createOAuthSecretVolumes   Indicates whether OAuth secret volumes will be added to the list
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static void configurePKCS12ClientAuthenticationVolumes(KafkaClientAuthentication authentication, List<Volume> volumeList, String oauthVolumeNamePrefix, boolean isOpenShift, String volumeNamePrefix, boolean createOAuthSecretVolumes)   {
         if (authentication != null) {
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
@@ -171,6 +173,7 @@ public class AuthenticationUtils {
      * @param volumeNamePrefix Prefix used for volume names
      * @param createOAuthSecretVolumes   Indicates whether OAuth secret volumes will be added to the list
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static void configureClientAuthenticationVolumes(KafkaClientAuthentication authentication, List<Volume> volumeList, String oauthCertsSecretName, boolean isOpenShift, String volumeNamePrefix, boolean createOAuthSecretVolumes)   {
         if (authentication != null) {
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
@@ -228,6 +231,7 @@ public class AuthenticationUtils {
      * @param mountOAuthSecretVolumes Indicates whether OAuth secret volume mounts will be added to the list
      * @param oauthSecretsVolumeMount Path where the OAuth secrets would be mounted
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static void configurePKCS12ClientAuthenticationVolumeMounts(KafkaClientAuthentication authentication, List<VolumeMount> volumeMountList, String tlsVolumeMount, String passwordVolumeMount, String oauthCertsVolumeMount, String oauthVolumeNamePrefix, String volumeNamePrefix, boolean mountOAuthSecretVolumes, String oauthSecretsVolumeMount) {
         if (authentication != null) {
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
@@ -277,6 +281,7 @@ public class AuthenticationUtils {
      * @param mountOAuthSecretVolumes Indicates whether OAuth secret volume mounts will be added to the list
      * @param oauthSecretsVolumeMount Path where the OAuth secrets would be mounted
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static void configureClientAuthenticationVolumeMounts(KafkaClientAuthentication authentication, List<VolumeMount> volumeMountList, String tlsVolumeMount, String passwordVolumeMount, String oauthCertsVolumeMount, String oauthCertsSecretName, String volumeNamePrefix, boolean mountOAuthSecretVolumes, String oauthSecretsVolumeMount) {
         if (authentication != null) {
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
@@ -323,6 +328,7 @@ public class AuthenticationUtils {
      * @param varList   List where the new environment variables should be added
      * @param envVarNamer   Function for naming the environment variables (ech components is using different names)
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static void configureClientAuthenticationEnvVars(KafkaClientAuthentication authentication, List<EnvVar> varList, Function<String, String> envVarNamer)   {
         if (authentication != null) {
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
@@ -369,6 +375,7 @@ public class AuthenticationUtils {
      * @param oauth The client OAuth authentication configuration.
      * @return The OAuth JAAS configuration options.
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static Map<String, String> oauthJaasOptions(KafkaClientAuthenticationOAuth oauth) {
         Map<String, String> options = new LinkedHashMap<>();
         addOption(options, ClientConfig.OAUTH_CLIENT_ID, oauth.getClientId());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
@@ -144,6 +144,7 @@ public class KafkaBridgeConfigurationBuilder {
      * @param authentication authentication configuration
      * @return  the builder instance
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public KafkaBridgeConfigurationBuilder withAuthentication(KafkaClientAuthentication authentication) {
         if (authentication != null) {
             printSectionHeader("Authentication configuration");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -331,6 +331,7 @@ public class KafkaBrokerConfigurationBuilder {
         return this;
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     private void configureOAuthPrincipalBuilderIfNeeded(PrintWriter writer, List<GenericKafkaListener> kafkaListeners) {
         for (GenericKafkaListener listener : kafkaListeners) {
             if (listener.getAuth() instanceof KafkaListenerAuthenticationOAuth) {
@@ -426,6 +427,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param tls   Flag whether this protocol is using TLS or not
      * @param auth  The authentication configuration from the Kafka CR
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     private void configureAuthentication(String listenerName, List<String> securityProtocol, boolean tls, KafkaListenerAuthentication auth)    {
         final String listenerNameInProperty = listenerName.toLowerCase(Locale.ENGLISH);
         final String listenerNameInEnvVar = listenerName.replace("-", "_");
@@ -522,6 +524,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param oauth     OAuth type authentication object
      * @return  Returns the builder instance
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     /*test*/ static Map<String, String> getOAuthOptions(KafkaListenerAuthenticationOAuth oauth)  {
         Map<String, String> options = new LinkedHashMap<>();
 
@@ -712,6 +715,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param authorization     Custom authorization configuration
      * @param superUsers        Super-users list who have all the rights on the cluster
      */
+    @SuppressWarnings("deprecation") // Keycloak Authorization is deprecated
     private void configureKeycloakAuthorization(String clusterName, KafkaAuthorizationKeycloak authorization, List<String> superUsers) {
         writer.println("authorizer.class.name=" + KafkaAuthorizationKeycloak.AUTHORIZER_CLASS_NAME);
         writer.println("strimzi.authorization.token.endpoint.uri=" + authorization.getTokenEndpointUri());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -288,7 +288,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return Kafka cluster instance
      */
-    @SuppressWarnings("NPathComplexity")
+    @SuppressWarnings({"NPathComplexity", "deprecation"}) // Keycloak Authorization is deprecated
     public static KafkaCluster fromCrd(Reconciliation reconciliation,
                                        Kafka kafka,
                                        List<KafkaPool> pools,
@@ -1360,7 +1360,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return List of non-data volumes used by the Kafka pods
      */
-    @SuppressWarnings("deprecation") // OPA authorization and Secrets in custom authentication are deprecated
+    @SuppressWarnings("deprecation") // OPA and Keycloak authorization, OAuth authentication, and Secrets in custom authentication are deprecated
     private List<Volume> getNonDataVolumes(boolean isOpenShift, NodeRef node, PodTemplate templatePod) {
         List<Volume> volumeList = new ArrayList<>();
 
@@ -1453,7 +1453,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of volume mounts
      */
-    @SuppressWarnings("deprecation") // OPA Authorization and Secrets in custom authentication are deprecated
+    @SuppressWarnings("deprecation") // OPA and Keycloak Authorization, OAuth authentication, and Secrets in custom authentication are deprecated
     private List<VolumeMount> getVolumeMounts(Storage storage, ContainerTemplate containerTemplate, boolean isBroker) {
         List<VolumeMount> volumeMountList = new ArrayList<>(VolumeUtils.createVolumeMounts(storage, false));
         volumeMountList.add(VolumeUtils.createTempDirVolumeMount());
@@ -1617,7 +1617,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of environment variables
      */
-    @SuppressWarnings("deprecation") // OPA Authorization is deprecated
+    @SuppressWarnings("deprecation") // OPA and Keycloak Authorization and OAuth authentication are deprecated
     private  List<EnvVar> getEnvVars(KafkaPool pool) {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_JMX_EXPORTER_ENABLED,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -903,6 +903,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      **
      * @return role for the Kafka Connect
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public Role generateRole() {
         List<String> certSecretNames = new ArrayList<>();
         if (tls != null && tls.getTrustedCertificates() != null && !tls.getTrustedCertificates().isEmpty()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
@@ -128,6 +128,7 @@ public class KafkaConnectConfigurationBuilder {
      * @param clusterName name of the cluster
      * @return  the builder instance
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public KafkaConnectConfigurationBuilder withAuthentication(KafkaClientAuthentication authentication, String clusterName) {
         if (authentication != null) {
             printSectionHeader("Authentication configuration");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -205,7 +205,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         return baseVolumeMount + path + "/";
     }
 
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "deprecation"}) // OAuth authentication is deprecated
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = super.getEnvVars();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -252,6 +252,7 @@ public class KafkaMirrorMaker2Connectors {
         return config;
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     /* test */ static void addClusterToMirrorMaker2ConnectorConfig(Reconciliation reconciliation, Map<String, Object> config, KafkaMirrorMaker2ClusterSpec cluster, String configPrefix) {
         config.put(configPrefix + "alias", cluster.getAlias());
         config.put(configPrefix + AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers());
@@ -310,6 +311,7 @@ public class KafkaMirrorMaker2Connectors {
         config.putAll(cluster.getAdditionalProperties());
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     private static String oauthJaasConfig(KafkaMirrorMaker2ClusterSpec cluster, KafkaClientAuthenticationOAuth oauth) {
         Map<String, String> jaasOptions = cluster.getAuthentication() instanceof KafkaClientAuthenticationOAuth ? AuthenticationUtils.oauthJaasOptions((KafkaClientAuthenticationOAuth) cluster.getAuthentication()) : new LinkedHashMap<>();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -49,6 +49,7 @@ public class ListenersUtils {
      *
      * @return  True if the listener is configured to use OAuth authentication. False otherwise.
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static boolean isListenerWithOAuth(GenericKafkaListener listener) {
         if (listener.getAuth() == null || listener.getAuth().getType() == null)
             return false;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -584,7 +584,7 @@ public class ListenersValidator {
      * @param errors    List where any found errors will be added
      * @param listener  The listener where OAuth authentication should be validated
      */
-    @SuppressWarnings({"checkstyle:BooleanExpressionComplexity", "checkstyle:NPathComplexity", "checkstyle:CyclomaticComplexity"})
+    @SuppressWarnings({"checkstyle:BooleanExpressionComplexity", "checkstyle:NPathComplexity", "checkstyle:CyclomaticComplexity", "deprecation"}) // OAuth authentication is deprecated
     private static void validateOauth(Set<String> errors, GenericKafkaListener listener) {
         if (isListenerWithOAuth(listener)) {
             KafkaListenerAuthenticationOAuth oAuth = (KafkaListenerAuthenticationOAuth) listener.getAuth();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -325,6 +325,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      *
      * @return  Future which completes when the reconciliation is done
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     protected Future<Void> oauthTrustedCertsSecret(Reconciliation reconciliation, String namespace, KafkaConnectCluster connect) {
         KafkaClientAuthentication authentication = connect.getAuthentication();
         Set<String> secretsToCopy = new HashSet<>();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -483,6 +483,7 @@ public class ReconcilerUtils {
      * @param certSecretSources TLS trusted certificates whose hashes are joined to result
      * @return Future computing hash from TLS + Auth
      */
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     public static Future<Integer> authTlsHash(SecretOperator secretOperations, String namespace, KafkaClientAuthentication auth, List<CertSecretSource> certSecretSources) {
         Future<Integer> tlsFuture;
         if (certSecretSources == null || certSecretSources.isEmpty()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
@@ -264,6 +264,7 @@ public class KafkaBridgeConfigurationBuilderTest {
         ));
 
         // test oauth authentication
+        @SuppressWarnings("deprecation") // OAuth authentication is deprecated
         KafkaClientAuthenticationOAuth authOAuth = new KafkaClientAuthenticationOAuthBuilder()
                 .withClientId("oauth-client-id")
                 .withTokenEndpointUri("http://token-endpoint-uri")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -2234,6 +2234,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"));
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthOptions()  {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -2498,6 +2499,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS"));
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthDefaultOptions()  {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -66,6 +66,7 @@ public class KafkaClusterOAuthValidationTest {
             new NodeRef("my-cluster-mixed-1", 1, "mixed", true, true),
             new NodeRef("my-cluster-mixed-2", 2, "mixed", true, true));
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     private static List<GenericKafkaListener> getListeners(KafkaListenerAuthenticationOAuth auth)   {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
                 .withName("listener1")
@@ -77,6 +78,7 @@ public class KafkaClusterOAuthValidationTest {
         return List.of(listener1);
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithIntrospectionMinimalPlain() {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -170,6 +172,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithJwksMinRefreshPauseAndIntrospection() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -188,6 +191,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithJwksExpiryAndIntrospection() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -206,6 +210,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithJwksRefreshAndIntrospection() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -224,6 +229,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithReauthAndIntrospection() {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -240,6 +246,7 @@ public class KafkaClusterOAuthValidationTest {
         ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationMissingValidIssuerUri() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -256,6 +263,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationRefreshSecondsRelationWithExpirySeconds() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -270,6 +278,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationRefreshSecondsSetWithExpirySecondsNotSet() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -283,6 +292,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationRefreshSecondsNotSetWithExpirySecondsSet() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -296,6 +306,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationNoUriSpecified() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -305,6 +316,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithMinimumJWKS() {
         KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
@@ -315,6 +327,7 @@ public class KafkaClusterOAuthValidationTest {
         ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithConnectTimeout() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -328,6 +341,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithReadTimeout() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -341,6 +355,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithGroupsClaim() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -354,6 +369,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationIntrospectionEndpointUriWithoutClientId() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -369,6 +385,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationIntrospectionEndpointUriWithoutClientSecret() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -381,6 +398,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationExpirySecondsWithoutEndpointUri() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -394,6 +412,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationRefreshSecondsWithoutEndpointUri() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -407,6 +426,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithOAuthWithIntrospectionWithNoTypeCheck() {
         assertThrows(InvalidResourceException.class, () -> {
@@ -425,6 +445,7 @@ public class KafkaClusterOAuthValidationTest {
         });
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testOAuthValidationWithOAuthWithJwksWithNotJwt() {
         assertThrows(InvalidResourceException.class, () -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -320,6 +320,7 @@ class KafkaConnectConfigurationBuilderTest {
         ));
     }
 
+    @SuppressWarnings("deprecation") // OAuth authentication is deprecated
     @Test
     public void testWithAuthOauth() {
         KafkaClientAuthenticationOAuth authOAuth = new KafkaClientAuthenticationOAuthBuilder()

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -214,8 +214,13 @@ It must have the value `scram-sha-512` for the type `KafkaListenerAuthentication
 [id='type-KafkaListenerAuthenticationOAuth-{context}']
 = `KafkaListenerAuthenticationOAuth` schema reference
 
+*The type `KafkaListenerAuthenticationOAuth` has been deprecated.*
+Please use xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`] instead.
+
 Used in: xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`]
 
+
+The type KafkaListenerAuthenticationOAuth is supported only in the Strimzi API version(s) v1beta2.
 
 The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationOAuth` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
 It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
@@ -800,8 +805,13 @@ It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 [id='type-KafkaAuthorizationKeycloak-{context}']
 = `KafkaAuthorizationKeycloak` schema reference
 
+*The type `KafkaAuthorizationKeycloak` has been deprecated.*
+Please use xref:type-KafkaAuthorizationCustom-{context}[`KafkaAuthorizationCustom`] instead.
+
 Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 
+
+The type KafkaAuthorizationKeycloak is supported only in the Strimzi API version(s) v1beta2.
 
 The `type` property is a discriminator that distinguishes use of the `KafkaAuthorizationKeycloak` type from xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`], xref:type-KafkaAuthorizationOpa-{context}[`KafkaAuthorizationOpa`], xref:type-KafkaAuthorizationCustom-{context}[`KafkaAuthorizationCustom`].
 It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
@@ -2710,6 +2720,9 @@ It must have the value `plain` for the type `KafkaClientAuthenticationPlain`.
 [id='type-KafkaClientAuthenticationOAuth-{context}']
 = `KafkaClientAuthenticationOAuth` schema reference
 
+*The type `KafkaClientAuthenticationOAuth` has been deprecated.*
+Please use xref:type-KafkaClientAuthenticationCustom-{context}[`KafkaClientAuthenticationCustom`] instead.
+
 Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`]
 
 xref:type-KafkaClientAuthenticationOAuth-schema-{context}[Full list of `KafkaClientAuthenticationOAuth` schema properties]
@@ -2719,6 +2732,8 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 [id='type-KafkaClientAuthenticationOAuth-schema-{context}']
 == `KafkaClientAuthenticationOAuth` schema properties
 
+
+The type KafkaClientAuthenticationOAuth is supported only in the Strimzi API version(s) v1beta2.
 
 The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationOAuth` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationCustom-{context}[`KafkaClientAuthenticationCustom`].
 It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.

--- a/packaging/examples/security/keycloak-authorization/README.md
+++ b/packaging/examples/security/keycloak-authorization/README.md
@@ -1,9 +1,10 @@
 # Keycloak authorization example
 
-This folder contains an example `Kafka` custom resource configured for OAuth 2.0 token-based authorization using Keycloak. The example resource is configured with:
+This folder contains an example `Kafka` custom resource configured for OAuth 2.0 token-based authorization using Keycloak.
+The example resource is configured with:
 
-- `keycloak` authorization
-- the corresponding `oauth` authentication
+* `custom` authentication using OAuth
+* `custom` authorization based on the Keycloak authorizer
 
 The folder also contains a Keycloak realm export to import into your Keycloak instance to support the example.
 
@@ -12,10 +13,10 @@ Full instructions for the example are available in the [Strimzi Documentation](h
 - [kafka-authz-realm.json](./kafka-authz-realm.json)
   - The Keycloak realm export file
 - [kafka-ephemeral-oauth-single-keycloak-authz.yaml](./kafka-ephemeral-oauth-single-keycloak-authz.yaml)
-  - The Kafka CR that defines a single-node Kafka cluster with `oauth` authentication and `keycloak` authorization,
+  - The Kafka CR that defines a single-node Kafka cluster with OAuth authentication and Keycloak authorization,
     using the `kafka-authz` realm. See [full example instructions](https://strimzi.io/docs/operators/in-development/configuring.html#proc-oauth-authorization-keycloak-example_str) for proper preparation and deployment.
 - [kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml](./kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml)
-  - The Kafka CR that defines a single-node Kafka cluster with `oauth` authentication and `keycloak` authorization,
+  - The Kafka CR that defines a single-node Kafka cluster with OAuth authentication and Keycloak authorization,
     with included configuration for exporting the OAuth metrics using Prometheus JMX exporter.
 
 More examples are available at the oauth module [example documentation](https://github.com/strimzi/strimzi-kafka-oauth/tree/main/examples).

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
@@ -33,32 +33,45 @@ spec:
         type: internal
         tls: true
         authentication:
-          type: oauth
-          validIssuerUri: https://${SSO_HOST}/realms/kafka-authz
-          jwksEndpointUri: https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/certs
-          userNameClaim: preferred_username
-          maxSecondsWithoutReauthentication: 3600
-          enableMetrics: true
-          tlsTrustedCertificates:
-            - secretName: oauth-server-cert
-              certificate: sso.crt
+          type: custom
+          sasl: true
+          listenerConfig:
+            sasl.enabled.mechanisms: OAUTHBEARER
+            oauthbearer.sasl.server.callback.handler.class: io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
+            oauthbearer.sasl.jaas.config: |
+              org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub="thePrincipalName" oauth.valid.issuer.uri="https://${SSO_HOST}/realms/kafka-authz" oauth.jwks.endpoint.uri="https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/certs" oauth.username.claim="preferred_username" oauth.enable.metrics="true" oauth.ssl.truststore.location="/mnt/oauth-certs/tls.crt" oauth.ssl.truststore.type="PEM";
+            connections.max.reauth.ms: 3600
     authorization:
-      type: keycloak
-      clientId: kafka
-      tokenEndpointUri: https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/token
-      tlsTrustedCertificates:
-        - secretName: oauth-server-cert
-          certificate: sso.crt
-      delegateToKafkaAcls: true
-      enableMetrics: true
+      type: custom
+      authorizerClass: io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer
       superUsers:
         - service-account-kafka
     config:
+      # Needed for Oauth authentication and Keycloak authroization
+      principal.builder.class: io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
+      # Needed for Keycloak authorization
+      strimzi.authorization.client.id: kafka
+      strimzi.authorization.token.endpoint.uri: https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/token
+      strimzi.authorization.ssl.endpoint.identification.algorithm: ""
+      strimzi.authorization.delegate.to.kafka.acl: "false"
+      strimzi.authorization.ssl.truststore.location: /mnt/oauth-certs/tls.crt
+      strimzi.authorization.ssl.truststore.type: PEM
+      # Other Kafka configuration options
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
+    template:
+      pod:
+        volumes:
+          - name: oauth-certs
+            secret:
+              name: oauth-server-cert
+      kafkaContainer:
+        volumeMounts:
+          - name: oauth-certs
+            mountPath: /mnt/oauth-certs
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -33,30 +33,45 @@ spec:
         type: internal
         tls: true
         authentication:
-          type: oauth
-          validIssuerUri: https://${SSO_HOST}/realms/kafka-authz
-          jwksEndpointUri: https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/certs
-          userNameClaim: preferred_username
-          maxSecondsWithoutReauthentication: 3600
-          tlsTrustedCertificates:
-            - secretName: oauth-server-cert
-              certificate: sso.crt
+          type: custom
+          sasl: true
+          listenerConfig:
+            sasl.enabled.mechanisms: OAUTHBEARER
+            oauthbearer.sasl.server.callback.handler.class: io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
+            oauthbearer.sasl.jaas.config: |
+              org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub="thePrincipalName" oauth.valid.issuer.uri="https://${SSO_HOST}/realms/kafka-authz" oauth.jwks.endpoint.uri="https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/certs" oauth.username.claim="preferred_username" oauth.ssl.truststore.location="/mnt/oauth-certs/tls.crt" oauth.ssl.truststore.type="PEM";
+            connections.max.reauth.ms: 3600
     authorization:
-      type: keycloak
-      clientId: kafka
-      tokenEndpointUri: https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/token
-      tlsTrustedCertificates:
-        - secretName: oauth-server-cert
-          certificate: sso.crt
-      delegateToKafkaAcls: true
+      type: custom
+      authorizerClass: io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer
       superUsers:
         - service-account-kafka
     config:
+      # Needed for Oauth authentication and Keycloak authroization
+      principal.builder.class: io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
+      # Needed for Keycloak authorization
+      strimzi.authorization.client.id: kafka
+      strimzi.authorization.token.endpoint.uri: https://${SSO_HOST}/realms/kafka-authz/protocol/openid-connect/token
+      strimzi.authorization.ssl.endpoint.identification.algorithm: ""
+      strimzi.authorization.delegate.to.kafka.acl: "false"
+      strimzi.authorization.ssl.truststore.location: /mnt/oauth-certs/tls.crt
+      strimzi.authorization.ssl.truststore.type: PEM
+      # Other Kafka configuration options
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
+    template:
+      pod:
+        volumes:
+          - name: oauth-certs
+            secret:
+              name: oauth-server-cert
+      kafkaContainer:
+        volumeMounts:
+          - name: oauth-certs
+            mountPath: /mnt/oauth-certs
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -767,7 +767,7 @@ spec:
                             - opa
                             - keycloak
                             - custom
-                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.49.0, `opa` and `keycloak` types are deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
+                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. `opa` (as of Strimzi 0.46.0) and `keycloak` (as of Strimzi 0.49.0) types are deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                         url:
                           type: string
                           example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -271,7 +271,7 @@ spec:
                                   - scram-sha-512
                                   - oauth
                                   - custom
-                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                                description: "Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners. `custom` type allows for any authentication type to be used. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                               userInfoEndpointUri:
                                 type: string
                                 description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
@@ -767,7 +767,7 @@ spec:
                             - opa
                             - keycloak
                             - custom
-                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.46.0, `opa` type is deprecated and will be removed in the future. Please use `custom` type instead."
+                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.49.0, `opa` and `keycloak` types are deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                         url:
                           type: string
                           example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -280,7 +280,7 @@ spec:
                         - plain
                         - oauth
                         - custom
-                      description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism."
+                      description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -283,7 +283,7 @@ spec:
                         - plain
                         - oauth
                         - custom
-                      description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism."
+                      description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -292,7 +292,7 @@ spec:
                               - plain
                               - oauth
                               - custom
-                            description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism."
+                            description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                           username:
                             type: string
                             description: Username used for the authentication.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -270,7 +270,7 @@ spec:
                               - scram-sha-512
                               - oauth
                               - custom
-                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                              description: "Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners. `custom` type allows for any authentication type to be used. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                             userInfoEndpointUri:
                               type: string
                               description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '
@@ -766,7 +766,7 @@ spec:
                         - opa
                         - keycloak
                         - custom
-                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.46.0, `opa` type is deprecated and will be removed in the future. Please use `custom` type instead."
+                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.49.0, `opa` and `keycloak` types are deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                       url:
                         type: string
                         example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -766,7 +766,7 @@ spec:
                         - opa
                         - keycloak
                         - custom
-                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. As of Strimzi 0.49.0, `opa` and `keycloak` types are deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
+                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization. `custom` authorization type uses user-provided implementation for authorization. `opa` (as of Strimzi 0.46.0) and `keycloak` (as of Strimzi 0.49.0) types are deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                       url:
                         type: string
                         example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -279,7 +279,7 @@ spec:
                     - plain
                     - oauth
                     - custom
-                    description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism."
+                    description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -282,7 +282,7 @@ spec:
                     - plain
                     - oauth
                     - custom
-                    description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism."
+                    description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -291,7 +291,7 @@ spec:
                           - plain
                           - oauth
                           - custom
-                          description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism."
+                          description: "Specifies the authentication type. Supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and `custom`. `tls` uses TLS client authentication and is supported only over TLS connections. `scram-sha-256` and `scram-sha-512` use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 authentication, respectively. `plain` uses SASL PLAIN authentication. `oauth` uses SASL OAUTHBEARER authentication. `custom` allows you to configure a custom authentication mechanism. As of Strimzi 0.49.0, `oauth` type is deprecated and will be removed in the `v1` API version. Please use `custom` type instead."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/CustomOauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/CustomOauthAuthorizationST.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.security.oauth;
+
+import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.skodjob.testframe.resources.KubeResourceManager;
+import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.FIPSNotSupported;
+import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaOauthClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaOauthClientsBuilder;
+import io.strimzi.systemtest.keycloak.KeycloakInstance;
+import io.strimzi.systemtest.resources.crd.KafkaComponents;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.strimzi.systemtest.TestTags.OAUTH;
+import static io.strimzi.systemtest.TestTags.REGRESSION;
+
+@Tag(OAUTH)
+@Tag(REGRESSION)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
+public class CustomOauthAuthorizationST extends OauthAbstractST {
+    protected static final Logger LOGGER = LogManager.getLogger(CustomOauthAuthorizationST.class);
+
+    private final String oauthClusterName = "oauth-cluster-authz-name";
+
+    private static final String TEAM_A_CLIENT = "team-a-client";
+    private static final String TEAM_B_CLIENT = "team-b-client";
+
+    private static final String TEAM_A_CLIENT_SECRET = "team-a-client-secret";
+    private static final String TEAM_B_CLIENT_SECRET = "team-b-client-secret";
+
+    private static final String TOPIC_A = "a-topic";
+    private static final String TOPIC_B = "b-topic";
+    private static final String TOPIC_X = "x-topic";
+
+    private static final String TEAM_A_PRODUCER_NAME = TEAM_A_CLIENT + "-producer";
+    private static final String TEAM_A_CONSUMER_NAME = TEAM_A_CLIENT + "-consumer";
+    private static final String TEAM_B_PRODUCER_NAME = TEAM_B_CLIENT + "-producer";
+    private static final String TEAM_B_CONSUMER_NAME = TEAM_B_CLIENT + "-consumer";
+
+    private static final String TEST_REALM = "kafka-authz";
+
+    /**
+     * As a member of team A, I should be able to read and write to all topics starting with a-.
+     */
+    @ParallelTest
+    @Order(1)
+    void smokeTestForClients() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String teamAProducerName = TEAM_A_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String teamAConsumerName = TEAM_A_CONSUMER_NAME + "-" + testStorage.getClusterName();
+        String topicName = TOPIC_A + "-" + testStorage.getTopicName();
+        String consumerGroup = "a-consumer_group-" + testStorage.getClusterName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, topicName, oauthClusterName).build());
+
+        KafkaOauthClients teamAOauthClientJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(teamAProducerName)
+            .withConsumerName(teamAConsumerName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
+            .withTopicName(topicName)
+            .withMessageCount(testStorage.getMessageCount())
+            .withConsumerGroup(consumerGroup)
+            .withOauthClientId(TEAM_A_CLIENT)
+            .withOauthClientSecret(TEAM_A_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAConsumerName, testStorage.getMessageCount());
+    }
+
+    /**
+     * As a member of team A, I should be able to write to topics that starts with x- on any cluster and " +
+     * and should also write and read to topics starting with 'a-'.
+     */
+    @ParallelTest
+    @Order(2)
+    void testTeamAWriteToTopic() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String teamAProducerName = TEAM_A_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String teamAConsumerName = TEAM_A_CONSUMER_NAME + "-" + testStorage.getClusterName();
+        String consumerGroup = "a-consumer_group-" + testStorage.getClusterName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), oauthClusterName).build());
+
+        KafkaOauthClients teamAOauthClientJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(teamAProducerName)
+            .withConsumerName(teamAConsumerName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withConsumerGroup(consumerGroup)
+            .withOauthClientId(TEAM_A_CLIENT)
+            .withOauthClientSecret(TEAM_A_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            // by default it's set to 1000, which makes the job longer to fail
+            .withAdditionalConfig("retry.backoff.max.ms=100\n")
+            .build();
+
+        LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), testStorage.getTopicName());
+        LOGGER.info("Producer will not produce messages because authorization Topic will failed. Team A can write only to Topic starting with 'x-'");
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        JobUtils.waitForJobFailure(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, 30_000);
+        JobUtils.deleteJobWithWait(Environment.TEST_SUITE_NAMESPACE, teamAProducerName);
+
+        String topicXName = TOPIC_X + "-" + testStorage.getClusterName();
+        LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), topicXName);
+
+        teamAOauthClientJob = new KafkaOauthClientsBuilder(teamAOauthClientJob)
+            .withConsumerGroup(consumerGroup)
+            .withTopicName(topicXName)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        JobUtils.waitForJobFailure(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, 30_000);
+        JobUtils.deleteJobWithWait(Environment.TEST_SUITE_NAMESPACE, teamAProducerName);
+
+        // Team A can not create topic starting with 'x-' only write to existing on
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, topicXName, oauthClusterName).build());
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
+
+        String topicAName = TOPIC_A + "-" + testStorage.getClusterName();
+
+        LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), topicAName);
+
+        teamAOauthClientJob = new KafkaOauthClientsBuilder(teamAOauthClientJob)
+            .withConsumerGroup(consumerGroup)
+            .withTopicName(topicAName)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
+    }
+
+    /**
+     * As a member of team A, I should be able only read from consumer that starts with a_.
+     */
+    @ParallelTest
+    @Order(3)
+    void testTeamAReadFromTopic() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String teamAProducerName = TEAM_A_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String teamAConsumerName = TEAM_A_CONSUMER_NAME + "-" + testStorage.getClusterName();
+        String topicAName = TOPIC_A + "-" + testStorage.getTopicName();
+        String consumerGroup = "a-consumer_group-" + testStorage.getClusterName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, topicAName, oauthClusterName).build());
+
+        KafkaOauthClients teamAOauthClientJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(teamAProducerName)
+            .withConsumerName(teamAConsumerName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
+            .withTopicName(topicAName)
+            .withMessageCount(testStorage.getMessageCount())
+            .withConsumerGroup(consumerGroup)
+            .withOauthClientId(TEAM_A_CLIENT)
+            .withOauthClientSecret(TEAM_A_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), topicAName);
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
+
+        // team A client shouldn't be able to consume messages with wrong consumer group
+
+        teamAOauthClientJob = new KafkaOauthClientsBuilder(teamAOauthClientJob)
+            .withConsumerGroup("bad_consumer_group" + testStorage.getClusterName())
+            .withTopicName(topicAName)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.consumerStrimziOauthTls(oauthClusterName));
+        JobUtils.waitForJobFailure(Environment.TEST_SUITE_NAMESPACE, teamAConsumerName, 30_000);
+        JobUtils.deleteJobWithWait(Environment.TEST_SUITE_NAMESPACE, teamAProducerName);
+
+        // team A client should be able to consume messages with correct consumer group
+
+        teamAOauthClientJob = new KafkaOauthClientsBuilder(teamAOauthClientJob)
+            .withConsumerGroup("a-correct_consumer_group" + testStorage.getClusterName())
+            .withTopicName(topicAName)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
+    }
+
+    /**
+     * As a member of team B, I should be able to write and read from topics that starts with b-.
+     */
+    @ParallelTest
+    @Order(4)
+    void testTeamBWriteToTopic() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String consumerGroup = "x-" + testStorage.getClusterName();
+        String teamBProducerName = TEAM_B_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String teamBConsumerName = TEAM_B_CONSUMER_NAME + "-" + testStorage.getClusterName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), oauthClusterName).build());
+
+        KafkaOauthClients teamBOauthClientJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(teamBProducerName)
+            .withConsumerName(teamBConsumerName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withConsumerGroup(consumerGroup)
+            .withOauthClientId(TEAM_B_CLIENT)
+            .withOauthClientSecret(TEAM_B_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            // by default it's set to 1000, which makes the job longer to fail
+            .withAdditionalConfig("retry.backoff.max.ms=100\n")
+            .build();
+
+        LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), testStorage.getTopicName());
+        // Producer will not produce messages because authorization topic will failed. Team A can write only to topic starting with 'x-'
+        KubeResourceManager.get().createResourceWithWait(teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        JobUtils.waitForJobFailure(Environment.TEST_SUITE_NAMESPACE, teamBProducerName, 30_000);
+        JobUtils.deleteJobWithWait(Environment.TEST_SUITE_NAMESPACE, teamBProducerName);
+
+        LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), TOPIC_B);
+
+        teamBOauthClientJob = new KafkaOauthClientsBuilder(teamBOauthClientJob)
+            .withConsumerGroup("x-consumer_group_b-" + testStorage.getClusterName())
+            .withTopicName(TOPIC_B)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        KubeResourceManager.get().createResourceWithWait(teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientsSuccess(Environment.TEST_SUITE_NAMESPACE, teamBConsumerName, teamBProducerName, testStorage.getMessageCount());
+    }
+
+    /**
+     * As a member of team A, I can write to topics starting with 'x-' and as a member of team B can read from topics starting with 'x-'.
+     */
+    @ParallelTest
+    @Order(5)
+    void testTeamAWriteToTopicStartingWithXAndTeamBReadFromTopicStartingWithX() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String teamAProducerName = TEAM_A_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String teamAConsumerName = TEAM_A_CONSUMER_NAME + "-" + testStorage.getClusterName();
+        String teamBProducerName = TEAM_B_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String teamBConsumerName = TEAM_B_CONSUMER_NAME + "-" + testStorage.getClusterName();
+        // only write means that Team A can not create new topic 'x-.*'
+        String topicXName = TOPIC_X + testStorage.getTopicName();
+        String consumerGroup = "x-" + testStorage.getClusterName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, topicXName, oauthClusterName).build());
+
+        KafkaOauthClients teamAOauthClientJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(teamAProducerName)
+            .withConsumerName(teamAConsumerName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
+            .withTopicName(topicXName)
+            .withMessageCount(testStorage.getMessageCount())
+            .withConsumerGroup(consumerGroup)
+            .withOauthClientId(TEAM_A_CLIENT)
+            .withOauthClientSecret(TEAM_A_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        teamAOauthClientJob = new KafkaOauthClientsBuilder(teamAOauthClientJob)
+            .withConsumerGroup("a-consumer_group" + testStorage.getClusterName())
+            .withTopicName(topicXName)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
+
+        KafkaOauthClients teamBOauthClientJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(teamBProducerName)
+            .withConsumerName(teamBConsumerName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
+            .withTopicName(topicXName)
+            .withMessageCount(testStorage.getMessageCount())
+            .withConsumerGroup("x-consumer_group_b-" + testStorage.getClusterName())
+            .withOauthClientId(TEAM_B_CLIENT)
+            .withOauthClientSecret(TEAM_B_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName));
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamBConsumerName, testStorage.getMessageCount());
+    }
+
+    @BeforeAll
+    void setUp()  {
+        super.setupCoAndKeycloak(Environment.TEST_SUITE_NAMESPACE);
+
+        keycloakInstance.setRealm(TEST_REALM, true);
+
+        String jaasConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+                Map.of(
+                        "unsecuredLoginStringClaim_sub", "thePrincipalName",
+                        "oauth.valid.issuer.uri", keycloakInstance.getValidIssuerUri(),
+                        "oauth.jwks.expiry.seconds", Integer.toString(keycloakInstance.getJwksExpireSeconds()),
+                        "oauth.jwks.refresh.seconds", Integer.toString(keycloakInstance.getJwksRefreshSeconds()),
+                        "oauth.jwks.endpoint.uri", keycloakInstance.getJwksEndpointUri(),
+                        "oauth.username.claim", keycloakInstance.getUserNameClaim(),
+                        "oauth.ssl.endpoint.identification.algorithm", "",
+                        "oauth.ssl.truststore.location", "/mnt/keycloak-certs/" + KeycloakInstance.KEYCLOAK_SECRET_CERT,
+                        "oauth.ssl.truststore.type", "PEM"
+                ));
+
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(Environment.TEST_SUITE_NAMESPACE, KafkaComponents.getBrokerPoolName(oauthClusterName), oauthClusterName, 3).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(Environment.TEST_SUITE_NAMESPACE, KafkaComponents.getControllerPoolName(oauthClusterName), oauthClusterName, 1).build()
+        );
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, 3)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName(TestConstants.TLS_LISTENER_DEFAULT_NAME)
+                                .withPort(9093)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withTls(true)
+                                .withNewKafkaListenerAuthenticationCustomAuth()
+                                    .withSasl(true)
+                                    .withListenerConfig(Map.of(
+                                            "sasl.enabled.mechanisms", "OAUTHBEARER",
+                                            "oauthbearer.sasl.server.callback.handler.class", "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
+                                            "oauthbearer.sasl.jaas.config", jaasConfig
+                                    ))
+                                .endKafkaListenerAuthenticationCustomAuth()
+                                .build())
+                        .withNewKafkaAuthorizationCustom()
+                            .withAuthorizerClass("io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer")
+                            .withSupportsAdminApi(false)
+                        .endKafkaAuthorizationCustom()
+                        .addToConfig(Map.of(
+                                "principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder",
+                                "strimzi.authorization.client.id", "kafka",
+                                "strimzi.authorization.token.endpoint.uri", keycloakInstance.getOauthTokenEndpointUri(),
+                                "strimzi.authorization.ssl.endpoint.identification.algorithm", "",
+                                "strimzi.authorization.delegate.to.kafka.acl", "true",
+                                "strimzi.authorization.ssl.truststore.location", "/mnt/keycloak-certs/" + KeycloakInstance.KEYCLOAK_SECRET_CERT,
+                                "strimzi.authorization.ssl.truststore.type", "PEM"
+                        ))
+                        .withNewTemplate()
+                            .withNewPod()
+                                .withVolumes(new AdditionalVolumeBuilder().withName("keycloak-certs").withSecret(new SecretVolumeSourceBuilder().withSecretName(KeycloakInstance.KEYCLOAK_SECRET_NAME).build()).build())
+                            .endPod()
+                            .withNewKafkaContainer()
+                                .withVolumeMounts(new VolumeMountBuilder().withName("keycloak-certs").withMountPath("/mnt/keycloak-certs").build())
+                            .endKafkaContainer()
+                        .endTemplate()
+                    .endKafka()
+                .endSpec()
+                .build());
+
+        LOGGER.info("Setting producer and consumer properties");
+
+        KubeResourceManager.get().createResourceWithWait(KafkaUserTemplates.tlsUser(Environment.TEST_SUITE_NAMESPACE, TEAM_A_CLIENT, oauthClusterName).build());
+        KubeResourceManager.get().createResourceWithWait(KafkaUserTemplates.tlsUser(Environment.TEST_SUITE_NAMESPACE, TEAM_B_CLIENT, oauthClusterName).build());
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/CustomOauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/CustomOauthPlainST.java
@@ -1,0 +1,649 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.security.oauth;
+
+import io.skodjob.testframe.MetricsCollector;
+import io.skodjob.testframe.resources.KubeResourceManager;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeResources;
+import io.strimzi.api.kafka.model.common.InlineLogging;
+import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
+import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
+import io.strimzi.api.kafka.model.common.template.ContainerEnvVarBuilder;
+import io.strimzi.api.kafka.model.common.template.ContainerEnvVarSourceBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpecBuilder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Resources;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.FIPSNotSupported;
+import io.strimzi.systemtest.annotations.IsolatedTest;
+import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaOauthClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaOauthClientsBuilder;
+import io.strimzi.systemtest.labels.LabelSelectors;
+import io.strimzi.systemtest.metrics.KafkaBridgeMetricsComponent;
+import io.strimzi.systemtest.metrics.KafkaConnectMetricsComponent;
+import io.strimzi.systemtest.metrics.KafkaMetricsComponent;
+import io.strimzi.systemtest.metrics.KafkaMirrorMaker2MetricsComponent;
+import io.strimzi.systemtest.resources.crd.KafkaComponents;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaBridgeTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaMirrorMaker2Templates;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.FileUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NetworkPolicyUtils;
+import io.strimzi.systemtest.utils.specific.MetricsUtils;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.WaitException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.systemtest.TestConstants.HTTP_BRIDGE_DEFAULT_PORT;
+import static io.strimzi.systemtest.TestTags.BRIDGE;
+import static io.strimzi.systemtest.TestTags.CONNECT;
+import static io.strimzi.systemtest.TestTags.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.TestTags.METRICS;
+import static io.strimzi.systemtest.TestTags.MIRROR_MAKER2;
+import static io.strimzi.systemtest.TestTags.NODEPORT_SUPPORTED;
+import static io.strimzi.systemtest.TestTags.OAUTH;
+import static io.strimzi.systemtest.TestTags.REGRESSION;
+
+@Tag(OAUTH)
+@Tag(REGRESSION)
+@FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
+public class CustomOauthPlainST extends OauthAbstractST {
+    protected static final Logger LOGGER = LogManager.getLogger(CustomOauthPlainST.class);
+
+    private static final String OAUTH_METRICS_CM_PATH = TestUtils.USER_PATH + "/../packaging/examples/metrics/oauth-metrics.yaml";
+    private static final String OAUTH_METRICS_CM_KEY = "metrics-config.yml";
+    private static final String OAUTH_METRICS_CM_NAME = "oauth-metrics";
+
+    private static final JmxPrometheusExporterMetrics OAUTH_METRICS =
+        new JmxPrometheusExporterMetricsBuilder()
+            .withNewValueFrom()
+                .withNewConfigMapKeyRef(OAUTH_METRICS_CM_KEY, OAUTH_METRICS_CM_NAME, false)
+            .endValueFrom()
+            .build();
+
+    private final String oauthClusterName = "oauth-cluster-plain-name";
+    private final String scraperName = "oauth-cluster-plain-scraper";
+    private String scraperPodName = "";
+    private final List<String> expectedOauthMetrics = Arrays.asList(
+        "strimzi_oauth_http_requests_maxtimems", "strimzi_oauth_http_requests_mintimems",
+        "strimzi_oauth_http_requests_avgtimems", "strimzi_oauth_http_requests_totaltimems",
+        "strimzi_oauth_http_requests_count"
+    );
+
+    private MetricsCollector metricsCollector;
+
+    /**
+     * As an OAuth producer, I should be able to produce messages to the Kafka Broker,
+     * As an OAuth consumer, I should be able to consumer messages from the Kafka Broker."
+     */
+    @ParallelTest
+    @Tag(METRICS)
+    void testProducerConsumerWithOauthMetrics() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + testStorage.getClusterName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), oauthClusterName).build());
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, producerName, testStorage.getMessageCount());
+
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
+
+        assertOauthMetricsForComponent(
+            metricsCollector.toBuilder()
+                .withComponent(KafkaMetricsComponent.create(oauthClusterName))
+                .build()
+        );
+    }
+
+    @ParallelTest
+    void testSaslPlainProducerConsumer() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String audienceProducerName = OAUTH_CLIENT_AUDIENCE_PRODUCER + "-" + testStorage.getClusterName();
+        String audienceConsumerName = OAUTH_CLIENT_AUDIENCE_CONSUMER + "-" + testStorage.getClusterName();
+
+        String plainAdditionalConfig =
+            "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=%s password=%s;\n" +
+                "sasl.mechanism=PLAIN";
+
+        KafkaOauthClients plainSaslOauthConsumerClientsJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withConsumerName(audienceConsumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .withAdditionalConfig(String.format(plainAdditionalConfig, OAUTH_CLIENT_AUDIENCE_CONSUMER, OAUTH_CLIENT_AUDIENCE_SECRET))
+            .build();
+
+        KafkaOauthClients plainSaslOauthProducerClientsJob = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(audienceProducerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .withAdditionalConfig(String.format(plainAdditionalConfig, OAUTH_CLIENT_AUDIENCE_PRODUCER, OAUTH_CLIENT_AUDIENCE_SECRET))
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(plainSaslOauthProducerClientsJob.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, audienceProducerName, testStorage.getMessageCount());
+
+        KubeResourceManager.get().createResourceWithWait(plainSaslOauthConsumerClientsJob.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, audienceConsumerName, testStorage.getMessageCount());
+    }
+
+    /**
+     * As an OAuth KafkaConnect, I should be able to sink messages from kafka Broker Topic.
+     */
+    @ParallelTest
+    @Tag(CONNECT)
+    @Tag(CONNECT_COMPONENTS)
+    @Tag(METRICS)
+    void testProducerConsumerConnectWithOauthMetrics() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + testStorage.getClusterName();
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), oauthClusterName).build());
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, producerName, testStorage.getMessageCount());
+
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
+
+        String connectJassConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule", Map.of(
+                "oauth.token.endpoint.uri", keycloakInstance.getOauthTokenEndpointUri(),
+                "oauth.client.id", "kafka-connect",
+                "oauth.client.secret", "${strimzienv:OAUTH_CLIENT_SECRET}",
+                "oauth.connect.timeout.seconds", Integer.toString(CONNECT_TIMEOUT_S),
+                "oauth.read.timeout.seconds", Integer.toString(READ_TIMEOUT_S),
+                "oauth.enable.metrics", "true"
+        ));
+
+        KafkaConnect connect = KafkaConnectTemplates.kafkaConnectWithFilePlugin(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, oauthClusterName, 1)
+            .editOrNewSpec()
+                .withReplicas(1)
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .withConfig(connectorConfig)
+                .addToConfig("key.converter.schemas.enable", false)
+                .addToConfig("value.converter.schemas.enable", false)
+                .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .withNewKafkaClientAuthenticationCustom()
+                    .withSasl(true)
+                    .withConfig(Map.of(
+                            "sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler",
+                            "sasl.mechanism", "OAUTHBEARER",
+                            "sasl.jaas.config", connectJassConfig
+                    ))
+                .endKafkaClientAuthenticationCustom()
+                .withNewTemplate()
+                    .withNewConnectContainer()
+                        .withEnv(new ContainerEnvVarBuilder().withName("OAUTH_CLIENT_SECRET").withValueFrom(new ContainerEnvVarSourceBuilder().withNewSecretKeyRef(OAUTH_KEY, CONNECT_OAUTH_SECRET, false).build()).build())
+                    .endConnectContainer()
+                .endTemplate()
+                .withMetricsConfig(OAUTH_METRICS)
+            .endSpec()
+            .build();
+        // This is required to be able to remove the TLS setting, the builder cannot remove it
+        connect.getSpec().setTls(null);
+
+        KubeResourceManager.get().createResourceWithWait(connect);
+
+        // Allow connections from scraper to Connect Pod when NetworkPolicies are set to denied by default
+        NetworkPolicyUtils.allowNetworkPolicySettingsForResource(connect, KafkaConnectResources.componentName(oauthClusterName));
+
+        final String kafkaConnectPodName = KubeResourceManager.get().kubeClient().listPods(Environment.TEST_SUITE_NAMESPACE,
+                LabelSelectors.connectLabelSelector(oauthClusterName, KafkaConnectResources.componentName(oauthClusterName))).get(0).getMetadata().getName();
+
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName);
+
+        KafkaConnectorUtils.createFileSinkConnector(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, testStorage.getTopicName(), TestConstants.DEFAULT_SINK_FILE_PATH, "http://localhost:8083");
+
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
+
+        final String kafkaConnectLogs = KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).logs(kafkaConnectPodName);
+        verifyOauthConfiguration(kafkaConnectLogs);
+
+        assertOauthMetricsForComponent(
+            metricsCollector.toBuilder()
+                .withComponent(KafkaConnectMetricsComponent.create(oauthClusterName))
+                .build()
+        );
+    }
+
+    @IsolatedTest("Using more than one Kafka cluster in one Namespace")
+    @Tag(MIRROR_MAKER2)
+    @Tag(CONNECT_COMPONENTS)
+    @Tag(NODEPORT_SUPPORTED)
+    @Tag(METRICS)
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    void testProducerConsumerMirrorMaker2WithOauthMetrics() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + testStorage.getClusterName();
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), oauthClusterName).build());
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, producerName, testStorage.getMessageCount());
+
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
+
+        String kafkaSourceClusterName = oauthClusterName;
+
+        String jaasConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+                Map.of(
+                        "unsecuredLoginStringClaim_sub", "thePrincipalName",
+                        "oauth.valid.issuer.uri", keycloakInstance.getValidIssuerUri(),
+                        "oauth.jwks.expiry.seconds", Integer.toString(keycloakInstance.getJwksExpireSeconds()),
+                        "oauth.jwks.refresh.seconds", Integer.toString(keycloakInstance.getJwksRefreshSeconds()),
+                        "oauth.jwks.endpoint.uri", keycloakInstance.getJwksEndpointUri(),
+                        "oauth.username.claim", keycloakInstance.getUserNameClaim()
+                ));
+
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getTargetBrokerPoolName(), testStorage.getTargetClusterName(), 1).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getTargetControllerPoolName(), testStorage.getTargetClusterName(), 1).build()
+        );
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(Environment.TEST_SUITE_NAMESPACE, testStorage.getTargetClusterName(), 1)
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                                    .withName(TestConstants.EXTERNAL_LISTENER_DEFAULT_NAME)
+                                    .withPort(9094)
+                                    .withType(KafkaListenerType.NODEPORT)
+                                    .withTls(false)
+                                    .withNewKafkaListenerAuthenticationCustomAuth()
+                                        .withSasl(true)
+                                        .withListenerConfig(Map.of(
+                                                "sasl.enabled.mechanisms", "OAUTHBEARER",
+                                                "oauthbearer.sasl.server.callback.handler.class", "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
+                                                "oauthbearer.sasl.jaas.config", jaasConfig,
+                                                "principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"
+                                        ))
+                                    .endKafkaListenerAuthenticationCustomAuth()
+                                    .build(),
+                                new GenericKafkaListenerBuilder()
+                                    .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                                    .withPort(9092)
+                                    .withType(KafkaListenerType.INTERNAL)
+                                    .withTls(false)
+                                    .withNewKafkaListenerAuthenticationCustomAuth()
+                                        .withSasl(true)
+                                        .withListenerConfig(Map.of(
+                                                "sasl.enabled.mechanisms", "OAUTHBEARER",
+                                                "oauthbearer.sasl.server.callback.handler.class", "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
+                                                "oauthbearer.sasl.jaas.config", jaasConfig,
+                                                "principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"
+                                        ))
+                                    .endKafkaListenerAuthenticationCustomAuth()
+                                    .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        // Deploy MirrorMaker2 with OAuth
+        String sourceJassConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule", Map.of(
+                "oauth.token.endpoint.uri", keycloakInstance.getOauthTokenEndpointUri(),
+                "oauth.client.id", "kafka-mirror-maker-2",
+                "oauth.client.secret", "${strimzienv:OAUTH_CLIENT_SECRET}",
+                "oauth.connect.timeout.seconds", Integer.toString(CONNECT_TIMEOUT_S),
+                "oauth.read.timeout.seconds", Integer.toString(READ_TIMEOUT_S),
+                "oauth.enable.metrics", "true"
+        ));
+
+        KafkaMirrorMaker2ClusterSpec sourceClusterWithOauth = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias(kafkaSourceClusterName)
+                .withConfig(connectorConfig)
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(kafkaSourceClusterName))
+                .withNewKafkaClientAuthenticationCustom()
+                    .withSasl(true)
+                    .withConfig(Map.of(
+                            "sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler",
+                            "sasl.mechanism", "OAUTHBEARER",
+                            "sasl.jaas.config", sourceJassConfig
+                    ))
+                .endKafkaClientAuthenticationCustom()
+                .build();
+
+        String targetJassConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule", Map.of(
+                "oauth.token.endpoint.uri", keycloakInstance.getOauthTokenEndpointUri(),
+                "oauth.client.id", "kafka-mirror-maker-2",
+                "oauth.client.secret", "${strimzienv:OAUTH_CLIENT_SECRET}",
+                "oauth.connect.timeout.seconds", Integer.toString(CONNECT_TIMEOUT_S),
+                "oauth.read.timeout.seconds", Integer.toString(READ_TIMEOUT_S),
+                "oauth.enable.metrics", "true"
+        ));
+        KafkaMirrorMaker2ClusterSpec targetClusterWithOauth = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias(testStorage.getTargetClusterName())
+                .withConfig(connectorConfig)
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(testStorage.getTargetClusterName()))
+                .withNewKafkaClientAuthenticationCustom()
+                    .withSasl(true)
+                    .withConfig(Map.of(
+                            "sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler",
+                            "sasl.mechanism", "OAUTHBEARER",
+                            "sasl.jaas.config", targetJassConfig
+                    ))
+                .endKafkaClientAuthenticationCustom()
+                .build();
+
+        String kafkaTargetClusterTopicName = kafkaSourceClusterName + "." + testStorage.getTopicName();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaMirrorMaker2Templates.kafkaMirrorMaker2(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, kafkaSourceClusterName, testStorage.getTargetClusterName(), 1, false)
+            .editSpec()
+                .withMetricsConfig(OAUTH_METRICS)
+                .withClusters(sourceClusterWithOauth, targetClusterWithOauth)
+                .editFirstMirror()
+                    .withSourceCluster(kafkaSourceClusterName)
+                .endMirror()
+                .withNewTemplate()
+                    .withNewConnectContainer()
+                        .withEnv(new ContainerEnvVarBuilder().withName("OAUTH_CLIENT_SECRET").withValueFrom(new ContainerEnvVarSourceBuilder().withNewSecretKeyRef(OAUTH_KEY, MIRROR_MAKER_2_OAUTH_SECRET, false).build()).build())
+                    .endConnectContainer()
+                .endTemplate()
+            .endSpec()
+            .build());
+
+        final String kafkaMirrorMaker2PodName = KubeResourceManager.get().kubeClient().listPods(Environment.TEST_SUITE_NAMESPACE,
+            LabelSelectors.mirrorMaker2LabelSelector(oauthClusterName, KafkaMirrorMaker2Resources.componentName(oauthClusterName))).get(0).getMetadata().getName();
+        final String kafkaMirrorMaker2Logs = KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).logs(kafkaMirrorMaker2PodName);
+        verifyOauthConfiguration(kafkaMirrorMaker2Logs);
+
+        TestUtils.waitFor("MirrorMaker2 to copy messages from " + kafkaSourceClusterName + " to " + testStorage.getTargetClusterName(),
+            Duration.ofSeconds(30).toMillis(), TestConstants.TIMEOUT_FOR_MIRROR_MAKER_2_COPY_MESSAGES_BETWEEN_BROKERS,
+            () -> {
+                LOGGER.info("Deleting Job: {}/{}", Environment.TEST_SUITE_NAMESPACE, consumerName);
+                JobUtils.deleteJobWithWait(Environment.TEST_SUITE_NAMESPACE, consumerName);
+
+                LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", testStorage.getTargetClusterName());
+
+                KafkaOauthClients kafkaOauthClientJob = new KafkaOauthClientsBuilder()
+                    .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+                    .withProducerName(producerName)
+                    .withConsumerName(consumerName)
+                    .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getTargetClusterName()))
+                    .withTopicName(kafkaTargetClusterTopicName)
+                    .withMessageCount(testStorage.getMessageCount())
+                    .withOauthClientId(OAUTH_CLIENT_NAME)
+                    .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+                    .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .build();
+
+                KubeResourceManager.get().createResourceWithWait(kafkaOauthClientJob.consumerStrimziOauthPlain());
+
+                try {
+                    ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
+                    return  true;
+                } catch (WaitException e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            });
+
+        assertOauthMetricsForComponent(
+            metricsCollector.toBuilder()
+                .withComponent(KafkaMirrorMaker2MetricsComponent.create(oauthClusterName))
+                .build()
+        );
+    }
+
+    /**
+     * As a OAuth bridge, I should be able to send messages to bridge endpoint.
+     */
+    @ParallelTest
+    @Tag(BRIDGE)
+    @Tag(METRICS)
+    void testProducerConsumerBridgeWithOauthMetrics() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + testStorage.getClusterName();
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + testStorage.getClusterName();
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), oauthClusterName).build());
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, producerName, testStorage.getMessageCount());
+
+        KubeResourceManager.get().createResourceWithWait(oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
+
+        // needed for a verification of oauth configuration
+        InlineLogging ilDebug = new InlineLogging();
+        ilDebug.setLoggers(Map.of("rootLogger.level", "DEBUG"));
+
+        String bridgeJassConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule", Map.of(
+                "oauth.token.endpoint.uri", keycloakInstance.getOauthTokenEndpointUri(),
+                "oauth.client.id", "kafka-bridge",
+                "oauth.client.secret", "${strimzienv:OAUTH_CLIENT_SECRET}",
+                "oauth.connect.timeout.seconds", Integer.toString(CONNECT_TIMEOUT_S),
+                "oauth.read.timeout.seconds", Integer.toString(READ_TIMEOUT_S),
+                "oauth.enable.metrics", "true"
+        ));
+
+        KubeResourceManager.get().createResourceWithWait(KafkaBridgeTemplates.kafkaBridgeWithMetrics(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
+            .editSpec()
+                .withNewKafkaClientAuthenticationCustom()
+                    .withSasl(true)
+                    .withConfig(Map.of(
+                            "sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler",
+                            "sasl.mechanism", "OAUTHBEARER",
+                            "sasl.jaas.config", bridgeJassConfig
+                    ))
+                .endKafkaClientAuthenticationCustom()
+                .withNewTemplate()
+                    .withNewBridgeContainer()
+                        .withEnv(new ContainerEnvVarBuilder().withName("OAUTH_CLIENT_SECRET").withValueFrom(new ContainerEnvVarSourceBuilder().withNewSecretKeyRef(OAUTH_KEY, BRIDGE_OAUTH_SECRET, false).build()).build())
+                    .endBridgeContainer()
+                .endTemplate()
+                .withLogging(ilDebug)
+            .endSpec()
+            .build());
+
+        // Allow connections from scraper to Bridge pods when NetworkPolicies are set to denied by default
+        NetworkPolicyUtils.allowNetworkPolicySettingsForBridgeScraper(Environment.TEST_SUITE_NAMESPACE, scraperPodName, KafkaBridgeResources.componentName(oauthClusterName));
+
+        final String kafkaBridgePodName = KubeResourceManager.get().kubeClient().listPods(Environment.TEST_SUITE_NAMESPACE,
+            LabelSelectors.bridgeLabelSelector(oauthClusterName, KafkaBridgeResources.componentName(oauthClusterName))).get(0).getMetadata().getName();
+        final String kafkaBridgeLogs = KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).logs(kafkaBridgePodName);
+        verifyOauthConfiguration(kafkaBridgeLogs);
+
+        String bridgeProducerName = "bridge-producer-" + testStorage.getClusterName();
+
+        BridgeClients kafkaBridgeClientJob = new BridgeClientsBuilder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withProducerName(bridgeProducerName)
+            .withBootstrapAddress(KafkaBridgeResources.serviceName(oauthClusterName))
+            .withComponentName(KafkaBridgeResources.componentName(oauthClusterName))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withPort(HTTP_BRIDGE_DEFAULT_PORT)
+            .withDelayMs(1000)
+            .withPollInterval(1000)
+            .build();
+
+        KubeResourceManager.get().createResourceWithWait(kafkaBridgeClientJob.producerStrimziBridge());
+        ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, bridgeProducerName, testStorage.getMessageCount());
+
+        assertOauthMetricsForComponent(
+            metricsCollector.toBuilder()
+                .withComponent(KafkaBridgeMetricsComponent.create(Environment.TEST_SUITE_NAMESPACE, oauthClusterName))
+                .build()
+        );
+    }
+
+    private void assertOauthMetricsForComponent(MetricsCollector collector) {
+        LOGGER.info("Checking OAuth metrics for component: {}", collector.toString());
+        collector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
+
+        for (final String podName : collector.getCollectedData().keySet()) {
+            for (final String expectedMetric : expectedOauthMetrics) {
+                LOGGER.info("Searching value from Pod with IP {} for metric {}", podName, expectedMetric);
+                MetricsUtils.assertContainsMetric(collector.getCollectedData().get(podName), expectedMetric);
+            }
+        }
+    }
+
+    @BeforeAll
+    void setUp() throws Exception {
+        super.setupCoAndKeycloak(Environment.TEST_SUITE_NAMESPACE);
+
+        keycloakInstance.setRealm("internal", false);
+
+        // Deploy OAuth metrics CM
+        KubeResourceManager.get().kubeCmdClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).apply(FileUtils.updateNamespaceOfYamlFile(Environment.TEST_SUITE_NAMESPACE, OAUTH_METRICS_CM_PATH));
+
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPool(Environment.TEST_SUITE_NAMESPACE, KafkaComponents.getBrokerPoolName(oauthClusterName), oauthClusterName, 3).build(),
+            KafkaNodePoolTemplates.controllerPool(Environment.TEST_SUITE_NAMESPACE, KafkaComponents.getControllerPoolName(oauthClusterName), oauthClusterName, 3).build()
+        );
+
+        String plainOauthbearerJaasConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+                Map.of(
+                        "unsecuredLoginStringClaim_sub", "thePrincipalName",
+                        "oauth.valid.issuer.uri", keycloakInstance.getValidIssuerUri(),
+                        "oauth.jwks.expiry.seconds", Integer.toString(keycloakInstance.getJwksExpireSeconds()),
+                        "oauth.jwks.refresh.seconds", Integer.toString(keycloakInstance.getJwksRefreshSeconds()),
+                        "oauth.jwks.endpoint.uri", keycloakInstance.getJwksEndpointUri(),
+                        "oauth.username.claim", keycloakInstance.getUserNameClaim(),
+                        "oauth.groups.claim", GROUPS_CLAIM,
+                        "oauth.groups.claim.delimiter", GROUPS_CLAIM_DELIMITER,
+                        "oauth.enable.metrics", "true"
+                ));
+        String plainPlainJaasConfig = JAAS_CONFIG_BUILDER.apply("org.apache.kafka.common.security.plain.PlainLoginModule",
+                Map.of(
+                        "oauth.valid.issuer.uri", keycloakInstance.getValidIssuerUri(),
+                        "oauth.jwks.expiry.seconds", Integer.toString(keycloakInstance.getJwksExpireSeconds()),
+                        "oauth.jwks.refresh.seconds", Integer.toString(keycloakInstance.getJwksRefreshSeconds()),
+                        "oauth.jwks.endpoint.uri", keycloakInstance.getJwksEndpointUri(),
+                        "oauth.username.claim", keycloakInstance.getUserNameClaim(),
+                        "oauth.token.endpoint.uri", keycloakInstance.getOauthTokenEndpointUri(),
+                        "oauth.groups.claim", GROUPS_CLAIM,
+                        "oauth.groups.claim.delimiter", GROUPS_CLAIM_DELIMITER,
+                        "oauth.enable.metrics", "true"
+                ));
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, 3)
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                                    .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                                    .withPort(9092)
+                                    .withType(KafkaListenerType.INTERNAL)
+                                    .withTls(false)
+                                    .withNewKafkaListenerAuthenticationCustomAuth()
+                                        .withSasl(true)
+                                        .withListenerConfig(Map.of(
+                                                "sasl.enabled.mechanisms", "OAUTHBEARER,PLAIN",
+
+                                                "oauthbearer.sasl.server.callback.handler.class", "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
+                                                "oauthbearer.sasl.jaas.config", plainOauthbearerJaasConfig,
+
+                                                "plain.sasl.server.callback.handler.class", "io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler",
+                                                "plain.sasl.jaas.config", plainPlainJaasConfig,
+
+                                                "principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"
+                                        ))
+                                    .endKafkaListenerAuthenticationCustomAuth()
+                                    .build())
+                    .withMetricsConfig(OAUTH_METRICS)
+                .endKafka()
+            .endSpec()
+            .build());
+
+        KubeResourceManager.get().createResourceWithWait(ScraperTemplates.scraperPod(Environment.TEST_SUITE_NAMESPACE, scraperName).build());
+        scraperPodName = KubeResourceManager.get().kubeClient().listPodsByPrefixInName(Environment.TEST_SUITE_NAMESPACE, scraperName).get(0).getMetadata().getName();
+
+        metricsCollector = new MetricsCollector.Builder()
+            .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
+            .withScraperPodName(scraperPodName)
+            .withComponent(KafkaMetricsComponent.create(oauthClusterName))
+            .build();
+
+        String brokerPodName = KubeResourceManager.get().kubeClient().listPods(Environment.TEST_SUITE_NAMESPACE,
+            LabelSelectors.kafkaLabelSelector(oauthClusterName, KafkaComponents.getBrokerPodSetName(oauthClusterName))).get(0).getMetadata().getName();
+        verifyOauthListenerConfiguration(KubeResourceManager.get().kubeClient().getLogsFromPod(Environment.TEST_SUITE_NAMESPACE, brokerPodName));
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(REGRESSION)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
+@SuppressWarnings("deprecation") // OAuth authentication and Keycloak Authorization are deprecated
 public class OauthAuthorizationST extends OauthAbstractST {
     protected static final Logger LOGGER = LogManager.getLogger(OauthAuthorizationST.class);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
@@ -46,6 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Tag(OAUTH)
 @Tag(REGRESSION)
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
+@SuppressWarnings("deprecation") // OAuth authentication is deprecated
 public class OauthScopeST extends OauthAbstractST {
     
     private final String oauthClusterName = "oauth-cluster-scope-name";


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR deprecates the `type: oauth` authentication and `type: keycloak` authorization. They still keep working. It also adds some new basic system tests for using OAuth authentication and Keyclok authorization using the `type: custom` APIs.

Docs will be done in a seprate PR.

This should resolve #11764 and this should resolve #10354.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md