### PR TITLE
Add `/tmp` cleanup to Connect and MM2 startup scripts

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_mm2_shared_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_mm2_shared_run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+set +x
+
+# Prepare hostname - for StrimziPodSets we use the Pod DNS name assigned through the headless service
+ADVERTISED_HOSTNAME=$(hostname -f | cut -d "." -f1-4)
+export ADVERTISED_HOSTNAME
+
+# Create dir where keystores and truststores will be stored
+mkdir -p /tmp/kafka
+
+# Generate and print the config file
+echo "Starting Kafka Connect with configuration:"
+tee /tmp/strimzi-connect.properties < "/opt/kafka/custom-config/kafka-connect.properties" | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
+echo ""
+
+# Disable Kafka's GC logging (which logs to a file)...
+export GC_LOG_ENABLED="false"
+
+if [ -z "$KAFKA_LOG4J_OPTS" ]; then
+  export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$KAFKA_HOME/custom-config/log4j2.properties"
+fi
+
+# We don't need LOG_DIR because we write no log files, but setting it to a
+# directory avoids trying to create it (and logging a permission denied error)
+export LOG_DIR="$KAFKA_HOME"
+
+# Enable Prometheus JMX Exporter as Java agent
+if [ "$KAFKA_CONNECT_JMX_EXPORTER_ENABLED" = "true" ]; then
+    KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
+    export KAFKA_OPTS
+fi
+
+. ./set_kafka_jmx_options.sh "${STRIMZI_JMX_ENABLED}" "${STRIMZI_JMX_USERNAME}" "${STRIMZI_JMX_PASSWORD}"
+
+# Enable Tracing agent (initializes tracing) as Java agent
+if [ "$STRIMZI_TRACING" = "jaeger" ] || [ "$STRIMZI_TRACING" = "opentelemetry" ]; then
+    KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=$STRIMZI_TRACING"
+    export KAFKA_OPTS
+    if [ "$STRIMZI_TRACING" = "opentelemetry" ] && [ -z "$OTEL_TRACES_EXPORTER" ]; then
+      # auto-set OTLP exporter
+      export OTEL_TRACES_EXPORTER="otlp"
+    fi
+fi
+
+if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
+    export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
+fi
+
+# Disable FIPS if needed
+if [ "$FIPS_MODE" = "disabled" ]; then
+    export KAFKA_OPTS="${KAFKA_OPTS} -Dcom.redhat.fips=false"
+fi
+
+# Configure heap based on the available resources if needed
+. ./dynamic_resources.sh
+
+# Configure Garbage Collection logging
+. ./set_kafka_gc_options.sh
+
+set -x
+
+# starting Kafka server with final configuration
+exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -2,63 +2,9 @@
 set -e
 set +x
 
-# Prepare hostname - for StrimziPodSets we use the Pod DNS name assigned through the headless service
-ADVERTISED_HOSTNAME=$(hostname -f | cut -d "." -f1-4)
-export ADVERTISED_HOSTNAME
+# Clean-up /tmp directory from files which might have remained from previous container restart
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/* || true
 
-# Create dir where keystores and truststores will be stored
-mkdir -p /tmp/kafka
-
-# Generate and print the config file
-echo "Starting Kafka Connect with configuration:"
-tee /tmp/strimzi-connect.properties < "/opt/kafka/custom-config/kafka-connect.properties" | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
-echo ""
-
-# Disable Kafka's GC logging (which logs to a file)...
-export GC_LOG_ENABLED="false"
-
-if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-  export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$KAFKA_HOME/custom-config/log4j2.properties"
-fi
-
-# We don't need LOG_DIR because we write no log files, but setting it to a
-# directory avoids trying to create it (and logging a permission denied error)
-export LOG_DIR="$KAFKA_HOME"
-
-# Enable Prometheus JMX Exporter as Java agent
-if [ "$KAFKA_CONNECT_JMX_EXPORTER_ENABLED" = "true" ]; then
-    KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
-    export KAFKA_OPTS
-fi
-
-. ./set_kafka_jmx_options.sh "${STRIMZI_JMX_ENABLED}" "${STRIMZI_JMX_USERNAME}" "${STRIMZI_JMX_PASSWORD}"
-
-# Enable Tracing agent (initializes tracing) as Java agent
-if [ "$STRIMZI_TRACING" = "jaeger" ] || [ "$STRIMZI_TRACING" = "opentelemetry" ]; then
-    KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=$STRIMZI_TRACING"
-    export KAFKA_OPTS
-    if [ "$STRIMZI_TRACING" = "opentelemetry" ] && [ -z "$OTEL_TRACES_EXPORTER" ]; then
-      # auto-set OTLP exporter
-      export OTEL_TRACES_EXPORTER="otlp"
-    fi
-fi
-
-if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
-    export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
-fi
-
-# Disable FIPS if needed
-if [ "$FIPS_MODE" = "disabled" ]; then
-    export KAFKA_OPTS="${KAFKA_OPTS} -Dcom.redhat.fips=false"
-fi
-
-# Configure heap based on the available resources if needed
-. ./dynamic_resources.sh
-
-# Configure Garbage Collection logging
-. ./set_kafka_gc_options.sh
-
-set -x
-
-# starting Kafka server with final configuration
-exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties
+# Run the script shared between Connect and MirrorMaker 2
+exec ./kafka_connect_mm2_shared_run.sh


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, we do not do any `/tmp` cleanup in the Connect and MM2 startup scripts as we do for example in the Kafka startup scripts. That can lead to running out of free space in the `/tmp` storage, for example, due to the use of native compression libraries (as an example, Snappy tends to create at every startup something like `snappy-1.1.10-3d4e9ee7-017f-4568-9d54-886d7455aadf-libsnappyjava.so`). While container restarts (rather than Pod restarts which would clear the `/tmp` on its own) are rare, this can cause issued.

This PR adds the cleanup to the Connect and MM2 startup scripts. However, as the MM2 startup script calls the Connect one, it was not as simple as adding the cleanup command. I had to split the logix from `kafka_connect_run.sh` into a separate script shared by Connect and MM2 (named `kafka_connect_mm2_shared_run.sh`). And this is called from the original startup scripts that continue to be used as the entrypoints in the container and contain the `/tmp` cleanup.

I also used this opportunity to remove some duplicate logic between the `kafka_mirror_maker_2_run.sh` and the `kafka_connect_mm2_shared_run.sh` script.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally