### PR TITLE
[ST] Fixes to LogCollector and UserST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestTags.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestTags.java
@@ -157,6 +157,11 @@ public interface TestTags {
     String PERFORMANCE = "performance";
 
     /**
+     * Tag for tests focusing on users - this one is especially for UserST in order to create `test-suite-namespace`.
+     */
+    String USER = "user";
+
+    /**
      * Tag for tests that covers Tiered Storage integration
      */
     String TIERED_STORAGE = "tieredstorage";

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -68,7 +68,8 @@ public class ExecutionListener implements TestExecutionListener {
             TestTags.DYNAMIC_CONFIGURATION, // Dynamic configuration also because in DynamicConfSharedST we use @TestFactory
             TestTags.TRACING,  // Tracing, because we deploy Jaeger operator inside additional namespace
             TestTags.KAFKA_SMOKE, // KafkaVersionsST, MigrationST because here we use @ParameterizedTest
-            TestTags.KRAFT_UPGRADE
+            TestTags.KRAFT_UPGRADE,
+            TestTags.USER // Needed for UserST mainly, where we are deploying Kafka into the `test-suite-namespace` before running all other tests
         );
 
         for (TestIdentifier testIdentifier : testCases) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
@@ -142,6 +142,7 @@ public class TestLogCollector {
             TestConstants.CONFIG_MAP.toLowerCase(Locale.ROOT),
             TestConstants.SERVICE.toLowerCase(Locale.ROOT),
             TestConstants.CERTIFICATE.toLowerCase(Locale.ROOT),
+            TestConstants.JOB.toLowerCase(Locale.ROOT),
             Kafka.RESOURCE_SINGULAR,
             KafkaNodePool.RESOURCE_SINGULAR,
             KafkaConnect.RESOURCE_SINGULAR,
@@ -190,21 +191,24 @@ public class TestLogCollector {
             String[] filesInLogsDir = logsForTestCase.list();
 
             if (filesInLogsDir != null && filesInLogsDir.length > 0) {
-                index = Integer.parseInt(
-                    Arrays
-                        .stream(filesInLogsDir)
-                        .filter(file -> {
-                            try {
-                                Integer.parseInt(file);
-                                return true;
-                            } catch (NumberFormatException e) {
-                                return false;
-                            }
-                        })
-                        .sorted()
-                        .toList()
-                        .get(filesInLogsDir.length - 1)
-                ) + 1;
+                List<String> indexes = Arrays
+                    .stream(filesInLogsDir)
+                    .filter(file -> {
+                        try {
+                            Integer.parseInt(file);
+                            return true;
+                        } catch (NumberFormatException e) {
+                            return false;
+                        }
+                    })
+                    .sorted()
+                    .toList();
+
+                // check if there is actually something in the list of folders
+                if (!indexes.isEmpty()) {
+                    // take the highest index and increase it by one for a new directory
+                    index = Integer.parseInt(indexes.get(indexes.size() - 1)) + 1;
+                }
             }
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
 import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,8 +90,6 @@ public class JobUtils {
     public static void deleteJobsWithWait(String namespace, String... names) {
         for (String jobName : names) {
             deleteJobWithWait(namespace, jobName);
-            // wait for all Pods for the Job to be deleted before continuing
-            PodUtils.waitForPodsWithPrefixDeletion(namespace, jobName);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
 import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,6 +91,8 @@ public class JobUtils {
     public static void deleteJobsWithWait(String namespace, String... names) {
         for (String jobName : names) {
             deleteJobWithWait(namespace, jobName);
+            // wait for all Pods for the Job to be deleted before continuing
+            PodUtils.waitForPodsWithPrefixDeletion(namespace, jobName);
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Tag;
 
 import static io.strimzi.systemtest.TestTags.ACCEPTANCE;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
+import static io.strimzi.systemtest.TestTags.USER;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -66,6 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
 @Tag(REGRESSION)
+@Tag(USER)
 @SuiteDoc(
     description = @Desc("Test suite for various Kafka User operations and configurations."),
     beforeTestSteps = {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR (tries) to fix few things which seems to be problematic when running UserST:

- We are not collecting the Job resource at all, so I added it to the list of resource that should be collected
- It seems that we are wrongly accessing the array when collecting logs and checking the highest index of folders
- When running UserST alone it usually fails because we are trying to deploy Kafka inside `test-suite-namespace` that is not created - so I added tag `USER` for the user related tests and I also added it to the list of cases when the `test-suite-namespace` should be deployed
- There seems to be race between deletion of the Job and its Pod and starting a new one - seen during `UserST#testTlsExternalUser` - for the last check I changed the name of the producer, which should fix this issue

### Checklist

- [x] Make sure all tests pass

