### PR TITLE
chore(monitoring): fix AbnormalControllerState alert rule

### DIFF
--- a/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-rules.yaml
@@ -26,13 +26,13 @@ spec:
         summary: 'Kafka under replicated partitions'
         description: 'There are {{ $value }} under replicated partitions on {{ $labels.kubernetes_pod_name }}'
     - alert: AbnormalControllerState
-      expr: sum(kafka_controller_kafkacontroller_activecontrollercount) by (strimzi_io_name, namespace, pod) != 1
+      expr: sum(kafka_controller_kafkacontroller_activecontrollercount) by (strimzi_io_name, namespace) != 1
       for: 10s
       labels:
         severity: warning
       annotations:
         summary: 'Kafka abnormal controller state'
-        description: 'Kafka instance on pod {{ $labels.namespace }}/{{ $labels.pod }} has {{ $value }} active controllers'
+        description: 'Kafka instance {{ $labels.strimzi_io_name }} on namespace {{ $labels.namespace }} has {{ $value }} active controllers'
     - alert: OfflinePartitions
       expr: sum(kafka_controller_kafkacontroller_offlinepartitionscount) by (namespace, pod) > 0
       for: 10s


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`AbnormalControllerState` alert rule should check controller state by `strimzi_io_name`, but not by pod. It's because there are multiple pod with different status of `kafka_controller_kafkacontroller_activecontrollercount` metric  across single `strimzi_io_name` like so:
```
kafka_controller_kafkacontroller_activecontrollercount{pod="cluster-controller-1",strimzi_io_name="cluster-kafka",namespace="kafka"} 0
kafka_controller_kafkacontroller_activecontrollercount{pod="cluster-controller-2",strimzi_io_name="cluster-kafka",namespace="kafka"} 1
kafka_controller_kafkacontroller_activecontrollercount{pod="cluster-controller-3",strimzi_io_name="cluster-kafka",namespace="kafka"} 0
```
... and it's ok

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

