### PR TITLE
[DOC] Update Kafka Access Operator Docs With User Provided Secret

### DIFF
--- a/documentation/modules/deploying/proc-using-access-operator.adoc
+++ b/documentation/modules/deploying/proc-using-access-operator.adoc
@@ -132,10 +132,9 @@ data:
 . Make the secret available to your application. 
 + 
 Applications can reference the secret directly, or you can inject it into an application's environment using an operator to implement the link:https://servicebinding.io/spec/core/1.0.0/[Service Binding specification].
-
-A user has the option for specifying the secret name if desired. This is achieved by adding `SecretName` field to the `KafkaAccess` spec.
-
-.Example access configuration with secretName
++
+Optionally, you can specify the name of the secret by adding the `secretName` field to the `KafkaAccess` resource specification:
++
 [source,yaml]
 ----
 apiVersion: access.strimzi.io/v1alpha1
@@ -149,5 +148,5 @@ spec:
     listener: tls
   secretName: my-custom-secret
 ----
-
-If no secret name is provided by the user, the secret will fallback to the name of the KafkaAccess.
++
+If no `secretName` is provided, the secret name defaults to the name of the `KafkaAccess` resource.


### PR DESCRIPTION
### Type of change

- Documentation

Description
Up to this point, the secret name was explicitly obtained by copying the name of the KafkaAccess CR. The user now has the ability to provide their own secret name. This PR updates the documents to reflect this changes.

Updates:
Procedure file: Using the Access Operator

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

