### PR TITLE
Disable test-container logging as build is stable

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -32,8 +32,7 @@ stages:
           artifactRunVersion: ''
           artifactRunId: ''
     variables:
-      # set to false when none error occurs during 2 weeks - https://github.com/strimzi/strimzi-kafka-operator/issues/11839
-      STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: true
+      STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: false
 
   # Builds Strimzi docs
   - stage: build_docs


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR disables test-container logging. After our fix, it seems the build is stable, and we didn't face the same issue. Therefore, I am reverting it (because it's no longer needed).


### Checklist

- [x] Write tests
- [x] Make sure all tests pass