### PR TITLE
Defaulting `min.insync.replicas` to 1 when it's not specified by the user

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -844,11 +844,6 @@ public class KafkaBrokerConfigurationBuilder {
                 ? new KafkaConfiguration(userConfig)
                 : new KafkaConfiguration(reconciliation, new ArrayList<>());
 
-        // Set default min.insync.replicas=1 if not specified by the user
-        if (userConfig.getConfigOption("min.insync.replicas") == null) {
-            userConfig.setConfigOption("min.insync.replicas", "1");
-        }
-
         printConfigProviders(userConfig);
 
         printMetricReporters(userConfig, injectCcMetricsReporter, injectKafkaJmxReporter, injectStrimziMetricsReporter);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -844,6 +844,11 @@ public class KafkaBrokerConfigurationBuilder {
                 ? new KafkaConfiguration(userConfig)
                 : new KafkaConfiguration(reconciliation, new ArrayList<>());
 
+        // Set default min.insync.replicas=1 if not specified by the user
+        if (userConfig.getConfigOption("min.insync.replicas") == null) {
+            userConfig.setConfigOption("min.insync.replicas", "1");
+        }
+
         printConfigProviders(userConfig);
 
         printMetricReporters(userConfig, injectCcMetricsReporter, injectKafkaJmxReporter, injectStrimziMetricsReporter);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -13,6 +13,7 @@ import io.strimzi.operator.common.Reconciliation;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,10 +32,14 @@ public class KafkaConfiguration extends AbstractConfiguration {
 
     private static final List<String> FORBIDDEN_PREFIXES;
     private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
+    private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaClusterSpec.FORBIDDEN_PREFIXES);
         FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+
+        DEFAULTS = new HashMap<>(6);
+        DEFAULTS.put("min.insync.replicas", "1");
     }
 
     /**
@@ -198,11 +203,11 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), Map.of());
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 
     private KafkaConfiguration(Reconciliation reconciliation, String configuration, List<String> forbiddenPrefixes) {
-        super(reconciliation, configuration, forbiddenPrefixes, List.of(), List.of(), Map.of());
+        super(reconciliation, configuration, forbiddenPrefixes, List.of(), List.of(), DEFAULTS);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -38,7 +38,9 @@ public class KafkaConfiguration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaClusterSpec.FORBIDDEN_PREFIXES);
         FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
-        DEFAULTS = new HashMap<>(6);
+        DEFAULTS = new HashMap<>(1);
+        // when users remove "min.insync.replicas" from the Kafka custom resource, the operator is going to force the
+        // default value (1) regardless of whether ELR (Eligible Leader Replicas) is enabled or disabled
         DEFAULTS.put("min.insync.replicas", "1");
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaSpecChecker.java
@@ -84,8 +84,10 @@ public class KafkaSpecChecker {
      * @param warnings List to add a warning to, if appropriate.
      */
     private void checkKafkaReplicationConfig(List<Condition> warnings) {
-        Object defaultReplicationFactor = kafkaSpec.getKafka().getConfig().get(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR);
-        Object minInsyncReplicas = kafkaSpec.getKafka().getConfig().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG);
+        Object defaultReplicationFactor = kafkaSpec.getKafka().getConfig() != null ?
+                kafkaSpec.getKafka().getConfig().get(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR) : null;
+        Object minInsyncReplicas = kafkaSpec.getKafka().getConfig() != null ?
+                kafkaSpec.getKafka().getConfig().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG) : null;
 
         if (defaultReplicationFactor == null && kafkaCluster.brokerNodes().size() > 1)   {
             warnings.add(StatusUtils.buildWarningCondition("KafkaDefaultReplicationFactor",

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaSpecChecker.java
@@ -33,6 +33,7 @@ public class KafkaSpecChecker {
 
     private final KafkaCluster kafkaCluster;
     private final String kafkaBrokerVersion;
+    private final KafkaSpec kafkaSpec;
 
     // This pattern is used to extract the MAJOR.MINOR version from the protocol or format version fields
     private final static Pattern MAJOR_MINOR_REGEX = Pattern.compile("(\\d+\\.\\d+).*");
@@ -47,6 +48,7 @@ public class KafkaSpecChecker {
      *                      this class to include awareness of what defaults are applied.
      */
     public KafkaSpecChecker(KafkaSpec spec, KafkaVersion.Lookup versions, KafkaCluster kafkaCluster) {
+        this.kafkaSpec = spec;
         this.kafkaCluster = kafkaCluster;
 
         if (spec.getKafka().getVersion() != null) {
@@ -82,8 +84,8 @@ public class KafkaSpecChecker {
      * @param warnings List to add a warning to, if appropriate.
      */
     private void checkKafkaReplicationConfig(List<Condition> warnings) {
-        String defaultReplicationFactor = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR);
-        String minInsyncReplicas = kafkaCluster.getConfiguration().getConfigOption(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG);
+        Object defaultReplicationFactor = kafkaSpec.getKafka().getConfig().get(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR);
+        Object minInsyncReplicas = kafkaSpec.getKafka().getConfig().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG);
 
         if (defaultReplicationFactor == null && kafkaCluster.brokerNodes().size() > 1)   {
             warnings.add(StatusUtils.buildWarningCondition("KafkaDefaultReplicationFactor",

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -34,7 +34,6 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.FeatureMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigException;
@@ -624,12 +623,8 @@ public class KafkaRoller {
             // Always get the broker config. This request gets sent to that specific broker, so it's a proof that we can
             // connect to the broker and that it's capable of responding.
             Config brokerConfig;
-            short elrVersion = 0;
             try {
                 brokerConfig = brokerConfig(nodeRef);
-                FeatureMetadata featureMetadata = featureMetadata();
-                elrVersion = featureMetadata.finalizedFeatures().get("eligible.leader.replicas.version") == null ?
-                        0 : featureMetadata.finalizedFeatures().get("eligible.leader.replicas.version").maxVersionLevel();
             } catch (ForceableProblem e) {
                 if (restartContext.backOff.done()) {
                     needsRestart = true;
@@ -641,7 +636,7 @@ public class KafkaRoller {
 
             if (!needsRestart && allowReconfiguration) {
                 LOGGER.traceCr(reconciliation, "Pod {}: description {}", nodeRef, brokerConfig);
-                brokerConfigDiff = new KafkaBrokerConfigurationDiff(reconciliation, brokerConfig, kafkaConfigProvider.apply(nodeRef.nodeId()), kafkaVersion, nodeRef, elrVersion);
+                brokerConfigDiff = new KafkaBrokerConfigurationDiff(reconciliation, brokerConfig, kafkaConfigProvider.apply(nodeRef.nodeId()), kafkaVersion, nodeRef);
 
                 if (brokerConfigDiff.getDiffSize() > 0) {
                     if (brokerConfigDiff.canBeUpdatedDynamically()) {
@@ -660,17 +655,6 @@ public class KafkaRoller {
         restartContext.needsReconfig = needsReconfig;
         restartContext.forceRestart = false;
         restartContext.brokerConfigDiff = brokerConfigDiff;
-    }
-
-    /**
-     * Returns the information about the features within the Kafka Cluster
-     * @return information about the features
-     */
-    /* test */ FeatureMetadata featureMetadata() throws ForceableProblem, InterruptedException {
-        return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerAdminClient.describeFeatures().featureMetadata()),
-                30, TimeUnit.SECONDS,
-                error -> new ForceableProblem("Error getting feature metadata", error)
-        );
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -499,7 +499,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "config.providers.strimzidir.param.allowed.paths=/opt/kafka"));
+                "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
+                "min.insync.replicas=1"));
     }
 
     @Test
@@ -516,7 +517,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"));
+                "metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter",
+                "min.insync.replicas=1"));
     }
 
     @Test
@@ -535,7 +537,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "config.providers.strimzidir.param.allowed.paths=/opt/kafka"));
+                "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
+                "min.insync.replicas=1"));
     }
 
     @Test
@@ -563,7 +566,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "auto.create.topics.enable=false",
                 "offsets.topic.replication.factor=3",
                 "transaction.state.log.replication.factor=3",
-                "transaction.state.log.min.isr=2"));
+                "transaction.state.log.min.isr=2",
+                "min.insync.replicas=1"));
     }
 
     @Test
@@ -587,7 +591,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider"));
+                "config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
+                "min.insync.replicas=1"));
 
         // Controller
         configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, new NodeRef("my-cluster-kafka-3", 3, "kafka", true, false))
@@ -598,7 +603,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers=env,strimzienv",
                 "config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "config.providers.strimzienv.param.allowlist.pattern=.*",
-                "config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider"));
+                "config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
+                "min.insync.replicas=1"));
     }
     
     @Test
@@ -631,7 +637,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "metric.reporters=org.apache.kafka.common.metrics.JmxReporter"));
+                "metric.reporters=org.apache.kafka.common.metrics.JmxReporter",
+                "min.insync.replicas=1"));
     }
 
     @Test
@@ -647,6 +654,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
+                "min.insync.replicas=1",
                 "metric.reporters=" + StrimziMetricsReporterConfig.KAFKA_CLASS,
                 "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
     }
@@ -666,6 +674,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
+                "min.insync.replicas=1",
                 "metric.reporters=" + CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER
                         + "," + StrimziMetricsReporterConfig.KAFKA_CLASS,
                 "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
@@ -688,7 +697,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "metric.reporters=" + CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER
                         + ",org.apache.kafka.common.metrics.JmxReporter"
                         + "," + StrimziMetricsReporterConfig.KAFKA_CLASS,
-                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
+                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS,
+                "min.insync.replicas=1"));
     }
 
     static Stream<Arguments> sourceUserConfigWithMetricsReporters() {
@@ -704,7 +714,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 + "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider\n"
                 + "config.providers.strimzifile.param.allowed.paths=/opt/kafka\n"
                 + "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider\n"
-                + "config.providers.strimzidir.param.allowed.paths=/opt/kafka\n";
+                + "config.providers.strimzidir.param.allowed.paths=/opt/kafka\n"
+                + "min.insync.replicas=1\n";
 
         // testing 8 combinations of 3 boolean values
         return Stream.of(
@@ -778,7 +789,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "metric.reporters=" + StrimziMetricsReporterConfig.KAFKA_CLASS,
-                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
+                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS,
+                "min.insync.replicas=1"));
     }
 
     @Test
@@ -2616,5 +2628,30 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("node.id=2",
                 "metadata.log.dir=/my/kraft/metadata/kafka-log2"
         ));
+    }
+
+    @Test
+    public void testDefaultMinInSyncReplicasWhenNotSpecified() {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("auto.create.topics.enable", "false");
+        userConfiguration.put("offsets.topic.replication.factor", 3);
+
+        KafkaConfiguration kafkaConfiguration = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
+
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
+                .withUserConfiguration(kafkaConfiguration, false, false, false)
+                .build();
+
+        assertThat(configuration, isEquivalent("node.id=2",
+                "config.providers=strimzienv,strimzifile,strimzidir",
+                "config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
+                "config.providers.strimzienv.param.allowlist.pattern=.*",
+                "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
+                "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
+                "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
+                "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
+                "min.insync.replicas=1",
+                "auto.create.topics.enable=false",
+                "offsets.topic.replication.factor=3"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiffTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class KafkaBrokerConfigurationDiffTest {
     KafkaVersion kafkaVersion = KafkaVersionTestUtils.getKafkaVersionLookup().defaultVersion();
     private final NodeRef nodeRef = new NodeRef("broker-0", 0, "broker", false, true);
-    private final short elrVersion = KafkaVersion.compareDottedVersions(kafkaVersion.version(), "4.1.0") >= 0 ? (short) 1 : (short) 0;
 
     private ConfigEntry instantiateConfigEntry(String name, String val) {
         // use reflection to instantiate ConfigEntry
@@ -101,7 +100,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testCustomPropertyAdded() {
         ArrayList<ConfigEntry> ces = new ArrayList<>();
         ces.add(new ConfigEntry("custom.property", "42"));
-        KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(new ArrayList<>()), getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+        KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(new ArrayList<>()), getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
 
@@ -111,7 +110,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testCustomPropertyRemoved() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("custom.property", "42"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(emptyList()), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(emptyList()), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
         // custom changes are applied by changing STS
@@ -121,7 +120,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testCustomPropertyKept() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("custom.property", "42"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -131,7 +130,7 @@ public class KafkaBrokerConfigurationDiffTest {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("custom.property", "42"));
         List<ConfigEntry> ces2 = singletonList(new ConfigEntry("custom.property", "43"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(ces2), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces2), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -140,7 +139,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedPresentValue() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("min.insync.replicas", "1"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
         assertConfig(kcd, new ConfigEntry("min.insync.replicas", "1"));
@@ -150,7 +149,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedPresentValueToDefault() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("min.insync.replicas", "2"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -160,7 +159,7 @@ public class KafkaBrokerConfigurationDiffTest {
         List<ConfigEntry> desiredControllerConfig = singletonList(new ConfigEntry("controller.quorum.election.timeout.ms", "5000"));
         List<ConfigEntry> currentControllerConfig = singletonList(new ConfigEntry("controller.quorum.election.timeout.ms", "1000"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(currentControllerConfig),
-                getDesiredConfiguration(desiredControllerConfig), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(desiredControllerConfig), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
     }
 
@@ -170,7 +169,7 @@ public class KafkaBrokerConfigurationDiffTest {
         List<ConfigEntry> desiredControllerConfig = singletonList(new ConfigEntry("controller.quorum.election.timeout.ms", "5000"));
         List<ConfigEntry> currentControllerConfig = singletonList(new ConfigEntry("controller.quorum.election.timeout.ms", "1000"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(currentControllerConfig),
-                getDesiredConfiguration(desiredControllerConfig), kafkaVersion, combinedNodeId, elrVersion);
+                getDesiredConfiguration(desiredControllerConfig), kafkaVersion, combinedNodeId);
         assertThat(kcd.getDiffSize(), is(1));
     }
 
@@ -178,7 +177,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedAdvertisedListener() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("advertised.listeners", "karel"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -187,7 +186,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedAdvertisedListenerFromNothingToDefault() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("advertised.listeners", "null"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -197,7 +196,7 @@ public class KafkaBrokerConfigurationDiffTest {
         // advertised listeners are filled after the pod started
         List<ConfigEntry> ces = singletonList(new ConfigEntry("advertised.listeners", "null"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -206,7 +205,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedLogDirs() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("log.dirs", "/var/lib/kafka/data/karel"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(false));
         assertConfig(kcd, new ConfigEntry("log.dirs", "/var/lib/kafka/data/karel"));
@@ -216,7 +215,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testLogDirsNonDefaultToDefault() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("log.dirs", "null"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(false));
         assertConfig(kcd, new ConfigEntry("log.dirs", "null"));
@@ -226,7 +225,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testLogDirsDefaultToDefault() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("log.dirs", "null"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -235,7 +234,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testUnchangedLogDirs() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("log.dirs", "null"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
 
         assertThat(kcd.getDiffSize(), is(0));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
@@ -245,7 +244,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedInterBrokerListenerName() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("inter.broker.listener.name", "david"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(false));
     }
@@ -254,7 +253,7 @@ public class KafkaBrokerConfigurationDiffTest {
     public void testChangedListenerSecurityProtocolMap() {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("listener.security.protocol.map", "david"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
     }
@@ -264,7 +263,7 @@ public class KafkaBrokerConfigurationDiffTest {
         List<ConfigEntry> ces = singletonList(new ConfigEntry("listener.security.protocol.map", "REPLICATION-9091:SSL,PLAIN-9092:SASL_PLAINTEXT,TLS-9093:SSL,EXTERNAL-9094:SSL"));
         List<ConfigEntry> ces2 = singletonList(new ConfigEntry("listener.security.protocol.map", "REPLICATION-9091:SSL,PLAIN-9092:SASL_PLAINTEXT,TLS-9093:SSL"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(ces2), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces2), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(true));
         assertConfig(kcd, new ConfigEntry("listener.security.protocol.map", "REPLICATION-9091:SSL,PLAIN-9092:SASL_PLAINTEXT,TLS-9093:SSL"));
@@ -278,7 +277,7 @@ public class KafkaBrokerConfigurationDiffTest {
         ces.add(new ConfigEntry("group.min.session.timeout.ms", "42"));
         ces.add(new ConfigEntry("auto.create.topics.enable", "false"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(emptyList()),
-                getDesiredConfiguration(ces), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(ces), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(3));
         assertThat(kcd.canBeUpdatedDynamically(), is(false));
     }
@@ -288,7 +287,7 @@ public class KafkaBrokerConfigurationDiffTest {
         // it is not seen as default because the ConfigEntry.ConfigSource.DEFAULT_CONFIG is not set
         List<ConfigEntry> ces = singletonList(new ConfigEntry("log.retention.hours", "168"));
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
-                getDesiredConfiguration(emptyList()), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(emptyList()), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(1));
         assertThat(kcd.canBeUpdatedDynamically(), is(false));
     }
@@ -304,7 +303,7 @@ public class KafkaBrokerConfigurationDiffTest {
                 new ConfigEntry("log.retention.bytes", "3000000")
         );
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(current),
-                getDesiredConfiguration(desired), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(desired), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(2));
         assertThat(kcd.getConfigDiff(Scope.CLUSTER_WIDE).size(), is(2));
         assertThat(kcd.getConfigDiff(Scope.PER_BROKER).size(), is(0));
@@ -325,7 +324,7 @@ public class KafkaBrokerConfigurationDiffTest {
                 new ConfigEntry("auto.create.topics.enable", "false")
         );
         KafkaBrokerConfigurationDiff kcd = new KafkaBrokerConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(current),
-                getDesiredConfiguration(desired), kafkaVersion, nodeRef, elrVersion);
+                getDesiredConfiguration(desired), kafkaVersion, nodeRef);
         assertThat(kcd.getDiffSize(), is(4));
         assertThat(kcd.getConfigDiff(Scope.CLUSTER_WIDE).size(), is(2));
         assertThat(kcd.getConfigDiff(Scope.PER_BROKER).size(), is(1));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -28,10 +28,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeMetadataQuorumResult;
-import org.apache.kafka.clients.admin.FeatureMetadata;
-import org.apache.kafka.clients.admin.FinalizedVersionRange;
 import org.apache.kafka.clients.admin.QuorumInfo;
-import org.apache.kafka.clients.admin.SupportedVersionRange;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.junit.jupiter.api.AfterAll;
@@ -49,7 +46,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
@@ -1028,26 +1024,6 @@ public class KafkaRollerTest {
             } else {
                 return super.deferController(nodeRef, restartContext);
             }
-        }
-
-        @Override
-        FeatureMetadata featureMetadata() throws ForceableProblem, InterruptedException {
-            FeatureMetadata mockFeatureMetadata = mock(FeatureMetadata.class);
-
-            Map<String, SupportedVersionRange> supportedVersionRanges = Map.of(
-                    "eligible.leader.replicas.version",
-                    new SupportedVersionRange((short) 0, (short) 1)
-            );
-            Map<String, FinalizedVersionRange> finalizedVersionRanges = Map.of(
-                    "eligible.leader.replicas.version",
-                    new FinalizedVersionRange((short) 0, (short) 1)
-            );
-            when(mockFeatureMetadata.supportedFeatures()).thenReturn(supportedVersionRanges);
-            when(mockFeatureMetadata.finalizedFeatures()).thenReturn(finalizedVersionRanges);
-            when(mockFeatureMetadata.finalizedFeaturesEpoch()).thenReturn(Optional.of(1L));
-
-            return mockFeatureMetadata;
-
         }
 
         @Override

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -183,3 +183,7 @@ spec:
 <24> Specified User Operator loggers and log levels.
 <25> Kafka Exporter configuration. Kafka Exporter is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use.
 <26> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
+
+WARNING: If you remove the `min.insync.replicas` property from `.spec.kafka.config` in the `Kafka` resource, the Cluster Operator
+forces Kafka to fall back to the default value (`1`), regardless of whether ELR (Eligible Leader Replicas) is enabled or disabled.
+To ensure durability of the cluster, explicitly define `min.insync.replicas` with a value higher than 1.

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -183,8 +183,3 @@ spec:
 <24> Specified User Operator loggers and log levels.
 <25> Kafka Exporter configuration. Kafka Exporter is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use.
 <26> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
-
-WARNING: If you remove the `min.insync.replicas` property from `.spec.kafka.config` within the `Kafka` resource, behavior depends on the ELR (Eligible Leader Replicas) setting.
-When ELR is enabled (default from Kafka 4.1.0), Kafka retains the last known value of `min.insync.replicas` defined in the `Kafka` resource.
-When ELR is disabled, Kafka falls back to the `min.insync.replicas` default (`1`).
-To ensure durability of the cluster, define `min.insync.replicas` explicitly.


### PR DESCRIPTION
This PR fixes https://github.com/strimzi/strimzi-kafka-operator/issues/11880
What it does is just defaulting the `min.insync.replicas` to `1` when the user doesn't specify it within the `.spec.kafka.config` in the `Kafka` custom resource and it happens despite what's the value of ELR (enabled or not).
This way, it happens:

* if its value is changed, it's handled as a normal dynamic configuration change and brokers rolling is not needed.
* if its value is removed, the new code force the `min.insync.replicas: 1` into the ConfigMap so that when it comes to the KafkaRoller it's still seen as an update (not a removal) and the dynamic configuration change is applied (still no brokers rolling).