### PR TITLE
Use the new snapshot repository for the Access Operator in STs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
             Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
             -->
             <id>oss-sonatype</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR tries to use the new Sonatype Snapshot repository for the Access Operator used in STs. This should help with test failures in #11883.