### PR TITLE
Set `blockOwnerDeletion` to `true` in Strimzi managed resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.49.0
 
-* Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources
+* Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources.
+  Deleting the Strimzi custom resources will now by default wait for the deletion of all the owned Kubernetes resources.
 
 ## 0.48.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.49.0
 
-* n/a
+* Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources
 
 ## 0.48.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -268,7 +268,7 @@ public class ModelUtils {
                 .withKind(owner.getKind())
                 .withName(owner.getMetadata().getName())
                 .withUid(owner.getMetadata().getUid())
-                .withBlockOwnerDeletion(false)
+                .withBlockOwnerDeletion(true)
                 .withController(isController)
                 .build();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -148,7 +148,7 @@ public class CaReconciler {
                 .withKind(kafkaCr.getKind())
                 .withName(kafkaCr.getMetadata().getName())
                 .withUid(kafkaCr.getMetadata().getUid())
-                .withBlockOwnerDeletion(false)
+                .withBlockOwnerDeletion(true)
                 .withController(false)
                 .build();
         this.clusterCaConfig = kafkaCr.getSpec().getClusterCa();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -6,6 +6,8 @@ package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.api.model.LoadBalancerIngressBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
@@ -112,6 +114,15 @@ import static org.mockito.Mockito.when;
     "checkstyle:ClassFanOutComplexity"
 })
 public class ResourceUtils {
+    public static final OwnerReference DUMMY_OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(true)
+            .withController(false)
+            .build();
+
     private ResourceUtils() { }
 
     public static Secret createInitialCaCertSecret(String clusterNamespace, String clusterName, String secretName,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
@@ -9,6 +9,8 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.operator.cluster.model.ModelUtils;
@@ -27,6 +29,8 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestUtils {
     public static JmxPrometheusExporterMetrics getJmxPrometheusExporterMetrics(String key, String name) {
@@ -64,6 +68,25 @@ public class TestUtils {
                 Collectors.toMap(EnvVar::getName, EnvVar::getValue,
                         // On duplicates, last-in wins
                         (u, v) -> v));
+    }
+
+    /**
+     * Checks that the resource has the owner reference pointing to the parent resource
+     *
+     * @param resource  The resource where the owner reference should be checked
+     * @param owner     The resource which should be the owner
+     */
+    public static void checkOwnerReference(HasMetadata resource, HasMetadata owner)  {
+        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
+
+        OwnerReference or = resource.getMetadata().getOwnerReferences().get(0);
+
+        assertThat(or.getApiVersion(), is(owner.getApiVersion()));
+        assertThat(or.getKind(), is(owner.getKind()));
+        assertThat(or.getName(), is(owner.getMetadata().getName()));
+        assertThat(or.getUid(), is(owner.getMetadata().getUid()));
+        assertThat(or.getBlockOwnerDeletion(), is(true));
+        assertThat(or.getController(), is(false));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ConfigMapUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ConfigMapUtilsTest.java
@@ -8,13 +8,12 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.strimzi.api.kafka.model.common.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.logging.SupportsLogging;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
@@ -33,14 +32,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ConfigMapUtilsTest {
     private final static String NAME = "my-cm";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -51,11 +42,11 @@ public class ConfigMapUtilsTest {
 
     @Test
     public void testConfigMapCreation() {
-        ConfigMap cm = ConfigMapUtils.createConfigMap(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, Map.of("key1", "value1", "key2", "value2"));
+        ConfigMap cm = ConfigMapUtils.createConfigMap(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, Map.of("key1", "value1", "key2", "value2"));
 
         assertThat(cm.getMetadata().getName(), is(NAME));
         assertThat(cm.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(cm.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(cm.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(cm.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(cm.getMetadata().getAnnotations(), is(Map.of()));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -234,7 +234,7 @@ public class CruiseControlTest {
         assertThat(dep.getMetadata().getName(), is(CruiseControlResources.componentName(CLUSTER_NAME)));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
-        TestUtils.checkOwnerReference(dep, kafka);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(dep, kafka);
 
         List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
         assertThat(containers.size(), is(1));
@@ -377,7 +377,7 @@ public class CruiseControlTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
-        TestUtils.checkOwnerReference(svc, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, KAFKA);
     }
 
     @SuppressWarnings("MethodLength")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -44,9 +44,9 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -125,7 +125,7 @@ public class EntityOperatorTest {
         assertThat(dep.getMetadata().getName(), is(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(dep.getSpec().getReplicas(), is(1));
-        TestUtils.checkOwnerReference(dep, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(dep, KAFKA);
 
         assertThat(containers.size(), is(2));
         // just check names of topic and user operators (their containers are tested in the related unit test classes)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -198,7 +198,7 @@ public class KafkaBridgeClusterTest {
 
         assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(KafkaBridgeCluster.DEFAULT_REST_API_PORT)));
 
-        TestUtils.checkOwnerReference(svc, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test
@@ -231,7 +231,7 @@ public class KafkaBridgeClusterTest {
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
             .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
-        TestUtils.checkOwnerReference(dep, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(dep, resource);
     }
 
     @Test
@@ -1350,7 +1350,7 @@ public class KafkaBridgeClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaBridgeCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(1874)));
-        TestUtils.checkOwnerReference(svc, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -34,11 +34,11 @@ import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -776,7 +776,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -786,11 +786,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                TestUtils.checkOwnerReference(service, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("ClusterIP"));
@@ -811,7 +811,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapRoutes.get(0).getSpec().getTo().getKind(), is("Service"));
         assertThat(bootstrapRoutes.get(0).getSpec().getTo().getName(), is(CLUSTER + "-kafka-external-bootstrap"));
         assertThat(bootstrapRoutes.get(0).getSpec().getPort().getTargetPort(), is(new IntOrString(9094)));
-        TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
 
         // Check per pod router
         List<Route> routes = kc.generateExternalRoutes();
@@ -821,11 +821,11 @@ public class KafkaClusterListenersTest {
             if (route.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(route.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(route.getSpec().getTo().getName(), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                TestUtils.checkOwnerReference(route, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_BROKERS);
             } else {
                 assertThat(route.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(route.getSpec().getTo().getName(), oneOf("foo-mixed-3", "foo-mixed-4"));
-                TestUtils.checkOwnerReference(route, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_MIXED);
             }
 
             assertThat(route.getSpec().getTls().getTermination(), is("passthrough"));
@@ -1011,7 +1011,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getExternalTrafficPolicy(), is("Cluster"));
         assertThat(bootstrapServices.get(0).getSpec().getLoadBalancerSourceRanges(), is(List.of()));
         assertThat(bootstrapServices.get(0).getSpec().getAllocateLoadBalancerNodePorts(), is(nullValue()));
-        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1021,11 +1021,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                TestUtils.checkOwnerReference(service, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getMetadata().getFinalizers(), is(List.of()));
@@ -1427,7 +1427,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1437,11 +1437,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                TestUtils.checkOwnerReference(service, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("NodePort"));
@@ -1614,7 +1614,7 @@ public class KafkaClusterListenersTest {
         assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(32001));
         assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        TestUtils.checkOwnerReference(ext, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1896,7 +1896,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1906,11 +1906,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                TestUtils.checkOwnerReference(service, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("ClusterIP"));
@@ -1939,7 +1939,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapIngresses.get(0).getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
         assertThat(bootstrapIngresses.get(0).getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(CLUSTER + "-kafka-external-bootstrap"));
         assertThat(bootstrapIngresses.get(0).getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
-        TestUtils.checkOwnerReference(bootstrapIngresses.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapIngresses.get(0), KAFKA);
 
         // Check per pod ingress
         List<Ingress> ingresses = kc.generateExternalIngresses();
@@ -1948,10 +1948,10 @@ public class KafkaClusterListenersTest {
         for (Ingress ingress : ingresses)    {
             if (ingress.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(ingress.getMetadata().getName(), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                TestUtils.checkOwnerReference(ingress, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ingress, POOL_BROKERS);
             } else {
                 assertThat(ingress.getMetadata().getName(), oneOf("foo-mixed-3", "foo-mixed-4"));
-                TestUtils.checkOwnerReference(ingress, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ingress, POOL_MIXED);
             }
 
             assertThat(ingress.getSpec().getIngressClassName(), is(nullValue()));
@@ -2131,7 +2131,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-clusterip"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -2141,19 +2141,19 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().startsWith("foo-brokers-clusterip-6")) {
                 assertThat(service.getMetadata().getAnnotations().get("anno"), is("anno-value-6"));
                 assertThat(service.getMetadata().getLabels().get("label"), is("label-value-6"));
-                TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else if (service.getMetadata().getName().startsWith("foo-mixed-clusterip-3")) {
                 assertThat(service.getMetadata().getAnnotations().get("anno"), is("anno-value-3"));
                 assertThat(service.getMetadata().getLabels().get("label"), is("label-value-3"));
-                TestUtils.checkOwnerReference(service, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
             } else {
                 assertThat(service.getMetadata().getAnnotations().get("anno"), is(nullValue()));
                 assertThat(service.getMetadata().getLabels().get("label"), is(nullValue()));
 
                 if (service.getMetadata().getName().startsWith("foo-controllers-")) {
-                    TestUtils.checkOwnerReference(service, POOL_CONTROLLERS);
+                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_CONTROLLERS);
                 } else if (service.getMetadata().getName().startsWith("foo-mixed-")) {
-                    TestUtils.checkOwnerReference(service, POOL_MIXED);
+                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
                 } else {
                     TestUtils.checkOwnerReference(service, POOL_BROKERS);
                 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -77,6 +77,7 @@ import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
@@ -94,7 +95,6 @@ import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.hamcrest.CoreMatchers;
@@ -292,11 +292,11 @@ public class KafkaClusterTest {
 
         for (ConfigMap cm : cms)    {
             if (cm.getMetadata().getName().contains("controllers")) {
-                TestUtils.checkOwnerReference(cm, POOL_CONTROLLERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, POOL_CONTROLLERS);
             } else if (cm.getMetadata().getName().contains("mixed")) {
-                TestUtils.checkOwnerReference(cm, POOL_MIXED);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, POOL_MIXED);
             } else {
-                TestUtils.checkOwnerReference(cm, POOL_BROKERS);
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, POOL_BROKERS);
             }
 
             assertThat(cm.getData().get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is("{\"animal\":\"wombat\"}"));
@@ -884,7 +884,7 @@ public class KafkaClusterTest {
         assertThat(clusterIp.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
         assertThat(clusterIp.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
-        TestUtils.checkOwnerReference(clusterIp, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clusterIp, KAFKA);
     }
 
     @Test
@@ -921,7 +921,7 @@ public class KafkaClusterTest {
         assertThat(clusterIp.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
         assertThat(clusterIp.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
-        TestUtils.checkOwnerReference(clusterIp, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clusterIp, KAFKA);
     }
 
     @Test
@@ -962,7 +962,7 @@ public class KafkaClusterTest {
 
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
 
-        TestUtils.checkOwnerReference(headless, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(headless, KAFKA);
     }
 
     @Test
@@ -1167,7 +1167,7 @@ public class KafkaClusterTest {
     public void testGenerateHeadlessService() {
         Service headless = KC.generateHeadlessService();
         checkHeadlessService(headless);
-        TestUtils.checkOwnerReference(headless, KAFKA);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(headless, KAFKA);
     }
 
     @Test
@@ -3377,7 +3377,7 @@ public class KafkaClusterTest {
         StrimziPodSet podSet = podSets.stream().filter(sps -> (CLUSTER + "-controllers").equals(sps.getMetadata().getName())).findFirst().orElse(null);
         assertThat(podSet, is(notNullValue()));
 
-        TestUtils.checkOwnerReference(podSet, POOL_CONTROLLERS);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(podSet, POOL_CONTROLLERS);
         assertThat(podSet.getMetadata().getName(), is(CLUSTER + "-controllers"));
         assertThat(podSet.getSpec().getSelector().getMatchLabels(), is(KC.getSelectorLabels().withStrimziPoolName("controllers").toMap()));
         assertThat(podSet.getMetadata().getLabels().entrySet().containsAll(KC.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
@@ -3443,7 +3443,7 @@ public class KafkaClusterTest {
         podSet = podSets.stream().filter(sps -> (CLUSTER + "-mixed").equals(sps.getMetadata().getName())).findFirst().orElse(null);
         assertThat(podSet, is(notNullValue()));
 
-        TestUtils.checkOwnerReference(podSet, POOL_MIXED);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(podSet, POOL_MIXED);
         assertThat(podSet.getMetadata().getName(), is(CLUSTER + "-mixed"));
         assertThat(podSet.getSpec().getSelector().getMatchLabels(), is(KC.getSelectorLabels().withStrimziPoolName("mixed").toMap()));
         assertThat(podSet.getMetadata().getLabels().entrySet().containsAll(KC.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -24,10 +24,10 @@ import io.strimzi.api.kafka.model.connect.build.Artifact;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -222,7 +222,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/kaniko/.docker"));
-        TestUtils.checkOwnerReference(pod, kc);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(pod, kc);
     }
 
     @Test
@@ -284,7 +284,7 @@ public class KafkaConnectBuildTest {
         assertThat(cm.getMetadata().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
         assertThat(cm.getMetadata().getNamespace(), is(namespace));
         assertThat(cm.getData().get("Dockerfile"), is(dockerfile.getDockerfile()));
-        TestUtils.checkOwnerReference(cm, kc);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, kc);
     }
 
     @Test
@@ -339,7 +339,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getSpec().getStrategy().getDockerStrategy(), is(notNullValue()));
         assertThat(bc.getSpec().getResources().getLimits(), is(limit));
         assertThat(bc.getSpec().getResources().getRequests(), is(request));
-        TestUtils.checkOwnerReference(bc, kc);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bc, kc);
     }
 
     // Test to validate that .spec.image and spec.build.output.image in Kafka Connect are not pointing to the same image

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -253,7 +253,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
-        TestUtils.checkOwnerReference(svc, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test
@@ -286,7 +286,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaConnectCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        TestUtils.checkOwnerReference(svc, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test
@@ -697,7 +697,7 @@ public class KafkaConnectClusterTest {
         assertThat(ps.getMetadata().getName(), is(KafkaConnectResources.componentName(clusterName)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(kc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
         assertThat(ps.getMetadata().getAnnotations(), is(Map.of("anno1", "anno-value1", "anno2", "anno-value2")));
-        TestUtils.checkOwnerReference(ps, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ps, resource);
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(kc.getSelectorLabels().withStrimziPodSetController(KafkaConnectResources.componentName(clusterName)).toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -39,10 +39,10 @@ import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -70,6 +70,7 @@ import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
@@ -81,7 +82,6 @@ import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider;
 import io.strimzi.test.ReadWriteUtils;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -259,7 +259,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
-        TestUtils.checkOwnerReference(svc, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test
@@ -284,7 +284,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getMetadata().getAnnotations().containsKey("prometheus.io/scrape"), is(false));
         assertThat(svc.getMetadata().getAnnotations().containsKey("prometheus.io/path"), is(false));
 
-        TestUtils.checkOwnerReference(svc, resource);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPoolTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPoolTest.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVarBuilder;
@@ -19,6 +17,7 @@ import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.nodepools.NodeIdAssignment;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -56,14 +55,6 @@ public class KafkaPoolTest {
                     .endKafka()
                 .endSpec()
                 .build();
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("Kafka")
-            .withName(CLUSTER_NAME)
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private final static KafkaNodePool POOL = new KafkaNodePoolBuilder()
             .withNewMetadata()
                 .withName("pool")
@@ -86,7 +77,7 @@ public class KafkaPoolTest {
                 POOL,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -145,7 +136,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -176,7 +167,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -216,7 +207,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -261,7 +252,7 @@ public class KafkaPoolTest {
                 POOL,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -321,7 +312,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -376,7 +367,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         );
 
@@ -413,7 +404,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build(),
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         ));
 
@@ -436,7 +427,7 @@ public class KafkaPoolTest {
                 pool,
                 new NodeIdAssignment(Set.of(10, 11, 13), Set.of(10, 11, 13), Set.of(), Set.of(), Set.of()),
                 null,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 SHARED_ENV_PROVIDER
         ));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -95,7 +95,7 @@ public class ModelUtilsTest {
         assertThat(ref.getKind(), is(owner.getKind()));
         assertThat(ref.getName(), is(owner.getMetadata().getName()));
         assertThat(ref.getUid(), is(owner.getMetadata().getUid()));
-        assertThat(ref.getBlockOwnerDeletion(), is(false));
+        assertThat(ref.getBlockOwnerDeletion(), is(true));
         assertThat(ref.getController(), is(false));
     }
 
@@ -114,7 +114,7 @@ public class ModelUtilsTest {
         assertThat(ref.getKind(), is(owner.getKind()));
         assertThat(ref.getName(), is(owner.getMetadata().getName()));
         assertThat(ref.getUid(), is(owner.getMetadata().getUid()));
-        assertThat(ref.getBlockOwnerDeletion(), is(false));
+        assertThat(ref.getBlockOwnerDeletion(), is(true));
         assertThat(ref.getController(), is(true));
     }
 
@@ -125,7 +125,7 @@ public class ModelUtilsTest {
                 .withKind("my-kind")
                 .withName("my-owner")
                 .withUid("a02c09d8-a04f-469d-97ba-920720abe9b3")
-                .withBlockOwnerDeletion(false)
+                .withBlockOwnerDeletion(true)
                 .withController(false)
                 .build();
 
@@ -134,7 +134,7 @@ public class ModelUtilsTest {
                 .withKind("my-other-kind")
                 .withName("my-other-owner")
                 .withUid("3dfcd6b9-ad05-4277-8d13-147346fe1f70")
-                .withBlockOwnerDeletion(false)
+                .withBlockOwnerDeletion(true)
                 .withController(false)
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NetworkPolicyUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NetworkPolicyUtilsTest.java
@@ -5,11 +5,10 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -23,14 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class NetworkPolicyUtilsTest {
     private final static String NAME = "my-np";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -45,11 +36,11 @@ public class NetworkPolicyUtilsTest {
                 NetworkPolicyUtils.createIngressRule(5678, List.of(NetworkPolicyUtils.createPeer(Map.of("key", "peer2"))))
         );
 
-        NetworkPolicy np = NetworkPolicyUtils.createNetworkPolicy(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, rules);
+        NetworkPolicy np = NetworkPolicyUtils.createNetworkPolicy(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, rules);
 
         assertThat(np.getMetadata().getName(), is(NAME));
         assertThat(np.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(np.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(np.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(np.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(np.getSpec().getPodSelector().getMatchLabels(), is(LABELS.strimziSelectorLabels().toMap()));
         assertThat(np.getSpec().getIngress(), is(rules));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
@@ -17,6 +15,7 @@ import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -32,14 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class PersistentVolumeClaimUtilsTest {
     private final static String NAME = "my-cluster-kafka";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-cluster")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-cluster-kafka")
@@ -69,7 +60,7 @@ public class PersistentVolumeClaimUtilsTest {
     public void testEphemeralStorage()  {
         assertThat(
                 PersistentVolumeClaimUtils
-                        .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, new EphemeralStorage(), false, LABELS, OWNER_REFERENCE, null),
+                        .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, new EphemeralStorage(), false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null),
                 is(List.of())
         );
     }
@@ -82,7 +73,7 @@ public class PersistentVolumeClaimUtilsTest {
 
         assertThat(
                 PersistentVolumeClaimUtils
-                        .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, jbod, false, LABELS, OWNER_REFERENCE, null),
+                        .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null),
                 is(List.of())
         );
     }
@@ -90,7 +81,7 @@ public class PersistentVolumeClaimUtilsTest {
     @Test
     public void testPersistentClaimStorage()  {
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, PERSISTENT_CLAIM_STORAGE, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, PERSISTENT_CLAIM_STORAGE, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(1));
 
@@ -115,7 +106,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, storage, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, storage, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(1));
 
@@ -142,7 +133,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(1));
 
@@ -169,7 +160,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, OWNER_REFERENCE, TEMPLATE);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE);
 
         assertThat(pvcs.size(), is(1));
 
@@ -197,7 +188,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(1));
 
@@ -225,7 +216,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(1));
 
@@ -233,7 +224,7 @@ public class PersistentVolumeClaimUtilsTest {
         assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "true")));
-        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
         assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
         assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
@@ -253,7 +244,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(1));
 
@@ -290,7 +281,7 @@ public class PersistentVolumeClaimUtilsTest {
                 .build();
 
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, jbod, false, LABELS, OWNER_REFERENCE, null);
+                .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pvcs.size(), is(6));
 
@@ -312,7 +303,7 @@ public class PersistentVolumeClaimUtilsTest {
             assertThat(pvcs.get(i).getMetadata().getNamespace(), is(NAMESPACE));
             assertThat(pvcs.get(i).getMetadata().getLabels(), is(LABELS.toMap()));
             assertThat(pvcs.get(i).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "true")));
-            assertThat(pvcs.get(i).getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+            assertThat(pvcs.get(i).getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
             assertThat(pvcs.get(i).getSpec().getVolumeMode(), is("Filesystem"));
             assertThat(pvcs.get(i).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
             assertThat(pvcs.get(i).getSpec().getSelector(), is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtilsTest.java
@@ -5,11 +5,10 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplateBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +23,6 @@ public class PodDisruptionBudgetUtilsTest {
     private final static String NAME = "my-pdb";
     private final static String NAMESPACE = "my-namespace";
     private final static int REPLICAS = 5;
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -48,11 +39,11 @@ public class PodDisruptionBudgetUtilsTest {
 
     @Test
     public void testPdbWithoutTemplate() {
-        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null);
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudget(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(pdb.getMetadata().getName(), is(NAME));
         assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(pdb.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(pdb.getMetadata().getAnnotations(), is(nullValue()));
 
@@ -66,11 +57,11 @@ public class PodDisruptionBudgetUtilsTest {
 
     @Test
     public void testPdbWithTemplate() {
-        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE);
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudget(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE);
 
         assertThat(pdb.getMetadata().getName(), is(NAME));
         assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(pdb.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(pdb.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
 
@@ -84,11 +75,11 @@ public class PodDisruptionBudgetUtilsTest {
 
     @Test
     public void testCustomControllerPdbWithoutTemplate() {
-        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, REPLICAS);
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null, REPLICAS);
 
         assertThat(pdb.getMetadata().getName(), is(NAME));
         assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(pdb.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(pdb.getMetadata().getAnnotations(), is(nullValue()));
 
@@ -102,11 +93,11 @@ public class PodDisruptionBudgetUtilsTest {
 
     @Test
     public void testCustomControllerPdbWithTemplate() {
-        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, REPLICAS);
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE, REPLICAS);
 
         assertThat(pdb.getMetadata().getName(), is(NAME));
         assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(pdb.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(pdb.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RbacUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RbacUtilsTest.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
@@ -17,6 +15,7 @@ import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -30,14 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class RbacUtilsTest {
     private final static String NAME = "my-name";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-cluster")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -59,11 +50,11 @@ public class RbacUtilsTest {
                 .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
                 .build();
 
-        Role role = RbacUtils.createRole(NAME, NAMESPACE, List.of(rule), LABELS, OWNER_REFERENCE, null);
+        Role role = RbacUtils.createRole(NAME, NAMESPACE, List.of(rule), LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(role.getMetadata().getName(), is(NAME));
         assertThat(role.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(role.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(role.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(role.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(role.getMetadata().getAnnotations(), is(nullValue()));
 
@@ -78,11 +69,11 @@ public class RbacUtilsTest {
                 .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
                 .build();
 
-        Role role = RbacUtils.createRole(NAME, NAMESPACE, List.of(rule), LABELS, OWNER_REFERENCE, TEMPLATE);
+        Role role = RbacUtils.createRole(NAME, NAMESPACE, List.of(rule), LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE);
 
         assertThat(role.getMetadata().getName(), is(NAME));
         assertThat(role.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(role.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(role.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(role.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(role.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
 
@@ -103,11 +94,11 @@ public class RbacUtilsTest {
                 .withKind("Role")
                 .build();
 
-        RoleBinding roleBinding = RbacUtils.createRoleBinding(NAME, NAMESPACE, roleRef, List.of(subject), LABELS, OWNER_REFERENCE, null);
+        RoleBinding roleBinding = RbacUtils.createRoleBinding(NAME, NAMESPACE, roleRef, List.of(subject), LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(roleBinding.getMetadata().getName(), is(NAME));
         assertThat(roleBinding.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(roleBinding.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(roleBinding.getMetadata().getAnnotations(), is(nullValue()));
 
@@ -129,11 +120,11 @@ public class RbacUtilsTest {
                 .withKind("Role")
                 .build();
 
-        RoleBinding roleBinding = RbacUtils.createRoleBinding(NAME, NAMESPACE, roleRef, List.of(subject), LABELS, OWNER_REFERENCE, TEMPLATE);
+        RoleBinding roleBinding = RbacUtils.createRoleBinding(NAME, NAMESPACE, roleRef, List.of(subject), LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE);
 
         assertThat(roleBinding.getMetadata().getName(), is(NAME));
         assertThat(roleBinding.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(roleBinding.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(roleBinding.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceAccountUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceAccountUtilsTest.java
@@ -4,11 +4,10 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -22,14 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ServiceAccountUtilsTest {
     private final static String NAME = "my-sa";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -39,22 +30,22 @@ public class ServiceAccountUtilsTest {
 
     @Test
     public void testServiceAccountCreationWithNullTemplate() {
-        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null);
+        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
 
         assertThat(sa.getMetadata().getName(), is(NAME));
         assertThat(sa.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sa.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(sa.getMetadata().getAnnotations(), is(nullValue()));
     }
 
     @Test
     public void testServiceAccountCreationWithEmptyTemplate() {
-        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, new ResourceTemplate());
+        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, new ResourceTemplate());
 
         assertThat(sa.getMetadata().getName(), is(NAME));
         assertThat(sa.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sa.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(sa.getMetadata().getAnnotations(), is(nullValue()));
     }
@@ -68,11 +59,11 @@ public class ServiceAccountUtilsTest {
                 .endMetadata()
                 .build();
 
-        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, template);
+        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, template);
 
         assertThat(sa.getMetadata().getName(), is(NAME));
         assertThat(sa.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sa.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(sa.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -4,14 +4,13 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplateBuilder;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -25,14 +24,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ServiceUtilsTest {
     private final static String NAME = "my-service";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -74,11 +65,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateHeadlessServiceWithNullTemplate() {
-        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT));
+        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null, List.of(PORT));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
 
@@ -97,11 +88,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateHeadlessServiceWithEmptyTemplate() {
-        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, new InternalServiceTemplate(), List.of(PORT));
+        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, new InternalServiceTemplate(), List.of(PORT));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
 
@@ -120,11 +111,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateHeadlessServiceWithTemplate() {
-        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT));
+        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE, List.of(PORT));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
 
@@ -143,11 +134,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateClusterIpServiceWithNullTemplate() {
-        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT));
+        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null, List.of(PORT));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of()));
 
@@ -164,11 +155,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateClusterIpServiceWithEmptyTemplate() {
-        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, new InternalServiceTemplate(), List.of(PORT));
+        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, new InternalServiceTemplate(), List.of(PORT));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of()));
 
@@ -185,11 +176,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateClusterIpServiceWithTemplate() {
-        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT));
+        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE, List.of(PORT));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
 
@@ -206,11 +197,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateDiscoverableServiceWithNullTemplate() {
-        Service svc = ServiceUtils.createDiscoverableClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT), LABELS.strimziSelectorLabels(), Map.of("discovery-label", "label-value"), Map.of("strimzi.io/discovery-anno", "anno-value"));
+        Service svc = ServiceUtils.createDiscoverableClusterIpService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null, List.of(PORT), LABELS.strimziSelectorLabels(), Map.of("discovery-label", "label-value"), Map.of("strimzi.io/discovery-anno", "anno-value"));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.withStrimziDiscovery().withAdditionalLabels(Map.of("discovery-label", "label-value")).toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of("strimzi.io/discovery-anno", "anno-value")));
 
@@ -227,11 +218,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateDiscoverableServiceWithTemplate() {
-        Service svc = ServiceUtils.createDiscoverableClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT), LABELS.strimziSelectorLabels(), Map.of("discovery-label", "label-value"), Map.of("strimzi.io/discovery-anno", "anno-value"));
+        Service svc = ServiceUtils.createDiscoverableClusterIpService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE, List.of(PORT), LABELS.strimziSelectorLabels(), Map.of("discovery-label", "label-value"), Map.of("strimzi.io/discovery-anno", "anno-value"));
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.withStrimziDiscovery().withAdditionalLabels(Map.of("discovery-label", "label-value", "label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of("strimzi.io/discovery-anno", "anno-value", "anno-1", "value-1", "anno-2", "value-2")));
 
@@ -248,11 +239,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateServiceWithNullTemplate() {
-        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6), true);
+        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6), true);
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label", "label-value")).toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno", "anno-value")));
 
@@ -268,11 +259,11 @@ public class ServiceUtilsTest {
 
     @Test
     public void testCreateServiceWithTemplate() {
-        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6), false);
+        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, TEMPLATE, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6), false);
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label", "label-value", "label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno", "anno-value", "anno-1", "value-1", "anno-2", "value-2")));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -15,8 +15,6 @@ import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodDNSConfig;
@@ -41,6 +39,7 @@ import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
@@ -67,14 +66,6 @@ public class WorkloadUtilsTest {
             new NodeRef("my-cluster-nodes-11", 11, "nodes", false, true),
             new NodeRef("my-cluster-nodes-12", 12, "nodes", false, true)
     );
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-workload")
@@ -150,7 +141,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 null,
                 REPLICAS,
                 Map.of("extra", "annotations"),
@@ -160,7 +151,7 @@ public class WorkloadUtilsTest {
 
         assertThat(dep.getMetadata().getName(), is(NAME));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(dep.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(dep.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
 
@@ -179,7 +170,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 new DeploymentTemplateBuilder()
                         .withNewMetadata()
                             .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
@@ -194,7 +185,7 @@ public class WorkloadUtilsTest {
 
         assertThat(dep.getMetadata().getName(), is(NAME));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(dep.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(dep.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
 
@@ -219,7 +210,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 null,
                 REPLICAS,
                 Map.of("extra", "annotations"),
@@ -236,7 +227,7 @@ public class WorkloadUtilsTest {
 
         assertThat(sps.getMetadata().getName(), is(NAME));
         assertThat(sps.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sps.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
 
@@ -260,7 +251,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 new ResourceTemplateBuilder()
                         .withNewMetadata()
                             .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
@@ -282,7 +273,7 @@ public class WorkloadUtilsTest {
 
         assertThat(sps.getMetadata().getName(), is(NAME));
         assertThat(sps.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sps.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
 
@@ -305,7 +296,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 null,
                 NODES,
                 Map.of("extra", "annotations"),
@@ -322,7 +313,7 @@ public class WorkloadUtilsTest {
 
         assertThat(sps.getMetadata().getName(), is(NAME));
         assertThat(sps.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sps.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
 
@@ -346,7 +337,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 new ResourceTemplateBuilder()
                         .withNewMetadata()
                             .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
@@ -368,7 +359,7 @@ public class WorkloadUtilsTest {
 
         assertThat(sps.getMetadata().getName(), is(NAME));
         assertThat(sps.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(sps.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
 
@@ -833,7 +824,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 null,
                 null,
                 null,
@@ -876,7 +867,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 null,
                 Map.of("default-label", "default-value"),
                 Map.of("extra", "annotations"),
@@ -920,7 +911,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 new PodTemplate(),
                 Map.of("default-label", "default-value"),
                 Map.of("extra", "annotations"),
@@ -964,7 +955,7 @@ public class WorkloadUtilsTest {
                 NAME,
                 NAMESPACE,
                 LABELS,
-                OWNER_REFERENCE,
+                ResourceUtils.DUMMY_OWNER_REFERENCE,
                 new PodTemplateBuilder()
                         .withNewMetadata()
                         .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentialsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentialsTest.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.operator.cluster.model.cruisecontrol;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
@@ -17,6 +15,7 @@ import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.MockSharedEnvironmentProvider;
@@ -55,15 +54,6 @@ public class HashLoginServiceApiCredentialsTest {
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
     private static final String SECRET_NAME = "secretName";
     private static final String SECRET_KEY = "secretKey";
-
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -119,7 +109,7 @@ public class HashLoginServiceApiCredentialsTest {
                 .endValueFrom()
             .endHashLoginServiceApiUsers()
             .build();
-        HashLoginServiceApiCredentials apiCredentials = new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, OWNER_REFERENCE, s1);
+        HashLoginServiceApiCredentials apiCredentials = new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, s1);
         assertThat(apiCredentials.getUserManagedApiSecretName(), is(SECRET_NAME));
         assertThat(apiCredentials.getUserManagedApiSecretKey(), is(SECRET_KEY));
 
@@ -131,7 +121,7 @@ public class HashLoginServiceApiCredentialsTest {
                     .endValueFrom()
             .endHashLoginServiceApiUsers()
             .build();
-        assertThrows(Exception.class, () -> new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, OWNER_REFERENCE, s2));
+        assertThrows(Exception.class, () -> new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, s2));
 
         // Ensure exception is thrown when invalid apiUsers config is provided
         CruiseControlSpec s3 = new CruiseControlSpecBuilder()
@@ -140,14 +130,14 @@ public class HashLoginServiceApiCredentialsTest {
                 .endValueFrom()
             .endHashLoginServiceApiUsers()
             .build();
-        assertThrows(Exception.class, () -> new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, OWNER_REFERENCE, s3));
+        assertThrows(Exception.class, () -> new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, s3));
 
         // Ensure exception is thrown when invalid apiUsers config is provided
         CruiseControlSpec s4 = new CruiseControlSpecBuilder()
             .withNewHashLoginServiceApiUsers()
             .endHashLoginServiceApiUsers()
             .build();
-        assertThrows(Exception.class, () -> new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, OWNER_REFERENCE, s4));
+        assertThrows(Exception.class, () -> new HashLoginServiceApiCredentials(NAMESPACE, CLUSTER, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, s4));
     }
 
     private void assertParseThrows(String illegalConfig) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/jmx/JmxModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/jmx/JmxModelTest.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.cluster.model.jmx;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpecBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class JmxModelTest {
     private final static String NAME = "my-jmx-secret";
     private final static String NAMESPACE = "my-namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -47,7 +38,7 @@ public class JmxModelTest {
     @Test
     public void testDisabledJmx() {
         KafkaClusterSpec spec = new KafkaClusterSpecBuilder().build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         assertThat(jmx.secretName(), is(NAME));
         assertThat(jmx.servicePorts(), is(List.of()));
@@ -64,7 +55,7 @@ public class JmxModelTest {
                 .endJmxOptions()
                 .build();
 
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         assertThat(jmx.secretName(), is(NAME));
 
@@ -99,7 +90,7 @@ public class JmxModelTest {
                 .endJmxOptions()
                 .build();
 
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         assertThat(jmx.secretName(), is(NAME));
 
@@ -131,7 +122,7 @@ public class JmxModelTest {
         Secret newSecret = jmx.jmxSecret(null);
         assertThat(newSecret.getMetadata().getName(), is(NAME));
         assertThat(newSecret.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(newSecret.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(newSecret.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(newSecret.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(newSecret.getMetadata().getAnnotations(), is(nullValue()));
         assertThat(newSecret.getData().size(), is(2));
@@ -141,7 +132,7 @@ public class JmxModelTest {
         Secret existingSecret = jmx.jmxSecret(EXISTING_JMX_SECRET);
         assertThat(existingSecret.getMetadata().getName(), is(NAME));
         assertThat(existingSecret.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(existingSecret.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(existingSecret.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(existingSecret.getMetadata().getLabels(), is(LABELS.toMap()));
         assertThat(existingSecret.getMetadata().getAnnotations(), is(nullValue()));
         assertThat(existingSecret.getData().size(), is(2));
@@ -166,12 +157,12 @@ public class JmxModelTest {
                 .endTemplate()
                 .build();
 
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         Secret newSecret = jmx.jmxSecret(null);
         assertThat(newSecret.getMetadata().getName(), is(NAME));
         assertThat(newSecret.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(newSecret.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(newSecret.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(newSecret.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label1", "value1")).toMap()));
         assertThat(newSecret.getMetadata().getAnnotations(), is(Map.of("anno1", "value1")));
         assertThat(newSecret.getData().size(), is(2));
@@ -181,7 +172,7 @@ public class JmxModelTest {
         Secret existingSecret = jmx.jmxSecret(EXISTING_JMX_SECRET);
         assertThat(existingSecret.getMetadata().getName(), is(NAME));
         assertThat(existingSecret.getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(existingSecret.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(existingSecret.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
         assertThat(existingSecret.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label1", "value1")).toMap()));
         assertThat(existingSecret.getMetadata().getAnnotations(), is(Map.of("anno1", "value1")));
         assertThat(existingSecret.getData().size(), is(2));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
@@ -19,6 +19,7 @@ import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -31,7 +32,6 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.test.ReadWriteUtils;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -1028,8 +1028,8 @@ public class CaReconcilerReconcileCasTest {
                     assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences(), hasSize(1));
                     assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences(), hasSize(1));
 
-                    TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
-                    TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
+                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
+                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
 
                     async.flag();
                 })));
@@ -1057,7 +1057,7 @@ public class CaReconcilerReconcileCasTest {
                     assertThat(captorSecrets.clientsCaCert().getMetadata().getOwnerReferences(), hasSize(0));
                     assertThat(captorSecrets.clientsCaKey().getMetadata().getOwnerReferences(), hasSize(0));
 
-                    TestUtils.checkOwnerReference(captorSecrets.clusterCaCert(), kafka);
+                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(captorSecrets.clusterCaCert(), kafka);
                     TestUtils.checkOwnerReference(captorSecrets.clusterCaKey(), kafka);
 
                     async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -4,10 +4,10 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.CertUtils;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.common.Reconciliation;
@@ -43,10 +43,9 @@ public class CertificateRenewalTest {
         String commonName = "deployment";
         String keyCertName = "deployment";
         Labels labels = Labels.forStrimziCluster("my-cluster");
-        OwnerReference ownerReference = new OwnerReference();
 
         Secret newSecret = CertUtils.buildTrustedCertificateSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, null, namespace, secretName, commonName,
-                keyCertName, labels, ownerReference, true);
+                keyCertName, labels, ResourceUtils.DUMMY_OWNER_REFERENCE, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", newCertAndKey.certAsBase64String()));
         assertThat(newSecret.getData(), hasEntry("deployment.key", newCertAndKey.keyAsBase64String()));
@@ -73,10 +72,9 @@ public class CertificateRenewalTest {
         String commonName = "deployment";
         String keyCertName = "deployment";
         Labels labels = Labels.forStrimziCluster("my-cluster");
-        OwnerReference ownerReference = new OwnerReference();
 
         Secret newSecret = CertUtils.buildTrustedCertificateSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
-                keyCertName, labels, ownerReference, true);
+                keyCertName, labels, ResourceUtils.DUMMY_OWNER_REFERENCE, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", newCertAndKey.certAsBase64String()));
         assertThat(newSecret.getData(), hasEntry("deployment.key", newCertAndKey.keyAsBase64String()));
@@ -103,10 +101,9 @@ public class CertificateRenewalTest {
         String commonName = "deployment";
         String keyCertName = "deployment";
         Labels labels = Labels.forStrimziCluster("my-cluster");
-        OwnerReference ownerReference = new OwnerReference();
 
         Secret newSecret = CertUtils.buildTrustedCertificateSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
-                keyCertName, labels, ownerReference, true);
+                keyCertName, labels, ResourceUtils.DUMMY_OWNER_REFERENCE, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", newCertAndKey.certAsBase64String()));
         assertThat(newSecret.getData(), hasEntry("deployment.key", newCertAndKey.keyAsBase64String()));
@@ -133,10 +130,9 @@ public class CertificateRenewalTest {
         String commonName = "deployment";
         String keyCertName = "deployment";
         Labels labels = Labels.forStrimziCluster("my-cluster");
-        OwnerReference ownerReference = new OwnerReference();
 
         Secret newSecret = CertUtils.buildTrustedCertificateSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
-                keyCertName, labels, ownerReference, false);
+                keyCertName, labels, ResourceUtils.DUMMY_OWNER_REFERENCE, false);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", Base64.getEncoder().encodeToString("old-cert".getBytes())));
         assertThat(newSecret.getData(), hasEntry("deployment.key", Base64.getEncoder().encodeToString("old-key".getBytes())));
@@ -165,10 +161,9 @@ public class CertificateRenewalTest {
         String commonName = "deployment";
         String keyCertName = "deployment";
         Labels labels = Labels.forStrimziCluster("my-cluster");
-        OwnerReference ownerReference = new OwnerReference();
 
         Secret newSecret = CertUtils.buildTrustedCertificateSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
-                keyCertName, labels, ownerReference, true);
+                keyCertName, labels, ResourceUtils.DUMMY_OWNER_REFERENCE, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", Base64.getEncoder().encodeToString("old-cert".getBytes())));
         assertThat(newSecret.getData(), hasEntry("deployment.key", Base64.getEncoder().encodeToString("old-key".getBytes())));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorOffsetsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorOffsetsTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.common.Condition;
@@ -311,9 +310,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                     .withName(CONFIGMAP_NAME)
                     .withNamespace(NAMESPACE)
                     .withLabels(existingCMLabels)
-                    .withOwnerReferences(new OwnerReferenceBuilder()
-                            .withName("foo")
-                            .build())
+                    .withOwnerReferences(ResourceUtils.DUMMY_OWNER_REFERENCE)
                     .endMetadata()
                 .withData(existingData)
                 .build();
@@ -338,7 +335,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
 
                     List<OwnerReference> ownerReferenceList = configMap.getMetadata().getOwnerReferences();
                     assertThat(ownerReferenceList, hasSize(1));
-                    assertThat(ownerReferenceList.get(0).getName(), is("foo"));
+                    assertThat(ownerReferenceList.get(0).getName(), is("my-name"));
                     assertThat(configMap.getMetadata().getLabels(), hasEntry("label1", "value1"));
                     assertThat(configMap.getMetadata().getLabels(), hasEntry("connector-label", "custom"));
                     Map<String, String> configMapData = configMap.getData();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.common.Condition;
@@ -486,9 +485,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 .withName(CONFIGMAP_NAME)
                 .withNamespace(NAMESPACE)
                 .withLabels(existingCMLabels)
-                .withOwnerReferences(new OwnerReferenceBuilder()
-                        .withName("foo")
-                        .build())
+                .withOwnerReferences(ResourceUtils.DUMMY_OWNER_REFERENCE)
                 .endMetadata()
                 .withData(existingData)
                 .build();
@@ -515,7 +512,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
 
                     List<OwnerReference> ownerReferenceList = configMap.getMetadata().getOwnerReferences();
                     assertThat(ownerReferenceList, hasSize(1));
-                    assertThat(ownerReferenceList.get(0).getName(), is("foo"));
+                    assertThat(ownerReferenceList.get(0).getName(), is("my-name"));
                     Map<String, String> configMapData = configMap.getData();
                     assertThat(configMapData, hasEntry(getConfigmapEntryName(connector), OFFSETS_JSON));
                     assertThat(configMapData, hasEntry("data1", "value1"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
@@ -6,8 +6,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -23,6 +21,7 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpecBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.jmx.SupportsJmx;
@@ -66,14 +65,6 @@ import static org.mockito.Mockito.when;
 public class ReconcilerUtilsTest {
     private final static String NAME = "my-jmx-secret";
     private final static String NAMESPACE = "namespace";
-    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
-            .withApiVersion("v1")
-            .withKind("my-kind")
-            .withName("my-name")
-            .withUid("my-uid")
-            .withBlockOwnerDeletion(false)
-            .withController(false)
-            .build();
     private static final Labels LABELS = Labels
             .forStrimziKind("my-kind")
             .withStrimziName("my-name")
@@ -162,7 +153,7 @@ public class ReconcilerUtilsTest {
     @Test
     public void testDisabledJmxWithMissingSecret(VertxTestContext context) {
         KafkaClusterSpec spec = new KafkaClusterSpecBuilder().build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture());
@@ -179,7 +170,7 @@ public class ReconcilerUtilsTest {
     @Test
     public void testDisabledJmxWithExistingSecret(VertxTestContext context) {
         KafkaClusterSpec spec = new KafkaClusterSpecBuilder().build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(EXISTING_JMX_SECRET));
@@ -203,7 +194,7 @@ public class ReconcilerUtilsTest {
     @Test
     public void testEnabledJmxWithoutAuthWithMissingSecret(VertxTestContext context) {
         KafkaClusterSpec spec = new KafkaClusterSpecBuilder().withNewJmxOptions().endJmxOptions().build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture());
@@ -220,7 +211,7 @@ public class ReconcilerUtilsTest {
     @Test
     public void testEnabledJmxWithoutAuthWithExistingSecret(VertxTestContext context) {
         KafkaClusterSpec spec = new KafkaClusterSpecBuilder().withNewJmxOptions().endJmxOptions().build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(EXISTING_JMX_SECRET));
@@ -249,7 +240,7 @@ public class ReconcilerUtilsTest {
                     .endKafkaJmxAuthenticationPassword()
                 .endJmxOptions()
                 .build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture());
@@ -265,7 +256,7 @@ public class ReconcilerUtilsTest {
                     assertThat(secret, is(notNullValue()));
                     assertThat(secret.getMetadata().getName(), is(NAME));
                     assertThat(secret.getMetadata().getNamespace(), is(NAMESPACE));
-                    assertThat(secret.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+                    assertThat(secret.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
                     assertThat(secret.getMetadata().getLabels(), is(LABELS.toMap()));
                     assertThat(secret.getMetadata().getAnnotations(), is(nullValue()));
                     assertThat(secret.getData().size(), is(2));
@@ -284,7 +275,7 @@ public class ReconcilerUtilsTest {
                     .endKafkaJmxAuthenticationPassword()
                 .endJmxOptions()
                 .build();
-        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, OWNER_REFERENCE, spec);
+        JmxModel jmx = new JmxModel(NAMESPACE, NAME, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, spec);
 
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(EXISTING_JMX_SECRET));
@@ -300,7 +291,7 @@ public class ReconcilerUtilsTest {
                     assertThat(secret, is(notNullValue()));
                     assertThat(secret.getMetadata().getName(), is(NAME));
                     assertThat(secret.getMetadata().getNamespace(), is(NAMESPACE));
-                    assertThat(secret.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+                    assertThat(secret.getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
                     assertThat(secret.getMetadata().getLabels(), is(LABELS.toMap()));
                     assertThat(secret.getMetadata().getAnnotations(), is(nullValue()));
                     assertThat(secret.getData().size(), is(2));

--- a/documentation/modules/configuring/proc-listing-connector-offsets.adoc
+++ b/documentation/modules/configuring/proc-listing-connector-offsets.adoc
@@ -79,7 +79,7 @@ metadata:
   # ...
   ownerReferences: # <1>
   - apiVersion: {KafkaConnectApiVersion}
-    blockOwnerDeletion: false
+    blockOwnerDeletion: true
     controller: false
     kind: KafkaConnector
     name: my-source-connector
@@ -115,7 +115,7 @@ metadata:
   # ...
   ownerReferences: # <1>
   - apiVersion: {KafkaConnectApiVersion}
-    blockOwnerDeletion: false
+    blockOwnerDeletion: true
     controller: false
     kind: KafkaConnector
     name: my-sink-connector

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -5,9 +5,7 @@
 package io.strimzi.test;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -173,25 +171,6 @@ public final class TestUtils {
 
             return result;
         }
-    }
-
-    /**
-     * Checks that the resource has the owner reference pointing to the parent resource
-     *
-     * @param resource  The resource where the owner reference should be checked
-     * @param owner     The resource which should be the owner
-     */
-    public static void checkOwnerReference(HasMetadata resource, HasMetadata owner)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-
-        OwnerReference or = resource.getMetadata().getOwnerReferences().get(0);
-
-        assertThat(or.getApiVersion(), is(owner.getApiVersion()));
-        assertThat(or.getKind(), is(owner.getKind()));
-        assertThat(or.getName(), is(owner.getMetadata().getName()));
-        assertThat(or.getUid(), is(owner.getMetadata().getUid()));
-        assertThat(or.getBlockOwnerDeletion(), is(false));
-        assertThat(or.getController(), is(false));
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -412,7 +412,7 @@ public class KafkaUserModel {
                 .withKind(ownerKind)
                 .withName(name)
                 .withUid(ownerUid)
-                .withBlockOwnerDeletion(false)
+                .withBlockOwnerDeletion(true)
                 .withController(false)
                 .build();
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR changes the `blockOwnerDeletion` flag in our owner references to be set to `true`. That way, when deleting the custom resources, the deletion should default to waiting for all resources to be deleted. Users can force the deletion to not wait if they decide to use a flag in the deletion command/request.

This should resolve #11679

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md