### PR TITLE
Deprecate and stop using the `.status.kafkaMetadataState` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources.
   Deleting the Strimzi custom resources will now by default wait for the deletion of all the owned Kubernetes resources.
 
+### Major changes, deprecations, and removals
+
+* The `.status.kafkaMetadataState` field in the `Kafka` custom resource is deprecated and not used anymore.
+
 ## 0.48.0
 
 * Add support for Kafka 4.1.0.

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaMetadataState.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaMetadataState.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Represents where metadata are stored for the current cluster (ZooKeeper or KRaft)
  * or if a migration from ZooKeeper to KRaft is in progress and in which phase
  */
+@Deprecated
 public enum KafkaMetadataState {
     /**
      * The metadata are stored in ZooKeeper.

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
@@ -109,11 +109,15 @@ public class KafkaStatus extends Status {
         this.kafkaMetadataVersion = kafkaMetadataVersion;
     }
 
-    @Description("Defines where cluster metadata are stored. Since Kafka KRaft has been fully adopted, the only applicable value is `KRaft`.")
+    @Description("Defines where cluster metadata are stored. This property is deprecated and not used anymore.")
+    @Deprecated
+    @DeprecatedProperty(description = "The `kafkaMetadataState` property is deprecated and will be removed in the future.")
+    @PresentInVersions("v1beta2")
     public KafkaMetadataState getKafkaMetadataState() {
         return kafkaMetadataState;
     }
 
+    @SuppressWarnings("deprecation") // KafkaMetadataState is deprecated
     public void setKafkaMetadataState(KafkaMetadataState metadataState) {
         this.kafkaMetadataState = metadataState;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -171,12 +171,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     status.setKafkaMetadataVersion(kafkaAssembly.getStatus().getKafkaMetadataVersion());
                 }
 
-                if (status.getKafkaMetadataState() == null
-                        && kafkaAssembly.getStatus().getKafkaMetadataState() != null)  {
-                    // Copy the metadata state if needed
-                    status.setKafkaMetadataState(kafkaAssembly.getStatus().getKafkaMetadataState());
-                }
-
                 if (status.getAutoRebalance() == null
                         && kafkaAssembly.getStatus().getAutoRebalance() != null
                         && reconcileState.isAutoRebalancingEnabled()) {
@@ -217,6 +211,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     Future<Void> reconcile(ReconciliationState reconcileState)  {
         Promise<Void> chainPromise = Promise.promise();
 
+        // The .status.kafkaMetadataState field is deprecated and we do not set it anymore. But we can still use it to
+        // check the state in the older resources previously reconciled by other operators. And we can prevent
+        // reconciliation of clusters not yet migrated to KRaft that way.
         if (ReconcilerUtils.nonMigratedCluster(reconcileState.kafkaAssembly)) {
             throw new InvalidConfigurationException("Strimzi " + OPERATOR_VERSION + " supports only KRaft-based Apache Kafka clusters. Please make sure your cluster is migrated to KRaft before using Strimzi " + OPERATOR_VERSION + ".");
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -14,7 +14,6 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.kafka.Kafka;
-import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.UsedNodePoolStatus;
@@ -1181,7 +1180,6 @@ public class KafkaReconciler {
     /* test */ Future<Void> updateKafkaStatus(KafkaStatus kafkaStatus) {
         kafkaStatus.setListeners(listenerReconciliationResults.listenerStatuses);
         kafkaStatus.setKafkaVersion(kafka.getKafkaVersion().version());
-        kafkaStatus.setKafkaMetadataState(KafkaMetadataState.KRaft);
 
         return Future.succeededFuture();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -390,6 +390,7 @@ public class ReconcilerUtils {
      *
      * @return      True ZooKeeper metadata are in use or when the cluster is in migration. False otherwise.
      */
+    @SuppressWarnings("deprecation") // KafkaMetadataState is deprecated, but we still use it to check for clusters not migrated to KRaft
     public static boolean nonMigratedCluster(Kafka kafka) {
         // When the Kafka status or the metadata state are null, we cannot decide anything about KRaft (it can be a new
         // cluster or a cluster that is still doing the first deployment). Only when it is set to one of the non-KRaft

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
@@ -261,7 +261,6 @@ public class KafkaAssemblyOperatorKRaftMockTest {
         assertThat(k.getStatus().getKafkaMetadataVersion(), startsWith(VERSIONS.defaultVersion().metadataVersion() + "-IV"));
         assertThat(k.getStatus().getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
         assertThat(k.getStatus().getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
-        assertThat(k.getStatus().getKafkaMetadataState().toValue(), is("KRaft"));
         assertThat(k.getStatus().getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("brokers", "controllers")));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
@@ -1435,6 +1435,7 @@ public class KafkaAssemblyOperatorWithKRaftTest {
      * @param context   Test context
      */
     @Test
+    @SuppressWarnings("deprecation") // KafkaMetadataState is deprecated
     public void testClusterWithZooKeeperMetadata(VertxTestContext context)  {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editStatus()
@@ -1471,6 +1472,7 @@ public class KafkaAssemblyOperatorWithKRaftTest {
      * @param context   Test context
      */
     @Test
+    @SuppressWarnings("deprecation") // KafkaMetadataState is deprecated
     public void testClusterWithMigrationMetadata(VertxTestContext context)  {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editStatus()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
-import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
@@ -172,9 +171,6 @@ public class KafkaReconcilerStatusTest {
 
             // Check kafka version
             assertThat(status.getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
-
-            // Check Kafka metadata state
-            assertThat(status.getKafkaMetadataState(), is(KafkaMetadataState.KRaft));
 
             // Check model warning conditions
             assertThat(status.getConditions().size(), is(2));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaList;
-import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
@@ -339,7 +338,6 @@ public class KafkaStatusTest {
                     .withKafkaVersion("old-kafka")
                     .withOperatorLastSuccessfulVersion("old-operator")
                     .withKafkaMetadataVersion("old-metadata-version")
-                    .withKafkaMetadataState(KafkaMetadataState.KRaft)
                 .endStatus()
                 .build();
 
@@ -380,7 +378,6 @@ public class KafkaStatusTest {
             assertThat(status.getKafkaVersion(), is("old-kafka"));
             assertThat(status.getOperatorLastSuccessfulVersion(), is("old-operator"));
             assertThat(status.getKafkaMetadataVersion(), is("old-metadata-version"));
-            assertThat(status.getKafkaMetadataState(), is(KafkaMetadataState.KRaft));
 
             async.flag();
         })));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2325,7 +2325,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |The KRaft metadata.version currently used by the Kafka cluster.
 |kafkaMetadataState
 |string (one of [PreKRaft, ZooKeeper, KRaftMigration, KRaftDualWriting, KRaftPostMigration, KRaft])
-|Defines where cluster metadata are stored. Since Kafka KRaft has been fully adopted, the only applicable value is `KRaft`.
+|**The `kafkaMetadataState` property has been deprecated.** The `kafkaMetadataState` property is deprecated and will be removed in the future. Defines where cluster metadata are stored. This property is deprecated and not used anymore.
 |autoRebalance
 |xref:type-KafkaAutoRebalanceStatus-{context}[`KafkaAutoRebalanceStatus`]
 |The status of an auto-rebalancing triggered by a cluster scaling request.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -8677,7 +8677,7 @@ spec:
                     - KRaftPostMigration
                     - PreKRaft
                     - KRaft
-                  description: "Defines where cluster metadata are stored. Since Kafka KRaft has been fully adopted, the only applicable value is `KRaft`."
+                  description: Defines where cluster metadata are stored. This property is deprecated and not used anymore.
                 autoRebalance:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -8676,7 +8676,7 @@ spec:
                 - KRaftPostMigration
                 - PreKRaft
                 - KRaft
-                description: "Defines where cluster metadata are stored. Since Kafka KRaft has been fully adopted, the only applicable value is `KRaft`."
+                description: Defines where cluster metadata are stored. This property is deprecated and not used anymore.
               autoRebalance:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As discussed in #11844 and approved in the [Strimzi Proposal 113](https://github.com/strimzi/proposals/blob/main/113-Strimzi-v1-CRD-API-and-1.0.0-release.md), this PR deprecates the `.status.kafkaMetadataState` field and removes it from the `v1` API. It also makes sure that our code does not set it anymore.

However, as long as the operator is still using the `v1beta2` API, the check for clusters not yet migrated to Kraft remains in place, as we actually don't reconcile the custom resource in this case.

This should resolve #11844.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md