### PR TITLE
Moved access-operator-api dep to systemtest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,6 @@
         <skodjob.test-frame.version>1.1.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.4.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
-        <!--
-            Currently, there are no released versions in Maven repository of this module,
-            using SNAPSHOT for having the `api` module available and usable in the STs.
-            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
-        -->
-        <access-operator.version>0.2.0-SNAPSHOT</access-operator.version>
         <!-- properties to skip surefire tests during failsafe execution -->
         <skipTests>false</skipTests>
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -823,11 +817,6 @@
                 <groupId> com.github.docker-java</groupId>
                 <artifactId>docker-java-api</artifactId>
                 <version>${docker-java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.strimzi.access-operator</groupId>
-                <artifactId>api</artifactId>
-                <version>${access-operator.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -14,6 +14,12 @@
     <properties>
         <skipTests>true</skipTests>
         <failsafe.forkCount>0</failsafe.forkCount>
+        <!--
+            Currently, there are no released versions in Maven repository of this module,
+            using SNAPSHOT for having the `api` module available and usable in the STs.
+            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
+        -->
+        <access-operator.version>0.2.0-SNAPSHOT</access-operator.version>
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
@@ -260,6 +266,7 @@
         <dependency>
             <groupId>io.strimzi.access-operator</groupId>
             <artifactId>api</artifactId>
+            <version>${access-operator.version}</version>
         </dependency>
         <dependency>
             <groupId>com.marcnuri.helm-java</groupId>


### PR DESCRIPTION
The release pipeline for 0.48.0 failed with the following error:

```shell
Deployment f6178548-049e-440a-855c-af36ee143d2d failed
pkg:maven/io.strimzi/crd-annotations@0.48.0-RC1:
 - Dependency management dependencies to SNAPSHOT versions not allowed for dependency: io.strimzi.access-operator:api

pkg:maven/io.strimzi/test@0.48.0-RC1:
 - Dependency management dependencies to SNAPSHOT versions not allowed for dependency: io.strimzi.access-operator:api

pkg:maven/io.strimzi/api@0.48.0-RC1:
 - Dependency management dependencies to SNAPSHOT versions not allowed for dependency: io.strimzi.access-operator:api

pkg:maven/io.strimzi/crd-generator@0.48.0-RC1:
 - Dependency management dependencies to SNAPSHOT versions not allowed for dependency: io.strimzi.access-operator:api

pkg:maven/io.strimzi/strimzi@0.48.0-RC1:
 - Dependency management dependencies to SNAPSHOT versions not allowed for dependency: io.strimzi.access-operator:api
```

It seems that Maven Central has a validation rule to not allow having `-SNAPSHOT` dependencies when it comes to publish artifacts.
It seems that in this case the issue is with the `io.strimzi.access-operator:api` which is actually used just by the systemtest module.
This PR tries to fix it by moving such dependency directly to systemtest (by removing from the root pom.xml) which is not published to Maven Central so hopefully it won't complain when publishing the other artifacts.