### PR TITLE
Moved access-operator-api dep to systemtest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,23 +39,6 @@
         </developer>
     </developers>
 
-    <repositories>
-        <repository>
-            <!--
-            Until there is a new release of Kafka Access Operator we are using the Sonatype repository with its SNAPSHOT.
-            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
-            -->
-            <id>oss-sonatype</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,6 @@
         <skodjob.test-frame.version>1.1.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.4.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
-        <!--
-            Currently, there are no released versions in Maven repository of this module,
-            using SNAPSHOT for having the `api` module available and usable in the STs.
-            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
-        -->
-        <access-operator.version>0.2.0-SNAPSHOT</access-operator.version>
         <!-- properties to skip surefire tests during failsafe execution -->
         <skipTests>false</skipTests>
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -823,11 +817,6 @@
                 <groupId> com.github.docker-java</groupId>
                 <artifactId>docker-java-api</artifactId>
                 <version>${docker-java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.strimzi.access-operator</groupId>
-                <artifactId>api</artifactId>
-                <version>${access-operator.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -14,6 +14,12 @@
     <properties>
         <skipTests>true</skipTests>
         <failsafe.forkCount>0</failsafe.forkCount>
+        <!--
+            Currently, there are no released versions in Maven repository of this module,
+            using SNAPSHOT for having the `api` module available and usable in the STs.
+            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
+        -->
+        <access-operator.version>0.2.0-SNAPSHOT</access-operator.version>
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
@@ -260,6 +266,7 @@
         <dependency>
             <groupId>io.strimzi.access-operator</groupId>
             <artifactId>api</artifactId>
+            <version>${access-operator.version}</version>
         </dependency>
         <dependency>
             <groupId>com.marcnuri.helm-java</groupId>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -25,6 +25,23 @@
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
     </properties>
 
+    <repositories>
+        <repository>
+            <!--
+            Until there is a new release of Kafka Access Operator we are using the Sonatype repository with its SNAPSHOT.
+            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
+            -->
+            <id>oss-sonatype</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/strimzi/strimzi-kafka-operator/pull/11904 into main branch.

In summary, it fixes the issue with Maven Central not allowing `-SNAPSHOT` dependencies in artifacts being pushed.
For this reason the access operator API dependency (which is `0.2.0-SNAPSHOT`) is moved to the systemtest directly which is the only one using it and not pushed to Maven Central.

More details on the above linked PR.