### PR TITLE
docs(autoRestart): document when the restart counter resets for connectors

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.connector.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connector.AutoRestart.adoc
@@ -4,6 +4,8 @@ When enabled, a back-off algorithm applies the automatic restart to each failed 
 An incremental back-off interval is calculated using the formula `n * n + n` where `n` represents the number of previous restarts.
 This interval is capped at a maximum of 60 minutes.
 Consequently, a restart occurs immediately, followed by restarts after 2, 6, 12, 20, 30, 42, 56 minutes, and then at 60-minute intervals.
+The restart counter is automatically reset once the connector has been running continuously for longer than the next backoff interval. 
+For example, if the connector has restarted 4 times, it must run without errors for 20 minutes before the restart count resets to 0.
 By default, Strimzi initiates restarts of the connector and its tasks indefinitely.
 However, you can use the `maxRestarts` property to set a maximum on the number of restarts.
 If `maxRestarts` is configured and the connector still fails even after the final restart attempt, you must then restart the connector manually.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

While walking through the Kafka Connect AutoReset implementation, I discovered the reset counter feature is not explained in the documentation. 

The feature is implemented in: 
https://github.com/strimzi/strimzi-kafka-operator/blob/9a0f0ca37c63906b5e8ee29f6a686976884efe15/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java#L733-L754

and it's used by the handler:

https://github.com/strimzi/strimzi-kafka-operator/blob/9a0f0ca37c63906b5e8ee29f6a686976884efe15/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java#L643-L650


See the full method code:
https://github.com/strimzi/strimzi-kafka-operator/blob/9a0f0ca37c63906b5e8ee29f6a686976884efe15/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java#L623-L664

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- ~[ ] Write tests~
- ~[ ] Make sure all tests pass~
- [x] Update documentation
- ~[ ] Check RBAC rights for Kubernetes / OpenShift roles~
- ~[ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally~
- ~[ ] Reference relevant issue(s) and close them after merging~
- ~[ ] Update CHANGELOG.md~
- ~[ ] Supply screenshots for visual changes, such as Grafana dashboards~

