### PR TITLE
[ST] Freeze Postgres version and use full image name

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -206,7 +206,7 @@ public class Environment {
     public static final String KAFKA_TIERED_STORAGE_CLASSPATH_DEFAULT = "/opt/kafka/plugins/tiered-storage/*";
     public static final String KANIKO_IMAGE_DEFAULT = "gcr.io/kaniko-project/executor:v1.23.2";
 
-    public static final String POSTGRES_IMAGE_DEFAULT = "postgres:latest";
+    public static final String POSTGRES_IMAGE_DEFAULT = "docker.io/library/postgres:17.6";
 
     /**
      * Set values


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR freezes the version of Postgres used in the OAuth tests - it seems that they pushed some breaking change into the `latest` tag, which failing our GHA pipelines where the OAuth tests are running.
Other than that, it makes sense to have stable version rather than latest.

### Checklist

- [x] Make sure all tests pass

