### PR TITLE
Enforce Connect's internal topic names and group ID configuration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -44,3 +44,5 @@ ignore:
   - "tools"
   - "systemtest"
   - "test"
+  # The API model is just getters and setters that are not tested. Measuring coverage for them adds only a little value.
+  - "api/src/main/java/io/strimzi/api/kafka/model"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources.
   Deleting the Strimzi custom resources will now by default wait for the deletion of all the owned Kubernetes resources.
+* New fields `.spec.groupId`, `.spec.configStorageTopic`, `.spec.offsetStorageTopic`, and `.spec.statusStorageTopic` in the `KafkaConnect` custom resource for configuring Connect's group ID and internal topics.
 
 ### Major changes, deprecations, and removals
 
@@ -16,6 +17,8 @@
   To use the Keycloak authorizer, you can use the `type: custom` authorization.
   The Strimzi OAuth library with the Keycloak authorizer continues to be packaged with the Strimzi container images.
   Follow the documentation for the examples and migration details.
+* The `group.id`, `config.storage.topic`, `offset.storage.topic`, and `status.storage.topic` fields in `.spec.config` section of the `KafkaConnect` resource are deprecated and will not be supported in the `v1` CRD API.
+  Please use the new `.spec.groupId`, `.spec.configStorageTopic`, `.spec.offsetStorageTopic`, and `.spec.statusStorageTopic` fields instead.
 
 ## 0.48.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   To use the Keycloak authorizer, you can use the `type: custom` authorization.
   The Strimzi OAuth library with the Keycloak authorizer continues to be packaged with the Strimzi container images.
   Follow the documentation for the examples and migration details.
-* The `group.id`, `config.storage.topic`, `offset.storage.topic`, and `status.storage.topic` fields in `.spec.config` section of the `KafkaConnect` resource are deprecated and will not be supported in the `v1` CRD API.
+* The `group.id`, `config.storage.topic`, `offset.storage.topic`, and `status.storage.topic` fields in `.spec.config` section of the `KafkaConnect` resource are deprecated and will be forbidden in the `v1` CRD API.
   Please use the new `.spec.groupId`, `.spec.configStorageTopic`, `.spec.offsetStorageTopic`, and `.spec.statusStorageTopic` fields instead.
 
 ## 0.48.0

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.connect.build.Build;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -27,7 +28,8 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "version", "replicas", "image", "bootstrapServers", "tls", "authentication", "config", "resources",
+@JsonPropertyOrder({ "version", "replicas", "image", "bootstrapServers", "groupId", "configStorageTopic",
+    "statusStorageTopic", "offsetStorageTopic", "tls", "authentication", "config", "resources",
     "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "logging", "clientRackInitImage", "rack",
     "metricsConfig", "tracing", "template", "externalConfiguration", "build", "plugins" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
@@ -38,6 +40,10 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     private Map<String, Object> config = new HashMap<>(0);
     private String bootstrapServers;
+    private String groupId;
+    private String configStorageTopic;
+    private String statusStorageTopic;
+    private String offsetStorageTopic;
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private Build build;
@@ -61,6 +67,46 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     public void setBootstrapServers(String bootstrapServers) {
         this.bootstrapServers = bootstrapServers;
+    }
+
+    @Description("A unique string that identifies the Connect cluster group this worker belongs to.")
+    @RequiredInVersions("v1+")
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    @Description("The name of the Kafka topic where connector configurations are stored.")
+    @RequiredInVersions("v1+")
+    public String getConfigStorageTopic() {
+        return configStorageTopic;
+    }
+
+    public void setConfigStorageTopic(String configStorageTopic) {
+        this.configStorageTopic = configStorageTopic;
+    }
+
+    @Description("The name of the Kafka topic where connector and task status are stored")
+    @RequiredInVersions("v1+")
+    public String getStatusStorageTopic() {
+        return statusStorageTopic;
+    }
+
+    public void setStatusStorageTopic(String statusStorageTopic) {
+        this.statusStorageTopic = statusStorageTopic;
+    }
+
+    @Description("The name of the Kafka topic where source connector offsets are stored.")
+    @RequiredInVersions("v1+")
+    public String getOffsetStorageTopic() {
+        return offsetStorageTopic;
+    }
+
+    public void setOffsetStorageTopic(String offsetStorageTopic) {
+        this.offsetStorageTopic = offsetStorageTopic;
     }
 
     @Description("TLS configuration")

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -69,7 +69,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
         this.bootstrapServers = bootstrapServers;
     }
 
-    @Description("A unique string that identifies the Connect cluster group this worker belongs to.")
+    @Description("A unique ID that identifies the Connect cluster group.")
     @RequiredInVersions("v1+")
     public String getGroupId() {
         return groupId;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -1052,7 +1052,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         data.put(
                 KAFKA_CONNECT_CONFIGURATION_FILENAME,
                 new KafkaConnectConfigurationBuilder(reconciliation, bootstrapServers)
-                        .withInternalTopicsAndGroupId(groupId, configStorageTopic, statusStorageTopic, offsetStorageTopic)
+                        .withGroupIdAndInternalTopics(groupId, configStorageTopic, statusStorageTopic, offsetStorageTopic)
                         .withRestListeners(REST_API_PORT)
                         .withPluginPath()
                         .withTls(tls, cluster)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -159,6 +159,10 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected String connectConfigMapName;
 
     protected String bootstrapServers;
+    protected String groupId;
+    protected String configStorageTopic;
+    protected String statusStorageTopic;
+    protected String offsetStorageTopic;
     @SuppressWarnings("deprecation") // External Configuration environment variables are deprecated
     protected List<ExternalConfigurationEnv> externalEnvs = Collections.emptyList();
 
@@ -254,7 +258,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                                                                 KafkaVersion.Lookup versions,
                                                                 C result) {
         result.replicas = spec.getReplicas();
-        result.tracing = spec.getTracing();
 
         // Might already contain configuration from Mirror Maker 2 which extends Connect
         // We have to check it and either use the Mirror Maker 2 configs or get the Connect configs
@@ -263,6 +266,15 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
             config = new KafkaConnectConfiguration(reconciliation, spec.getConfig().entrySet());
             result.configuration = config;
         }
+
+        // Internal Connect configurations
+        result.groupId = extractAndRemoveValueFromConfig(result.configuration, "group.id", spec.getGroupId(), "connect-cluster");
+        result.configStorageTopic = extractAndRemoveValueFromConfig(result.configuration, "config.storage.topic", spec.getConfigStorageTopic(), "connect-cluster-configs");
+        result.statusStorageTopic = extractAndRemoveValueFromConfig(result.configuration, "status.storage.topic", spec.getStatusStorageTopic(), "connect-cluster-status");
+        result.offsetStorageTopic = extractAndRemoveValueFromConfig(result.configuration, "offset.storage.topic", spec.getOffsetStorageTopic(), "connect-cluster-offsets");
+
+        // Tracing configuration
+        result.tracing = spec.getTracing();
         if (result.tracing != null)   {
             if (JaegerTracing.TYPE_JAEGER.equals(result.tracing.getType())) {
                 LOGGER.warnCr(reconciliation, "Tracing type \"{}\" is not supported anymore and will be ignored", JaegerTracing.TYPE_JAEGER);
@@ -346,6 +358,36 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         result.mountedPlugins = spec.getPlugins();
 
         return result;
+    }
+
+    /**
+     * Utility method to help with backward compatibility between the old Connect configuration and a new Connect
+     * configuration. This should be removed once v1beta2 API is dropped and we use only v1.
+     *      - We always use the new dedicated field if set (newConfig)
+     *      - If the new field is not set, we try to use the user values from .spec.config
+     *      - And if those are not set either, we use the defaults that were used from Strimzi beginnings.
+     *
+     * @param configuration     Kafka Connect configuration
+     * @param configKey         Kafka Connect configuration key
+     * @param newConfig         Configuration value from the new field or null if not set
+     * @param defaultConfig     Default configuration value
+     *
+     * @return  String with the value that should be used.
+     */
+    protected static String extractAndRemoveValueFromConfig(AbstractConfiguration configuration, String configKey, String newConfig, String defaultConfig) {
+        if (newConfig != null) {
+            configuration.removeConfigOption(configKey);
+            return newConfig;
+        } else {
+            String oldConfig = configuration.getConfigOption(configKey);
+
+            if (oldConfig != null) {
+                configuration.removeConfigOption(configKey);
+                return oldConfig;
+            } else {
+                return defaultConfig;
+            }
+        }
     }
 
     /**
@@ -1010,6 +1052,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         data.put(
                 KAFKA_CONNECT_CONFIGURATION_FILENAME,
                 new KafkaConnectConfigurationBuilder(reconciliation, bootstrapServers)
+                        .withInternalTopicsAndGroupId(groupId, configStorageTopic, statusStorageTopic, offsetStorageTopic)
                         .withRestListeners(REST_API_PORT)
                         .withPluginPath()
                         .withTls(tls, cluster)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -24,17 +24,13 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaConnectSpec.FORBIDDEN_PREFIXES);
         FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
-        DEFAULTS = new HashMap<>(6);
-        DEFAULTS.put("group.id", "connect-cluster");
-        DEFAULTS.put("offset.storage.topic", "connect-cluster-offsets");
-        DEFAULTS.put("config.storage.topic", "connect-cluster-configs");
-        DEFAULTS.put("status.storage.topic", "connect-cluster-status");
+        DEFAULTS = new HashMap<>(2);
         DEFAULTS.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         DEFAULTS.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
     }
 
     /**
-     * Copy constructor which creates new instance of the Kafka Connect configuration from existing configuration.
+     * Copy constructor which creates a new instance of the Kafka Connect configuration from an existing configuration.
      * It is useful when you need to modify an instance of the configuration without permanently changing the original.
      *
      * @param configuration User provided Kafka Connect configuration
@@ -49,7 +45,7 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
      * ConfigMap / CRD.
      *
      * @param reconciliation  The reconciliation
-     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     * @param jsonOptions     JSON object with configuration options as key ad value pairs.
      */
     public KafkaConnectConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
         super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
@@ -406,7 +406,7 @@ public class KafkaConnectConfigurationBuilder {
      *
      * @return  Returns the builder instance
      */
-    public KafkaConnectConfigurationBuilder withInternalTopicsAndGroupId(String groupId, String configStorageTopic, String statusStorageTopic, String offsetStorageTopic)  {
+    public KafkaConnectConfigurationBuilder withGroupIdAndInternalTopics(String groupId, String configStorageTopic, String statusStorageTopic, String offsetStorageTopic)  {
         printSectionHeader("Internal topics and group ID");
         writer.println("group.id=" + groupId);
         writer.println("config.storage.topic=" + configStorageTopic);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
@@ -397,6 +397,27 @@ public class KafkaConnectConfigurationBuilder {
     }
 
     /**
+     * Configures Connect's internal topics and group ID
+     *
+     * @param groupId               Connect's group ID
+     * @param configStorageTopic    Connect's configuration topic
+     * @param statusStorageTopic    Connect's statuses topic
+     * @param offsetStorageTopic    Connect's offsets topic
+     *
+     * @return  Returns the builder instance
+     */
+    public KafkaConnectConfigurationBuilder withInternalTopicsAndGroupId(String groupId, String configStorageTopic, String statusStorageTopic, String offsetStorageTopic)  {
+        printSectionHeader("Internal topics and group ID");
+        writer.println("group.id=" + groupId);
+        writer.println("config.storage.topic=" + configStorageTopic);
+        writer.println("status.storage.topic=" + statusStorageTopic);
+        writer.println("offset.storage.topic=" + offsetStorageTopic);
+        writer.println();
+
+        return this;
+    }
+
+    /**
      * Configures plugins.
      *
      * @return Returns the builder instance

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -55,7 +55,7 @@ class KafkaConnectConfigurationBuilderTest {
     @Test
     public void testInternalTopicsAndGroupId()  {
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
-                .withInternalTopicsAndGroupId("my-group", "my-config-topic", "my-status-topic", "my-offset-topic")
+                .withGroupIdAndInternalTopics("my-group", "my-config-topic", "my-status-topic", "my-offset-topic")
                 .build();
 
         assertThat(configuration, isEquivalent(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -38,7 +38,6 @@ import static io.strimzi.operator.cluster.TestUtils.IsEquivalent.isEquivalent;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class KafkaConnectConfigurationBuilderTest {
-
     private static final String BOOTSTRAP_SERVERS = "my-cluster-kafka-bootstrap:9092";
 
     @Test
@@ -46,6 +45,25 @@ class KafkaConnectConfigurationBuilderTest {
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS).build();
         assertThat(configuration, isEquivalent(
                 "bootstrap.servers=my-cluster-kafka-bootstrap:9092",
+                "security.protocol=PLAINTEXT",
+                "producer.security.protocol=PLAINTEXT",
+                "consumer.security.protocol=PLAINTEXT",
+                "admin.security.protocol=PLAINTEXT"
+        ));
+    }
+
+    @Test
+    public void testInternalTopicsAndGroupId()  {
+        String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
+                .withInternalTopicsAndGroupId("my-group", "my-config-topic", "my-status-topic", "my-offset-topic")
+                .build();
+
+        assertThat(configuration, isEquivalent(
+                "bootstrap.servers=my-cluster-kafka-bootstrap:9092",
+                "group.id=my-group",
+                "offset.storage.topic=my-offset-topic",
+                "config.storage.topic=my-config-topic",
+                "status.storage.topic=my-status-topic",
                 "security.protocol=PLAINTEXT",
                 "producer.security.protocol=PLAINTEXT",
                 "consumer.security.protocol=PLAINTEXT",
@@ -514,10 +532,6 @@ class KafkaConnectConfigurationBuilderTest {
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider",
-                "group.id=connect-cluster",
-                "offset.storage.topic=connect-cluster-offsets",
-                "config.storage.topic=connect-cluster-configs",
-                "status.storage.topic=connect-cluster-status",
                 "key.converter=org.apache.kafka.connect.json.JsonConverter",
                 "value.converter=org.apache.kafka.connect.json.JsonConverter")
         );
@@ -549,10 +563,6 @@ class KafkaConnectConfigurationBuilderTest {
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "myconfig=abc",
                 "myconfig2=123",
-                "group.id=connect-cluster",
-                "offset.storage.topic=connect-cluster-offsets",
-                "config.storage.topic=connect-cluster-configs",
-                "status.storage.topic=connect-cluster-status",
                 "key.converter=org.apache.kafka.connect.json.JsonConverter",
                 "value.converter=org.apache.kafka.connect.json.JsonConverter")
         );
@@ -583,10 +593,6 @@ class KafkaConnectConfigurationBuilderTest {
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "config.providers.userenv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider",
-                "group.id=connect-cluster",
-                "offset.storage.topic=connect-cluster-offsets",
-                "config.storage.topic=connect-cluster-configs",
-                "status.storage.topic=connect-cluster-status",
                 "key.converter=org.apache.kafka.connect.json.JsonConverter",
                 "value.converter=org.apache.kafka.connect.json.JsonConverter")
         );
@@ -675,13 +681,9 @@ class KafkaConnectConfigurationBuilderTest {
                 + "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider\n"
                 + "config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets\n"
                 + "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider\n"
-                + "config.storage.topic=connect-cluster-configs\n"
                 + "key.converter=org.apache.kafka.connect.json.JsonConverter\n"
-                + "offset.storage.topic=connect-cluster-offsets\n"
                 + "producer.security.protocol=PLAINTEXT\n"
                 + "security.protocol=PLAINTEXT\n"
-                + "status.storage.topic=connect-cluster-status\n"
-                + "group.id=connect-cluster\n"
                 + "value.converter=org.apache.kafka.connect.json.JsonConverter\n";
 
         // testing 4 combinations of 2 boolean values
@@ -754,12 +756,8 @@ class KafkaConnectConfigurationBuilderTest {
                 + "admin.metric.reporters=io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
                 + "producer.metric.reporters=io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
                 + "consumer.metric.reporters=io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
-                + "offset.storage.topic=connect-cluster-offsets\n"
                 + "value.converter=org.apache.kafka.connect.json.JsonConverter\n"
-                + "config.storage.topic=connect-cluster-configs\n"
                 + "key.converter=org.apache.kafka.connect.json.JsonConverter\n"
-                + "group.id=connect-cluster\n"
-                + "status.storage.topic=connect-cluster-status\n"
                 + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true\n"
                 + StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT + "\n"
                 + StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_connect_connector_metrics.*,kafka_connect_connector_task_metrics.*\n"

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -125,10 +125,6 @@ public class KafkaMirrorMaker2ClusterTest {
     private final String kafkaHeapOpts = "-Xms" + JvmOptionUtils.DEFAULT_JVM_XMS;
 
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
-            .addPair("config.storage.topic", "mirrormaker2-cluster-configs")
-            .addPair("group.id", "mirrormaker2-cluster")
-            .addPair("status.storage.topic", "mirrormaker2-cluster-status")
-            .addPair("offset.storage.topic", "mirrormaker2-cluster-offsets")
             .addPair("value.converter", "org.apache.kafka.connect.converters.ByteArrayConverter")
             .addPair("key.converter", "org.apache.kafka.connect.converters.ByteArrayConverter")
             .addPair("header.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
@@ -178,6 +174,10 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(configMap.getData().get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is(metricsCmJson));
         String connectConfigurations = configMap.getData().get(KafkaConnectCluster.KAFKA_CONNECT_CONFIGURATION_FILENAME);
         assertThat(connectConfigurations, containsString("bootstrap.servers=" + bootstrapServers));
+        assertThat(connectConfigurations, containsString("group.id=mirrormaker2-cluster"));
+        assertThat(connectConfigurations, containsString("config.storage.topic=mirrormaker2-cluster-configs"));
+        assertThat(connectConfigurations, containsString("offset.storage.topic=mirrormaker2-cluster-offsets"));
+        assertThat(connectConfigurations, containsString("status.storage.topic=mirrormaker2-cluster-status"));
         assertThat(connectConfigurations, containsString(expectedConfiguration.asPairs()));
         // MirrorMaker relies on env and file config providers to be configured by default
         assertThat(connectConfigurations, containsString("config.providers=strimzienv,strimzifile"));
@@ -225,6 +225,10 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(kmm2.livenessProbeOptions.getInitialDelaySeconds(), is(60));
         assertThat(kmm2.livenessProbeOptions.getTimeoutSeconds(), is(5));
         assertThat(kmm2.configuration.asOrderedProperties(), is(defaultConfiguration));
+        assertThat(kmm2.groupId, is("mirrormaker2-cluster"));
+        assertThat(kmm2.configStorageTopic, is("mirrormaker2-cluster-configs"));
+        assertThat(kmm2.offsetStorageTopic, is("mirrormaker2-cluster-offsets"));
+        assertThat(kmm2.statusStorageTopic, is("mirrormaker2-cluster-status"));
     }
 
     @Test
@@ -237,6 +241,10 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(kmm2.livenessProbeOptions.getTimeoutSeconds(), is(healthTimeout));
         assertThat(kmm2.configuration.asOrderedProperties(), is(expectedConfiguration));
         assertThat(kmm2.bootstrapServers, is(bootstrapServers));
+        assertThat(kmm2.groupId, is("mirrormaker2-cluster"));
+        assertThat(kmm2.configStorageTopic, is("mirrormaker2-cluster-configs"));
+        assertThat(kmm2.offsetStorageTopic, is("mirrormaker2-cluster-offsets"));
+        assertThat(kmm2.statusStorageTopic, is("mirrormaker2-cluster-status"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -211,7 +211,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     for (Pod pod : PodSetUtils.podSetToPods(podSet))  {
                         assertThat(pod.getMetadata().getAnnotations().size(), is(3));
                         assertThat(pod.getMetadata().getAnnotations().get(PodRevision.STRIMZI_REVISION_ANNOTATION), is(notNullValue())); // We do not check the exact value -> it just describes the exact pod configuration which might change with too many unrelated code or dependency changes
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH), is("c1f986e9"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH), is("413a55a2"));
                         assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("0")); // We do not use any security in this test, so it is set but as 0
                     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -197,7 +197,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
                     for (Pod pod : PodSetUtils.podSetToPods(podSet))  {
                         assertThat(pod.getMetadata().getAnnotations().size(), is(3));
                         assertThat(pod.getMetadata().getAnnotations().get(PodRevision.STRIMZI_REVISION_ANNOTATION), is(notNullValue())); // We do not check the exact value -> it just describes the exact pod configuration which might change with too many unrelated code or dependency changes
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH), is("97d17377"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH), is("337eabd4"));
                         assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("0")); // We do not use any security in this test, so it is set but as 0
                     }
 

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -24,7 +24,8 @@ spec:
 ----
 
 These fields are required in the `v1` CRD API version.
-They are optional in the `v1beta2` version and if not set, the following default values will be used:
+In the `v1beta2` version, these properties are optional.
+If not set, the following default values apply:
 
 * `groupId` will default value `connect-cluster`
 * `configStorageTopic` will default to `connect-cluster-configs`

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -2,8 +2,40 @@
 
 Configures a Kafka Connect cluster.
 
+[id='property-kafka-connect-internal-topics-grop-id-{context}']
+= Group ID and internal topics
+
+The group ID and the internal topics used by the Kafka Connect cluster are configured in the `.spec` section of the `KafkaConnect` resource
+
+.Example group ID and internal topics configuration
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect
+spec:
+  # ...
+  groupId: my-connect-group
+  configStorageTopic: my-config-topic
+  offsetStorageTopic: my-offset-topic
+  statusStorageTopic: my-status-topic
+  # ...
+----
+
+These fields are required in the `v1` CRD API version.
+They are optional in the `v1beta2` option and if not set, the following default values will be used:
+
+* `groupId` will default value `connect-cluster`
+* `configStorageTopic` will default to `connect-cluster-configs`
+* `offsetStorageTopic` will default to `connect-cluster-offsets`
+* `statusStorageTopic` will default to `connect-cluster-status`
+
+[id='property-kafka-connect-additional-configuration-{context}']
+= Additional configuration
+
 The `config` properties are one part of the overall configuration for the resource.
-Use the `config` properties to configure Kafka Connect options as keys.
+Use the `config` properties to configure additional Kafka Connect options as keys.
 
 .Example Kafka Connect configuration
 [source,yaml,subs="attributes+"]
@@ -15,10 +47,6 @@ metadata:
 spec:
   # ...
   config:
-    group.id: my-connect-cluster
-    offset.storage.topic: my-connect-cluster-offsets
-    config.storage.topic: my-connect-cluster-configs
-    status.storage.topic: my-connect-cluster-status
     key.converter: org.apache.kafka.connect.json.JsonConverter
     value.converter: org.apache.kafka.connect.json.JsonConverter
     key.converter.schemas.enable: true
@@ -37,10 +65,6 @@ The values can be one of the following JSON types:
 
 Certain options have default values:
 
-* `group.id` with default value `connect-cluster`
-* `offset.storage.topic` with default value `connect-cluster-offsets`
-* `config.storage.topic` with default value `connect-cluster-configs`
-* `status.storage.topic` with default value `connect-cluster-status`
 * `key.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
 * `value.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
 
@@ -82,7 +106,7 @@ In this case, fix the configuration so that the Cluster Operator can roll out th
 = Logging
 
 WARNING: Kafka 3.9 and earlier versions use log4j1 for logging.
-For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^]. 
+For log4j1-based configuration examples, refer to the link:{DocArchive}[Strimzi 0.45 documentation^].
 
 Kafka Connect has its own preconfigured loggers:
 
@@ -156,7 +180,7 @@ spec:
     valueFrom:
       configMapKeyRef:
         # name and key are mandatory
-        name: customConfigMap 
+        name: customConfigMap
         key: log4j2.properties
   # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc
@@ -24,7 +24,7 @@ spec:
 ----
 
 These fields are required in the `v1` CRD API version.
-They are optional in the `v1beta2` option and if not set, the following default values will be used:
+They are optional in the `v1beta2` version and if not set, the following default values will be used:
 
 * `groupId` will default value `connect-cluster`
 * `configStorageTopic` will default to `connect-cluster-configs`

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2521,7 +2521,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
 |groupId
 |string
-|A unique string that identifies the Connect cluster group this worker belongs to.
+|A unique ID that identifies the Connect cluster group.
 |configStorageTopic
 |string
 |The name of the Kafka topic where connector configurations are stored.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2519,6 +2519,18 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |bootstrapServers
 |string
 |Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
+|groupId
+|string
+|A unique string that identifies the Connect cluster group this worker belongs to.
+|configStorageTopic
+|string
+|The name of the Kafka topic where connector configurations are stored.
+|statusStorageTopic
+|string
+|The name of the Kafka topic where connector and task status are stored.
+|offsetStorageTopic
+|string
+|The name of the Kafka topic where source connector offsets are stored.
 |tls
 |xref:type-ClientTls-{context}[`ClientTls`]
 |TLS configuration.

--- a/documentation/modules/configuring/con-config-kafka-connect-multiple-instances.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect-multiple-instances.adoc
@@ -24,7 +24,7 @@ spec:
   # ...
 ----
 <1> The Kafka Connect cluster group ID within Kafka.
-<2> Kafka topic that stores connector and task status configurations.
+<2> Kafka topic that stores connector and task configurations.
 <3> Kafka topic that stores connector offsets.
 <4> Kafka topic that stores connector and task status updates.
 

--- a/documentation/modules/configuring/con-config-kafka-connect-multiple-instances.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect-multiple-instances.adoc
@@ -8,8 +8,7 @@
 = Configuring Kafka Connect for multiple instances
 
 [role="_abstract"]
-By default, Strimzi configures the group ID and names of the internal topics used by Kafka Connect.
-When running multiple instances of Kafka Connect, you must change these default settings using the following `config` properties:
+When running multiple instances of Kafka Connect, you must make sure that these settings are different for each instance:
 
 [source,yaml,subs="attributes+"]
 ----
@@ -18,23 +17,18 @@ kind: KafkaConnect
 metadata:
   name: my-connect
 spec:
-  config:
-    group.id: my-connect-cluster # <1>
-    offset.storage.topic: my-connect-cluster-offsets # <2>
-    config.storage.topic: my-connect-cluster-configs # <3>
-    status.storage.topic: my-connect-cluster-status # <4>
-    # ...
+  groupId: my-connect-cluster # <1>
+  configStorageTopic: my-connect-cluster-configs # <2>
+  offsetStorageTopic: my-connect-cluster-offsets # <3>
+  statusStorageTopic: my-connect-cluster-status # <4>
   # ...
 ----
 <1> The Kafka Connect cluster group ID within Kafka.
-<2> Kafka topic that stores connector offsets.
-<3> Kafka topic that stores connector and task status configurations.
+<2> Kafka topic that stores connector and task status configurations.
+<3> Kafka topic that stores connector offsets.
 <4> Kafka topic that stores connector and task status updates.
 
 NOTE: Values for the three topics must be the same for all instances with the same `group.id`.
 
-Unless you modify these default settings, each instance connecting to the same Kafka cluster is deployed with the same values. 
-In practice, this means all instances form a cluster and use the same internal topics.
-
+Unless you use different settings for each instance, all instances form a cluster and use the same internal topics.
 Multiple instances attempting to use the same internal topics will cause unexpected errors, so you must change the values of these properties for each instance.
-

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -43,7 +43,9 @@ spec:
   replicas: 3 # <3>
   # Bootstrap servers (required)
   bootstrapServers: my-cluster-kafka-bootstrap:9092 # <4>
+  # Connect cluster group ID (required in v1 CRD API)
   groupId: my-connect-cluster # <5>
+  # Connect cluster storage topics (required in v1 CRD API)
   configStorageTopic: my-connect-cluster-configs # <6>
   offsetStorageTopic: my-connect-cluster-offsets # <7>
   statusStorageTopic: my-connect-cluster-status # <8>

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -43,12 +43,12 @@ spec:
   replicas: 3 # <3>
   # Bootstrap servers (required)
   bootstrapServers: my-cluster-kafka-bootstrap:9092 # <4>
+  groupId: my-connect-cluster # <5>
+  configStorageTopic: my-connect-cluster-configs # <6>
+  offsetStorageTopic: my-connect-cluster-offsets # <7>
+  statusStorageTopic: my-connect-cluster-status # <8>
   # Kafka Connect configuration (recommended)
-  config: # <5>
-    group.id: my-connect-cluster
-    offset.storage.topic: my-connect-cluster-offsets
-    config.storage.topic: my-connect-cluster-configs
-    status.storage.topic: my-connect-cluster-status
+  config: # <9>
     key.converter: org.apache.kafka.connect.json.JsonConverter
     value.converter: org.apache.kafka.connect.json.JsonConverter
     key.converter.schemas.enable: true
@@ -57,7 +57,7 @@ spec:
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3
   # Resources requests and limits (recommended)
-  resources: # <6>
+  resources: # <10>
     requests:
       cpu: "1"
       memory: 2Gi
@@ -65,26 +65,26 @@ spec:
       cpu: "2"
       memory: 2Gi
   # Authentication (optional)
-  authentication: # <7>
+  authentication: # <11>
     type: tls
     certificateAndKey:
       certificate: source.crt
       key: source.key
       secretName: my-user-source
   # TLS configuration (optional)
-  tls: # <8>
+  tls: # <12>
     trustedCertificates:
       - secretName: my-cluster-cluster-cert
         pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
         pattern: "*.crt"
   # Build configuration (optional)
-  build: # <9>
-    output: # <10>
+  build: # <13>
+    output: # <14>
       type: docker
       image: my-registry.io/my-org/my-connect-cluster:latest
       pushSecret: my-registry-credentials
-    plugins: # <11>
+    plugins: # <15>
       - name: connector-1
         artifacts:
           - type: tgz
@@ -96,13 +96,13 @@ spec:
             url: <url_to_download_connector_2_artifact>
             sha512sum: <SHA-512_checksum_of_connector_2_artifact>
   # Logging configuration (optional)
-  logging: # <12>
+  logging: # <16>
     type: inline
     loggers:
       # Kafka 4.0+ uses Log4j2
       rootLogger.level: INFO
   # Readiness probe (optional)
-  readinessProbe: # <13>
+  readinessProbe: # <17>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   # Liveness probe (optional)
@@ -110,23 +110,23 @@ spec:
     initialDelaySeconds: 15
     timeoutSeconds: 5
   # Metrics configuration (optional)
-  metricsConfig: # <14>
+  metricsConfig: # <18>
     type: jmxPrometheusExporter
     valueFrom:
       configMapKeyRef:
         name: my-config-map
         key: my-key
   # JVM options (optional)
-  jvmOptions: # <15>
+  jvmOptions: # <19>
     "-Xmx": "1g"
     "-Xms": "1g"
   # Custom image (optional)
-  image: my-org/my-image:latest # <16>
+  image: my-org/my-image:latest # <20>
   # Rack awareness (optional)
   rack:
-    topologyKey: topology.kubernetes.io/zone # <17>
+    topologyKey: topology.kubernetes.io/zone # <21>
   # Pod and container template (optional)
-  template: # <18>
+  template: # <22>
     pod:
       affinity:
         podAntiAffinity:
@@ -139,7 +139,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: # <19>
+    connectContainer: # <23>
       env:
         - name: OTEL_SERVICE_NAME
           value: my-otel-service
@@ -157,31 +157,35 @@ spec:
               key: awsSecretAccessKey
   # Tracing configuration (optional)
   tracing:
-    type: opentelemetry # <20>
+    type: opentelemetry # <24>
 ----
 <1> Use `KafkaConnect`.
 <2> Enables the use of `KafkaConnector` resources to start, stop, and manage connector instances.
 <3> The number of replica nodes for the workers that run tasks.
 <4> Bootstrap address for connection to the Kafka cluster. The address takes the format `<cluster_name>-kafka-bootstrap:<port_number>`. The Kafka cluster doesn't need to be managed by Strimzi or deployed to a Kubernetes cluster.
-<5> Kafka Connect configuration of workers (not connectors) that run connectors and their tasks.
+<5> Group ID that identifies the Connect cluster group this worker belongs to. Required in `v1` CRD API.
+<6> Name of the Kafka topic where connector configurations are stored. Required in `v1` CRD API.
+<7> Name of the Kafka topic where source connector offsets are stored. Required in `v1` CRD API.
+<8> Name of the Kafka topic where connector and task statuses are stored. Required in `v1` CRD API.
+<9> Kafka Connect configuration of workers (not connectors) that run connectors and their tasks.
 Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 In this example, JSON convertors are specified.
 A replication factor of 3 is set for the internal topics used by Kafka Connect (minimum requirement for production environment).
 Changing the replication factor after the topics have been created has no effect.
-<6> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<7> Authentication for the Kafka Connect cluster, specified as `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, or `oauth`.
+<10> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<11> Authentication for the Kafka Connect cluster, specified as `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, or `oauth`.
 By default, Kafka Connect connects to Kafka brokers using a plaintext connection.
 For details on configuring authentication, see the link:{BookURLConfiguring}#type-KafkaConnectSpec-schema-reference[`KafkaConnectSpec` schema properties^].
-<8> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
-<9> Build configuration properties for building a container image with connector plugins automatically.
-<10> (Required) Configuration of the container registry where new images are pushed.
-<11> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
-<12> Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
-<13> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<14> Prometheus metrics, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
-<15> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka Connect.
-<16> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
-<17> SPECIALIZED OPTION: Rack awareness configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
-<18> Template customization. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<19> Environment variables are set for distributed tracing and to pass credentials to connectors.
-<20> Distributed tracing is enabled by using OpenTelemetry.
+<12> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
+<13> Build configuration properties for building a container image with connector plugins automatically.
+<14> (Required) Configuration of the container registry where new images are pushed.
+<15> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
+<16> Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
+<17> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<18> Prometheus metrics, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<19> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka Connect.
+<20> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
+<21> SPECIALIZED OPTION: Rack awareness configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
+<22> Template customization. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<23> Environment variables are set for distributed tracing and to pass credentials to connectors.
+<24> Distributed tracing is enabled by using OpenTelemetry.

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -163,7 +163,7 @@ spec:
 <2> Enables the use of `KafkaConnector` resources to start, stop, and manage connector instances.
 <3> The number of replica nodes for the workers that run tasks.
 <4> Bootstrap address for connection to the Kafka cluster. The address takes the format `<cluster_name>-kafka-bootstrap:<port_number>`. The Kafka cluster doesn't need to be managed by Strimzi or deployed to a Kubernetes cluster.
-<5> Group ID that identifies the Connect cluster group this worker belongs to. Required in `v1` CRD API.
+<5> A unique ID that identifies the Connect cluster group. Required in `v1` CRD API.
 <6> Name of the Kafka topic where connector configurations are stored. Required in `v1` CRD API.
 <7> Name of the Kafka topic where source connector offsets are stored. Required in `v1` CRD API.
 <8> Name of the Kafka topic where connector and task statuses are stored. Required in `v1` CRD API.

--- a/packaging/examples/connect/kafka-connect-build.yaml
+++ b/packaging/examples/connect/kafka-connect-build.yaml
@@ -11,15 +11,15 @@ spec:
   version: 4.1.0
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9093
+  groupId: my-connect-group
+  configStorageTopic: my-connect-configs
+  statusStorageTopic: my-connect-status
+  offsetStorageTopic: my-connect-offsets
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         pattern: "*.crt"
   config:
-    group.id: connect-cluster
-    offset.storage.topic: connect-cluster-offsets
-    config.storage.topic: connect-cluster-configs
-    status.storage.topic: connect-cluster-status
     # -1 means it will use the default replication factor configured in the broker
     config.storage.replication.factor: -1
     offset.storage.replication.factor: -1

--- a/packaging/examples/connect/kafka-connect.yaml
+++ b/packaging/examples/connect/kafka-connect.yaml
@@ -11,15 +11,15 @@ spec:
   version: 4.1.0
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9093
+  groupId: my-connect-group
+  configStorageTopic: my-connect-configs
+  statusStorageTopic: my-connect-status
+  offsetStorageTopic: my-connect-offsets
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         pattern: "*.crt"
   config:
-    group.id: connect-cluster
-    offset.storage.topic: connect-cluster-offsets
-    config.storage.topic: connect-cluster-configs
-    status.storage.topic: connect-cluster-status
     # -1 means it will use the default replication factor configured in the broker
     config.storage.replication.factor: -1
     offset.storage.replication.factor: -1

--- a/packaging/examples/security/scram-sha-512-auth/connect.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/connect.yaml
@@ -13,38 +13,38 @@ spec:
     # Kafka Connects internal topics used to store configuration, offsets or status
     - resource:
         type: group
-        name: connect-cluster
+        name: my-connect-group
       operations:
         - Read
     - resource:
         type: topic
-        name: connect-cluster-configs
+        name: my-connect-configs
       operations:
-        - Create
-        - Describe
         - Read
+        - Describe
         - Write
+        - Create
     - resource:
         type: topic
-        name: connect-cluster-status
+        name: my-connect-status
       operations:
-        - Create
-        - Describe
         - Read
+        - Describe
         - Write
+        - Create
     - resource:
         type: topic
-        name: connect-cluster-offsets
+        name: my-connect-offsets
       operations:
-        - Create
-        - Describe
         - Read
+        - Describe
         - Write
+        - Create
     # Additional topics and groups used by connectors
     # Change to match the topics used by your connectors
     - resource:
         type: group
-        name: connect-cluster
+        name: my-connect-group
       operations:
        - Read
     - resource:
@@ -69,6 +69,10 @@ spec:
   version: 4.1.0
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9093
+  groupId: my-connect-group
+  configStorageTopic: my-connect-configs
+  statusStorageTopic: my-connect-status
+  offsetStorageTopic: my-connect-offsets
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
@@ -80,7 +84,7 @@ spec:
       secretName: my-connect
       password: password
   config:
-    group.id: connect-cluster
-    offset.storage.topic: connect-cluster-offsets
-    config.storage.topic: connect-cluster-configs
-    status.storage.topic: connect-cluster-status
+    # -1 means it will use the default replication factor configured in the broker
+    config.storage.replication.factor: -1
+    offset.storage.replication.factor: -1
+    status.storage.replication.factor: -1

--- a/packaging/examples/security/tls-auth/connect.yaml
+++ b/packaging/examples/security/tls-auth/connect.yaml
@@ -13,12 +13,12 @@ spec:
     # Kafka Connects internal topics used to store configuration, offsets or status
     - resource:
         type: group
-        name: connect-cluster
+        name: my-connect-group
       operations:
         - Read
     - resource:
         type: topic
-        name: connect-cluster-configs
+        name: my-connect-configs
       operations:
         - Read
         - Describe
@@ -26,7 +26,7 @@ spec:
         - Create
     - resource:
         type: topic
-        name: connect-cluster-status
+        name: my-connect-status
       operations:
         - Read
         - Describe
@@ -34,17 +34,17 @@ spec:
         - Create
     - resource:
         type: topic
-        name: connect-cluster-offsets
+        name: my-connect-offsets
       operations:
         - Read
         - Describe
         - Write
         - Create
-      # Additional topics and groups used by connectors
+    # Additional topics and groups used by connectors
     # Change to match the topics used by your connectors
     - resource:
         type: group
-        name: connect-cluster
+        name: my-connect-group
       operations:
         - Read
     - resource:
@@ -69,6 +69,10 @@ spec:
   version: 4.1.0
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9093
+  groupId: my-connect-group
+  configStorageTopic: my-connect-configs
+  statusStorageTopic: my-connect-status
+  offsetStorageTopic: my-connect-offsets
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
@@ -80,7 +84,7 @@ spec:
       certificate: user.crt
       key: user.key
   config:
-    group.id: connect-cluster
-    offset.storage.topic: connect-cluster-offsets
-    config.storage.topic: connect-cluster-configs
-    status.storage.topic: connect-cluster-status
+    # -1 means it will use the default replication factor configured in the broker
+    config.storage.replication.factor: -1
+    offset.storage.replication.factor: -1
+    status.storage.replication.factor: -1

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -69,7 +69,7 @@ spec:
                   description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
                 groupId:
                   type: string
-                  description: A unique string that identifies the Connect cluster group this worker belongs to.
+                  description: A unique ID that identifies the Connect cluster group.
                 configStorageTopic:
                   type: string
                   description: The name of the Kafka topic where connector configurations are stored.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -67,6 +67,18 @@ spec:
                 bootstrapServers:
                   type: string
                   description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
+                groupId:
+                  type: string
+                  description: A unique string that identifies the Connect cluster group this worker belongs to.
+                configStorageTopic:
+                  type: string
+                  description: The name of the Kafka topic where connector configurations are stored.
+                statusStorageTopic:
+                  type: string
+                  description: The name of the Kafka topic where connector and task status are stored.
+                offsetStorageTopic:
+                  type: string
+                  description: The name of the Kafka topic where source connector offsets are stored.
                 tls:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -68,7 +68,7 @@ spec:
                 description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
               groupId:
                 type: string
-                description: A unique string that identifies the Connect cluster group this worker belongs to.
+                description: A unique ID that identifies the Connect cluster group.
               configStorageTopic:
                 type: string
                 description: The name of the Kafka topic where connector configurations are stored.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -66,6 +66,18 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
+              groupId:
+                type: string
+                description: A unique string that identifies the Connect cluster group this worker belongs to.
+              configStorageTopic:
+                type: string
+                description: The name of the Kafka topic where connector configurations are stored.
+              statusStorageTopic:
+                type: string
+                description: The name of the Kafka topic where connector and task status are stored.
+              offsetStorageTopic:
+                type: string
+                description: The name of the Kafka topic where source connector offsets are stored.
               tls:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements [Strimzi Proposal 115](https://github.com/strimzi/proposals/blob/main/115-enforce-connect-group-id-and-internal-topic-names.md) and adds dedicated fields for Connect's group ID and internal topic names. The new fields will be required in the `v1` API, but are optional in `v1beta2` and use the options from `.spec.config` and current defaults when not set.

This does not impact MM2 in any way. The MM2 related work will be done together with [Strimzi Proposal 116](https://github.com/strimzi/proposals/blob/main/116-update-KafkaMirrorMaker2-resource-to-better-correspond-its-use.md).

This should close #10075.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md