### PR TITLE
feat(cluster-operator) bump quartz version to fix cve CVE-2023-39017

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <snappy.version>1.1.10.5</snappy.version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.0</log4j.version>
-        <quartz.version>2.3.2</quartz.version>
+        <quartz.version>2.5.0</quartz.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>12.0.22</jetty.version>


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Fixes #11490
According to this CVE (https://nvd.nist.gov/vuln/detail/cve-2023-39017) we need to upgrade quartz version.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

