### PR TITLE
docs(toc): updates the toc level to 2

### DIFF
--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -11,7 +11,7 @@
 :source-highlighter: highlightjs
 :toc: left
 :linkattrs:
-:toclevels: 3
+:toclevels: 2
 
 //Latest Strimzi version
 :ProductVersion: 0.49.0


### PR DESCRIPTION
**Documentation**

Adjusts the default TOC level for the docs to 2 from 3.
The update is primarily for the Deploying guide to make it easier to locate topics.
The other guides are not really affected as most content does not go lower than two levels. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

