### PR TITLE
docs(script): updates script with content type for table snippet

### DIFF
--- a/documentation/snip-images.sh
+++ b/documentation/snip-images.sh
@@ -12,6 +12,8 @@ source $(dirname $(realpath $0))/../tools/multi-platform-support.sh
 get_kafka_versions
 
 cat <<EOF
+:_mod-docs-content-type: SNIPPET
+
 // Auto generated content - DO NOT EDIT BY HAND
 // Edit documentation/snip-images.sh instead
 [table,stripes=none]


### PR DESCRIPTION
**Documentation**

Adjusts the snip-images.sh script to add the images table to the docs so that the content type is included when regenerating.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

