### PR TITLE
Bumped grpc-netty-shaded to fix CVE-2025-55163

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -26,7 +26,7 @@
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
         <log4j.version>2.24.3</log4j.version>
     </properties>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -26,7 +26,7 @@
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
         <log4j.version>2.24.3</log4j.version>
     </properties>


### PR DESCRIPTION
This PR bumps the gprc-netty-shaded version in order to fix CVE https://nvd.nist.gov/vuln/detail/CVE-2025-55163.
It replaces https://github.com/strimzi/strimzi-kafka-operator/pull/11954