### PR TITLE
Add publish container job depending on preparing artifacts

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -54,7 +54,7 @@ stages:
     dependsOn:
       - prepare_release_artifacts
       - containers_publish_with_suffix
-    condition: and(in(dependencies.containers_publish_with_suffix.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    condition: and(in(dependencies.containers_publish_with_suffix.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'), in(dependencies.prepare_release_artifacts.result, 'Succeeded', 'SucceededWithIssues'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/build/push_containers.yaml'
         parameters:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -52,6 +52,7 @@ stages:
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
+      - prepare_release_artifacts
       - containers_publish_with_suffix
     condition: and(in(dependencies.containers_publish_with_suffix.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:


### PR DESCRIPTION
Looking at this operator release pipeline build https://dev.azure.com/cncf/strimzi/_build/results?buildId=186729&view=results I noticed that the first stage (`prepare_release_artifacts`) failed but it anyway ran the `containers_publish` one.
I guess it's because the `containers_publish` depends only on `containers_publish_with_suffix`. But the last one can be skipped during an RC so the `containers_publish` runs anyway.
This PR adds the dependency on the `prepare_release_artifacts` as well.