### PR TITLE
Update Cruise Control to 2.5.145

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -19,7 +19,7 @@
         <strimzi-oauth.version>0.17.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
-        <cruise-control.version>2.5.143</cruise-control.version>
+        <cruise-control.version>2.5.145</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -19,7 +19,7 @@
         <strimzi-oauth.version>0.17.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
-        <cruise-control.version>2.5.142</cruise-control.version>
+        <cruise-control.version>2.5.145</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.143</cruise-control.version>
+        <cruise-control.version>2.5.145</cruise-control.version>
         <log4j.version>2.17.2</log4j.version>
     </properties>
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Cruise Control to a new version 2.5.145.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally