### PR TITLE
Fixed cluster ID code comment still mentioning migration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1883,7 +1883,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 // script to generate the node configuration.
                 data.put(BROKER_LISTENERS_FILENAME, node.broker() ? listeners.stream().map(ListenersUtils::envVarIdentifier).collect(Collectors.joining(" ")) : null);
 
-                // controller and broker both get the Cluster ID and metadata version
                 data.put(BROKER_CLUSTER_ID_FILENAME, clusterId);
                 data.put(BROKER_METADATA_VERSION_FILENAME, metadataVersion);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1883,8 +1883,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 // script to generate the node configuration.
                 data.put(BROKER_LISTENERS_FILENAME, node.broker() ? listeners.stream().map(ListenersUtils::envVarIdentifier).collect(Collectors.joining(" ")) : null);
 
-                // controller and broker gets the Cluster ID in different states during migration
-                // and they both get it when in full KRaft-mode
+                // controller and broker both get the Cluster ID and metadata version
                 data.put(BROKER_CLUSTER_ID_FILENAME, clusterId);
                 data.put(BROKER_METADATA_VERSION_FILENAME, metadataVersion);
 


### PR DESCRIPTION
This trivial PR just updates a code comment related to the cluster ID which still refers to KRaft migration which no longer exists.