### PR TITLE
Use keyless container sign within GitHub actions

### DIFF
--- a/.github/actions/build/containers-push/action.yml
+++ b/.github/actions/build/containers-push/action.yml
@@ -116,7 +116,7 @@ runs:
         path: sbom.tar.gz
         
     - name: Push SBOMs to registry
-      if: ${{ startsWith(github.ref, 'refs/heads/keyless-image-sign') }}
+      if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
       shell: bash
       run: |
         IFS=',' read -ra ARCH_ARRAY <<< "${{ inputs.architectures }}"

--- a/.github/actions/build/containers-push/action.yml
+++ b/.github/actions/build/containers-push/action.yml
@@ -15,31 +15,29 @@ inputs:
   quayPass:
     description: "Quay.io password"
     required: true
-  cosignPassword:
-    description: "Cosign password for signing"
-    required: true
-  cosignPrivateKey:
-    description: "Cosign private key for signing"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Install prerequisites
       shell: bash
-      run: |
-        .azure/scripts/install_cosign.sh
-        .azure/scripts/install_syft.sh
+      run: .azure/scripts/install_syft.sh
       env:
         ARCH: ${{ inputs.runnerArch }}
 
-    - uses: ./.github/actions/dependencies/install-docker
-    - uses: ./.github/actions/dependencies/install-yq
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.10.0
+
+    - name: Install Docker
+      uses: ./.github/actions/dependencies/install-docker
+
+    - name: Install yq
+      uses: ./.github/actions/dependencies/install-yq
       with:
         architecture: ${{ inputs.runnerArch }}
 
     - name: Download container artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v4
       with:
         pattern: containers-*
         path: ./
@@ -85,33 +83,27 @@ runs:
         BUILD_REASON: "IndividualCI"
         BRANCH: ${{ github.ref }}
 
-    # TODO - We can use cosign in better way. See https://github.com/strimzi/strimzi-kafka-operator/issues/11826 for more details.
     - name: Sign container manifests
       shell: bash
-      run: make docker_sign_manifest
+      run: make docker_gha_sign_manifest
       env:
         BUILD_REASON: "IndividualCI"
         BRANCH: ${{ github.ref }}
         BUILD_ID: ${{ github.run_number }}
         BUILD_COMMIT: ${{ github.sha }}
-        COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
-        COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
 
-    # TODO - We can use existing GitHub Action for SBOMs - https://github.com/strimzi/strimzi-kafka-operator/issues/11827
-    - name: Generate SBOMs
+    - name: Generate and sign SBOMs
       shell: bash
       run: |
         IFS=',' read -ra ARCH_ARRAY <<< "${{ inputs.architectures }}"
         for arch in "${ARCH_ARRAY[@]}"; do
           echo "Generating SBOM for architecture: ${arch}"
           export DOCKER_ARCHITECTURE="${arch}"
-          make docker_sbom
+          make docker_gha_sbom
         done
       env:
         BUILD_REASON: "IndividualCI"
         BRANCH: ${{ github.ref }}
-        COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
-        COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
 
     - name: Create SBOM archive
       shell: bash
@@ -124,17 +116,17 @@ runs:
         path: sbom.tar.gz
         
     - name: Push SBOMs to registry
-      if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
+      if: ${{ startsWith(github.ref, 'refs/heads/keyless-image-sign') }}
       shell: bash
       run: |
         IFS=',' read -ra ARCH_ARRAY <<< "${{ inputs.architectures }}"
         for arch in "${ARCH_ARRAY[@]}"; do
-          echo "Generating SBOM for architecture: ${arch}"
+          echo "Pushing SBOM for architecture: ${arch}"
           export DOCKER_ARCHITECTURE="${arch}"
-          make docker_push_sbom
+          make docker_gha_push_sbom
         done
       env:
         BUILD_REASON: "IndividualCI"
         BRANCH: ${{ github.ref }}
-        COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
-        COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
+        BUILD_ID: ${{ github.run_number }}
+        BUILD_COMMIT: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "main"
       - "release-*"
-      - "keyless-image-sign"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,16 @@ jobs:
           runnerArch: "amd64"
 
   # Runs Strimzi unit and integration tests
-#  test-strimzi:
-#    name: Strimzi Unit & IT tests
-#    needs:
-#      - build-strimzi
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v5
-#      - uses: ./.github/actions/build/test-strimzi
-#        with:
-#          runnerArch: "amd64"
+  test-strimzi:
+    name: Strimzi Unit & IT tests
+    needs:
+      - build-strimzi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/build/test-strimzi
+        with:
+          runnerArch: "amd64"
 
   # Builds Strimzi docs
   build-docs:
@@ -73,32 +73,32 @@ jobs:
           runnerArch: "amd64"
 
   # Push Strimzi containers - run only on main branch
-  push-containers:
-    name: Push Containers
-    needs:
-      - build-strimzi
+#  push-containers:
+#    name: Push Containers
+#    needs:
+#      - build-strimzi
 #      - test-strimzi
-      - build-containers
-      - build-docs
-    if: ${{ github.ref == 'refs/heads/keyless-image-sign' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      # Required for keyless signing with GitHub OIDC
-      id-token: write
-    env:
-      DOCKER_REGISTRY: "quay.io"
-      DOCKER_ORG: "jstejska"
-      DOCKER_TAG: "latest"
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/build/containers-push
-        with:
-          architectures: "amd64,arm64,ppc64le,s390x"
-          runnerArch: "amd64"
-          quayUser: ${{ secrets.QUAY_USER }}
-          quayPass: ${{ secrets.QUAY_PASS }}
+#      - build-containers
+#      - build-docs
+#    if: ${{ github.ref == 'refs/heads/main' }}
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: read
+#      packages: write
+#      # Required for keyless signing with GitHub OIDC
+#      id-token: write
+#    env:
+#      DOCKER_REGISTRY: "quay.io"
+#      DOCKER_ORG: "strimzi"
+#      DOCKER_TAG: "latest"
+#    steps:
+#      - uses: actions/checkout@v5
+#      - uses: ./.github/actions/build/containers-push
+#        with:
+#          architectures: "amd64,arm64,ppc64le,s390x"
+#          runnerArch: "amd64"
+#          quayUser: ${{ secrets.QUAY_USER }}
+#          quayPass: ${{ secrets.QUAY_PASS }}
 
 #  # Publish Strimzi docs to the website - run only on main branch
 #  publish-docs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "main"
       - "release-*"
+      - "keyless-image-sign"
   pull_request:
     branches:
       - "*"
@@ -18,25 +19,25 @@ jobs:
   # Build Strimzi Java code and does basic checks of the PR
   build-strimzi:
     name: Build Strimzi
-    runs-on: oracle-2cpu-8gb-arm64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/build/build-strimzi-binaries
         with:
           mvnArgs: "-B -DskipTests -Dmaven.javadoc.skip=true"
-          runnerArch: "arm64"
+          runnerArch: "amd64"
 
   # Runs Strimzi unit and integration tests
-  test-strimzi:
-    name: Strimzi Unit & IT tests
-    needs:
-      - build-strimzi
-    runs-on: oracle-vm-4cpu-16gb-arm64
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/build/test-strimzi
-        with:
-          runnerArch: "arm64"
+#  test-strimzi:
+#    name: Strimzi Unit & IT tests
+#    needs:
+#      - build-strimzi
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v5
+#      - uses: ./.github/actions/build/test-strimzi
+#        with:
+#          runnerArch: "amd64"
 
   # Builds Strimzi docs
   build-docs:
@@ -63,41 +64,42 @@ jobs:
           - arm64
           - s390x
           - ppc64le
-    runs-on: oracle-vm-2cpu-8gb-arm64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/build/containers-build
         with:
           architecture: ${{ matrix.architecture }}
-          runnerArch: "arm64"
+          runnerArch: "amd64"
 
-# The following jobs are used to push artifacts into respective services
-# Uncomment them once we want to migrate from Azure to GHA
-#  # Push Strimzi containers - run only on main branch
-#  push-containers:
-#    name: Push Containers
-#    needs:
-#      - build-strimzi
+  # Push Strimzi containers - run only on main branch
+  push-containers:
+    name: Push Containers
+    needs:
+      - build-strimzi
 #      - test-strimzi
-#      - build-containers
-#      - build-docs
-#    if: ${{ github.ref == 'refs/heads/gha-build' }}
-#    runs-on: ubuntu-latest
-#    env:
-#      DOCKER_REGISTRY: "quay.io"
-#      DOCKER_ORG: "strimzi"
-#      DOCKER_TAG: "latest"
-#    steps:
-#      - uses: actions/checkout@v5
-#      - uses: ./.github/actions/build/containers-push
-#        with:
-#          architectures: "amd64,arm64,ppc64le,s390x"
-#          runnerArch: "amd64"
-#          quayUser: ${{ secrets.QUAY_USER }}
-#          quayPass: ${{ secrets.QUAY_PASS }}
-#          cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
-#          cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
-#
+      - build-containers
+      - build-docs
+    if: ${{ github.ref == 'refs/heads/keyless-image-sign' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # Required for keyless signing with GitHub OIDC
+      id-token: write
+    env:
+      DOCKER_REGISTRY: "quay.io"
+      DOCKER_ORG: "jstejska"
+      DOCKER_TAG: "latest"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/build/containers-push
+        with:
+          architectures: "amd64,arm64,ppc64le,s390x"
+          runnerArch: "amd64"
+          quayUser: ${{ secrets.QUAY_USER }}
+          quayPass: ${{ secrets.QUAY_PASS }}
+
 #  # Publish Strimzi docs to the website - run only on main branch
 #  publish-docs:
 #    name: Publish Docs
@@ -107,7 +109,7 @@ jobs:
 #      - build-containers
 #      - build-docs
 #    if: ${{ github.ref == 'refs/heads/main' }}
-#    runs-on: oracle-2cpu-8gb-x86_64
+#    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@v5
 #      - uses: ./.github/actions/build/publish-docs
@@ -124,7 +126,7 @@ jobs:
 #      - build-containers
 #      - build-docs
 #    if: ${{ github.ref == 'refs/heads/main' }}
-#    runs-on: oracle-2cpu-8gb-x86_64
+#    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@v5
 #      - uses: ./.github/actions/build/deploy-java

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 SUBDIRS=kafka-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init systemtest docker-images/artifacts packaging/helm-charts/helm3 packaging/install packaging/examples
 DOCKERDIRS=docker-images/base docker-images/operator docker-images/kafka-based docker-images/maven-builder docker-images/kaniko-executor
-DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_sign_manifest docker_delete_manifest docker_delete_archive docker_sbom docker_push_sbom docker_e2e
+DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_sign_manifest docker_delete_manifest docker_delete_archive docker_sbom docker_push_sbom docker_e2e docker_gha_sign_manifest docker_gha_sbom docker_gha_push_sbom
 JAVA_TARGETS=java_build java_install java_clean
 
 all: prerequisites_check $(SUBDIRS) $(DOCKERDIRS) crd_install dashboard_install helm_install shellcheck docu_versions docu_check

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -117,5 +117,40 @@ docker_push_sbom_default:
 	cosign sign --tlog-upload=false -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) --key cosign.key --attachment sbom $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
 	@rm cosign.key
 
+# GitHub Actions specific targets with keyless signing
+# TODO - remove gha prefix once migrated fully to gha
+.PHONY: docker_gha_sign_manifest_default
+docker_gha_sign_manifest_default:
+	# Signs the manifest and its images using keyless signing (GitHub OIDC)
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign --yes --recursive --timeout 6m0s -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
+
+.PHONY: docker_gha_sbom_default
+docker_gha_sbom_default:
+	# Saves the SBOM of the image and signs with keyless signing
+	test -d $(SBOM_DIR) || mkdir -p $(SBOM_DIR)
+	# Generate the text format
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	syft packages $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST --output syft-table --file $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.txt
+	# Generate the SPDX JSON format for machine processing
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	syft packages $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST --output spdx-json --file $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json
+	# Sign the TXT and SPDX-JSON SBOM with keyless signing
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign-blob --yes --bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.txt.bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.txt
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign-blob --yes --bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json.bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json
+
+.PHONY: docker_gha_push_sbom_default
+docker_gha_push_sbom_default:
+	# Push the SBOM to the container registry and sign it with keyless signing
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign attach sbom --sbom $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign --yes -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) --attachment sbom $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
+
+docker_gha_%: docker_gha_%_default
+	@  true
+
 docker_%: docker_%_default
 	@  true

--- a/docker-images/base/Makefile
+++ b/docker-images/base/Makefile
@@ -18,10 +18,22 @@ docker_push_manifest:
 docker_sign_manifest:
 	# Do nothing
 
+# TODO - remove gha prefix once migrated fully to gha
+docker_gha_sign_manifest:
+	# Do nothing
+
 docker_sbom:
 	# Do nothing
 
 docker_push_sbom:
+	# Do nothing
+
+# TODO - remove gha prefix once migrated fully to gha
+docker_gha_sbom:
+	# Do nothing
+
+# TODO - remove gha prefix once migrated fully to gha
+docker_gha_push_sbom:
 	# Do nothing
 
 .PHONY: build clean release

--- a/docker-images/kafka-based/Makefile
+++ b/docker-images/kafka-based/Makefile
@@ -53,11 +53,11 @@ docker_push_sbom:
 
 # TODO - remove gha prefix once migrated fully to gha
 docker_gha_sbom:
-	./build.sh docker_sbom
+	./build.sh docker_gha_sbom
 
 # TODO - remove gha prefix once migrated fully to gha
 docker_gha_push_sbom:
-	./build.sh docker_push_sbom
+	./build.sh docker_gha_push_sbom
 
 all: docker_build docker_push
 

--- a/docker-images/kafka-based/Makefile
+++ b/docker-images/kafka-based/Makefile
@@ -35,6 +35,10 @@ docker_push_manifest:
 docker_sign_manifest:
 	./build.sh docker_sign_manifest
 
+# TODO - remove gha prefix once migrated fully to gha
+docker_gha_sign_manifest:
+	./build.sh docker_gha_sign_manifest
+
 docker_delete_manifest:
 	./build.sh docker_delete_manifest
 
@@ -45,6 +49,14 @@ docker_sbom:
 	./build.sh docker_sbom
 
 docker_push_sbom:
+	./build.sh docker_push_sbom
+
+# TODO - remove gha prefix once migrated fully to gha
+docker_gha_sbom:
+	./build.sh docker_sbom
+
+# TODO - remove gha prefix once migrated fully to gha
+docker_gha_push_sbom:
 	./build.sh docker_push_sbom
 
 all: docker_build docker_push


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements keyless container signing via `cosign` and keyless sbom signing within GitHub Actions workflows.

The "native" way for sbom cannot be easily used within our workflow as it us more designed for single image only. I at least added keyless signing of sbom container.

Resolves https://github.com/strimzi/strimzi-kafka-operator/issues/11826
Resolves https://github.com/strimzi/strimzi-kafka-operator/issues/11827

Build example from my fork: https://github.com/Frawless/strimzi-kafka-operator/actions/runs/18291356175/job/52080179965
Images on quay (just change image name for others): https://quay.io/repository/jstejska/operator?tab=tags&tag=latest 

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation

