### PR TITLE
Use `deprecated` flag in CRD API versions only when it is `true`

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -354,10 +354,12 @@ class CrdGenerator {
             versionNode.put("served", servedVersion != null ? servedVersion.contains(crApiVersion) : version.served());
             versionNode.put("storage", storageVersion != null ? crApiVersion.equals(storageVersion) : version.storage());
 
-            // Deprecation
-            versionNode.put("deprecated", version.deprecated());
-            if (version.deprecationWarning() != null && !version.deprecationWarning().isEmpty()) {
-                versionNode.put("deprecationWarning", version.deprecationWarning());
+            // Deprecation -> we add it only when the version is deprecated to avoid issues in ArgoCD when diffing the CRDs
+            if (version.deprecated()) {
+                versionNode.put("deprecated", true);
+                if (version.deprecationWarning() != null && !version.deprecationWarning().isEmpty()) {
+                    versionNode.put("deprecationWarning", version.deprecationWarning());
+                }
             }
 
             // Subresources

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -628,7 +628,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     additionalPrinterColumns:
     - name: Foo
       description: The foo

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -634,7 +634,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     additionalPrinterColumns:
     - name: Foo
       description: The foo

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithSubresources.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithSubresources.yaml
@@ -18,7 +18,6 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:
@@ -53,7 +52,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -621,7 +621,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     additionalPrinterColumns:
     - name: Foo
       description: The foo

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
@@ -18,7 +18,6 @@ spec:
   - name: v1
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:
@@ -64,7 +63,6 @@ spec:
   - name: v2
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -132,7 +131,6 @@ spec:
     - name: v1beta1
       served: true
       storage: false
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -240,7 +238,6 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -256,7 +255,6 @@ spec:
     - name: v1beta1
       served: true
       storage: false
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -488,7 +486,6 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
         scale:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -24,7 +24,6 @@ spec:
     - name: v1beta2
       served: true
       storage: true
-      deprecated: false
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
+++ b/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -131,7 +130,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -239,7 +237,6 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -255,7 +254,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -487,7 +485,6 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
       scale:

--- a/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -131,7 +130,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -239,7 +237,6 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -23,7 +23,6 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -255,7 +254,6 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:
@@ -487,7 +485,6 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
-    deprecated: false
     subresources:
       status: {}
     additionalPrinterColumns:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Right now, we set the `deprecated` flag in our CRDs for the API versions even when the version is not deprecated. That seems to cause issues with tools such as ArgoCD as described in #11984.

This PR updates the CRD generator to set the flag only for the versions that are actually deprecated to avoid these issues.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging