### PR TITLE
[ST] Delete CRDs after Helm `uninstall` manually

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmInstallation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/HelmInstallation.java
@@ -16,8 +16,13 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.specific.BridgeUtils;
 import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 
@@ -29,6 +34,8 @@ public class HelmInstallation implements InstallationMethod {
     public static final String HELM_RELEASE_NAME = "strimzi-systemtests";
 
     private final ClusterOperatorConfiguration clusterOperatorConfiguration;
+
+    private static final Logger LOGGER = LogManager.getLogger(HelmInstallation.class);
 
     /**
      * Constructor with specific {@link ClusterOperatorConfiguration}.
@@ -136,6 +143,28 @@ public class HelmInstallation implements InstallationMethod {
             .call();
 
         KubeResourceManager.get().kubeClient().getClient().namespaces().withName(clusterOperatorConfiguration.getNamespaceName()).delete();
+        // Because Helm is not deleting CRDs, we need to delete them "manually"
+        deleteCrds();
+    }
+
+    /**
+     * Deletes CRDs created by Helm - as Helm is not removing those during uninstall.
+     */
+    private void deleteCrds() {
+        List<File> crdFiles = Arrays.stream(new File(YamlInstallation.CO_INSTALL_DIR).listFiles()).sorted()
+            .filter(File::isFile)
+            .filter(file ->
+                // Skipping files that are not CRDs
+                file.getName().matches(".*Crd-.*"))
+            .toList();
+
+        for (File crdFile : crdFiles) {
+            try {
+                KubeResourceManager.get().kubeCmdClient().delete(crdFile);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to delete CRD: {}", crdFile.getAbsolutePath(), e.getCause());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds deletion of CRDs after Helm uninstall command - as Helm is not removing CRDs "automatically" during the uninstall phase, we need to remove them "manually".
That is needed in case that next testcase is using special mechanism for creation of CRDs - for example `RbacST` - which seems to be failing for few runs.

### Checklist

- [ ] Make sure all tests pass

