### PR TITLE
Prepare the `api` module for the `v1` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources.
   Deleting the Strimzi custom resources will now by default wait for the deletion of all the owned Kubernetes resources.
+* Make `.spec` sections required in the `v1` version of all Strimzi custom resources.
+* Make `.spec.replicas` properties required in the `v1` of the `KafkaBridge`, `KafkaConnect`, and `KafkaMirrorMaker2` custom resources.
 * New fields `.spec.groupId`, `.spec.configStorageTopic`, `.spec.offsetStorageTopic`, and `.spec.statusStorageTopic` in the `KafkaConnect` custom resource for configuring Connect's group ID and internal topics.
 * New way of defining the target (`.spec.target`) and source clusters (`.spec.mirrors[].source`) in the `KafkaMirrorMaker2` custom resources.
 * Strimzi Access Operator installation files updated to version 0.2.0

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -110,6 +111,7 @@ public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStat
     
     @Override
     @Description("The specification of the Kafka Bridge.")
+    @RequiredInVersions("v1+")
     public KafkaBridgeSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
@@ -28,6 +28,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -69,10 +70,12 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     private String clientRackInitImage;
     private Rack rack;
 
-    @Description("The number of pods in the `Deployment`.  " +
-            "Defaults to `1`.")
+    @Description("The number of pods in the `Deployment`. " +
+            "Required in the `v1` version of the Strimzi API. " +
+            "Defaults to `1` in the `v1beta2` version of the Strimzi API.")
     @Minimum(0)
     @JsonProperty(defaultValue = "1")
+    @RequiredInVersions("v1+")
     public int getReplicas() {
         return replicas;
     }
@@ -84,8 +87,8 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     @Deprecated
     @DeprecatedProperty(movedToPath = ".spec.metricsConfig",
             description = "The `enableMetrics` configuration is deprecated and will be removed in the future.")
-    @PresentInVersions("v1alpha1-v1beta2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @PresentInVersions("v1beta2")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Description("Enable the metrics for the Kafka Bridge. Default is false.")
     public boolean getEnableMetrics() {
         return enableMetrics;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
@@ -7,7 +7,6 @@ package io.strimzi.api.kafka.model.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -37,7 +36,6 @@ public class ExternalLogging extends Logging {
     }
 
     @Description("`ConfigMap` entry where the logging configuration is stored. ")
-    @PresentInVersions("v1alpha1+")
     public ExternalConfigurationReference getValueFrom() {
         return valueFrom;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -53,7 +52,6 @@ public class InternalServiceTemplate implements HasMetadataTemplate, UnknownProp
             "`RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. " +
             "If unspecified, Kubernetes will choose the default value based on the service type.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @PresentInVersions("v1beta2+")
     public IpFamilyPolicy getIpFamilyPolicy() {
         return ipFamilyPolicy;
     }
@@ -66,7 +64,6 @@ public class InternalServiceTemplate implements HasMetadataTemplate, UnknownProp
             "Available options are `IPv4` and `IPv6`. " +
             "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @PresentInVersions("v1beta2+")
     public List<IpFamily> getIpFamilies() {
         return ipFamilies;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -26,11 +27,9 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
+@PresentInVersions("v1beta2")
 public class JaegerTracing extends Tracing {
     public static final String TYPE_JAEGER = "jaeger";
-
-    public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentracing.contrib.kafka.TracingConsumerInterceptor";
-    public static final String PRODUCER_INTERCEPTOR_CLASS_NAME = "io.opentracing.contrib.kafka.TracingProducerInterceptor";
 
     @Description("Must be `" + TYPE_JAEGER + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -25,6 +25,8 @@ import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -59,8 +61,10 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     private Rack rack;
 
     @Description("The number of pods in the Kafka Connect group. " +
-            "Defaults to `3`.")
+            "Required in the `v1` version of the Strimzi API. " +
+            "Defaults to `3` in the `v1beta2` version of the Strimzi API.")
     @JsonProperty(defaultValue = "3")
+    @RequiredInVersions("v1+")
     public int getReplicas() {
         return replicas;
     }
@@ -193,6 +197,7 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     @Deprecated
     @DeprecatedProperty(description = "The external configuration is deprecated and will be removed in the future. " +
             "Please use the template section instead to configure additional environment variables or volumes.")
+    @PresentInVersions("v1beta2")
     public ExternalConfiguration getExternalConfiguration() {
         return externalConfiguration;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -32,6 +33,7 @@ import java.util.Map;
 @JsonPropertyOrder({ "env", "volumes" })
 @Deprecated
 @DeprecatedType(replacedWithType = KafkaConnectTemplate.class)
+@PresentInVersions("v1beta2")
 @EqualsAndHashCode
 @ToString
 public class ExternalConfiguration implements UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -104,6 +105,7 @@ public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectS
 
     @Override
     @Description("The specification of the Kafka Connect cluster.")
+    @RequiredInVersions("v1+")
     public KafkaConnectSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -60,6 +61,7 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, UnknownProper
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Deprecated
     @DeprecatedProperty(description = "Kafka Connect and MirrorMaker 2 operands do not use `Deployment` resources anymore. This field will be ignored.")
+    @PresentInVersions("v1beta2")
     public DeploymentTemplate getDeployment() {
         return deployment;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.Spec;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -89,6 +90,7 @@ public abstract class AbstractConnectorSpec extends Spec {
     @Description("Whether the connector should be paused. Defaults to false.")
     @Deprecated
     @DeprecatedProperty(description = "Deprecated in Strimzi 0.38.0, use state instead.")
+    @PresentInVersions("v1beta2")
     public Boolean getPause() {
         return pause;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -111,6 +112,7 @@ public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConn
 
     @Override
     @Description("The specification of the Kafka Connector.")
+    @RequiredInVersions("v1+")
     public KafkaConnectorSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -104,6 +105,7 @@ public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Nam
 
     @Override
     @Description("The specification of the Kafka cluster.")
+    @RequiredInVersions("v1+")
     public KafkaSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -33,6 +34,7 @@ import java.util.List;
 @ToString(callSuper = true)
 @Deprecated
 @DeprecatedType(replacedWithType = KafkaAuthorizationCustom.class)
+@PresentInVersions("v1beta2")
 public class KafkaAuthorizationOpa extends KafkaAuthorization {
     public static final String TYPE_OPA = "opa";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -75,7 +75,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
             + "broker.session.timeout.ms, broker.heartbeat.interval.ms, controller.socket.timeout.ms, "
             + "controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms"; // KRaft options
 
-    protected Storage storage;
+    private Storage storage;
     private String version;
     private String metadataVersion;
     private Map<String, Object> config = new HashMap<>(0);
@@ -152,7 +152,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     @Deprecated
     @DeprecatedProperty(description = "Use `KafkaNodePool` resources.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Description("Storage is now configured in the `KafkaNodePool` resources and this option is ignored.")
     public Storage getStorage() {
         return storage;
@@ -176,7 +176,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     @Deprecated
     @DeprecatedProperty(description = "Use `KafkaNodePool` resources.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Description("Replicas are now configured in `KafkaNodePool` resources and this option is ignored.")
     @Minimum(1)
     public Integer getReplicas() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
@@ -17,6 +17,7 @@ import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.common.template.StatefulSetTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -65,6 +66,7 @@ public class KafkaClusterTemplate implements HasJmxSecretTemplate, UnknownProper
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Deprecated
     @DeprecatedProperty(description = "Support for StatefulSets was removed in Strimzi 0.35.0. This property is ignored.")
+    @PresentInVersions("v1beta2")
     public StatefulSetTemplate getStatefulset() {
         return statefulset;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
@@ -62,7 +62,7 @@ public class KafkaSpec extends Spec {
 
     @Deprecated
     @DeprecatedProperty(description = "ZooKeeper-based Apache Kafka clusters are not supported anymore since Strimzi 0.46.0.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Description("As of Strimzi 0.46.0, ZooKeeper-based Apache Kafka clusters are not supported anymore and this option is ignored.")
     public ZookeeperClusterSpec getZookeeper() {
         return zookeeper;
@@ -107,7 +107,7 @@ public class KafkaSpec extends Spec {
 
     @Deprecated
     @DeprecatedProperty(description = "JMXTrans is deprecated and related resources removed in Strimzi 0.35.0.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Description("As of Strimzi 0.35.0, JMXTrans is not supported anymore and this option is ignored.")
     public JmxTransSpec getJmxTrans() {
         return jmxTrans;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -115,7 +115,7 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
 
     @Description("As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     @DeprecatedProperty(description = "The storage overrides for individual brokers are not supported anymore since Strimzi 0.46.0.")
     public List<PersistentClaimStorageOverride> getOverrides() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Maximum;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -44,6 +45,7 @@ public class BrokerCapacity implements UnknownPropertyPreserving {
 
     @Deprecated
     @DeprecatedProperty(description = "The Cruise Control disk capacity setting has been deprecated, is ignored, and will be removed in the future")
+    @PresentInVersions("v1beta2")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Pattern("^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$")
     @Description("Broker capacity for disk in bytes. " +
@@ -59,6 +61,7 @@ public class BrokerCapacity implements UnknownPropertyPreserving {
 
     @Deprecated
     @DeprecatedProperty(description = "The Cruise Control CPU capacity setting has been deprecated, is ignored, and will be removed in the future")
+    @PresentInVersions("v1beta2")
     @Minimum(0)
     @Maximum(100)
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -24,6 +24,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.MinimumItems;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -84,6 +85,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
     @Deprecated
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @PresentInVersions("v1beta2")
     public TlsSidecar getTlsSidecar() {
         return tlsSidecar;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -98,6 +99,7 @@ public class CruiseControlTemplate implements UnknownPropertyPreserving {
 
     @DeprecatedProperty
     @Deprecated
+    @PresentInVersions("v1beta2")
     @Description("Template for the Cruise Control TLS sidecar container")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ContainerTemplate getTlsSidecarContainer() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
@@ -10,6 +10,7 @@ import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -58,6 +59,7 @@ public class EntityOperatorSpec implements UnknownPropertyPreserving {
 
     @Deprecated
     @DeprecatedProperty(description = "TLS sidecar was removed in Strimzi 0.41.0. This property is ignored.")
+    @PresentInVersions("v1beta2")
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public TlsSidecar getTlsSidecar() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -118,6 +119,7 @@ public class EntityOperatorTemplate implements UnknownPropertyPreserving {
 
     @Deprecated
     @DeprecatedProperty(description = "TLS sidecar was removed in Strimzi 0.41.0. This property is ignored.")
+    @PresentInVersions("v1beta2")
     @Description("Template for the Entity Operator TLS sidecar container")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ContainerTemplate getTlsSidecarContainer() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
@@ -83,7 +83,7 @@ public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLiven
     @Minimum(0)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @DeprecatedProperty(movedToPath = ".spec.entityOperator.topicOperator.reconciliationIntervalMs")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     public Integer getReconciliationIntervalSeconds() {
         return reconciliationIntervalSeconds;
@@ -108,7 +108,7 @@ public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLiven
     @Minimum(0)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @DeprecatedProperty(description = "This property is not used anymore in Strimzi 0.41.0 and it is ignored.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     public Integer getZookeeperSessionTimeoutSeconds() {
         return zookeeperSessionTimeoutSeconds;
@@ -122,7 +122,7 @@ public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLiven
     @Minimum(0)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @DeprecatedProperty(description = "This property is not used anymore in Strimzi 0.41.0 and it is ignored.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     public Integer getTopicMetadataMaxAttempts() {
         return topicMetadataMaxAttempts;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
@@ -82,7 +82,7 @@ public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivene
     @Minimum(0)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @DeprecatedProperty(movedToPath = ".spec.entityOperator.userOperator.reconciliationIntervalMs")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     public Long getReconciliationIntervalSeconds() {
         return reconciliationIntervalSeconds;
@@ -111,7 +111,7 @@ public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivene
     @Minimum(0)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @DeprecatedProperty(description = "This property has been deprecated because ZooKeeper is not used anymore by the User Operator.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     public Long getZookeeperSessionTimeoutSeconds() {
         return zookeeperSessionTimeoutSeconds;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
@@ -65,7 +65,7 @@ public class KafkaExporterTemplate implements UnknownPropertyPreserving {
 
     @Description("Template for Kafka Exporter `Service`.")
     @DeprecatedProperty(description = "The Kafka Exporter service has been removed.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ResourceTemplate getService() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -15,7 +15,6 @@ import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
-import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -214,7 +213,6 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
             "\n" +
             "If unspecified, Kubernetes will choose the default value based on the service type.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @PresentInVersions("v1beta2+")
     public IpFamilyPolicy getIpFamilyPolicy() {
         return ipFamilyPolicy;
     }
@@ -227,7 +225,6 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
             "Available options are `IPv4` and `IPv6`. " +
             "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @PresentInVersions("v1beta2+")
     public List<IpFamily> getIpFamilies() {
         return ipFamilies;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -71,7 +71,7 @@ public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthenticati
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Deprecated
     @DeprecatedProperty(description = "Please use the template section to configure additional volumes instead.")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     public List<GenericSecretSource> getSecrets() {
         return secrets;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -431,7 +431,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     }
 
     @DeprecatedProperty
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     @Description("Enable or disable ECDSA support by installing BouncyCastle crypto provider. " +
             "ECDSA support is always enabled. The BouncyCastle libraries are no longer packaged with Strimzi. Value is ignored.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
@@ -10,6 +10,7 @@ import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -39,8 +40,9 @@ public class ListenerStatus implements UnknownPropertyPreserving {
     private Map<String, Object> additionalProperties;
 
     @Deprecated
-    @DeprecatedProperty(description = "The `type` property is not used anymore. Use the `name` property with the same value.")
+    @DeprecatedProperty(description = "The `type` property is not used anymore. Use the `name` property with the same value.", movedToPath = ".status.listeners.name")
     @Description("The name of the listener.")
+    @PresentInVersions("v1beta2")
     public String getType() {
         return type;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -104,6 +105,7 @@ public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, Kaf
 
     @Override
     @Description("The specification of the Kafka MirrorMaker 2 cluster.")
+    @RequiredInVersions("v1+")
     public KafkaMirrorMaker2Spec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
@@ -64,7 +64,7 @@ public class KafkaMirrorMaker2MirrorSpec implements UnknownPropertyPreserving {
     }
 
     @DeprecatedProperty(movedToPath = ".spec.mirrors.topicsExcludePattern")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     @Description("A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.")
     public String getTopicsBlacklistPattern() {
@@ -94,7 +94,7 @@ public class KafkaMirrorMaker2MirrorSpec implements UnknownPropertyPreserving {
     }
 
     @DeprecatedProperty(movedToPath = ".spec.mirrors.groupsExcludePattern")
-    @PresentInVersions("v1alpha1-v1beta2")
+    @PresentInVersions("v1beta2")
     @Deprecated
     @Description("A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.")
     public String getGroupsBlacklistPattern() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -110,6 +111,7 @@ public class KafkaNodePool extends CustomResource<KafkaNodePoolSpec, KafkaNodePo
 
     @Override
     @Description("The specification of the KafkaNodePool.")
+    @RequiredInVersions("v1+")
     public KafkaNodePoolSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -113,6 +114,7 @@ public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodS
 
     @Override
     @Description("The specification of the StrimziPodSet.")
+    @RequiredInVersions("v1+")
     public StrimziPodSetSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -104,6 +105,7 @@ public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaReba
 
     @Override
     @Description("The specification of the Kafka rebalance.")
+    @RequiredInVersions("v1+")
     public KafkaRebalanceSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -111,6 +112,7 @@ public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus>
 
     @Override
     @Description("The specification of the topic.")
+    @RequiredInVersions("v1+")
     public KafkaTopicSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CustomResourceConditions;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -111,6 +112,7 @@ public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> im
 
     @Override
     @Description("The specification of the user.")
+    @RequiredInVersions("v1+")
     public KafkaUserSpec getSpec() {
         return super.getSpec();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -13,6 +13,8 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -91,6 +93,7 @@ public class AclRule implements UnknownPropertyPreserving {
             "Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.")
     @DeprecatedProperty(movedToPath = "spec.authorization.acls[*].operations")
     @Deprecated
+    @PresentInVersions("v1alpha1-v1beta2")
     public AclOperation getOperation() {
         return operation;
     }
@@ -103,6 +106,7 @@ public class AclRule implements UnknownPropertyPreserving {
             "Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All. " +
             "Only certain operations work with the specified resource.")
     @Example("operations: [\"Read\",\"Write\"]")
+    @RequiredInVersions("v1+")
     public List<AclOperation> getOperations() {
         return operations;
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/bridge/KafkaBridge.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/bridge/KafkaBridge.out.yaml
@@ -16,4 +16,3 @@ spec:
     enabled: true
     config:
       foo: "buz"
-  enableMetrics: false

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -770,6 +770,8 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaAuthorizationOpa.adoc[leve
 == `KafkaAuthorizationOpa` schema properties
 
 
+The type KafkaAuthorizationOpa is supported only in the Strimzi API version(s) v1beta2.
+
 The `type` property is a discriminator that distinguishes use of the `KafkaAuthorizationOpa` type from xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`], xref:type-KafkaAuthorizationCustom-{context}[`KafkaAuthorizationCustom`].
 It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 [cols="2,2,3a",options="header"]
@@ -2380,7 +2382,7 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |Property |Property type |Description
 |type
 |string
-|**The `type` property has been deprecated.** The `type` property is not used anymore. Use the `name` property with the same value. The name of the listener.
+|**The `type` property has been deprecated, and should now be configured using `.status.listeners.name`.** The `type` property is not used anymore. Use the `name` property with the same value. The name of the listener.
 |name
 |string
 |The name of the listener.
@@ -2512,7 +2514,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |replicas
 |integer
-|The number of pods in the Kafka Connect group. Defaults to `3`.
+|The number of pods in the Kafka Connect group. Required in the `v1` version of the Strimzi API. Defaults to `3` in the `v1beta2` version of the Strimzi API.
 |image
 |string
 |The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration.
@@ -2870,6 +2872,8 @@ It must have the value `custom` for the type `KafkaClientAuthenticationCustom`.
 
 Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 
+
+The type JaegerTracing is supported only in the Strimzi API version(s) v1beta2.
 
 The `type` property is a discriminator that distinguishes use of the `JaegerTracing` type from xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`].
 It must have the value `jaeger` for the type `JaegerTracing`.
@@ -3818,7 +3822,7 @@ include::../api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc[leveloffs
 |Property |Property type |Description
 |replicas
 |integer
-|The number of pods in the `Deployment`.  Defaults to `1`.
+|The number of pods in the `Deployment`. Required in the `v1` version of the Strimzi API. Defaults to `1` in the `v1beta2` version of the Strimzi API.
 |image
 |string
 |The container image used for Kafka Bridge pods. If no image name is explicitly specified, the image name corresponds to the image specified in the Cluster Operator configuration. If an image name is not defined in the Cluster Operator configuration, a default value is used.
@@ -4225,7 +4229,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |replicas
 |integer
-|The number of pods in the Kafka Connect group. Defaults to `3`.
+|The number of pods in the Kafka Connect group. Required in the `v1` version of the Strimzi API. Defaults to `3` in the `v1beta2` version of the Strimzi API.
 |image
 |string
 |The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -59,7 +59,7 @@ spec:
                   description: The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.
                 replicas:
                   type: integer
-                  description: The number of pods in the Kafka Connect group. Defaults to `3`.
+                  description: The number of pods in the Kafka Connect group. Required in the `v1` version of the Strimzi API. Defaults to `3` in the `v1beta2` version of the Strimzi API.
                 image:
                   type: string
                   description: "The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -62,7 +62,7 @@ spec:
                 replicas:
                   type: integer
                   minimum: 0
-                  description: The number of pods in the `Deployment`.  Defaults to `1`.
+                  description: The number of pods in the `Deployment`. Required in the `v1` version of the Strimzi API. Defaults to `1` in the `v1beta2` version of the Strimzi API.
                 image:
                   type: string
                   description: "The container image used for Kafka Bridge pods. If no image name is explicitly specified, the image name corresponds to the image specified in the Cluster Operator configuration. If an image name is not defined in the Cluster Operator configuration, a default value is used."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -59,7 +59,7 @@ spec:
                   description: The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.
                 replicas:
                   type: integer
-                  description: The number of pods in the Kafka Connect group. Defaults to `3`.
+                  description: The number of pods in the Kafka Connect group. Required in the `v1` version of the Strimzi API. Defaults to `3` in the `v1beta2` version of the Strimzi API.
                 image:
                   type: string
                   description: "The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration."

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -58,7 +58,7 @@ spec:
                 description: The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.
               replicas:
                 type: integer
-                description: The number of pods in the Kafka Connect group. Defaults to `3`.
+                description: The number of pods in the Kafka Connect group. Required in the `v1` version of the Strimzi API. Defaults to `3` in the `v1beta2` version of the Strimzi API.
               image:
                 type: string
                 description: "The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration."

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -61,7 +61,7 @@ spec:
               replicas:
                 type: integer
                 minimum: 0
-                description: The number of pods in the `Deployment`.  Defaults to `1`.
+                description: The number of pods in the `Deployment`. Required in the `v1` version of the Strimzi API. Defaults to `1` in the `v1beta2` version of the Strimzi API.
               image:
                 type: string
                 description: "The container image used for Kafka Bridge pods. If no image name is explicitly specified, the image name corresponds to the image specified in the Cluster Operator configuration. If an image name is not defined in the Cluster Operator configuration, a default value is used."

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -58,7 +58,7 @@ spec:
                 description: The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.
               replicas:
                 type: integer
-                description: The number of pods in the Kafka Connect group. Defaults to `3`.
+                description: The number of pods in the Kafka Connect group. Required in the `v1` version of the Strimzi API. Defaults to `3` in the `v1beta2` version of the Strimzi API.
               image:
                 type: string
                 description: "The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration."


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR prepares the `api` module for the `v1` changes. It implements the following changes:
* Makes `.spec` sections required in the `v1` API
* Makes `.spec.replicas` properties required in the `v1` API (apart from `KafkaTopic`)
* Makes sure all deprecated fields are present only in the `v1beta2` API and not in the `v1` API
* Makes sure all deprecated subtypes are present only in the `v1beta2` API and not in the `v1` API

_Note: This Pr on its own does not introduce the `v1` API. It just merges some of the prerequisite changes to simplify reviews through smaller PRs._

This contributes to #11809, #10074, and #11933.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md