### PR TITLE
docs(glossary): adds link macro for refs

### DIFF
--- a/documentation/modules/glossary/a.adoc
+++ b/documentation/modules/glossary/a.adoc
@@ -30,8 +30,8 @@ Supported types include `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and `c
 
 For more information, see the following:
 
-* {BookURLDeploying}#con-securing-kafka-authentication-str[Configuring client authentication on listeners^]
-* {BookURLDeploying}#con-securing-client-authentication-str[Configuring user authentication^]
+* link:{BookURLDeploying}#con-securing-kafka-authentication-str[Configuring client authentication on listeners^]
+* link:{BookURLDeploying}#con-securing-client-authentication-str[Configuring user authentication^]
 
 [id="glossary-authorization_{context}"]
 == Authorization (cluster-wide)
@@ -50,5 +50,5 @@ If using a custom authorization mechanism, user permissions are typically manage
 
 For more information, see the following:
 
-* {BookURLDeploying}#con-securing-kafka-authorization-str[Configuring authorized access to Kafka^]
-* {BookURLDeploying}#con-securing-client-authorization-str[Configuring user authorization^]
+* link:{BookURLDeploying}#con-securing-kafka-authorization-str[Configuring authorized access to Kafka^]
+* link:{BookURLDeploying}#con-securing-client-authorization-str[Configuring user authorization^]

--- a/documentation/modules/glossary/c.adoc
+++ b/documentation/modules/glossary/c.adoc
@@ -19,8 +19,8 @@ The central operator responsible for deploying and managing Kafka clusters, Kafk
 
 For more information, see the following:
 
-* {BookURLOverview}#overview-components-cluster-operator-str[Cluster Operator^]
-* {BookURLDeploying}#ref-operator-cluster-str[Configuring the Cluster Operator^]
+* link:{BookURLOverview}#overview-components-cluster-operator-str[Cluster Operator^]
+* link:{BookURLDeploying}#ref-operator-cluster-str[Configuring the Cluster Operator^]
 
 == Cruise Control
 [id="glossary-cruise-control_{context}"]
@@ -29,6 +29,6 @@ Cruise Control is configured through the `Kafka` custom resource, while rebalanc
 
 For more information, see the following:
 
-* {BookURLDeploying}#cruise-control-concepts-str[Using Cruise Control for cluster rebalancing^]
-* {BookURLDeploying}#proc-cruise-control-topic-replication-str[Using Cruise Control to modify topic replication factor^]
-* {BookURLDeploying}#proc-cruise-control-moving-data-str[Using Cruise Control to reassign partitions on JBOD disks^]
+* link:{BookURLDeploying}#cruise-control-concepts-str[Using Cruise Control for cluster rebalancing^]
+* link:{BookURLDeploying}#proc-cruise-control-topic-replication-str[Using Cruise Control to modify topic replication factor^]
+* link:{BookURLDeploying}#proc-cruise-control-moving-data-str[Using Cruise Control to reassign partitions on JBOD disks^]

--- a/documentation/modules/glossary/d.adoc
+++ b/documentation/modules/glossary/d.adoc
@@ -7,4 +7,4 @@
 [id="glossary-drain-cleaner_{context}"]
 A utility installed as a separate component that ensures safe pod evictions during rolling updates to prevent data loss or downtime.
 
-For more information, see {BookURLDeploying}#assembly-drain-cleaner-str[Evicting pods with the Strimzi Drain Cleaner^].
+For more information, see link:{BookURLDeploying}#assembly-drain-cleaner-str[Evicting pods with the Strimzi Drain Cleaner^].

--- a/documentation/modules/glossary/f.adoc
+++ b/documentation/modules/glossary/f.adoc
@@ -8,4 +8,4 @@
 Used to enable or disable specific features and functions managed by Strimzi operators.
 New features may be introduced initially through feature gates.
 
-For more information, see {BookURLDeploying}#ref-operator-cluster-feature-gates-str[Feature gates^].
+For more information, see link:{BookURLDeploying}#ref-operator-cluster-feature-gates-str[Feature gates^].

--- a/documentation/modules/glossary/k.adoc
+++ b/documentation/modules/glossary/k.adoc
@@ -7,51 +7,51 @@
 [id="glossary-kafka-cr_{context}"]
 A custom resource for deploying and configuring a Kafka cluster, including settings for nodes, listeners, storage, security, and internal components like Cruise Control and the Entity Operator.
 
-For more information, see the {BookURLConfiguring}#type-Kafka-reference[`Kafka` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-Kafka-reference[`Kafka` schema reference^].
 
 == Kafka Bridge
 [id="glossary-kafka-bridge_{context}"]
 Provides a RESTful interface that allows HTTP-based clients to interact with a Kafka cluster.
 
-For more information, see {BookURLBridge}[Using the Kafka Bridge^].
+For more information, see link:{BookURLBridge}[Using the Kafka Bridge^].
 
 == KafkaBridge (custom resource)
 [id="glossary-kafkabridge-cr_{context}"]
 A custom resource used to deploy and configure a Kafka Bridge instance, specifying replicas, authentication, and connection details.
 
-For more information, see the {BookURLConfiguring}#type-KafkaBridge-reference[`KafkaBridge` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaBridge-reference[`KafkaBridge` schema reference^].
 
 == KafkaConnect (custom resource)
 [id="glossary-kafkaconnect-cr_{context}"]
 A custom resource used to deploy and configure a Kafka Connect cluster for integrating external systems with Kafka.
 
-For more information, see the {BookURLConfiguring}#type-KafkaConnect-reference[`KafkaConnect` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaConnect-reference[`KafkaConnect` schema reference^].
 
 == KafkaConnector (custom resource)
 [id="glossary-kafkaconnector-cr_{context}"]
 A custom resource for managing individual Kafka connectors in a Kafka Connect cluster declaratively and independently of the `KafkaConnect` deployment.
 
-For more information, see the {BookURLConfiguring}#type-KafkaConnector-reference[`KafkaConnector` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaConnector-reference[`KafkaConnector` schema reference^].
 
 == KafkaExporter
 [id="glossary-kafkaexporter_{context}"]
 The Kafka Exporter exposes Kafka metrics for Prometheus. 
 It is configured as part of the `Kafka` custom resource.
 
-For more information, see the {BookURLConfiguring}#type-KafkaExporterSpec-reference[`KafkaExporterSpec` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaExporterSpec-reference[`KafkaExporterSpec` schema reference^].
 
 == KafkaMirrorMaker2 (custom resource)
 [id="glossary-kafkamirrormaker2-cr_{context}"]
 A custom resource for deploying a Kafka MirrorMaker 2 instance to replicate data between Kafka clusters.
 
-For more information, see the {BookURLConfiguring}#type-KafkaMirrorMaker2-reference[`KafkaMirrorMaker2` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaMirrorMaker2-reference[`KafkaMirrorMaker2` schema reference^].
 
 == KafkaNodePool (custom resource)
 [id="glossary-kafkanodepool-cr_{context}"]
 A custom resource used to configure distinct groups of nodes within a Kafka cluster.
 Nodes in a node pool can be configured to operate as Kafka brokers, controllers, or both.
 
-For more information, see the {BookURLConfiguring}#type-KafkaNodePool-reference[`KafkaNodePool` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaNodePool-reference[`KafkaNodePool` schema reference^].
 
 == KafkaRebalance (custom resource)
 [id="glossary-kafkarebalance-cr_{context}"]
@@ -64,16 +64,16 @@ add-brokers:: Replicas moved to newly added brokers
 remove-brokers:: Replicas moved off brokers being removed  
 remove-disks:: Data moved between storage volumes within the same broker
 
-For more information, see the {BookURLConfiguring}#type-KafkaRebalance-reference[`KafkaRebalance` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaRebalance-reference[`KafkaRebalance` schema reference^].
 
 == KafkaTopic (custom resource)
 [id="glossary-kafkatopic-cr_{context}"]
 A custom resource for managing Kafka topics (creation, configuration, deletion) through the Topic Operator.
 
-For more information, see the {BookURLConfiguring}#type-KafkaTopic-reference[`KafkaTopic` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaTopic-reference[`KafkaTopic` schema reference^].
 
 == KafkaUser (custom resource)
 [id="glossary-kafkauser-cr_{context}"]
 A custom resource for managing Kafka users (creation, configuration, deletion) through the User Operator, including their authentication credentials and access permissions.
 
-For more information, see the {BookURLConfiguring}#type-KafkaUser-reference[`KafkaUser` schema reference^].
+For more information, see the link:{BookURLConfiguring}#type-KafkaUser-reference[`KafkaUser` schema reference^].

--- a/documentation/modules/glossary/m.adoc
+++ b/documentation/modules/glossary/m.adoc
@@ -8,7 +8,7 @@
 Strimzi components can expose Prometheus-formatted metrics for monitoring. 
 Metrics for components are enabled through its custom resource.
 
-For more information, see {BookURLDeploying}#assembly-metrics-str[Introducing metrics^].
+For more information, see link:{BookURLDeploying}#assembly-metrics-str[Introducing metrics^].
 
 == Metrics Reporter
 [id="glossary-metrics-reporter_{context}"]

--- a/documentation/modules/glossary/s.adoc
+++ b/documentation/modules/glossary/s.adoc
@@ -13,7 +13,7 @@ ephemeral:: Temporary storage tied to the pod lifecycle
 persistent-claim:: Durable storage using PersistentVolumeClaims (PVCs)  
 jbod:: Multiple disks or volumes (ephemeral or persistent)
 
-For more information, see {BookURLDeploying}#assembly-storage-str[Configuring Kafka storage^].
+For more information, see link:{BookURLDeploying}#assembly-storage-str[Configuring Kafka storage^].
 
 == Strimzi API schema
 [id="glossary-strimzi-cr-schema_{context}"]

--- a/documentation/modules/glossary/t.adoc
+++ b/documentation/modules/glossary/t.adoc
@@ -10,12 +10,12 @@ It is configured through the `Kafka` custom resource.
 
 For more information, see the following:
 
-* {BookURLDeploying}#ref-tiered-storage-str[Tiered storage^]
-* {BookURLConfiguring}#type-TieredStorageCustom-reference[`TieredStorageCustom` schema reference^]
+* link:{BookURLDeploying}#ref-tiered-storage-str[Tiered storage^]
+* link:{BookURLConfiguring}#type-TieredStorageCustom-reference[`TieredStorageCustom` schema reference^]
 
 == Topic Operator
 [id="glossary-topic-operator_{context}"]
 The operator responsible for managing Kafka topics through `KafkaTopic` custom resources.
 
-* {BookURLOverview}#overview-concepts-topic-operator-str[Topic Operator^]
-* {BookURLDeploying}#using-the-topic-operator-str[Using the Topic Operator to manage Kafka topics^]
+* link:{BookURLOverview}#overview-concepts-topic-operator-str[Topic Operator^]
+* link:{BookURLDeploying}#using-the-topic-operator-str[Using the Topic Operator to manage Kafka topics^]

--- a/documentation/modules/glossary/u.adoc
+++ b/documentation/modules/glossary/u.adoc
@@ -13,11 +13,11 @@ Upgrade paths:
 incremental upgrade:: Move between consecutive minor versions  
 multi-version upgrade:: Skip one or more minor versions
 
-For more information, see {BookURLDeploying}#assembly-upgrade-str[Upgrading Strimzi^].
+For more information, see link:{BookURLDeploying}#assembly-upgrade-str[Upgrading Strimzi^].
 
 == User Operator
 [id="glossary-user-operator_{context}"]
 The operator responsible for managing Kafka users and ACLs through `KafkaUser` custom resources.
 
-* {BookURLOverview}#overview-concepts-user-operator-str[User Operator^]
-* {BookURLDeploying}#assembly-using-the-user-operator-str[Using the User Operator to manage Kafka users^]
+* link:{BookURLOverview}#overview-concepts-user-operator-str[User Operator^]
+* link:{BookURLDeploying}#assembly-using-the-user-operator-str[Using the User Operator to manage Kafka users^]


### PR DESCRIPTION
**Documentation**

Some of the links in the glossary need the `link:` macro to render properly with asciidoctor.
I've added to all.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

