### PR TITLE
docs(format): makes note layouts consistent

### DIFF
--- a/documentation/assemblies/deploying/assembly-uninstalling.adoc
+++ b/documentation/assemblies/deploying/assembly-uninstalling.adoc
@@ -22,15 +22,10 @@ Such resources include:
 
 These are resources referenced by `Kafka`, `KafkaConnect`, `KafkaMirrorMaker2`, or `KafkaBridge` configuration.
 
-[WARNING]
-====
-*Deleting CRDs and related custom resources*
-
-When a `CustomResourceDefinition` is deleted, custom resources of that type are also deleted. 
+WARNING: When a `CustomResourceDefinition` is deleted, custom resources of that type are also deleted. 
 This includes the `Kafka`, `KafkaConnect`, `KafkaMirrorMaker2`, and `KafkaBridge` resources managed by Strimzi, as well as the `StrimziPodSet` resource Strimzi uses to manage the pods of the Kafka components. 
 In addition, any Kubernetes resources created by these custom resources, such as `Deployment`, `Pod`, `Service`, and `ConfigMap` resources, are also removed.
 Always exercise caution when deleting these resources to avoid unintended data loss.
-====
 
 //Uninstall from command line
 include::../../modules/deploying/proc-uninstalling.adoc[leveloffset=+1]

--- a/documentation/assemblies/metrics/assembly_metrics-prometheus-deploy.adoc
+++ b/documentation/assemblies/metrics/assembly_metrics-prometheus-deploy.adoc
@@ -13,12 +13,8 @@ link:https://prometheus.io/[Prometheus^] provides an open source set of componen
 
 We describe here how you can use the link:https://github.com/coreos/prometheus-operator[CoreOS Prometheus Operator^] to run and manage a Prometheus server that is suitable for use in production environments, but with the correct configuration you can run any Prometheus server.
 
-[NOTE]
-====
-The Prometheus server configuration uses service discovery to discover the pods in the cluster from which it gets metrics.  For this feature to work correctly, the service account used for running the Prometheus service pod must have access to the API server so it can retrieve the pod list.
-
-For more information, see {K8sServiceDiscovery}.
-====
+NOTE: The Prometheus server configuration uses service discovery to discover the pods in the cluster from which it gets metrics.  For this feature to work correctly, the service account used for running the Prometheus service pod must have access to the API server so it can retrieve the pod list.
+For more information, see link:{K8sServiceDiscovery}.
 
 include::../../modules/metrics/con_metrics-prometheus-options.adoc[leveloffset=+1]
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
@@ -135,14 +135,6 @@ You can change the frequency by adding `refresh.topics.interval.seconds` to the 
 
 |===
 
-[WARNING] 
-====
-The following properties must be *identically configured across both connectors* (source and checkpoint):
-
-* `replication.policy.class`
-* `replication.policy.separator`
-* `offset-syncs.topic.location`
-* `topic.filter.class`
-
+WARNING: The following properties must be *identically configured across both connectors* (source and checkpoint):
+`replication.policy.class`, `replication.policy.separator`, `offset-syncs.topic.location`, and `topic.filter.class`.
 Mismatches cause replication failures or offset sync issues.
-====

--- a/documentation/modules/configuring/con-config-mirrormaker2-sync-acls.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-sync-acls.adoc
@@ -16,11 +16,8 @@ With `simple` authorization:
 * ACL rules apply to both source and target topics
 * Users with source topic access automatically get equivalent target topic access
 
-[IMPORTANT]
-====
-* This feature is not compatible with the User Operator, so disable by setting `sync.topic.acls.enabled` to `false`.
-* When using OAuth 2.0 authorization, the setting has no effect.
-====
+IMPORTANT: This feature is not compatible with the User Operator, so disable by setting `sync.topic.acls.enabled` to `false`.
+When using OAuth 2.0 authorization, the setting has no effect.
 
 .Example configuration to enable offset synchronization
 [source,yaml,subs="+quotes,attributes"]

--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -133,8 +133,6 @@ securityContext:
 # ...
 ----
 
-[NOTE]
-====
 Container capabilities and `seccomp` are Linux kernel features that support container security. 
 
 * Capabilities add fine-grained privileges for processes running on a container. The `NET_BIND_SERVICE` capability allows non-root user applications to bind to ports below 1024. 
@@ -142,7 +140,6 @@ Container capabilities and `seccomp` are Linux kernel features that support cont
 The `RuntimeDefault` profile provides a default set of system calls.
 A `LocalHost` profile uses a profile defined in a file on the node.   
 
-====
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -245,13 +245,10 @@ com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException:
 [CpuCapacityGoal] Insufficient capacity for cpu (Utilization 615.21, Allowed Capacity 420.00, Threshold: 0.70). Add at least 3 brokers with the same cpu capacity (100.00) as broker-0. Add at least 3 brokers with the same cpu capacity (100.00) as broker-0.
 ----
 
-[NOTE]
-====
-The error shows CPU capacity as a percentage rather than the number of CPU cores. 
+NOTE: The error shows CPU capacity as a percentage rather than the number of CPU cores. 
 For this reason, it does not directly map to the number of CPUs configured in the Kafka custom resource.
 It is like having a single _virtual_ CPU per broker, which has the cycles of the CPUs configured in `Kafka.spec.kafka.resources.limits.cpu`.
 This has no effect on the rebalance behavior, since the ratio between CPU utilization and capacity remains the same.
-====
 
 .What to do next
 

--- a/documentation/modules/managing/con-broker-config-properties.adoc
+++ b/documentation/modules/managing/con-broker-config-properties.adoc
@@ -137,8 +137,6 @@ num.recovery.threads.per.data.dir=4 <4>
 Configuration updates to the thread pools for all brokers might occur dynamically at the cluster level.
 These updates are restricted to between half the current size and twice the current size.
 
-[TIP]
-====
 The following Kafka broker metrics can help with working out the number of threads required:
 
 * `kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent` provides metrics on the average time network threads are idle as a percentage.
@@ -146,7 +144,6 @@ The following Kafka broker metrics can help with working out the number of threa
 
 If there is 0% idle time, all resources are in use, which means that adding more threads might be beneficial.
 When idle time goes below 30%, performance may start to suffer.
-====
 
 If threads are slow or limited due to the number of disks, you can try increasing the size of the buffers for network requests to improve throughput:
 

--- a/documentation/modules/metrics/con-metrics-cruise-control.adoc
+++ b/documentation/modules/metrics/con-metrics-cruise-control.adoc
@@ -31,8 +31,6 @@ The Cruise Control metric for balancedness score (`balancedness-score`) might di
 Cruise Control calculates each score using `anomaly.detection.goals` which might not be the same as the `default.goals` used in the `KafkaRebalance` resource.
 The `anomaly.detection.goals` are specified in the `spec.cruiseControl.config` of the `Kafka` custom resource.
 
-[NOTE]
-====
 Refreshing the `KafkaRebalance` resource fetches an optimization proposal.
 The latest cached optimization proposal is fetched if one of the following conditions applies:
 
@@ -40,7 +38,6 @@ The latest cached optimization proposal is fetched if one of the following condi
 * KafkaRebalance `goals` are not specified
 
 Otherwise, Cruise Control generates a new optimization proposal based on KafkaRebalance `goals`. If new proposals are generated with each refresh, this can impact performance monitoring.
-====
 
 == Setting up alerts for anomaly detection
 

--- a/documentation/modules/oauth/con-mapping-keycloak-authz-services-to-kafka-model.adoc
+++ b/documentation/modules/oauth/con-mapping-keycloak-authz-services-to-kafka-model.adoc
@@ -11,12 +11,9 @@ You then specify Keycloak Authorization Services rules on the client.
 Typically, the client ID of the OAuth client that represents the Kafka cluster is `kafka`.
 The xref:proc-oauth-authorization-keycloak-example_str[example configuration files] provided with Strimzi use `kafka` as the OAuth client id.
 
-[NOTE]
-====
-If you have multiple Kafka clusters, you can use a single OAuth client (`kafka`) for all of them.
+NOTE: If you have multiple Kafka clusters, you can use a single OAuth client (`kafka`) for all of them.
 This gives you a single, unified space in which to define and manage authorization rules.
 However, you can also use different OAuth client ids (for example, `my-cluster-kafka` or `cluster-dev-kafka`) and define authorization rules for each cluster within each client configuration.
-====
 
 The `kafka` client definition must have the *Authorization Enabled* option enabled in the Keycloak Admin Console.
 For information on enabling authorization services, see the guide to {keycloak-authorization-services}.
@@ -49,10 +46,7 @@ Authorization scopes should contain the following Kafka permissions regardless o
 If you're certain you won't need a permission (for example, `IdempotentWrite`), you can omit it from the list of authorization scopes.
 However, that permission won't be available to target on Kafka resources.
 
-[NOTE]
-====
-The `All` permission is not supported.
-====
+NOTE: The `All` permission is not supported.
 
 .Resource patterns for permissions checks
 

--- a/documentation/modules/overview/con-key-features-kafka-connect.adoc
+++ b/documentation/modules/overview/con-key-features-kafka-connect.adoc
@@ -39,13 +39,10 @@ MirrorMaker 2 also uses the Kafka Connect framework.
 In this case, the external data system is another Kafka cluster.
 Specialized connectors for MirrorMaker 2 manage data replication between source and target Kafka clusters.
 
-[NOTE]
-====
 In addition to the MirrorMaker 2 connectors, Kafka provides two connectors as examples:
 
 * `FileStreamSourceConnector` streams data from a file on the worker's filesystem to Kafka, reading the input file and sending each line to a given Kafka topic.
 * `FileStreamSinkConnector` streams data from Kafka to the worker's filesystem, reading messages from a Kafka topic and writing a line for each in an output file.
-====
 
 The following source connector diagram shows the process flow for a source connector that streams records from an external data system.
 A Kafka Connect cluster might operate source and sink connectors at the same time.

--- a/documentation/modules/security/con-certificate-renewal.adoc
+++ b/documentation/modules/security/con-certificate-renewal.adoc
@@ -133,9 +133,6 @@ For an example of configuring secure clients, see xref:proc-configuring-secure-k
 If you provision client certificates manually, generate and distribute new certificates before the current ones expire. 
 Failure to do so can result in clients being unable to connect to the Kafka cluster.
 
-[NOTE]
-====
-For workloads in the same Kubernetes cluster and namespace, you can mount secrets as volumes. 
+NOTE: For workloads in the same Kubernetes cluster and namespace, you can mount secrets as volumes. 
 This allows client pods to construct keystores and truststores dynamically from the current state of the secrets.
 For details, see xref:configuring-internal-clients-to-trust-cluster-ca-{context}[Configuring internal clients to trust the cluster CA].
-====

--- a/documentation/modules/upgrading/con-upgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-upgrade-paths.adoc
@@ -29,13 +29,10 @@ However, if you attempt to upgrade to a new Strimzi version that does not suppor
 In this case, you must upgrade the Kafka version as part of the Strimzi upgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the new Strimzi version.
 
 ifdef::Section[]
-[NOTE]
-====
-You can review supported Kafka versions in the link:https://strimzi.io/downloads/[Supported versions^] table.
+Review supported Kafka versions in the link:https://strimzi.io/downloads/[Supported versions^] table on the Strimzi website.
 
 * The *Operators* column lists all released Strimzi versions (the Strimzi version is often called the "Operator version").
 * The *Kafka versions* column lists the supported Kafka versions for each Strimzi version.
-====
 endif::Section[]
 
 == Upgrading from a Strimzi version earlier than 0.39

--- a/documentation/modules/upgrading/proc-upgrade-kafka-kraft.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-kraft.adoc
@@ -51,12 +51,9 @@ NOTE: The value of `metadataVersion` must be a string to prevent it from being i
 
 . Change the `Kafka.spec.kafka.version` to specify the new Kafka version; leave the `metadataVersion` at the default for the _current_ Kafka version.
 +
-[NOTE]
-====
-Changing the `kafka.version` ensures that all brokers in the cluster are upgraded to start using the new broker binaries.
+NOTE: Changing the `kafka.version` ensures that all brokers in the cluster are upgraded to start using the new broker binaries.
 During this process, some brokers are using the old binaries while others have already upgraded to the new ones.
 Leaving the `metadataVersion` unchanged at the current setting ensures that the Kafka brokers and controllers can continue to communicate with each other throughout the upgrade.
-====
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:
 +


### PR DESCRIPTION
**Documentation**

Format fix to make notes consistent throughout the docs.
Some larger notes changed to inline text

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

