### PR TITLE
docs(storage): update the tiered storage note in api reference

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorageCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorageCustom.adoc
@@ -9,8 +9,8 @@ Custom tiered storage configuration enables the use of a custom `RemoteStorageMa
 
 If custom tiered storage is enabled, Strimzi uses the https://github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java[`TopicBasedRemoteLogMetadataManager`^] for Remote Log Metadata Management (RLMM).
 
-WARNING: Tiered storage is an early access Kafka feature, which is also available in Strimzi. 
-Due to its https://kafka.apache.org/documentation/#tiered_storage_limitation[current limitations^], it is not recommended for production environments.
+NOTE: Tiered storage is a production-ready feature in Kafka since version 3.9.0, and it is also supported in Strimzi.
+Before introducing tiered storage to your environment, review the https://kafka.apache.org/documentation/#tiered_storage_limitation[known limitations^] of this feature.
 
 .Example custom tiered storage configuration
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
**Documentation**

Updates the tiered storage note in the api reference guide.
Was showing as preview. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

