### PR TITLE
Add support for Kafka 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.49.0
 
+* Add support for Kafka 4.0.1
 * Set `blockOwnerDeletion` to `true` in the owner references in Strimzi managed resources.
   Deleting the Strimzi custom resources will now by default wait for the deletion of all the owned Kubernetes resources.
 * Make `.spec` sections required in the `v1` version of all Strimzi custom resources.

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -9,6 +9,7 @@
 |Kafka
 a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-4.0.0
+* {DockerOrg}/kafka:{DockerTag}-kafka-4.0.1
 * {DockerOrg}/kafka:{DockerTag}-kafka-4.1.0
 
 a|

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -259,6 +259,13 @@
   third-party-libs: 4.0.x
   supported: true
   default: false
+- version: 4.0.1
+  metadata: 4.0
+  url: https://archive.apache.org/dist/kafka/4.0.1/kafka_2.13-4.0.1.tgz
+  checksum: 23B241098672D828CA86A6DD1DD99102FCDB9DE8680ECF213B47251A7AE7A342343CF41ADF6FEE9F920D171AE13F94C39475165F5A246E1A46609A7D9D5A6811
+  third-party-libs: 4.0.x
+  supported: true
+  default: false
 - version: 4.1.0
   metadata: 4.1
   url: https://archive.apache.org/dist/kafka/4.1.0/kafka_2.13-4.1.0.tgz

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -12,13 +12,16 @@
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
                 4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.0.0")) }}
+                4.0.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.0.1")) }}
                 4.1.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-4.1.0")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
                 4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.0.0")) }}
+                4.0.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.0.1")) }}
                 4.1.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-4.1.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
                 4.0.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.0.0")) }}
+                4.0.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.0.1")) }}
                 4.1.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-4.1.0")) }}
 {{- end -}}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -54,14 +54,17 @@ spec:
             - name: STRIMZI_KAFKA_IMAGES
               value: |
                 4.0.0=quay.io/strimzi/kafka:latest-kafka-4.0.0
+                4.0.1=quay.io/strimzi/kafka:latest-kafka-4.0.1
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 4.0.0=quay.io/strimzi/kafka:latest-kafka-4.0.0
+                4.0.1=quay.io/strimzi/kafka:latest-kafka-4.0.1
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 4.0.0=quay.io/strimzi/kafka:latest-kafka-4.0.0
+                4.0.1=quay.io/strimzi/kafka:latest-kafka-4.0.1
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: quay.io/strimzi/operator:latest


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds support for Kafka 4.0.1 to the main branch.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md