### PR TITLE
Continue STs workflow when commit-sha.txt doesn't exist

### DIFF
--- a/.github/actions/utils/compare-merge-commit/action.yml
+++ b/.github/actions/utils/compare-merge-commit/action.yml
@@ -137,6 +137,8 @@ runs:
           core.info(`Build URL: ${context.serverUrl}/${owner}/${repo}/actions/runs/${buildRun.id}`);
 
     - name: Download build metadata
+      id: download-metadata
+      continue-on-error: true
       uses: actions/download-artifact@v4
       with:
         name: commit-sha.txt


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As part of https://github.com/strimzi/strimzi-kafka-operator/pull/12008 I forgot to handle scenarios where `commit-sha.txt` artifact doesn't exists which could happen for branches that doesn't contain commits from #12008, this should resolve it.
### Checklist

- [x] Make sure all tests pass

