### PR TITLE
Deprecate resources configuration in `.spec.kafka` in `Kafka` CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   To use the Keycloak authorizer, you can use the `type: custom` authorization.
   The Strimzi OAuth library with the Keycloak authorizer continues to be packaged with the Strimzi container images.
   Follow the documentation for the examples and migration details.
+* CPU and memory configuration for the Kafka nodes in `.spec.kafka.resources` is deprecated and will be removed in the `v1` CRD API.
+  Please use the `KafkaNodePool` resources to configure CPU and memory for Kafka nodes.
 * The `group.id`, `config.storage.topic`, `offset.storage.topic`, and `status.storage.topic` fields in `.spec.config` section of the `KafkaConnect` resource are deprecated and will be forbidden in the `v1` CRD API.
   Please use the new `.spec.groupId`, `.spec.configStorageTopic`, `.spec.offsetStorageTopic`, and `.spec.statusStorageTopic` fields instead.
 * The `.spec.connectCluster`, `.spec.clusters`, `.spec.mirrors[].sourceCluster`, `.spec.mirrors[].targetCluster`, and `.spec.mirrors[].heartbeatConnector` fields of the `KafkaMirrorMaker2` resource are deprecated and will be removed in the `v1` CRD API.

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -204,6 +204,9 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @KubeLink(group = "core", version = "v1", kind = "resourcerequirements")
     @Description("CPU and memory resources to reserve.")
+    @Deprecated
+    @DeprecatedProperty(description = "Use `KafkaNodePool` custom resources to configure CPU and memory.")
+    @PresentInVersions("v1beta2")
     public ResourceRequirements getResources() {
         return resources;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -286,7 +286,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return Kafka cluster instance
      */
-    @SuppressWarnings({"NPathComplexity", "deprecation"}) // Keycloak Authorization is deprecated
+    @SuppressWarnings({"NPathComplexity", "deprecation"}) // Keycloak Authorization is deprecated; resource configuration in Kafka CR (.spec.kafka.resources) is deprecated
     public static KafkaCluster fromCrd(Reconciliation reconciliation,
                                        Kafka kafka,
                                        List<KafkaPool> pools,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -135,6 +135,7 @@ public class KafkaPool extends AbstractModel {
      *
      * @return Kafka pool instance
      */
+    @SuppressWarnings("deprecation") // Resource configuration in Kafka CR (.spec.kafka.resources) is deprecated
     public static KafkaPool fromCrd(
             Reconciliation reconciliation,
             Kafka kafka,

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -116,7 +116,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |JMX Options for Kafka brokers.
 |resources
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core[ResourceRequirements]
-|CPU and memory resources to reserve.
+|**The `resources` property has been deprecated.** Use `KafkaNodePool` custom resources to configure CPU and memory. CPU and memory resources to reserve.
 |metricsConfig
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -77,22 +77,14 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-    # Resources requests and limits (recommended)
-    resources: # <13>
-      requests:
-        memory: 64Gi
-        cpu: "8"
-      limits:
-        memory: 64Gi
-        cpu: "12"
     # Logging configuration (optional)
-    logging: # <14>
+    logging: # <13>
       type: inline
       loggers:
         # Kafka 4.0+ uses Log4j2
         rootLogger.level: INFO
     # Readiness probe (optional)
-    readinessProbe: # <15>
+    readinessProbe: # <14>
       initialDelaySeconds: 15
       timeoutSeconds: 5
     # Liveness probe (optional)  
@@ -100,26 +92,26 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     # JVM options (optional)
-    jvmOptions: # <16>
+    jvmOptions: # <15>
       -Xms: 8192m
       -Xmx: 8192m
     # Custom image (optional)  
-    image: my-org/my-image:latest # <17>
+    image: my-org/my-image:latest # <16>
     # Authorization (optional)
-    authorization: # <18>
+    authorization: # <17>
       type: simple
     # Rack awareness (optional) 
-    rack: # <19>
+    rack: # <18>
       topologyKey: topology.kubernetes.io/zone
     # Metrics configuration (optional)
-    metricsConfig: # <20>
+    metricsConfig: # <19>
       type: jmxPrometheusExporter
       valueFrom:
-        configMapKeyRef: # <21>
+        configMapKeyRef: # <20>
           name: my-config-map
           key: my-key
   # Entity Operator (recommended)
-  entityOperator: # <22>
+  entityOperator: # <21>
     topicOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalMs: 60000
@@ -132,7 +124,7 @@ spec:
           memory: 512Mi
           cpu: "1"
       # Logging configuration (optional)
-      logging: # <23>
+      logging: # <22>
         type: inline
         loggers:
           rootLogger.level: INFO
@@ -148,15 +140,15 @@ spec:
           memory: 512Mi
           cpu: "1"
       # Logging configuration (optional)
-      logging: # <24>
+      logging: # <23>
         type: inline
         loggers:
           rootLogger.level: INFO
   # Kafka Exporter (optional)
-  kafkaExporter: # <25>
+  kafkaExporter: # <24>
     # ...
   # Cruise Control (optional)
-  cruiseControl: # <26>
+  cruiseControl: # <25>
     # ...
 ----
 <1> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are configured as _internal_ or _external_ listeners for connection from inside or outside the Kubernetes cluster.
@@ -171,20 +163,19 @@ spec:
 <10> Kafka version, which can be changed to a supported version by following the upgrade procedure.
 <11> Kafka metadata version, which can be changed to a supported version by following the upgrade procedure.
 <12> Broker configuration. Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
-<13> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<14> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
-<15> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<16> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka.
-<17> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
-<18> Authorization enables simple, OAuth 2.0, custom, or OPA (deprecated) authorization on the Kafka broker. Simple authorization uses the `StandardAuthorizer` Kafka plugin.
-<19> Rack awareness configuration to spread replicas across different racks, data centers, or availability zones. The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label.
-<20> Prometheus metrics enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
-<21> Rules for exporting metrics in Prometheus format to a Grafana dashboard through the Prometheus JMX Exporter, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
-<22> Entity Operator configuration, which specifies the configuration for the Topic Operator and User Operator.
-<23> Specified Topic Operator loggers and log levels. This example uses `inline` logging.
-<24> Specified User Operator loggers and log levels.
-<25> Kafka Exporter configuration. Kafka Exporter is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use.
-<26> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
+<13> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a `ConfigMap`. Custom Log4j configuration must be placed under the `log4j2.properties` key in the `ConfigMap`. You can set log levels to `INFO`, `ERROR`, `WARN`, `TRACE`, `DEBUG`, `FATAL` or `OFF`.
+<14> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<15> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka.
+<16> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
+<17> Authorization enables simple, OAuth 2.0, custom, or OPA (deprecated) authorization on the Kafka broker. Simple authorization uses the `StandardAuthorizer` Kafka plugin.
+<18> Rack awareness configuration to spread replicas across different racks, data centers, or availability zones. The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label.
+<19> Prometheus metrics enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
+<20> Rules for exporting metrics in Prometheus format to a Grafana dashboard through the Prometheus JMX Exporter, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<21> Entity Operator configuration, which specifies the configuration for the Topic Operator and User Operator.
+<22> Specified Topic Operator loggers and log levels. This example uses `inline` logging.
+<23> Specified User Operator loggers and log levels.
+<24> Kafka Exporter configuration. Kafka Exporter is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use.
+<25> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
 
 WARNING: If you remove the `min.insync.replicas` property from `.spec.kafka.config` in the `Kafka` resource, the Cluster Operator
 forces Kafka to fall back to the default value (`1`), regardless of whether ELR (Eligible Leader Replicas) is enabled or disabled.


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR deprecates the `.spec.kafka.resources` field in `Kafka` CR as approved in the [Strimzi Proposal 121](https://github.com/strimzi/proposals/blob/main/121-deprecate-and-remove-kafka-spec-kafka-resources.md). The logic is kept intact and it still can be used. But it is removed in the `v1` API.

I also went through the docs, but there were not many references to it, so there are not many changes.

This should resolve #11881.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md