### PR TITLE
Fix permanent `KafkaBridge` `enableMetrics` deprecation warning

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
@@ -61,7 +61,7 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     private ResourceRequirements resources;
     private JvmOptions jvmOptions;
     private Logging logging;
-    private boolean enableMetrics;
+    private Boolean enableMetrics;
     private MetricsConfig metricsConfig;
     private Probe livenessProbe;
     private Probe readinessProbe;
@@ -90,11 +90,11 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     @PresentInVersions("v1beta2")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Description("Enable the metrics for the Kafka Bridge. Default is false.")
-    public boolean getEnableMetrics() {
+    public Boolean getEnableMetrics() {
         return enableMetrics;
     }
 
-    public void setEnableMetrics(boolean enableMetrics) {
+    public void setEnableMetrics(Boolean enableMetrics) {
         this.enableMetrics = enableMetrics;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -203,7 +203,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         } else if (spec.getMetricsConfig() instanceof StrimziMetricsReporter) {
             result.metrics = new StrimziMetricsReporterModel(spec, DEFAULT_METRICS_ALLOW_LIST);
         } else {
-            result.isLegacyMetricsConfigEnabled = spec.getEnableMetrics();
+            result.isLegacyMetricsConfigEnabled = Boolean.TRUE.equals(spec.getEnableMetrics());
         }
 
         result.setTls(spec.getTls() != null ? spec.getTls() : null);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `enableMetrics` field in the `KafkaBridge` resource is deprecated. But because it is using a primitive `boolean` type, it is always set (`boolean` default to false) and users always get  the deprecation warning telling them to not use it.

This PR changes the field type to `Boolean`, so that it is set to null when it is not set. And that way the deprecatin warning is not permanently raised.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally