### PR TITLE
Bump test-metadata-generator to 0.6.0

### DIFF
--- a/.github/actions/build/build-strimzi-binaries/action.yml
+++ b/.github/actions/build/build-strimzi-binaries/action.yml
@@ -55,19 +55,7 @@ runs:
         MVN_ARGS: ${{ inputs.mvnArgs }}
         CURL_ARGS: "-s"
 
-    - name: Upload containers artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: MirrorMaker2ST.md
-        path: development-docs/systemtests/io.strimzi.systemtest.mirrormaker.MirrorMaker2ST.md
-
-    - name: Upload containers artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: TopicReplicasChangeST.md
-        path: development-docs/systemtests/io.strimzi.systemtest.operators.topic.TopicReplicasChangeST.md
-
-        # Additional checks
+    # Additional checks
     - name: Run Spotbugs
       shell: bash
       run: "make spotbugs"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   # Build Strimzi Java code and does basic checks of the PR
   build-strimzi:
     name: Build Strimzi
-    runs-on: oracle-2cpu-8gb-arm64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -37,7 +37,7 @@ jobs:
       - uses: ./.github/actions/build/build-strimzi-binaries
         with:
           mvnArgs: "-B -DskipTests -Dmaven.javadoc.skip=true"
-          runnerArch: "arm64"
+          runnerArch: "amd64"
 
   # Runs Strimzi unit and integration tests
   test-strimzi:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Bump test-metadata-generator version to 0.6.0 that resolves arm64 build differences.

### Checklist

- [ ] Make sure all tests pass


