### PR TITLE
Clean Maven cache in Azure pipelines

### DIFF
--- a/.azure/templates/steps/maven_cache.yaml
+++ b/.azure/templates/steps/maven_cache.yaml
@@ -1,9 +1,11 @@
 steps:
   - task: Cache@2
     inputs:
-      key: 'maven-cache | $(System.JobName) | **/pom.xml'
+      # The first key is used to clean the cache after some time to avoid it getting bigger and bigger
+      # Once the cache gets too big, try to bump it to for example `summer-2027`
+      key: 'autumn-2025 | maven-cache | $(System.JobName) | **/pom.xml'
       restoreKeys: |
-        maven-cache | $(System.JobName)
-        maven-cache
+        autumn-2025 | maven-cache | $(System.JobName)
+        autumn-2025 | maven-cache
       path: $(HOME)/.m2/repository
     displayName: Maven cache


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR renames Maven cache keys to flush the cache. Unlike in the last attempt to do it (#11998), this time I realized I have to rename the restore keys as well to not start from the old cache. This should help to fix the cache size / disk space issues.