### PR TITLE
Make Strimzi work with the `OwnerReferencesPermissionEnforcement` admission controller

### DIFF
--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -42,6 +42,14 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+      - kafkatopics/finalizers
+      - kafkausers/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - ""
     resources:
       # The entity operator user-operator needs to access and manage secrets to store generated credentials

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -728,6 +728,11 @@ public class EntityOperatorTest {
                 .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
                 .build());
         rules.add(new PolicyRuleBuilder()
+                .addToResources("kafkatopics/finalizers", "kafkausers/finalizers")
+                .addToVerbs("update")
+                .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
+                .build());
+        rules.add(new PolicyRuleBuilder()
                 .addToResources("secrets")
                 .addToVerbs("get", "list", "watch", "create", "delete", "patch", "update")
                 .addToApiGroups("")

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -56,6 +56,19 @@ rules:
   - patch
   - update
 - apiGroups:
+    - "kafka.strimzi.io"
+  resources:
+    # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+    - kafkas/finalizers
+    - kafkanodepools/finalizers
+    - kafkaconnects/finalizers
+    - kafkaconnectors/finalizers
+    - kafkabridges/finalizers
+    - kafkamirrormaker2s/finalizers
+    - kafkarebalances/finalizers
+  verbs:
+    - update
+- apiGroups:
   - "core.strimzi.io"
   resources:
   # The cluster operator uses StrimziPodSets to manage the Kafka, Kafka Connect, and Kafka MirrorMaker 2 pods
@@ -76,6 +89,13 @@ rules:
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - "core.strimzi.io"
+  resources:
+  # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+  - strimzipodsets/finalizers
+  verbs:
   - update
 - apiGroups:
     - "kafka.strimzi.io"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -47,6 +47,14 @@ rules:
   - patch
   - update
 - apiGroups:
+    - "kafka.strimzi.io"
+  resources:
+    # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+    - kafkatopics/finalizers
+    - kafkausers/finalizers
+  verbs:
+    - update
+- apiGroups:
   - ""
   resources:
     # The entity operator user-operator needs to access and manage secrets to store generated credentials

--- a/packaging/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -51,6 +51,19 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+      - kafkas/finalizers
+      - kafkanodepools/finalizers
+      - kafkaconnects/finalizers
+      - kafkaconnectors/finalizers
+      - kafkabridges/finalizers
+      - kafkamirrormaker2s/finalizers
+      - kafkarebalances/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - "core.strimzi.io"
     resources:
       # The cluster operator uses StrimziPodSets to manage the Kafka, Kafka Connect, and Kafka MirrorMaker 2 pods
@@ -71,6 +84,13 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+      - strimzipodsets/finalizers
+    verbs:
       - update
   - apiGroups:
       - "kafka.strimzi.io"

--- a/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -42,6 +42,14 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+      - kafkatopics/finalizers
+      - kafkausers/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - ""
     resources:
       # The entity operator user-operator needs to access and manage secrets to store generated credentials

--- a/packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml
@@ -25,3 +25,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+    # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+    - "kafka.strimzi.io"
+  resources:
+    - kafkatopics/finalizers
+  verbs:
+    - update

--- a/packaging/install/user-operator/02-Role-strimzi-user-operator.yaml
+++ b/packaging/install/user-operator/02-Role-strimzi-user-operator.yaml
@@ -25,6 +25,13 @@ rules:
   - patch
   - update
 - apiGroups:
+    - "kafka.strimzi.io"
+  resources:
+    # Needed for environments with enabled OwnerReferencesPermissionEnforcement admission controller (e.g. OpenShift)
+    - kafkausers/finalizers
+  verbs:
+    - update
+- apiGroups:
   - ""
   resources:
   - secrets


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds the RBAC rights that allow us to set the blockOwnerDeletion flag in environments with [`OwnerReferencesPermissionEnforcement` admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) enabled.

This should resolve #11980.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging