### PR TITLE
docs(build): makes glossary unversioned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,11 @@ release_docu: docu_html docu_htmlnoheader docu_pdf
 	$(CP) -rv documentation/pdf/overview.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
 	$(CP) -rv documentation/pdf/deploying.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
 	$(CP) -rv documentation/pdf/configuring.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
+	$(CP) -rv documentation/pdf/glossary.pdf strimzi-$(RELEASE_VERSION)/docs/pdf/
 	$(CP) -rv documentation/html/overview.html strimzi-$(RELEASE_VERSION)/docs/html/
 	$(CP) -rv documentation/html/deploying.html strimzi-$(RELEASE_VERSION)/docs/html/
 	$(CP) -rv documentation/html/configuring.html strimzi-$(RELEASE_VERSION)/docs/html/
+	$(CP) -rv documentation/html/glossary.html strimzi-$(RELEASE_VERSION)/docs/html/
 	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/html/images/
 
 docu_clean: docu_htmlclean docu_htmlnoheaderclean docu_pdfclean


### PR DESCRIPTION
**Documentation**

Removes glossary from versioned build.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

