### PR TITLE
Add S390x CI Build Status Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Strimzi is licensed under the [Apache License](./LICENSE), Version 2.0
 
 ## Community Testing
 
-### Linux on IBM Z (s390x) :
+### Linux on IBM Z (s390x)
 
 [![Jenkins](https://ibmz-ci.osuosl.org/job/Strimzi_Kafka_Operator_IBMZ_CI/badge/icon)](https://ibmz-ci.osuosl.org/job/Strimzi_Kafka_Operator_IBMZ_CI/)
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As per the discussion thread [here](https://github.com/orgs/strimzi/discussions/11221#discussioncomment-13129973), we have now setup the CI for s390x at https://ibmz-ci.osuosl.org/job/Strimzi_Kafka_Operator_IBMZ_CI/ and would like to add a build status badge in the README.md file.
The badge provides a visual indicator of the latest build status (e.g., passing, failing, or in progress) from the S390x Jenkins pipeline.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

