### PR TITLE
Update the Kindcontainer to 1.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
         <valid4j.version>1.1</valid4j.version>
         <javax.json.version>1.1.4</javax.json.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
-        <kindcontainer.version>1.4.9</kindcontainer.version>
-        <testcontainer.version>1.20.1</testcontainer.version>
+        <kindcontainer.version>1.4.10</kindcontainer.version>
+        <testcontainer.version>1.21.3</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
         <junit4.version>4.13.2</junit4.version>
         <skodjob.test-frame.version>1.2.0</skodjob.test-frame.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kindcontainer used in the MockKube tests to 1.4.10 which allows us to test against Kubernetes 1.34.

### Checklist

- [x] Make sure all tests pass