### PR TITLE
Tidy up IGNORABLE_PROPERTIES and logging

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaConfigurationDiff.java
@@ -289,25 +289,25 @@ public class KafkaConfigurationDiff extends AbstractJsonDiff {
                     .filter(configEntry -> configEntry.name().equals(pathValueWithoutSlash))
                     .findFirst();
 
-            boolean logConfigDiff = false;
+            boolean isConfigUpdated = false;
             String op = d.get("op").asText();
             if (optEntry.isPresent()) {
                 ConfigEntry entry = optEntry.get();
                 if ("remove".equals(op)) {
-                    logConfigDiff = removeProperty(configModel, updatedCE, pathValueWithoutSlash, entry);
+                    isConfigUpdated = removeProperty(configModel, updatedCE, pathValueWithoutSlash, entry);
                 } else if ("replace".equals(op)) {
                     // entry is in the current, desired is updated value
-                    logConfigDiff = updateOrAdd(entry.name(), configModel, desiredMap, updatedCE);
+                    isConfigUpdated = updateOrAdd(entry.name(), configModel, desiredMap, updatedCE);
                 }
             } else {
                 if ("add".equals(op)) {
                     // entry is not in the current, it is added
-                    logConfigDiff = updateOrAdd(pathValueWithoutSlash, configModel, desiredMap, updatedCE);
+                    isConfigUpdated = updateOrAdd(pathValueWithoutSlash, configModel, desiredMap, updatedCE);
                 }
             }
 
-            // Log config difference only if they are not ignorable or custom as they always contain different values and are not dynamically updated, logging them causes very noisy log output.
-            if (logConfigDiff) {
+            // Log only if a config is getting updated, otherwise ignorable and custom configs produces very noisy log output as they always have different desired and current values.
+            if (isConfigUpdated) {
                 LOGGER.debugCr(reconciliation, "Kafka Broker {} Config Differs : {}", nodeRef.nodeId(), d);
                 LOGGER.debugCr(reconciliation, "Current Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(source, pathValue));
                 LOGGER.debugCr(reconciliation, "Desired Kafka Broker Config path {} has value {}", pathValueWithoutSlash, lookupPath(target, pathValue));


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Remove the custom properties that are in IGNORABLE_PROPERTIES as they get skipped using KafkaConfiguration.isCustomConfigurationOption() anyway. 

The debug logs for the configuration difference include the properties that are ignorable or custom even though they are not included in the final update. The current and desired values for these properties are always different as they contain placeholders or are custom, which results in logging them all the time:
```
2025-10-21 08:55:12 DEBUG KafkaBrokerConfigurationDiff:183 - Reconciliation #1(watch) Kafka(namespace-0/cluster-ebf06a3a): Kafka Broker 0 Config Differs : {"op":"replace","path":"/config.providers.strimzifile.param.allowed.paths","value":"/opt/kafka"}
2025-10-21 08:55:12 DEBUG KafkaBrokerConfigurationDiff:184 - Reconciliation #1(watch) Kafka(namespace-0/cluster-ebf06a3a): Current Kafka Broker Config path config.providers.strimzifile.param.allowed.paths has value "null"
2025-10-21 08:55:12 DEBUG KafkaBrokerConfigurationDiff:185 - Reconciliation #1(watch) Kafka(namespace-0/cluster-ebf06a3a): Desired Kafka Broker Config path config.providers.strimzifile.param.allowed.paths has value "/opt/kafka"
(repeated for all the config providers)
...
2025-10-21 08:55:12 DEBUG KafkaBrokerConfigurationDiff:183 - Reconciliation #1(watch) Kafka(namespace-0/cluster-ebf06a3a): Kafka Broker 0 Config Differs : {"op":"replace","path":"/listener.name.tls-9093.ssl.keystore.key","value":"${strimzisecrets:namespace-0/cluster-ebf06a3a-b-3b9ba644-0:cluster-ebf06a3a-b-3b9ba644-0.key}"}
2025-10-21 08:55:12 DEBUG KafkaBrokerConfigurationDiff:184 - Reconciliation #1(watch) Kafka(namespace-0/cluster-ebf06a3a): Current Kafka Broker Config path listener.name.tls-9093.ssl.keystore.key has value "null"
2025-10-21 08:55:12 DEBUG KafkaBrokerConfigurationDiff:185 - Reconciliation #1(watch) Kafka(namespace-0/cluster-ebf06a3a): Desired Kafka Broker Config path listener.name.tls-9093.ssl.keystore.key has value "${strimzisecrets:namespace-0/cluster-ebf06a3a-b-3b9ba644-0:cluster-ebf06a3a-b-3b9ba644-0.key}"
(repeated for all the listener ssl properties)
```
But these get skipped from the update since they are ignorable or custom. 

This PR changes the condition of the logs so that properties with different desired and current values get logged only if they are not ignored or not custom, in another word, if it is a property we intend to update. So it would look like this:
```
2025-10-21 10:32:55 DEBUG KafkaBrokerConfigurationDiff:175 - Reconciliation #11(watch) Kafka(namespace-0/cluster-ebf06a3a): Kafka Broker 0 Config Differs : {"op":"replace","path":"/min.insync.replicas","value":"1"}
2025-10-21 10:32:55 DEBUG KafkaBrokerConfigurationDiff:176 - Reconciliation #11(watch) Kafka(namespace-0/cluster-ebf06a3a): Current Kafka Broker Config path min.insync.replicas has value "2"
2025-10-21 10:32:55 DEBUG KafkaBrokerConfigurationDiff:177 - Reconciliation #11(watch) Kafka(namespace-0/cluster-ebf06a3a): Desired Kafka Broker Config path min.insync.replicas has value "1"
2025-10-21 10:32:55 DEBUG KafkaRoller:615 - Reconciliation #11(watch) Kafka(namespace-0/cluster-ebf06a3a): Pod cluster-ebf06a3a-b-3b9ba644-0/0 needs to be reconfigured.
2025-10-21 10:32:55 DEBUG KafkaRoller:654 - Reconciliation #11(watch) Kafka(namespace-0/cluster-ebf06a3a): Updating broker configuration cluster-ebf06a3a-b-3b9ba644-0/0
2025-10-21 10:32:56 INFO  KafkaRoller:673 - Reconciliation #11(watch) Kafka(namespace-0/cluster-ebf06a3a): Dynamic update of pod cluster-ebf06a3a-b-3b9ba644-0/0 was successful.
```
The logs will no longer include ignorable or custom properties. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

