### PR TITLE
Fixed HTTP bridge related Prometheus rules

### DIFF
--- a/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-bridge-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules/prometheus-kafka-bridge-rules.yaml
@@ -42,7 +42,7 @@ spec:
         summary: 'Kafka Bridge consumer average commit latency'
         description: 'The average consumer commit latency is {{ $value }} on {{ $labels.clientId }}'
     - alert: Http4xxErrorRate
-      expr: strimzi_bridge_http_server_requestCount_total{code=~"^4..$", container=~"^.+-bridge", path !="/favicon.ico"} > 10
+      expr: strimzi_bridge_http_server_requests_total{code=~"^4..$", container=~"^.+-bridge", path !="/favicon.ico"} > 10
       for: 1m
       labels:
         severity: warning
@@ -50,7 +50,7 @@ spec:
         summary: 'Kafka Bridge returns code 4xx too often'
         description: 'Kafka Bridge returns code 4xx too much ({{ $value }}) for the path {{ $labels.path }}'
     - alert: Http5xxErrorRate
-      expr: strimzi_bridge_http_server_requestCount_total{code=~"^5..$", container=~"^.+-bridge"} > 10
+      expr: strimzi_bridge_http_server_requests_total{code=~"^5..$", container=~"^.+-bridge", path !="/favicon.ico"} > 10
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It seems that since Vert.x 4.x the naming convention for the metrics related to the HTTP server requests total changed.

In previous version Vert.x 3.x it was using `requestCount` as per here https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/src/main/java/io/vertx/micrometer/MetricsNaming.java#L167 so the exposed metric was `strimzi_bridge_http_server_requestCount_total`.
From Vert.x 4.x it has been using "requests" as per here https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/src/main/java/io/vertx/micrometer/MetricsNaming.java#L211 so the exposed metric is `strimzi_bridge_http_server_requests_total`.

It means that the current provided Prometheus rules using old `strimzi_bridge_http_server_requestCount_total` are not working anymore and they should use `strimzi_bridge_http_server_requests_total` instead.

This was raised via https://github.com/strimzi/strimzi-kafka-bridge/discussions/1034