### PR TITLE
Bumped Vert.x and Netty to fix CVEs on 0.45.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
         <fasterxml.jackson-annotations.version>2.16.2</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.2</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.13</vertx.version>
-        <vertx-junit5.version>4.5.13</vertx-junit5.version>
+        <vertx.version>4.5.21</vertx.version>
+        <vertx-junit5.version>4.5.21</vertx-junit5.version>
         <kafka.version>3.9.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.4</zookeeper.version>
@@ -144,7 +144,7 @@
         <jetty.version>9.4.57.v20241219</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.1</strimzi-oauth.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.125.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <jsonsmart.version>2.5.2</jsonsmart.version>


### PR DESCRIPTION
This PR bumps Vert.x and Netty to fix some CVEs.
