### PR TITLE
update tiered storage version to the latest v1.1.1

### DIFF
--- a/systemtest/src/test/resources/tiered-storage/Dockerfile
+++ b/systemtest/src/test/resources/tiered-storage/Dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
-
 ARG AIVEN_PLUGIN_VERSION="1.1.1"
 ARG TIERED_STORAGE_URL="https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases/download"
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

update tiered storage version to the latest v1.1.1. Check [here](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [V ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

