### PR TITLE
Update API Version in docs to `v1`

### DIFF
--- a/documentation/modules/configuring/con-external-config.adoc
+++ b/documentation/modules/configuring/con-external-config.adoc
@@ -13,7 +13,7 @@ You can enable one or more configuration providers using the `config.providers` 
 .Example configuration to enable a configuration provider
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -137,9 +137,9 @@ my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
 
 . Finally, edit the `KafkaTopic` custom resource to change `.spec.replicas` to 3, and then wait the reconciliation.
 +
-[source,shell,subs=+quotes]
+[source,shell,subs=+attributes]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaTopicApiVersion}
 kind: KafkaTopic
 metadata:
   name: my-topic

--- a/documentation/modules/configuring/proc-dedicated-nodes.adoc
+++ b/documentation/modules/configuring/proc-dedicated-nodes.adoc
@@ -51,7 +51,7 @@ This example applies a rule to a `Kafka` resource that assigns all its broker po
 .Example cluster-wide affinity configuration for dedicated nodes
 [source,yaml,subs=attributes+]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
   name: my-cluster

--- a/documentation/modules/configuring/proc-loading-config-from-config-map.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-config-map.adoc
@@ -45,7 +45,7 @@ The specification shown here can support loading values from config maps and sec
 .Example Kafka Connect configuration to use config maps and secrets
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect
@@ -119,7 +119,7 @@ The service account name format is `<cluster_name>-connect`, where `<cluster_nam
 .Example connector configuration referencing the config map
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaConnectorApiVersion}
 kind: KafkaConnector
 metadata:
   name: my-connector

--- a/documentation/modules/configuring/proc-loading-config-from-env-vars.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-env-vars.adoc
@@ -48,7 +48,7 @@ data:
 .Example Kafka Connect configuration to use external environment variables
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect
@@ -98,7 +98,7 @@ kubectl apply -f <kafka_connect_configuration_file>
 .Example connector configuration referencing the environment variable
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaConnectorApiVersion}
 kind: KafkaConnector
 metadata:
   name: my-connector

--- a/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
+++ b/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
@@ -28,7 +28,7 @@ To understand the relationship between a CRD and a custom resource, let's look a
 .Kafka topic CRD
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: {KafkaApiVersion}
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: <1>
   name: kafkatopics.kafka.strimzi.io

--- a/documentation/modules/security/proc-replacing-your-own-private-keys.adoc
+++ b/documentation/modules/security/proc-replacing-your-own-private-keys.adoc
@@ -71,7 +71,7 @@ The following example shows a `Kafka` custom resource with both cluster and clie
 .Example `Kafka` configuration using your own CA certificates
 [source,yaml,subs=attributes+]
 ----
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 # ...
 spec:

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -148,16 +148,16 @@
 :DockerImageUser: 1001
 
 // API Versions current
-:ApiVersion: v1beta2
-:KafkaApiVersion: kafka.strimzi.io/v1beta2
-:KafkaNodePoolApiVersion: kafka.strimzi.io/v1beta2
-:KafkaConnectApiVersion: kafka.strimzi.io/v1beta2
-:KafkaConnectorApiVersion: kafka.strimzi.io/v1beta2
-:KafkaTopicApiVersion: kafka.strimzi.io/v1beta2
-:KafkaUserApiVersion: kafka.strimzi.io/v1beta2
-:KafkaMirrorMaker2ApiVersion: kafka.strimzi.io/v1beta2
-:KafkaRebalanceApiVersion: kafka.strimzi.io/v1beta2
-:KafkaBridgeApiVersion: kafka.strimzi.io/v1beta2
+:ApiVersion: v1
+:KafkaApiVersion: kafka.strimzi.io/v1
+:KafkaNodePoolApiVersion: kafka.strimzi.io/v1
+:KafkaConnectApiVersion: kafka.strimzi.io/v1
+:KafkaConnectorApiVersion: kafka.strimzi.io/v1
+:KafkaTopicApiVersion: kafka.strimzi.io/v1
+:KafkaUserApiVersion: kafka.strimzi.io/v1
+:KafkaMirrorMaker2ApiVersion: kafka.strimzi.io/v1
+:KafkaRebalanceApiVersion: kafka.strimzi.io/v1
+:KafkaBridgeApiVersion: kafka.strimzi.io/v1
 
 // Section enablers
 :Section:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR updates the API version used in the docs to be the `v1` API. In some places it also updates the examples to use the variables instead of the hardcoded version.

### Checklist

- [x] Update documentation