### PR TITLE
Update examples to use the `v1` API

### DIFF
--- a/packaging/examples/bridge/kafka-bridge.yaml
+++ b/packaging/examples/bridge/kafka-bridge.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaBridge
 metadata:
   name: my-bridge

--- a/packaging/examples/connect/kafka-connect-build.yaml
+++ b/packaging/examples/connect/kafka-connect-build.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster

--- a/packaging/examples/connect/kafka-connect.yaml
+++ b/packaging/examples/connect/kafka-connect.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster

--- a/packaging/examples/connect/source-connector.yaml
+++ b/packaging/examples/connect/source-connector.yaml
@@ -2,7 +2,7 @@
 # the strimzi.io/use-connector-resources annotation on the KafkaConnect custom resource.
 # From Apache Kafka 3.1.1 and 3.2.0, you also have to add the FileStreamSourceConnector
 # connector to the container image. You can do that using the kafka-connect-build.yaml example.
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnector
 metadata:
   name: my-source-connector

--- a/packaging/examples/cruise-control/kafka-cruise-control-auto-rebalancing.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control-auto-rebalancing.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -16,7 +16,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -34,7 +34,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster
@@ -69,7 +69,7 @@ spec:
         template:
           name: my-remove-brokers-rebalancing-template
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-add-brokers-rebalancing-template
@@ -78,7 +78,7 @@ metadata:
 # no goals specified, using the default goals from the Cruise Control configuration
 spec: {}
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-remove-brokers-rebalancing-template

--- a/packaging/examples/cruise-control/kafka-cruise-control-with-goals.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control-with-goals.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -16,7 +16,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -34,7 +34,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/cruise-control/kafka-cruise-control.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -16,7 +16,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -34,7 +34,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/cruise-control/kafka-rebalance-add-brokers.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-add-brokers.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-rebalance

--- a/packaging/examples/cruise-control/kafka-rebalance-full.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-full.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-rebalance

--- a/packaging/examples/cruise-control/kafka-rebalance-remove-brokers.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-remove-brokers.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-rebalance

--- a/packaging/examples/cruise-control/kafka-rebalance-remove-disks.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-remove-disks.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-rebalance

--- a/packaging/examples/cruise-control/kafka-rebalance-with-goals.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-with-goals.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: my-rebalance

--- a/packaging/examples/kafka/kafka-ephemeral.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -16,7 +16,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -34,7 +34,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -18,7 +18,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -43,7 +43,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -18,7 +18,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -38,7 +38,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/kafka/kafka-single-node.yaml
+++ b/packaging/examples/kafka/kafka-single-node.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/kafka/kafka-with-dual-role-nodes.yaml
+++ b/packaging/examples/kafka/kafka-with-dual-role-nodes.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/metrics/kafka-bridge-metrics.yaml
+++ b/packaging/examples/metrics/kafka-bridge-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaBridge
 metadata:
   name: my-bridge

--- a/packaging/examples/metrics/kafka-connect-metrics.yaml
+++ b/packaging/examples/metrics/kafka-connect-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster

--- a/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -16,7 +16,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -34,7 +34,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -18,7 +18,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -38,7 +38,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/metrics/kafka-mirror-maker-2-metrics.yaml
+++ b/packaging/examples/metrics/kafka-mirror-maker-2-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mm2-cluster

--- a/packaging/examples/metrics/kube-state-metrics/configmap.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/configmap.yaml
@@ -9,7 +9,7 @@ data:
       resources:
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaTopic
           metricNamePrefix: strimzi_kafka_topic
           metrics:
@@ -31,7 +31,7 @@ data:
                 topicName: [ status, topicName ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaUser
           metricNamePrefix: strimzi_kafka_user
           metrics:
@@ -51,7 +51,7 @@ data:
                 username: [ status, username ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: Kafka
           metricNamePrefix: strimzi_kafka
           metrics:
@@ -74,7 +74,7 @@ data:
                 generation: [ status, observedGeneration ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaNodePool
           metricNamePrefix: strimzi_kafka_node_pool
           metrics:
@@ -97,7 +97,7 @@ data:
                 generation: [ status, observedGeneration ]
         - groupVersionKind:
             group: core.strimzi.io
-            version: v1beta2
+            version: v1
             kind: StrimziPodSet
           metricNamePrefix: strimzi_pod_set
           metrics:
@@ -117,7 +117,7 @@ data:
                 generation: [ status, observedGeneration ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaRebalance
           metricNamePrefix: strimzi_kafka_rebalance
           metrics:
@@ -137,7 +137,7 @@ data:
                 template: [ metadata, annotations, "strimzi.io/rebalance-template" ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaConnect
           metricNamePrefix: strimzi_kafka_connect
           metrics:
@@ -160,7 +160,7 @@ data:
                 labelSelector: [ status, labelSelector ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaConnector
           metricNamePrefix: strimzi_kafka_connector
           metrics:
@@ -182,7 +182,7 @@ data:
                 topics: [ status, topics ]
         - groupVersionKind:
             group: kafka.strimzi.io
-            version: v1beta2
+            version: v1
             kind: KafkaMirrorMaker2
           metricNamePrefix: strimzi_kafka_mm2
           metrics:

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-bridge-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-bridge-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaBridge
 metadata:
   name: my-bridge

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-connect-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-connect-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -17,7 +17,7 @@ spec:
         kraftMetadata: shared
         deleteClaim: false
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -36,7 +36,7 @@ spec:
         kraftMetadata: shared
         deleteClaim: false
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-mirror-maker-2-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-mirror-maker-2-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mm2-cluster

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: source
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: cluster-a

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: target
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: cluster-b

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/security/scram-sha-512-auth/bridge.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/bridge.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-bridge
@@ -26,7 +26,7 @@ spec:
         - Read
         - Write
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaBridge
 metadata:
   name: my-bridge

--- a/packaging/examples/security/scram-sha-512-auth/connect.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/connect.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-connect
@@ -56,7 +56,7 @@ spec:
         - Read
         - Write
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: my-connect

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -18,7 +18,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -38,7 +38,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: source
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: cluster-a
@@ -47,7 +47,7 @@ spec:
     userOperator: {}
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: target
@@ -68,7 +68,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: cluster-b
@@ -96,7 +96,7 @@ spec:
     userOperator: {}
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: cluster-a-user
@@ -140,7 +140,7 @@ spec:
           - Read
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: cluster-b-user
@@ -219,7 +219,7 @@ spec:
           - Read
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2

--- a/packaging/examples/security/scram-sha-512-auth/topic.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: my-topic

--- a/packaging/examples/security/scram-sha-512-auth/user.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/user.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-user

--- a/packaging/examples/security/tls-auth/bridge.yaml
+++ b/packaging/examples/security/tls-auth/bridge.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-bridge
@@ -26,7 +26,7 @@ spec:
         - Write
         - Create
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaBridge
 metadata:
   name: my-bridge

--- a/packaging/examples/security/tls-auth/connect.yaml
+++ b/packaging/examples/security/tls-auth/connect.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-connect
@@ -56,7 +56,7 @@ spec:
         - Write
         - Create
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: my-connect

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -18,7 +18,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -38,7 +38,7 @@ spec:
         deleteClaim: false
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: source
@@ -19,7 +19,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: cluster-a
@@ -47,7 +47,7 @@ spec:
     userOperator: {}
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: target
@@ -68,7 +68,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: cluster-b
@@ -96,7 +96,7 @@ spec:
     userOperator: {}
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: cluster-a-user
@@ -135,7 +135,7 @@ spec:
           - Describe
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: cluster-b-user
@@ -210,7 +210,7 @@ spec:
           - Describe
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: my-mirror-maker-2

--- a/packaging/examples/security/tls-auth/topic.yaml
+++ b/packaging/examples/security/tls-auth/topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: my-topic

--- a/packaging/examples/security/tls-auth/user.yaml
+++ b/packaging/examples/security/tls-auth/user.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-user

--- a/packaging/examples/topic/kafka-topic.yaml
+++ b/packaging/examples/topic/kafka-topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: my-topic

--- a/packaging/examples/user/kafka-user.yaml
+++ b/packaging/examples/user/kafka-user.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: my-user


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates our examples to use the `v1` API. This should lead any new users to already use the new API and have it easier to _convert_ the API later.

### Checklist

- [x] Update Examples