### PR TITLE
Add comment right after STs start and then update after build finish

### DIFF
--- a/.github/actions/utils/add-comment/action.yml
+++ b/.github/actions/utils/add-comment/action.yml
@@ -1,10 +1,18 @@
 name: Add Comment
-description: "Posts a comment on the pull-request"
+description: "Posts a comment on the pull-request or updates an existing one"
 
 inputs:
   commentMessage:
     description: "Message that will be put as a comment"
     required: true
+  commentId:
+    description: "Optional comment ID to update instead of creating new one"
+    required: false
+
+outputs:
+  commentId:
+    description: "The ID of the created or updated comment"
+    value: ${{ steps.comment-and-check.outputs.comment-id }}
 
 runs:
   using: composite
@@ -14,11 +22,13 @@ runs:
       uses: actions/github-script@v7
       env:
         MESSAGE: ${{ inputs.commentMessage }}
+        COMMENT_ID: ${{ inputs.commentId }}
       with:
         script: |
           const {owner, repo} = context.repo;
 
           const msg       = process.env.MESSAGE
+          const commentId = process.env.COMMENT_ID
           let   sha       = undefined
           let   prNumber  = undefined;
 
@@ -38,14 +48,29 @@ runs:
           } else {
             sha ||= context.sha;
           }
-          
-          core.info(`Going to put a comment to PR “${prNumber}” (“${sha}”) - ”${msg}”`);
+
+          core.info(`Going to put a comment to PR "${prNumber}" ("${sha}") - "${msg}"`);
 
           //------------------------------------------------------------------
           // 2) Add / update PR comment
           //------------------------------------------------------------------
           if (prNumber) {
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: prNumber, body: msg
-            });
+            // Update existing comment if commentId provided
+            if (commentId) {
+              core.info(`Updating existing comment ${commentId}`);
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: commentId,
+                body: msg
+              });
+              core.setOutput('comment-id', commentId);
+            } else {
+              // Create new comment
+              core.info(`Creating new comment`);
+              const comment = await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body: msg
+              });
+              core.setOutput('comment-id', comment.data.id);
+            }
           }

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -91,18 +91,28 @@ jobs:
     if: |-
       ${{ always() &&
         (needs.check-rights.result == 'success' || github.event_name == 'pull_request') &&
-        needs.parse-params.outputs.shouldRun == 'true' 
+        needs.parse-params.outputs.shouldRun == 'true'
       }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     outputs:
       buildRunId: ${{ steps.verify.outputs.buildRunId }}
       buildMetadataSha: ${{ steps.verify.outputs.buildMetadataSha }}
+      commentId: ${{ steps.initial-comment.outputs.commentId }}
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
+      - name: Add initial comment
+        id: initial-comment
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: ./.github/actions/utils/add-comment
+        with:
+          commentMessage: ':hourglass_flowing_sand: System test verification started: [link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Waiting for build to finish...'
       - name: Get merge commit SHA
         id: get-merge-sha
         run: |
@@ -170,6 +180,7 @@ jobs:
         if: ${{ github.event_name == 'issue_comment' && steps.validate.outputs.isValid == 'true' }}
         uses: ./.github/actions/utils/add-comment
         with:
+          commentId: ${{ needs.check-build.outputs.commentId }}
           commentMessage: ':hourglass_flowing_sand: System test verification started: [link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ${{ steps.validate.outputs.message }}'


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This change introduces comment right after STs workflow is triggered. In case it is triggered when `build` workflow is still running, it will wait until it finishes without any notification. Now, the user will be notified via comment and once the `build` finish, the original comment will be updated with list of pipelines.


<img width="1597" height="840" alt="Screenshot 2025-10-31 at 10 50 17" src="https://github.com/user-attachments/assets/318ec716-280d-4176-afc4-50959d62fe0c" />
<img width="1224" height="683" alt="Screenshot 2025-10-31 at 11 07 20" src="https://github.com/user-attachments/assets/cbe122f4-5c76-48f3-88b5-2426c57c90e2" />

### Checklist

- [x] Make sure all tests pass
- [ ] Update documentation
