### PR TITLE
[ST] Fix RecoveryST failing on deletion of PVCs and change Kafka deletion to background

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/types/KafkaType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/types/KafkaType.java
@@ -91,7 +91,7 @@ public class KafkaType implements ResourceType<Kafka> {
         // proceed only if kafka is still present as Kafka is purposefully deleted in some test cases
         if (currentKafka != null) {
             client.inNamespace(namespaceName).withName(
-                kafka.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                kafka.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds clean up phase to RecoveryST, as the jobs are regularly being stuck on deletion of Kafka + NodePools + PVCs.
The correct path for deletion of the resources is - KafkaNodePools -> Kafka - however we are deleting resources as we have them in stack - we firstly add KNP and then Kafka - so in deletion it means firstly Kafka is deleted and then KNP.

It also changes the deletion from FOREGROUND to BACKGROUND in Kafka - which possibly fixes also other deletion stuff with Kafka and v1 API.

### Checklist

- [x] Make sure all tests pass
