### PR TITLE
Remove use of deprecated `enableMetrics` field in Bridge STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -201,6 +201,7 @@ public interface TestConstants {
     String PATH_TO_KAFKA_CONNECT_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/connect/kafka-connect.yaml";
     String PATH_TO_KAFKA_CONNECT_METRICS_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/metrics/kafka-connect-metrics.yaml";
     String PATH_TO_KAFKA_BRIDGE_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/bridge/kafka-bridge.yaml";
+    String PATH_TO_KAFKA_BRIDGE_METRICS_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/metrics/kafka-bridge-metrics.yaml";
     String PATH_TO_KAFKA_REBALANCE_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/cruise-control/kafka-rebalance-full.yaml";
     String PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/cruise-control/kafka-cruise-control.yaml";
     String PATH_TO_KAFKA_CRUISE_CONTROL_METRICS_CONFIG = PATH_TO_PACKAGING_EXAMPLES + "/metrics/kafka-cruise-control-metrics.yaml";

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -453,12 +453,13 @@ public class MetricsST extends AbstractST {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
         KubeResourceManager.get().createResourceWithWait(
-            KafkaBridgeTemplates.kafkaBridgeWithMetrics(
-                namespaceFirst,
-                bridgeClusterName,
-                KafkaResources.plainBootstrapAddress(kafkaClusterFirstName),
-                1
-                ).build()
+                KafkaBridgeTemplates.bridgeMetricsConfigMap(namespaceFirst, bridgeClusterName),
+                KafkaBridgeTemplates.kafkaBridgeWithMetrics(
+                        namespaceFirst,
+                        bridgeClusterName,
+                        KafkaResources.plainBootstrapAddress(kafkaClusterFirstName),
+                        1
+                        ).build()
         );
 
         // Allow connections from scraper to Bridge pods when NetworkPolicies are set to denied by default

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -561,22 +561,25 @@ public class OauthPlainST extends OauthAbstractST {
         InlineLogging ilDebug = new InlineLogging();
         ilDebug.setLoggers(Map.of("rootLogger.level", "DEBUG"));
 
-        KubeResourceManager.get().createResourceWithWait(KafkaBridgeTemplates.kafkaBridgeWithMetrics(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
-            .editSpec()
-                .withNewKafkaClientAuthenticationOAuth()
-                    .withEnableMetrics()
-                    .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
-                    .withClientId("kafka-bridge")
-                    .withNewClientSecret()
-                        .withSecretName(BRIDGE_OAUTH_SECRET)
-                        .withKey(OAUTH_KEY)
-                    .endClientSecret()
-                    .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
-                    .withReadTimeoutSeconds(READ_TIMEOUT_S)
-                .endKafkaClientAuthenticationOAuth()
-                .withLogging(ilDebug)
-            .endSpec()
-            .build());
+        KubeResourceManager.get().createResourceWithWait(
+                KafkaBridgeTemplates.bridgeMetricsConfigMap(Environment.TEST_SUITE_NAMESPACE, oauthClusterName),
+                KafkaBridgeTemplates.kafkaBridgeWithMetrics(Environment.TEST_SUITE_NAMESPACE, oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
+                        .editSpec()
+                            .withNewKafkaClientAuthenticationOAuth()
+                                .withEnableMetrics()
+                                .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                                .withClientId("kafka-bridge")
+                                .withNewClientSecret()
+                                    .withSecretName(BRIDGE_OAUTH_SECRET)
+                                    .withKey(OAUTH_KEY)
+                                .endClientSecret()
+                                .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
+                                .withReadTimeoutSeconds(READ_TIMEOUT_S)
+                            .endKafkaClientAuthenticationOAuth()
+                            .withLogging(ilDebug)
+                        .endSpec()
+                        .build()
+        );
 
         // Allow connections from scraper to Bridge pods when NetworkPolicies are set to denied by default
         NetworkPolicyUtils.allowNetworkPolicySettingsForBridgeScraper(Environment.TEST_SUITE_NAMESPACE, scraperPodName, KafkaBridgeResources.componentName(oauthClusterName));


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the tests using Bridge metrics to use the new future-proof metrics configuration instead of the old boolean `enableMetrics` flag. The implementation logic follows what Connect STs are doing.

This contributes to #11934.

### Checklist

- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging