### PR TITLE
Cleanup the Connect and MM2 model classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -48,8 +48,6 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
-import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
-import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
@@ -73,7 +71,6 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.jmx.SupportsJmx;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
-import io.strimzi.operator.cluster.model.logging.LoggingUtils;
 import io.strimzi.operator.cluster.model.logging.SupportsLogging;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
@@ -84,7 +81,6 @@ import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderCon
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.model.OrderedProperties;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -92,16 +88,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE;
-
 /**
  * Kafka Connect model class
  */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaConnectCluster extends AbstractModel implements SupportsMetrics, SupportsLogging, SupportsJmx {
     /**
-     * Default Strimzi Metrics Reporter allow list.
-     * Check example dashboards compatibility in case of changes to existing regexes.
+     * Default Strimzi Metrics Reporter allowlist.
+     * Check example dashboard compatibility in case of changes to existing regexes.
      */
     private static final List<String> DEFAULT_METRICS_ALLOW_LIST = List.of(
             "kafka_admin_client_admin_client_metrics_connection_count",
@@ -181,7 +175,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     // Templates
     protected PodDisruptionBudgetTemplate templatePodDisruptionBudget;
     protected ResourceTemplate templateInitClusterRoleBinding;
-    protected DeploymentTemplate templateDeployment;
     protected ResourceTemplate templatePodSet;
     protected PodTemplate templatePod;
     protected InternalServiceTemplate templateService;
@@ -210,10 +203,10 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     /**
      * Constructor
      *
-     * @param reconciliation The reconciliation
-     * @param resource Kubernetes resource with metadata containing the namespace and cluster name
-     * @param name              Name of the Strimzi component usually consisting from the cluster name and component type
-     * @param componentType configurable allow other classes to extend this class
+     * @param reconciliation            The reconciliation
+     * @param resource                  Kubernetes resource with metadata containing the namespace and cluster name
+     * @param name                      The name of the Strimzi component usually consisting from the cluster name and component type
+     * @param componentType             Type of the component this mode handles
      * @param sharedEnvironmentProvider Shared environment provider
      */
     protected KafkaConnectCluster(Reconciliation reconciliation, HasMetadata resource, String name, String componentType, SharedEnvironmentProvider sharedEnvironmentProvider) {
@@ -227,7 +220,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      * Creates the Kafka Connect model instance from the Kafka Connect CRD
      *
      * @param reconciliation    Reconciliation marker
-     * @param kafkaConnect      Kafka connect custom resource
+     * @param kafkaConnect      Kafka Connect custom resource
      * @param versions          Supported Kafka versions
      * @param sharedEnvironmentProvider Shared environment provider
      *
@@ -241,14 +234,13 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     }
 
     /**
-     * Abstracts the calling of setters on a (subclass of) KafkaConnectCluster
-     * from the instantiation of the (subclass of) KafkaConnectCluster,
-     * thus permitting reuse of the setter-calling code for subclasses.
+     * Abstracts the calling of setters on a (subclass of) KafkaConnectCluster from the instantiation of the (subclass of)
+     * KafkaConnectCluster, thus permitting reuse of the setter-calling code for subclasses.
      *
      * @param reconciliation    Reconciliation marker
      * @param spec              Spec section of the Kafka Connect resource
      * @param versions          Supported Kafka versions
-     * @param result            Kafka Connect resource which will be returned as the result
+     * @param result            Kafka Connect resource, which will be returned as the result
      *
      * @param <C>   Type of the Kafka Connect cluster
      */
@@ -334,7 +326,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
 
             result.templatePodDisruptionBudget = template.getPodDisruptionBudget();
             result.templateInitClusterRoleBinding = template.getClusterRoleBinding();
-            result.templateDeployment = template.getDeployment();
             result.templatePodSet = template.getPodSet();
             result.templatePod = template.getPod();
             result.templateService = template.getApiService();
@@ -363,7 +354,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
 
     /**
      * Utility method to help with backward compatibility between the old Connect configuration and a new Connect
-     * configuration. This should be removed once v1beta2 API is dropped and we use only v1.
+     * configuration. This should be removed once v1beta2 API is dropped, and we use only v1.
      *      - We always use the new dedicated field if set (newConfig)
      *      - If the new field is not set, we try to use the user values from .spec.config
      *      - And if those are not set either, we use the defaults that were used from Strimzi beginnings.
@@ -625,7 +616,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      * @param podSetAnnotations         Map with StrimziPodSet annotations
      * @param podAnnotations            Map with Pod annotations
      * @param isOpenShift               Flags whether we are on OpenShift or not
-     * @param imagePullPolicy           Image pull policy which will be used by the pods
+     * @param imagePullPolicy           Image pull policy, which will be used by the pods
      * @param imagePullSecrets          List of image pull secrets
      * @param customContainerImage      Custom container image produced by Kafka Connect Build. If null, the default
      *                                  image will be used.
@@ -914,7 +905,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     }
 
     /**
-     * Creates the ClusterRoleBinding which is used to bind the Kafka Connect SA to the ClusterRole
+     * Creates the ClusterRoleBinding, which is used to bind the Kafka Connect SA to the ClusterRole
      * which permissions the Kafka init container to access K8S nodes (necessary for rack-awareness).
      *
      * @return The cluster role binding.
@@ -969,8 +960,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                 .withResourceNames(certSecretNames)
                 .build());
 
-        Role role = RbacUtils.createRole(componentName, namespace, rules, labels, ownerReference, null);
-        return role;
+        return RbacUtils.createRole(componentName, namespace, rules, labels, ownerReference, null);
     }
 
     /**
@@ -991,10 +981,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                 .withKind("Role")
                 .build();
 
-        RoleBinding rb = RbacUtils
-               .createRoleBinding(getRoleBindingName(), namespace, roleRef, List.of(subject), labels, ownerReference, null);
-
-        return rb;
+        return RbacUtils.createRoleBinding(getRoleBindingName(), namespace, roleRef, List.of(subject), labels, ownerReference, null);
     }
 
     /**
@@ -1019,15 +1006,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     }
 
     /**
-     * @return  Default logging configuration needed to update loggers in Kafka Connect (and Kafka Mirror Maker 2 which
-     *          is based on Kafka Connect)
-     */
-    public OrderedProperties defaultLogConfig()   {
-        return LoggingUtils.defaultLogConfig(reconciliation, logging.getDefaultLogConfigBaseName());
-    }
-
-    /**
-     * The default labels Connect pod has to be passed through a method so that we can handle different labels for
+     * The default labels Connect pod uses have to be passed through a method so that we can handle different labels for
      * Connect and Mirror Maker 2 (which inherits from this class) without duplicating the whole pod creation.
      * This method is overridden in KafkaMirrorMaker2Model.
      *
@@ -1103,13 +1082,5 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
      */
     public LoggingModel logging()   {
         return logging;
-    }
-
-    /**
-     * @return  Returns the preferred Deployment Strategy. This is used for the migration form Deployment to
-     * StrimziPodSet or the other way around
-     */
-    public DeploymentStrategy deploymentStrategy()  {
-        return TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -83,7 +83,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     }
 
     /**
-     * Creates instance of KafkaMirrorMaker2Cluster from CRD definition.
+     * Creates an instance of KafkaMirrorMaker2Cluster from CRD definition.
      *
      * @param reconciliation    The reconciliation
      * @param kafkaMirrorMaker2 The Custom Resource based on which the cluster model should be created.
@@ -343,7 +343,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         for (KafkaMirrorMaker2ClusterSpec mirrorMaker2Cluster : clusters) {
             String clusterAlias = mirrorMaker2Cluster.getAlias();
 
-            if (clusterAliases.length() > 0) {
+            if (!clusterAliases.isEmpty()) {
                 clusterAliases.append(";");
             }
             clusterAliases.append(clusterAlias);
@@ -367,17 +367,17 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
 
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_CLUSTERS, clusterAliases.toString()));
 
-        if (clustersTrustedCerts.length() > 0) {
+        if (!clustersTrustedCerts.isEmpty()) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_TRUSTED_CERTS_CLUSTERS, clustersTrustedCerts.toString()));
         }
 
-        if (clustersTlsAuthCerts.length() > 0 || clustersTlsAuthKeys.length() > 0) {
+        if (!clustersTlsAuthCerts.isEmpty() || !clustersTlsAuthKeys.isEmpty()) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_TLS_AUTH_CLUSTERS, "true"));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_TLS_AUTH_CERTS_CLUSTERS, clustersTlsAuthCerts.toString()));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_TLS_AUTH_KEYS_CLUSTERS, clustersTlsAuthKeys.toString()));
         }
 
-        if (clustersOauthTrustedCerts.length() > 0) {
+        if (!clustersOauthTrustedCerts.isEmpty()) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS, clustersOauthTrustedCerts.toString()));
         }
 
@@ -391,8 +391,8 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         if (tls != null) {
             List<CertSecretSource> trustedCertificates = tls.getTrustedCertificates();
    
-            if (trustedCertificates != null && trustedCertificates.size() > 0) {
-                if (clustersTrustedCerts.length() > 0) {
+            if (trustedCertificates != null && !trustedCertificates.isEmpty()) {
+                if (!clustersTrustedCerts.isEmpty()) {
                     clustersTrustedCerts.append("\n");
                 }
                 clustersTrustedCerts.append(clusterAlias);
@@ -407,7 +407,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     }
 
     private static void appendCluster(final StringBuilder clusters, String clusterAlias, Supplier<String> function) {
-        if (clusters.length() > 0) {
+        if (!clusters.isEmpty()) {
             clusters.append("\n");
         }                   
         clusters.append(clusterAlias);
@@ -419,7 +419,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
      * The command for running Connect has to be passed through a method so that we can handle different run commands
      * for Connect and Mirror Maker 2 (which inherits from this class) without duplicating the whole container creation.
      *
-     * @return  Command for starting Kafka Mirror Maker 2 container
+     * @return  Command for starting the Kafka Mirror Maker 2 container
      */
     @Override
     protected String getCommand() {
@@ -427,7 +427,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     }
 
     /**
-     * The default labels Connect pod has to be passed through a method so that we can handle different labels for
+     * The default labels Connect pod uses have to be passed through a method so that we can handle different labels for
      * Connect and Mirror Maker 2 (which inherits from this class) without duplicating the whole pod creation.
      *
      * @return Default Pod Labels for Kafka Mirror Maker 2


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR does some minor clean-up to the Connect and MM2 model classes. It fixes some IDE warnings but also cleans some unused methods and fields not reported by IntelliJ.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally