### PR TITLE
Do not cache external snapshot dependencies

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -66,3 +66,6 @@ jobs:
         displayName: "Tar the binaries"
       - publish: $(System.DefaultWorkingDirectory)/binaries.tar
         artifact: Binaries
+
+      # Clean SNAPSHOT dependencies before caching
+      - template: "../../steps/clean_maven_snapshots.yaml"

--- a/.azure/templates/jobs/build/deploy_strimzi_java.yaml
+++ b/.azure/templates/jobs/build/deploy_strimzi_java.yaml
@@ -33,3 +33,6 @@ jobs:
           GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
           CENTRAL_USERNAME: $(CENTRAL_USERNAME)
           CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
+
+      # Clean SNAPSHOT dependencies before caching
+      - template: "../../steps/clean_maven_snapshots.yaml"

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -47,3 +47,6 @@ jobs:
         inputs:
           summaryFileLocation: $(System.DefaultWorkingDirectory)/**/target/site/jacoco/jacoco.xml
         displayName: "Publish Test Coverage"
+
+      # Clean SNAPSHOT dependencies before caching
+      - template: "../../steps/clean_maven_snapshots.yaml"

--- a/.azure/templates/steps/clean_maven_snapshots.yaml
+++ b/.azure/templates/steps/clean_maven_snapshots.yaml
@@ -1,0 +1,7 @@
+steps:
+  # Clean external SNAPSHOT dependencies before caching
+  - bash: |
+      mvn dependency:purge-local-repository \
+        -DsnapshotsOnly=true \
+        -DreResolve=false -q || true
+    displayName: "Clean external SNAPSHOT dependencies"

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -161,6 +161,9 @@ jobs:
         CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN: $(connectImage)
       displayName: 'Run systemtests'
 
+    # Clean SNAPSHOT dependencies before caching
+    - template: "./clean_maven_snapshots.yaml"
+
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: JUnit

--- a/.github/actions/build/build-strimzi-binaries/action.yml
+++ b/.github/actions/build/build-strimzi-binaries/action.yml
@@ -109,6 +109,15 @@ runs:
         name: strimzi-binaries.tar
         path: strimzi-binaries.tar
 
+    # Clean external SNAPSHOT dependencies before caching
+    - name: Clean external SNAPSHOT dependencies from Maven repository
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: |
+        mvn dependency:purge-local-repository \
+        -DsnapshotsOnly=true \
+        -DreResolve=false || true
+
     # Save maven cache for main branches
     - name: Save Maven cache
       if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Do not cache SNAPSHOT dependencies. This will help to prevent issue when snapshot in maven central is updated with new code and GHA or Azure want to to test it and it always get cached old library.

