### PR TITLE
Does the NFS Tiered Storage ST work with 2Gi volume?

### DIFF
--- a/systemtest/src/test/resources/nfs/nfs.yaml
+++ b/systemtest/src/test/resources/nfs/nfs.yaml
@@ -230,4 +230,4 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 5Gi
+      storage: 2Gi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The NFS tiered storage ST is failing on Azure because of lack of disk space. This PR should try if the test would work with `2Gi` volume or not ...

### Checklist

- [ ] Make sure all tests pass