### PR TITLE
Use correct repository to retain release artifacts

### DIFF
--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -38,7 +38,7 @@ jobs:
           oras pull ghcr.io/${{ env.REPOSITORY }}/strimzi-binaries:${{ env.TAG }}
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
-          REPOSITORY: "frawless"
+          REPOSITORY: "strimzi"
 
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           oras push ghcr.io/${{ env.REPOSITORY }}/strimzi-binaries:${{ env.TAG }} strimzi-binaries.tar:application/x-tar
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
-          REPOSITORY: "frawless"
+          REPOSITORY: "strimzi"
 
   # Push containers with suffix (e.g., 0.49.0-0) - optional step
   push-containers-with-suffix:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the repository where the artifacts are retained during release. It seems we forgot to update it wen merging the release pipeline.