### PR TITLE
fix: update MirrorSourceConnector metrics pattern example to include source field

### DIFF
--- a/packaging/examples/metrics/kafka-mirror-maker-2-metrics.yaml
+++ b/packaging/examples/metrics/kafka-mirror-maker-2-metrics.yaml
@@ -203,12 +203,13 @@ data:
       type: GAUGE
 
     #kafka.connect:type=MirrorSourceConnector
-    - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>([a-z-_]+)
-      name: kafka_connect_mirror_mirrorsourceconnector_$4
+    - pattern: kafka.connect.mirror<type=MirrorSourceConnector, source=(.+), target=(.+), topic=(.+), partition=(.+)><>([a-z-_]+)
+      name: kafka_connect_mirror_mirrorsourceconnector_$5
       labels:
-        target: "$1"
-        topic: "$2"
-        partition: "$3"
+        source: "$1"
+        target: "$2"
+        topic: "$3"
+        partition: "$4"
       help: "Kafka Mirror Maker 2 Source Connector metrics"
       type: GAUGE
 


### PR DESCRIPTION
### Type of change

- Examples Bugfix

### Description

This was a breaking change introduced Kafka v4.0 where the `source` label was previously optional and disabled by default. Since Kafka 4.0 the `source` label is always enabled.

Using the existing Kafka Connect MirrorSourceConnector metric configuration from the examples with Kafka 4.0 results in the metrics missing.

Before:
```
curl localhost:9404/metrics | grep -i kafka_connect_mirror_mirrorsourceconnector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  619k  100  619k    0     0  7199k      0 --:--:-- --:--:-- --:--:-- 7199k

```

After:
```
curl localhost:9404/metrics | grep -i kafka_connect_mirror_mirrorsourceconnector | head
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP kafka_connect_mirror_mirrorsourceconnector_byte_count Kafka Mirror Maker 2 Source Connector metrics
# TYPE kafka_connect_mirror_mirrorsourceconnector_byte_count gauge
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="0",source="testsrc",target="testtarget",topic="topic1"} 0.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="0",source="testsrc",target="testtarget",topic="topic2"} 2538022.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="1",source="testsrc",target="testtarget",topic="topic1"} 0.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="1",source="testsrc",target="testtarget",topic="topic2"} 2499668.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="1",source="testsrc",target="testtarget",topic="topic3"} 129662.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="10",source="testsrc",target="testtarget",topic="topic1"} 0.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="100",source="testsrc",target="testtarget",topic="topic1"} 0.0
kafka_connect_mirror_mirrorsourceconnector_byte_count{partition="101",source="testsrc",target="testtarget",topic="topic1"} 0.0
...
```

Ref: https://github.com/apache/kafka/commit/7fb25a2b0683bd4e7238eb705f03c955210bea1f

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally


