### PR TITLE
Add Strimzi 0.49.0 to upgrade tests

### DIFF
--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -31,18 +31,18 @@
 #    toKafka: path to Kafka and KafkaNodePool resources, collected in one file, in the version of Strimzi, to which we are doing the downgrade
 # --- Structure ---
 - fromVersion: HEAD
-  toVersion: 0.48.0
+  toVersion: 0.49.0
   fromExamples: HEAD
-  toExamples: strimzi-0.48.0
+  toExamples: strimzi-0.49.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    kafka: strimzi/kafka:0.48.0-kafka-4.1.0
-    topicOperator: strimzi/operator:0.48.0
-    userOperator: strimzi/operator:0.48.0
-  deployKafkaVersion: 4.1.0
+    kafka: strimzi/kafka:0.49.0-kafka-4.1.1
+    topicOperator: strimzi/operator:0.49.0
+    userOperator: strimzi/operator:0.49.0
+  deployKafkaVersion: 4.1.1
   client:
     continuousClientsMessages: 400
   environmentInfo:
@@ -56,18 +56,18 @@
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
 - fromVersion: HEAD
-  toVersion: 0.48.0
+  toVersion: 0.49.0
   fromExamples: HEAD
-  toExamples: strimzi-0.48.0
+  toExamples: strimzi-0.49.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    kafka: strimzi/kafka:0.48.0-kafka-4.1.0
-    topicOperator: strimzi/operator:0.48.0
-    userOperator: strimzi/operator:0.48.0
-  deployKafkaVersion: 4.1.0
+    kafka: strimzi/kafka:0.49.0-kafka-4.1.1
+    topicOperator: strimzi/operator:0.49.0
+    userOperator: strimzi/operator:0.49.0
+  deployKafkaVersion: 4.1.1
   client:
     continuousClientsMessages: 400
   environmentInfo:
@@ -81,18 +81,18 @@
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
 - fromVersion: HEAD
-  toVersion: 0.48.0
+  toVersion: 0.49.0
   fromExamples: HEAD
-  toExamples: strimzi-0.48.0
+  toExamples: strimzi-0.49.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    kafka: strimzi/kafka:0.48.0-kafka-4.1.0
-    topicOperator: strimzi/operator:0.48.0
-    userOperator: strimzi/operator:0.48.0
-  deployKafkaVersion: 4.1.0
+    kafka: strimzi/kafka:0.49.0-kafka-4.1.1
+    topicOperator: strimzi/operator:0.49.0
+    userOperator: strimzi/operator:0.49.0
+  deployKafkaVersion: 4.1.1
   client:
     continuousClientsMessages: 400
   environmentInfo:

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -32,11 +32,11 @@
 #  toKafka: path to Kafka and KafkaNodePool resources, collected in one file, in the version of Strimzi, to which we are doing the upgrade
 #  --- Structure ---
 
-- fromVersion: 0.48.0
-  fromExamples: strimzi-0.48.0
-  deployKafkaVersion: 4.1.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.48.0/kafka-versions.yaml
+- fromVersion: 0.49.0
+  fromExamples: strimzi-0.49.0
+  deployKafkaVersion: 4.1.1
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.49.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     kafka: strimzi/kafka:latest-kafka-4.1.1
@@ -54,11 +54,11 @@
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
-- fromVersion: 0.48.0
-  fromExamples: strimzi-0.48.0
-  deployKafkaVersion: 4.1.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.48.0/kafka-versions.yaml
+- fromVersion: 0.49.0
+  fromExamples: strimzi-0.49.0
+  deployKafkaVersion: 4.1.1
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.49.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     kafka: strimzi/kafka:latest-kafka-4.1.1
@@ -76,11 +76,11 @@
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
-- fromVersion: 0.48.0
-  fromExamples: strimzi-0.48.0
-  deployKafkaVersion: 4.1.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.48.0/kafka-versions.yaml
+- fromVersion: 0.49.0
+  fromExamples: strimzi-0.49.0
+  deployKafkaVersion: 4.1.1
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.49.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     kafka: strimzi/kafka:latest-kafka-4.1.1

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -16,11 +16,11 @@
 #  Kubernetes cluster.
 #  --- Prerequisites ---
 
-fromVersion: 0.48.0
-fromOlmChannelName: strimzi-0.48.x
-fromExamples: strimzi-0.48.0
-fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-0.48.0.zip
-fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.48.0/kafka-versions.yaml
+fromVersion: 0.49.0
+fromOlmChannelName: strimzi-0.49.x
+fromExamples: strimzi-0.49.0
+fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.49.0/strimzi-0.49.0.zip
+fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.49.0/kafka-versions.yaml
 filePaths:
   fromKafka: "/examples/kafka/kafka-persistent.yaml"
   toKafka: "/examples/kafka/kafka-persistent.yaml"


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr updates the upgrade tests to use the newly released 0.49.0 version.

### Checklist

- [ ] Make sure all tests pass