### PR TITLE
Use the v1 API when scaling Connect and MM2 clusters

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -1328,8 +1328,7 @@ class ConnectST extends AbstractST {
         LOGGER.info("-------> Scaling KafkaConnect subresource <-------");
         LOGGER.info("Scaling subresource replicas to {}", scaleTo);
 
-        // We use the KafkaConnect.v1beta2.kafka.strimzi.io kind to use the v1beta2 API. It should be removed once the KafkaConnect CR used is a valid v1 resource.
-        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaConnect.RESOURCE_KIND + ".v1beta2.kafka.strimzi.io", testStorage.getClusterName(), scaleTo);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaConnect.RESOURCE_KIND + ".kafka.strimzi.io", testStorage.getClusterName(), scaleTo);
 
         PodUtils.waitForPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaConnectSelector(), scaleTo, true);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -544,8 +544,7 @@ class MirrorMaker2ST extends AbstractST {
 
         LOGGER.info("Scaling subresource replicas to {}", scaleTo);
 
-        // We use the KafkaMirrorMaker2.v1beta2.kafka.strimzi.io kind to use the v1beta2 API. It should be removed once the KafkaConnect CR used is a valid v1 resource.
-        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaMirrorMaker2.RESOURCE_KIND + ".v1beta2.kafka.strimzi.io", testStorage.getClusterName(), scaleTo);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaMirrorMaker2.RESOURCE_KIND + ".kafka.strimzi.io", testStorage.getClusterName(), scaleTo);
         RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getMM2Selector(), scaleTo);
 
         LOGGER.info("Check if replicas is set to {}, naming prefix should be same and observed generation higher", scaleTo);


### PR DESCRIPTION
### Type of change

- Task

### Description

During the development of the 0.49.0 release, we needed to use the `v1beta2` API to scale the Connect and MM2 clusters. This should not be needed anymore as the Connect and MM2 clusters used should be `v1` valid. This PR removes it from the code.

### Checklist

- [x] Make sure all tests pass