### PR TITLE
doc(11784): specify in kafka listener broker cert chain that PKCS#8 is mandatory

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -52,7 +52,9 @@ public class CertAndKeySecretSource implements UnknownPropertyPreserving {
         this.certificate = certificate;
     }
 
-    @Description("The name of the private key in the Secret.")
+    @Description("The name of the private key in the secret. " +
+            "The private key must be in unencrypted PKCS #8 format. " +
+            "For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208.")
     @JsonProperty(required = true)
     public String getKey() {
         return key;

--- a/api/src/test/resources/crds/v1/040-Crd-kafka.yaml
+++ b/api/src/test/resources/crds/v1/040-Crd-kafka.yaml
@@ -126,7 +126,7 @@ spec:
                                   description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the Secret.
+                                  description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                               required:
                               - secretName
                               - certificate

--- a/api/src/test/resources/crds/v1/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/crds/v1/041-Crd-kafkaconnect.yaml
@@ -121,7 +121,7 @@ spec:
                         description: The name of the file certificate in the Secret.
                       key:
                         type: string
-                        description: The name of the private key in the Secret.
+                        description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                     required:
                     - secretName
                     - certificate

--- a/api/src/test/resources/crds/v1/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/crds/v1/046-Crd-kafkabridge.yaml
@@ -112,7 +112,7 @@ spec:
                         description: The name of the file certificate in the Secret.
                       key:
                         type: string
-                        description: The name of the private key in the Secret.
+                        description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                     required:
                     - secretName
                     - certificate

--- a/api/src/test/resources/crds/v1/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/crds/v1/048-Crd-kafkamirrormaker2.yaml
@@ -128,7 +128,7 @@ spec:
                             description: The name of the file certificate in the Secret.
                           key:
                             type: string
-                            description: The name of the private key in the Secret.
+                            description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                         required:
                         - secretName
                         - certificate
@@ -240,7 +240,7 @@ spec:
                                   description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the Secret.
+                                  description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                               required:
                               - secretName
                               - certificate

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
@@ -27,6 +27,8 @@ listeners:
 
 When the certificate or key in the `brokerCertChainAndKey` secret is updated, the operator automatically detects it in the next reconciliation and triggers a rolling update of the Kafka brokers to reload the certificate.
 
+NOTE: The private key referenced in `brokerCertChainAndKey` must be in an unencrypted PKCS #8 format. If you obtain the certificate is obtained using the {CertManagerProject}, you can set {CertManagerPrivateKeyEncoding} to use PKCS#8.
+
 [id='property-listener-config-traffic-policy-{context}']
 = Avoiding hops to other nodes
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -543,7 +543,7 @@ Used in: xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaList
 |The name of the file certificate in the Secret.
 |key
 |string
-|The name of the private key in the Secret.
+|The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208.
 |====
 
 [id='type-GenericKafkaListenerConfigurationBootstrap-{context}']

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -108,6 +108,8 @@
 :OPAAuthorizer: link:https://github.com/anderseknert/opa-kafka-plugin[Open Policy Agent plugin for Kafka authorization^]
 :external-cors-link: link:https://fetch.spec.whatwg.org/[Fetch CORS specification^]
 :HelmCustomResourceDefinitions: link:https://helm.sh/docs/chart_best_practices/custom_resource_definitions/[Custom Resource Definitions for Helm^]
+:CertManagerProject: link:https://cert-manager.io/docs/[cert-manager project^]
+:CertManagerPrivateKeyEncoding: link:https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.PrivateKeyEncoding[key encoding^]
 
 //distributed tracing versions and links
 :OpenTelemetryAlphaVersion: 1.34.1-alpha

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -122,7 +122,7 @@ spec:
                           description: The name of the file certificate in the Secret.
                         key:
                           type: string
-                          description: The name of the private key in the Secret.
+                          description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                       required:
                         - secretName
                         - certificate
@@ -2655,7 +2655,7 @@ spec:
                           description: The name of the file certificate in the Secret.
                         key:
                           type: string
-                          description: The name of the private key in the Secret.
+                          description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                       required:
                         - secretName
                         - certificate

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -113,7 +113,7 @@ spec:
                           description: The name of the file certificate in the Secret.
                         key:
                           type: string
-                          description: The name of the private key in the Secret.
+                          description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                       required:
                         - secretName
                         - certificate
@@ -1623,7 +1623,7 @@ spec:
                           description: The name of the file certificate in the Secret.
                         key:
                           type: string
-                          description: The name of the private key in the Secret.
+                          description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                       required:
                         - secretName
                         - certificate

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -129,7 +129,7 @@ spec:
                               description: The name of the file certificate in the Secret.
                             key:
                               type: string
-                              description: The name of the private key in the Secret.
+                              description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                           required:
                             - secretName
                             - certificate
@@ -241,7 +241,7 @@ spec:
                                     description: The name of the file certificate in the Secret.
                                   key:
                                     type: string
-                                    description: The name of the private key in the Secret.
+                                    description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                                 required:
                                   - secretName
                                   - certificate
@@ -2761,7 +2761,7 @@ spec:
                                 description: The name of the file certificate in the Secret.
                               key:
                                 type: string
-                                description: The name of the private key in the Secret.
+                                description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                             required:
                               - secretName
                               - certificate
@@ -3011,7 +3011,7 @@ spec:
                               description: The name of the file certificate in the Secret.
                             key:
                               type: string
-                              description: The name of the private key in the Secret.
+                              description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                           required:
                             - secretName
                             - certificate
@@ -3264,7 +3264,7 @@ spec:
                                     description: The name of the file certificate in the Secret.
                                   key:
                                     type: string
-                                    description: The name of the private key in the Secret.
+                                    description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                                 required:
                                   - secretName
                                   - certificate

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -121,7 +121,7 @@ spec:
                         description: The name of the file certificate in the Secret.
                       key:
                         type: string
-                        description: The name of the private key in the Secret.
+                        description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                     required:
                     - secretName
                     - certificate
@@ -2654,7 +2654,7 @@ spec:
                         description: The name of the file certificate in the Secret.
                       key:
                         type: string
-                        description: The name of the private key in the Secret.
+                        description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                     required:
                     - secretName
                     - certificate

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -112,7 +112,7 @@ spec:
                         description: The name of the file certificate in the Secret.
                       key:
                         type: string
-                        description: The name of the private key in the Secret.
+                        description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                     required:
                     - secretName
                     - certificate
@@ -1622,7 +1622,7 @@ spec:
                         description: The name of the file certificate in the Secret.
                       key:
                         type: string
-                        description: The name of the private key in the Secret.
+                        description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                     required:
                     - secretName
                     - certificate

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -128,7 +128,7 @@ spec:
                             description: The name of the file certificate in the Secret.
                           key:
                             type: string
-                            description: The name of the private key in the Secret.
+                            description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                         required:
                         - secretName
                         - certificate
@@ -240,7 +240,7 @@ spec:
                                   description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the Secret.
+                                  description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                               required:
                               - secretName
                               - certificate
@@ -2760,7 +2760,7 @@ spec:
                               description: The name of the file certificate in the Secret.
                             key:
                               type: string
-                              description: The name of the private key in the Secret.
+                              description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                           required:
                           - secretName
                           - certificate
@@ -3010,7 +3010,7 @@ spec:
                             description: The name of the file certificate in the Secret.
                           key:
                             type: string
-                            description: The name of the private key in the Secret.
+                            description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                         required:
                         - secretName
                         - certificate
@@ -3263,7 +3263,7 @@ spec:
                                   description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
-                                  description: The name of the private key in the Secret.
+                                  description: "The name of the private key in the secret. The private key must be in unencrypted PKCS #8 format. For more information, see RFC 5208: https://datatracker.ietf.org/doc/html/rfc5208."
                               required:
                               - secretName
                               - certificate


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Specify in kafka listener broker cert chain that PKCS#8 is mandatory
Also complete the 'Providing your own listener certificates' sub part with explanation to how obtain a PKCS#8 with cert-manager

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging

Discuss here https://github.com/orgs/strimzi/discussions/12164

Closes #11784
