### PR TITLE
Bump Test-Frame to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <testcontainer.version>1.21.3</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
         <junit4.version>4.13.2</junit4.version>
+        <skodjob.test-frame.version>1.3.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.6.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
         <access-operator.version>0.2.0</access-operator.version>
@@ -628,6 +629,33 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <!-- The skodjob dependency is required at compile time, not solely in the test scope, due to the creation of custom metrics components. -->
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-metrics-collector</artifactId>
+                <version>${skodjob.test-frame.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-log-collector</artifactId>
+                <version>${skodjob.test-frame.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-common</artifactId>
+                <version>${skodjob.test-frame.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-kubernetes</artifactId>
+                <version>${skodjob.test-frame.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-openshift</artifactId>
+                <version>${skodjob.test-frame.version}</version>
+                <scope>test</scope>
             </dependency>
             <!-- Test dependencies -->
             <dependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -17,24 +17,7 @@
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
-
-        <!--   Once new version of Test-Frame is released, we need to remove all the deps from here and return it back to the main pom.xml     -->
-        <skodjob.test-frame.version>1.3.0-SNAPSHOT</skodjob.test-frame.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <name>Central Portal Snapshots</name>
-            <id>central-portal-snapshots</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
@@ -249,31 +232,25 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-model-operatorhub</artifactId>
         </dependency>
-        <!-- The skodjob dependency is required at compile time, not solely in the test scope, due to the creation of custom metrics components. -->
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-metrics-collector</artifactId>
-            <version>${skodjob.test-frame.version}</version>
         </dependency>
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-log-collector</artifactId>
-            <version>${skodjob.test-frame.version}</version>
         </dependency>
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-common</artifactId>
-            <version>${skodjob.test-frame.version}</version>
         </dependency>
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-kubernetes</artifactId>
-            <version>${skodjob.test-frame.version}</version>
         </dependency>
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-openshift</artifactId>
-            <version>${skodjob.test-frame.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates Test-Frame to 1.3.0 after the release and returns back everything from the STs pom.xml to the main pom.xml.

### Checklist

- [x] Make sure all tests pass
