### PR TITLE
Improve the UX of the `v1` API Conversion tool

### DIFF
--- a/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/AbstractCommand.java
+++ b/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/AbstractCommand.java
@@ -21,7 +21,6 @@ public abstract class AbstractCommand implements Runnable {
 
     protected static final ApiVersion FROM_API_VERSION = ApiVersion.V1BETA2;
     protected static final ApiVersion TO_API_VERSION = ApiVersion.V1;
-    protected static final String STRIMZI_API = "kafka.strimzi.io";
     protected static final Set<String> STRIMZI_KINDS = Set.of(
             "Kafka",
             "KafkaConnect",
@@ -46,6 +45,21 @@ public abstract class AbstractCommand implements Runnable {
             "KafkaRebalance", "kafka.strimzi.io",
             "KafkaNodePool", "kafka.strimzi.io",
             "StrimziPodSet", "core.strimzi.io"
+    );
+
+    // Mapping between kinds and the CRD names used to get the right CRD from the Kubernetes API
+    @SuppressWarnings("SpellCheckingInspection")
+    protected static final Map<String, String> CRD_NAMES = Map.of(
+            "Kafka", "kafkas.kafka.strimzi.io",
+            "KafkaConnect", "kafkaconnects.kafka.strimzi.io",
+            "KafkaBridge", "kafkabridges.kafka.strimzi.io",
+            "KafkaMirrorMaker2", "kafkamirrormaker2s.kafka.strimzi.io",
+            "KafkaTopic", "kafkatopics.kafka.strimzi.io",
+            "KafkaUser", "kafkausers.kafka.strimzi.io",
+            "KafkaConnector", "kafkaconnectors.kafka.strimzi.io",
+            "KafkaRebalance", "kafkarebalances.kafka.strimzi.io",
+            "KafkaNodePool", "kafkanodepools.kafka.strimzi.io",
+            "StrimziPodSet", "strimzipodsets.core.strimzi.io"
     );
 
     @CommandLine.Spec

--- a/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/CrdUpgradeCommand.java
+++ b/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/CrdUpgradeCommand.java
@@ -17,28 +17,12 @@ import picocli.CommandLine;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Upgrades the API versions in CRDs to store the new v1 version only
  */
 @CommandLine.Command(name = "crd-upgrade", aliases = {"crd"}, description = "Upgrades the Strimzi CRDs and CRs to use v1beta2 version")
 public class CrdUpgradeCommand extends AbstractCommand {
-    // Mapping between kinds and the CRD names used to get the right CRD from the Kubernetes API
-    @SuppressWarnings("SpellCheckingInspection")
-    final static Map<String, String> CRD_NAMES = Map.of(
-            "Kafka", "kafkas.kafka.strimzi.io",
-            "KafkaConnect", "kafkaconnects.kafka.strimzi.io",
-            "KafkaBridge", "kafkabridges.kafka.strimzi.io",
-            "KafkaMirrorMaker2", "kafkamirrormaker2s.kafka.strimzi.io",
-            "KafkaTopic", "kafkatopics.kafka.strimzi.io",
-            "KafkaUser", "kafkausers.kafka.strimzi.io",
-            "KafkaConnector", "kafkaconnectors.kafka.strimzi.io",
-            "KafkaRebalance", "kafkarebalances.kafka.strimzi.io",
-            "KafkaNodePool", "kafkanodepools.kafka.strimzi.io",
-            "StrimziPodSet", "strimzipodsets.core.strimzi.io"
-    );
-
     private KubernetesClient client;
 
     /**
@@ -153,6 +137,10 @@ public class CrdUpgradeCommand extends AbstractCommand {
     @Override
     public void run() {
         client = new KubernetesClientBuilder().build();
+
+        // Pre-check for more user-friendliness
+        println("Checking that the CRDs are present and have the desired API versions.");
+        Utils.checkCrdsHaveApiVersions(client, CRD_NAMES.values(), FROM_API_VERSION, TO_API_VERSION);
 
         // Change the stored version in CRD spec to v1beta2
         println("Changing stored version in all Strimzi CRDs to " + TO_API_VERSION + ":");

--- a/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/utils/Utils.java
+++ b/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/utils/Utils.java
@@ -6,10 +6,14 @@ package io.strimzi.kafka.api.conversion.v1.utils;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.annotations.ApiVersion;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Various utility methods useful during the conversion
@@ -23,9 +27,33 @@ public class Utils {
      * @param group         Group
      * @param apiVersion    API version
      *
-     * @return  Client for working with given Kubernetes resource
+     * @return  Client for working with a given Kubernetes resource
      */
     public static MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> versionedOperation(KubernetesClient client, String kind, String group, ApiVersion apiVersion) {
         return client.genericKubernetesResources(group + "/" + apiVersion, kind);
+    }
+
+    /**
+     * Checks if the CRDs are installed and have the correct API versions. This is used as a pre-check to avoid running
+     * the conversion tool against older Strimzi versions missing the `v1` CRD API or missing the CRDs entirely.
+     *
+     * @param client        Kubernetes client
+     * @param crdNames      Collection of the CRD names
+     * @param apiVersions   Array of required API versions
+     */
+    public static void checkCrdsHaveApiVersions(KubernetesClient client, Collection<String> crdNames, ApiVersion... apiVersions)   {
+        for (String crdName : crdNames) {
+            CustomResourceDefinition crd = client.apiextensions().v1().customResourceDefinitions().withName(crdName).get();
+
+            if (crd == null) {
+                throw new RuntimeException("CRD " + crdName + " is missing");
+            }
+
+            for (ApiVersion apiVersion : apiVersions) {
+                if (crd.getSpec().getVersions().stream().noneMatch(v -> apiVersion.toString().equals(v.getName()))) {
+                    throw new RuntimeException("CRD " + crdName + " is missing at least one of the required API versions " + Arrays.toString(apiVersions));
+                }
+            }
+        }
     }
 }

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/utils/UtilsIT.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/utils/UtilsIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.v1.utils;
+
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.kafka.api.conversion.v1.cli.ConversionTestUtils;
+import io.strimzi.test.CrdUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UtilsIT {
+    private static KubernetesClient client;
+
+    @BeforeAll
+    static void setupEnvironment() {
+        client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().build()).build();
+        ConversionTestUtils.createOrUpdateCrd(client, CrdUtils.CRD_KAFKA_NAME, ConversionTestUtils.CRD_V1_KAFKA);
+    }
+
+    @AfterAll
+    static void teardownEnvironment() {
+        CrdUtils.deleteCrd(client, CrdUtils.CRD_KAFKA_NAME);
+        client.close();
+    }
+
+    @Test
+    public void testMissingVersion() {
+        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () -> Utils.checkCrdsHaveApiVersions(client, List.of("kafkas.kafka.strimzi.io"), ApiVersion.V1BETA2, ApiVersion.V1));
+        assertThat(ex.getMessage(), containsString("CRD kafkas.kafka.strimzi.io is missing at least one of the required API versions [v1beta2, v1]"));
+    }
+
+    @Test
+    public void testMissingCrd() {
+        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () -> Utils.checkCrdsHaveApiVersions(client, List.of("kafkaconnects.kafka.strimzi.io"), ApiVersion.V1BETA2, ApiVersion.V1));
+        assertThat(ex.getMessage(), containsString("CRD kafkaconnects.kafka.strimzi.io is missing"));
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR does some slight improvements to the user experience of the `v1` API Conversion Tool:
* Adds a pre-check to make sure the CRDs are present and have the `v1` nd `v1beta2` versions. This is useful to prevent users from getting weird errors when running it against older Strimzi versions.
* It adds a new log message when the resource is replaced in Kubernetes
* It adds an exception catch and better runtime exception to provide more information when the replacement fails

This is based on the user feedback from https://cloud-native.slack.com/archives/CMH3Q3SNP/p1764104599210349

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally