### PR TITLE
Updade the columns in the `Kafka` CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
@@ -52,14 +52,19 @@ import java.util.function.Predicate;
                 jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
                 type = "string"),
             @Crd.Spec.AdditionalPrinterColumn(
-                name = "Metadata State",
-                description = "The state of the cluster metadata",
-                jsonPath = ".status.kafkaMetadataState",
-                type = "string"),
-            @Crd.Spec.AdditionalPrinterColumn(
                 name = "Warnings",
                 description = "Warnings related to the custom resource",
                 jsonPath = ".status.conditions[?(@.type==\"Warning\")].status",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "Kafka version",
+                description = "The Kafka version used by the cluster",
+                jsonPath = ".status.kafkaVersion",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "Metadata version",
+                description = "The Kafka metadata version used by the cluster",
+                jsonPath = ".status.kafkaMetadataVersion",
                 type = "string")
         }
     )

--- a/api/src/test/resources/crds/v1/040-Crd-kafka.yaml
+++ b/api/src/test/resources/crds/v1/040-Crd-kafka.yaml
@@ -30,13 +30,17 @@ spec:
       description: The state of the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
       type: string
-    - name: Metadata State
-      description: The state of the cluster metadata
-      jsonPath: .status.kafkaMetadataState
-      type: string
     - name: Warnings
       description: Warnings related to the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+      type: string
+    - name: Kafka version
+      description: The Kafka version used by the cluster
+      jsonPath: .status.kafkaVersion
+      type: string
+    - name: Metadata version
+      description: The Kafka metadata version used by the cluster
+      jsonPath: .status.kafkaMetadataVersion
       type: string
     schema:
       openAPIV3Schema:

--- a/api/src/test/resources/crds/v1beta2/040-Crd-kafka.yaml
+++ b/api/src/test/resources/crds/v1beta2/040-Crd-kafka.yaml
@@ -30,13 +30,17 @@ spec:
       description: The state of the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
       type: string
-    - name: Metadata State
-      description: The state of the cluster metadata
-      jsonPath: .status.kafkaMetadataState
-      type: string
     - name: Warnings
       description: Warnings related to the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+      type: string
+    - name: Kafka version
+      description: The Kafka version used by the cluster
+      jsonPath: .status.kafkaVersion
+      type: string
+    - name: Metadata version
+      description: The Kafka metadata version used by the cluster
+      jsonPath: .status.kafkaMetadataVersion
       type: string
     schema:
       openAPIV3Schema:
@@ -4966,13 +4970,17 @@ spec:
       description: The state of the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
       type: string
-    - name: Metadata State
-      description: The state of the cluster metadata
-      jsonPath: .status.kafkaMetadataState
-      type: string
     - name: Warnings
       description: Warnings related to the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+      type: string
+    - name: Kafka version
+      description: The Kafka version used by the cluster
+      jsonPath: .status.kafkaVersion
+      type: string
+    - name: Metadata version
+      description: The Kafka metadata version used by the cluster
+      jsonPath: .status.kafkaMetadataVersion
       type: string
     schema:
       openAPIV3Schema:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -31,13 +31,17 @@ spec:
           description: The state of the custom resource
           jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
           type: string
-        - name: Metadata State
-          description: The state of the cluster metadata
-          jsonPath: .status.kafkaMetadataState
-          type: string
         - name: Warnings
           description: Warnings related to the custom resource
           jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+          type: string
+        - name: Kafka version
+          description: The Kafka version used by the cluster
+          jsonPath: .status.kafkaVersion
+          type: string
+        - name: Metadata version
+          description: The Kafka metadata version used by the cluster
+          jsonPath: .status.kafkaMetadataVersion
           type: string
       schema:
         openAPIV3Schema:
@@ -4967,13 +4971,17 @@ spec:
           description: The state of the custom resource
           jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
           type: string
-        - name: Metadata State
-          description: The state of the cluster metadata
-          jsonPath: .status.kafkaMetadataState
-          type: string
         - name: Warnings
           description: Warnings related to the custom resource
           jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+          type: string
+        - name: Kafka version
+          description: The Kafka version used by the cluster
+          jsonPath: .status.kafkaVersion
+          type: string
+        - name: Metadata version
+          description: The Kafka metadata version used by the cluster
+          jsonPath: .status.kafkaMetadataVersion
           type: string
       schema:
         openAPIV3Schema:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -30,13 +30,17 @@ spec:
       description: The state of the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
       type: string
-    - name: Metadata State
-      description: The state of the cluster metadata
-      jsonPath: .status.kafkaMetadataState
-      type: string
     - name: Warnings
       description: Warnings related to the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+      type: string
+    - name: Kafka version
+      description: The Kafka version used by the cluster
+      jsonPath: .status.kafkaVersion
+      type: string
+    - name: Metadata version
+      description: The Kafka metadata version used by the cluster
+      jsonPath: .status.kafkaMetadataVersion
       type: string
     schema:
       openAPIV3Schema:
@@ -4966,13 +4970,17 @@ spec:
       description: The state of the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
       type: string
-    - name: Metadata State
-      description: The state of the cluster metadata
-      jsonPath: .status.kafkaMetadataState
-      type: string
     - name: Warnings
       description: Warnings related to the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Warning\")].status"
+      type: string
+    - name: Kafka version
+      description: The Kafka version used by the cluster
+      jsonPath: .status.kafkaVersion
+      type: string
+    - name: Metadata version
+      description: The Kafka metadata version used by the cluster
+      jsonPath: .status.kafkaMetadataVersion
       type: string
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The current columns printed when listing CRDs list the _metadata state_. That is not very useful anymore as we don't set it. This PR removes it from the additional printer columns and instead adds the Kafka version and the Metadata version, which might be more useful than the empty column.

```
kubectl get kafka -o wide
NAME         READY   WARNINGS   KAFKA VERSION   METADATA VERSION
my-cluster   True               4.1.1           4.1-IV1
```

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally