### PR TITLE
Fix `kafka_server_kafkaserver_clusterid` metric configuration for Strimzi Metrics Reporter

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -130,7 +130,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             "kafka_server_brokertopicmetrics.*",
             "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent",
             "kafka_server_kafkaserver_brokerstate",
-            "kafka_server_kafkaserver_clusterid_info",
+            "kafka_server_kafkaserver_clusterid",
             "kafka_server_kafkaserver_linux.*",
             "kafka_server_raft.*",
             "kafka_server_replicamanager.*",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#12142 fixed two metrics that were incorrectly configured in the default metrics list for Strimzi Metrics Reporter because of having the metric type based suffix. But it did not fix all of the metrics suffering from the same issue. This PR fix the same problem also for `kafka_server_kafkaserver_clusterid` by removing the `_info` suffix.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally