### PR TITLE
[ST] Fix env vars in YAML installation of CO and create co-namespace correctly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -5,11 +5,11 @@
 package io.strimzi.systemtest.resources.operator;
 
 import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.enums.InstallType;
 import io.skodjob.testframe.installation.InstallationMethod;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.utils.kubeUtils.NamespaceUtils;
 
 /**
  * Class for handling the installation of ClusterOperator.
@@ -127,12 +127,7 @@ public class SetupClusterOperator {
             }
         }
 
-        KubeResourceManager.get().createResourceWithWait(new NamespaceBuilder()
-            .withNewMetadata()
-                .withName(clusterOperatorConfiguration.getNamespaceName())
-            .endMetadata()
-            .build()
-        );
+        NamespaceUtils.createNamespaceAndPrepare(clusterOperatorConfiguration.getNamespaceName());
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/YamlInstallation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/YamlInstallation.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -397,7 +398,12 @@ public class YamlInstallation implements InstallationMethod {
 
         // Map the current envVars list to Map for easier manipulation
         Map<String, EnvVar> envVarMap = envVars.stream()
-            .collect(Collectors.toMap(EnvVar::getName, Function.identity()));
+            .collect(Collectors.toMap(
+                EnvVar::getName,
+                Function.identity(),
+                (existing, replacement) -> existing,
+                LinkedHashMap::new
+            ));
 
         // Adding custom evn vars specified by user in installation
         if (clusterOperatorConfiguration.getExtraEnvVars() != null) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes order of env vars that are being taken from the CO Deployment file and then added to the CO Deployment - as now the mechanism will mix up the env variables and in case that we have some env variables that points to different env var (which should be there before the other env var), the order can cause a lot of issues in the deployment - and also fixes the way how the `co-namespace` created - as now we are just creating the Namespace, without creating pull secret and properly preparing the Namespace for the test-cases.

### Checklist

- [x] Make sure all tests pass

