### PR TITLE
[ST] Isolate two JSON logging tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -103,7 +103,7 @@ class LoggingChangeST extends AbstractST {
 
     private static final Pattern DEFAULT_LOG4J_PATTERN = Pattern.compile("^(?<date>[\\d-]+) (?<time>[\\d:,]+) (?<status>\\w+) (?<message>.+)");
 
-    @ParallelNamespaceTest
+    @IsolatedTest("We are configuring and scraping logs from CO")
     @TestDoc(
         description = @Desc("Test verifying that the logging in JSON format works correctly across Kafka and operators using the JsonTemplateLayout."),
         steps = {
@@ -349,7 +349,7 @@ class LoggingChangeST extends AbstractST {
         KubeResourceManager.get().updateResource(configMapCO);
     }
 
-    @ParallelNamespaceTest
+    @IsolatedTest("We are configuring and scraping logs from CO")
     @TestDoc(
             description = @Desc("Test verifying that the logging in JSON format works correctly across Kafka and operators."),
             steps = {


### PR DESCRIPTION
### Type of change

- Test fix

### Description

This small PR adds `IsolatedTest` annotation to two of the JSON logging tests - `testJsonTemplateLayoutFormatLogging` and `testJSONFormatLogging` - as in parallel they can configure at the same time the CO with JSON logging stuff (both in a different way), causing the `testJsonTemplateLayoutFormatLogging` failing on check for particular pattern of the JSON log to appear.

### Checklist

- [x] Make sure all tests pass
