### PR TITLE
[CRD-v1] Fix handling of storage overrides in non-JBOD storage

### DIFF
--- a/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/converter/conversions/NodePoolConversions.java
+++ b/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/converter/conversions/NodePoolConversions.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.kafka.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
-import io.strimzi.kafka.api.conversion.v1.converter.ApiConversionFailedException;
 
 /**
  * Class for holding the various conversions specific for the KafkaNodePool API conversion
@@ -40,8 +39,6 @@ public class NodePoolConversions {
                     }
                 } else if (storage instanceof PersistentClaimStorage persistentVolume && persistentVolume.getOverrides() != null) {
                     persistentVolume.setOverrides(null);
-                } else {
-                    throw new ApiConversionFailedException("Cannot remove storage overrides in " + storage.getClass().getName());
                 }
 
                 return storage;

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertFileCommandTest.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertFileCommandTest.java
@@ -160,6 +160,8 @@ public class ConvertFileCommandTest {
                 Arguments.of("nodepool-v1beta2.yaml", "nodepool-v1beta2.out"),
                 Arguments.of("nodepool-no-jbod.yaml", "nodepool-no-jbod.out"),
                 Arguments.of("nodepool-no-overrides.yaml", "nodepool-no-overrides.out"),
+                Arguments.of("nodepool-no-overrides-no-jbod.yaml", "nodepool-no-overrides-no-jbod.out"),
+                Arguments.of("nodepool-ephemeral.yaml", "nodepool-ephemeral.out"),
                 Arguments.of("connect-v1beta2.yaml", "connect-v1beta2.out"),
                 Arguments.of("connect-up-to-date.yaml", "connect-up-to-date.out"),
                 Arguments.of("mm2-v1beta2.yaml", "mm2-v1beta2.out"),

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertResourceCommandSampleResourcesIT.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertResourceCommandSampleResourcesIT.java
@@ -79,6 +79,8 @@ public class ConvertResourceCommandSampleResourcesIT {
                 Arguments.of("nodepool-v1beta2.yaml"),
                 Arguments.of("nodepool-no-jbod.yaml"),
                 Arguments.of("nodepool-no-overrides.yaml"),
+                Arguments.of("nodepool-no-overrides-no-jbod.yaml"),
+                Arguments.of("nodepool-ephemeral.yaml"),
                 Arguments.of("connect-v1beta2.yaml"),
                 Arguments.of("connect-up-to-date.yaml"),
                 Arguments.of("mm2-v1beta2.yaml"),

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-ephemeral.out
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-ephemeral.out
@@ -1,0 +1,13 @@
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+  - controller
+  storage:
+    type: ephemeral

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-ephemeral.yaml
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-ephemeral.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: ephemeral

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-no-overrides-no-jbod.out
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-no-overrides-no-jbod.out
@@ -1,0 +1,14 @@
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+  - controller
+  storage:
+    type: persistent-claim
+    size: 100Gi

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-no-overrides-no-jbod.yaml
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/nodepool-no-overrides-no-jbod.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: persistent-claim
+    size: 100Gi
+    deleteClaim: false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `v1` API Conversion Tool has a bug in how it handles the non-JBOD storage without overrides. As described in #12189, it throws an `ApiConversionFailedException` instead of just ignoring the storage and returning it.

This PR fixes that by removing the invalid `else` condition and adding tests for non-jbod persistent storage without overrides and ephemeral storage. We were missing those in the coverage.

This should resolve #12189.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging