### PR TITLE
chore: fix MM2 with TLS example

### DIFF
--- a/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
@@ -25,9 +25,10 @@ spec:
   - source:
       alias: cluster-a
       bootstrapServers: cluster-a-kafka-bootstrap:9093
-      trustedCertificates:
-        - secretName: cluster-a-cluster-ca-cert
-          pattern: "*.crt"
+      tls:
+        trustedCertificates:
+          - secretName: cluster-a-cluster-ca-cert
+            pattern: "*.crt"
     sourceConnector:
       tasksMax: 1
       config:


### PR DESCRIPTION
During testing, it became apparent that the `trustedCertificates` should be placed under a `tls` key which was not present in the official TLS example

### Type of change

- Documentation

### Description

During testing of MirrorMaker2 following the v0.49.0 upgrade, it became apparent that the `trustedCertificates` field needed to be placed under a `tls` field which was not present in the official TLS example.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

