### PR TITLE
Add planned 0.49.1 to the `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 * Nothing here yet, but we will surely develop something new pretty soon 😉
 
+## 0.49.1
+
+* Fixed TLS configuration in MirrorMaker 2 examples
+* `v1` API Conversion Tool bug fixes (Improved CRD validation before doing the conversion, conversion of Node Pools with single volume persistent storage, various typos)
+* Fixed incorrect default names for Strimzi Metrics Provider metrics
+* Fixed Push secret handling when `UseConnectBuildWithBuildah` feature gate is enabled
+* Documentation improvements
+
 ## 0.49.0
 
 * Add support for Kafka 4.0.1 and 4.1.1


### PR DESCRIPTION
### Type of change

- Task

### Description

As we are planning the 0.49.1 bugfix release, this PR adds a new 0.49.1 section to the CHANGELOG to track its changes.

Once approved and merged, this will be also cherry-picked to the 0.49.x branch.

### Checklist

- [x] Update CHANGELOG.md