### PR TITLE
[ST] Remove MirrorMaker2ST.testMirrorMaker2CorrectlyMirrorsHeaders

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.mirrormaker.MirrorMaker2ST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.mirrormaker.MirrorMaker2ST.md
@@ -101,23 +101,6 @@
 * [mirror-maker-2](labels/mirror-maker-2.md)
 
 
-## testMirrorMaker2CorrectlyMirrorsHeaders
-
-**Description:** Checks that Kafka headers are correctly mirrored by MM2.
-
-**Steps:**
-
-| Step | Action | Result |
-| - | - | - |
-| 1. | Deploy Kafka clusters, topic, and MM2. | Kafka clusters, topic and MM2 are ready. |
-| 2. | Produce messages with specific headers to the source Kafka cluster. | Messages with headers are produced to source Kafka cluster. |
-| 3. | Consume from mirrored topic on target Kafka cluster. | Headers are present in consumer log. |
-
-**Labels:**
-
-* [mirror-maker-2](labels/mirror-maker-2.md)
-
-
 ## testMirrorMaker2TlsAndScramSha512Auth
 
 **Description:** Checks message mirroring over TLS with SCRAM-SHA-512 authentication.

--- a/development-docs/systemtests/labels/mirror-maker-2.md
+++ b/development-docs/systemtests/labels/mirror-maker-2.md
@@ -18,7 +18,6 @@ and error handling via status or conditions and offset introspection.
 - [testKafkaMirrorMaker2WrongBootstrap](../io.strimzi.systemtest.operators.CustomResourceStatusST.md)
 - [testLeaderElection](../io.strimzi.systemtest.operators.LeaderElectionST.md)
 - [testMirrorMaker2](../io.strimzi.systemtest.mirrormaker.MirrorMaker2ST.md)
-- [testMirrorMaker2CorrectlyMirrorsHeaders](../io.strimzi.systemtest.mirrormaker.MirrorMaker2ST.md)
 - [testMirrorMaker2LogSetting](../io.strimzi.systemtest.log.LogSettingST.md)
 - [testMirrorMaker2Metrics](../io.strimzi.systemtest.metrics.MetricsST.md)
 - [testMirrorMaker2TlsAndScramSha512Auth](../io.strimzi.systemtest.mirrormaker.MirrorMaker2ST.md)


### PR DESCRIPTION
### Type of change

- Test removal

### Description

This PR removes `MirrorMaker2ST.testMirrorMaker2CorrectlyMirrorsHeaders` as it tests something that should be covered in Kafka's testsuite rather than Strimzi testsuite, as it doesn't test anything related to the operator (like API or behavior of the operator), just that MM2 is able to mirror headers.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
