### PR TITLE
Fix Prometheus deployment documentation

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -64,6 +64,6 @@ kubectl apply -f prometheus-additional.yaml
 . Deploy the Prometheus resources:
 +
 [source,shell,subs="+quotes,attributes"]
-kubectl apply -f pod-monitors/*.yaml
-kubectl apply -f prometheus-rules/*.yaml
+kubectl apply -f pod-monitors/
+kubectl apply -f prometheus-rules/
 kubectl apply -f prometheus.yaml


### PR DESCRIPTION
By using the following lines in the Prometheus deployment documentation ...

```shell
kubectl apply -f pod-monitors/*.yaml
kubectl apply -f prometheus-rules/*.yaml
kubectl apply -f prometheus.yaml
```

... the output rendered on the website is the following:

<img width="456" height="152" alt="image" src="https://github.com/user-attachments/assets/ec7bfb54-eaf2-4285-b895-ce027a8ab762" />

As you can see the asterisks are used to render part of the text in bold which is wrong.
A user just doing copy/paste from the website (like me :-P) will get an error because the `/.yaml` syntax is wrong.
This trivial PR just remove that part by leaving the trailing `/` which is enough to apply all the YAML files within the directory (we don't have other files there). 