### PR TITLE
Fix flaky test assertion 

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -427,7 +427,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
                     assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
                     assertThat(mm2Status.getReplicas(), is(3));
-                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    // Compare as Sets to avoid order-dependent flakiness due to HashMap iteration order in labelSelector
+                    assertThat(Set.of(mm2Status.getLabelSelector().split(",")), is(Set.of("strimzi.io/cluster=my-mm2", "strimzi.io/name=my-mm2-mirrormaker2", "strimzi.io/kind=KafkaMirrorMaker2")));
                     assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
                     assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
 


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

The fix addressed flaky test failures in the `KafkaMirrorMaker2AssemblyOperatorPodSetTest.java` file, specifically in the `testScaleUpCluster` method, where assertions on the labelSelector field were failing intermittently due to non-deterministic HashMap iteration order, as HashMap order is not always promised. Using NonDex, a tool that shuffles method executions to expose order-dependent bugs, I ran the tests over 100 times to confirm the flakiness stemmed from varying comma-separated label strings `(e.g., "strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2" vs. reordered versions)`. To resolve this, I replaced the direct string equality assertion with a Set-based comparison, splitting the labelSelector by commas and comparing unordered Sets, ensuring order independence and eliminating the HashMap variability.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

