### PR TITLE
Refactor `KafkaConnectBuildTest` to unify it with other tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -5,18 +5,12 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.openshift.api.model.BuildConfig;
@@ -26,7 +20,6 @@ import io.strimzi.api.kafka.model.common.template.ContainerEnvVarBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
-import io.strimzi.api.kafka.model.connect.build.Artifact;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -46,125 +39,102 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaConnectBuildTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
-
-    private final String cluster = "my-connect";
-    private final String namespace = "my-ns";
-    private final boolean useBuildah = false;
-
-    private final Artifact jarArtifactNoChecksum = new JarArtifactBuilder()
-            .withUrl("https://mydomain.tld/my.jar")
-            .build();
-
-    private final Artifact jarArtifactWithChecksum = new JarArtifactBuilder()
-            .withUrl("https://mydomain.tld/my2.jar")
-            .withSha512sum("sha-512-checksum")
-            .build();
-
-    private final List<String> defaultKanikoArgs = List.of("--dockerfile=/dockerfile/Dockerfile",
+    private static final List<String> EXPECTED_DEFAULT_KANIKO_OPTIONS = List.of("--dockerfile=/dockerfile/Dockerfile",
             "--image-name-with-digest-file=/dev/termination-log",
             "--destination=my-image:latest");
+    private static final String EXPECTED_DEFAULT_BUILDAH_BUILD_ARGS = "--file=/dockerfile/Dockerfile --tag=my-image:latest --storage-driver=vfs";
+    private static final String EXPECTED_DEFAULT_BUILDAH_PUSH_ARGS = "--storage-driver=vfs --digestfile=/tmp/digest";
 
-    private final String defaultBuildahBuildArgs = "--file=/dockerfile/Dockerfile --tag=my-image:latest --storage-driver=vfs";
-    private final String defaultBuildahPushArgs = "--storage-driver=vfs --digestfile=/tmp/digest";
+    private static final String NAMESPACE = "my-ns";
+    private static final String NAME = "my-connect";
+    private static final KafkaConnect RESOURCE = new KafkaConnectBuilder()
+            .withNewMetadata()
+                .withName(NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(2)
+                .withImage("my-source-image:latest")
+                .withBootstrapServers("my-kafka:9092")
+                .withGroupId("my-group")
+                .withConfigStorageTopic("my-config-topic")
+                .withOffsetStorageTopic("my-offset-topic")
+                .withStatusStorageTopic("my-status-topic")
+            .withNewBuild()
+                .withNewDockerOutput()
+                    .withImage("my-image:latest")
+                    .withPushSecret("my-docker-credentials")
+                .endDockerOutput()
+                .withPlugins(
+                        new PluginBuilder().withName("my-connector").withArtifacts(new JarArtifactBuilder().withUrl("https://mydomain.tld/my.jar").build()).build(),
+                        new PluginBuilder().withName("my-connector2").withArtifacts(new JarArtifactBuilder().withUrl("https://mydomain.tld/my2.jar").withSha512sum("sha-512-checksum").build()).build())
+            .endBuild()
+            .endSpec()
+            .build();
 
     @Test
     public void testFromCrd()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                    .endBuild()
-                .endSpec()
-                .build();
+        assertDoesNotThrow(() -> {
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), RESOURCE, VERSIONS, SHARED_ENV_PROVIDER, false);
+        });
 
-        KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah);
     }
 
     @Test
     public void testValidationPluginsExist()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
                     .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
+                        .withPlugins()
                     .endBuild()
                 .endSpec()
                 .build();
 
-        assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah)
+        InvalidResourceException thrown = assertThrows(InvalidResourceException.class, () ->
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
         );
+        assertThat(thrown.getMessage(), is("List of connector plugins is required when Kafka Connect Build is used."));
     }
 
     @Test
     public void testValidationArtifactsExist()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withPlugins(new PluginBuilder().withName("my-connector").build())
                     .endBuild()
                 .endSpec()
                 .build();
 
-        assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah)
+        InvalidResourceException thrown = assertThrows(InvalidResourceException.class, () ->
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
         );
+        assertThat(thrown.getMessage(), is("Each connector plugin needs to have a list of artifacts."));
     }
 
     @Test
     public void testValidationUniqueNames()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactNoChecksum).build())
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withPlugins(
+                                new PluginBuilder().withName("my-connector").withArtifacts(new JarArtifactBuilder().withUrl("https://mydomain.tld/my.jar").build()).build(),
+                                new PluginBuilder().withName("my-connector").withArtifacts(new JarArtifactBuilder().withUrl("https://mydomain.tld/my2.jar").withSha512sum("sha-512-checksum").build()).build()
+                        )
                     .endBuild()
                 .endSpec()
                 .build();
 
-        assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah)
+        InvalidResourceException thrown = assertThrows(InvalidResourceException.class, () ->
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
         );
+        assertThat(thrown.getMessage(), is("Connector plugins names have to be unique within a single KafkaConnect resource."));
     }
 
     @Test
@@ -177,47 +147,35 @@ public class KafkaConnectBuildTest {
         request.put("cpu", new Quantity("1000m"));
         request.put("memory", new Quantity("1Gi"));
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withImage("my-source-image:latest")
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withResources(new ResourceRequirementsBuilder().withLimits(limit).withRequests(request).build())
                     .endBuild()
                 .endSpec()
                 .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
         assertThat(build.baseImage, is("my-source-image:latest"));
 
         Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
-        assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(cluster)));
-        assertThat(pod.getMetadata().getNamespace(), is(namespace));
+        assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(NAME)));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
 
-        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
-                Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, NAME,
+                Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(NAME),
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
                 Labels.KUBERNETES_NAME_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
-                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-                Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + this.cluster,
+                Labels.KUBERNETES_INSTANCE_LABEL, NAME,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + NAME,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
         assertThat(pod.getMetadata().getLabels(), is(expectedDeploymentLabels));
-        assertThat(pod.getSpec().getServiceAccountName(), is(KafkaConnectResources.buildServiceAccountName(cluster)));
+        assertThat(pod.getSpec().getServiceAccountName(), is(KafkaConnectResources.buildServiceAccountName(NAME)));
         assertThat(pod.getSpec().getContainers().size(), is(1));
-        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(defaultKanikoArgs));
-        assertThat(pod.getSpec().getContainers().get(0).getName(), is(KafkaConnectResources.buildPodName(this.cluster)));
+        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(EXPECTED_DEFAULT_KANIKO_OPTIONS));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is(KafkaConnectResources.buildPodName(NAME)));
         // TODO: use configuration from the `ClusterOperatorConfig` rather than from env variables directly - https://github.com/strimzi/strimzi-kafka-operator/issues/11981
         assertThat(pod.getSpec().getContainers().get(0).getImage(), is(KafkaConnectBuild.DEFAULT_KANIKO_EXECUTOR_IMAGE));
         assertThat(pod.getSpec().getContainers().get(0).getPorts(), is(nullValue()));
@@ -225,7 +183,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getResources().getRequests(), is(request));
         assertThat(pod.getSpec().getVolumes().size(), is(2));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
-        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
         assertThat(pod.getSpec().getVolumes().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getVolumes().get(1).getSecret().getSecretName(), is("my-docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(2));
@@ -233,6 +191,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/kaniko/.docker"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(0));
         io.strimzi.operator.cluster.TestUtils.checkOwnerReference(pod, kc);
     }
 
@@ -246,50 +205,38 @@ public class KafkaConnectBuildTest {
         request.put("cpu", new Quantity("1000m"));
         request.put("memory", new Quantity("1Gi"));
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withImage("my-source-image:latest")
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("my-docker-credentials")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                    .withResources(new ResourceRequirementsBuilder().withLimits(limit).withRequests(request).build())
-                .endBuild()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withResources(new ResourceRequirementsBuilder().withLimits(limit).withRequests(request).build())
+                    .endBuild()
+                .endSpec()
+                .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
 
         assertThat(build.baseImage, is("my-source-image:latest"));
 
         Pod pod = build.generateBuilderPod(true, true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
-        assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(cluster)));
-        assertThat(pod.getMetadata().getNamespace(), is(namespace));
+        assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(NAME)));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
 
-        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
-            Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, NAME,
+            Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(NAME),
             Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
             Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
             Labels.KUBERNETES_NAME_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
-            Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-            Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + this.cluster,
+            Labels.KUBERNETES_INSTANCE_LABEL, NAME,
+            Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + NAME,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
         String[] commands = pod.getSpec().getContainers().get(0).getArgs().get(2).split("\n");
 
         assertThat(pod.getMetadata().getLabels(), is(expectedDeploymentLabels));
-        assertThat(pod.getSpec().getServiceAccountName(), is(KafkaConnectResources.buildServiceAccountName(cluster)));
+        assertThat(pod.getSpec().getServiceAccountName(), is(KafkaConnectResources.buildServiceAccountName(NAME)));
         assertThat(pod.getSpec().getContainers().size(), is(1));
-        assertThat(commands[0], containsString(defaultBuildahBuildArgs));
-        assertThat(commands[1], containsString(defaultBuildahPushArgs));
-        assertThat(pod.getSpec().getContainers().get(0).getName(), is(KafkaConnectResources.buildPodName(this.cluster)));
+        assertThat(commands[0], containsString(EXPECTED_DEFAULT_BUILDAH_BUILD_ARGS));
+        assertThat(commands[1], containsString(EXPECTED_DEFAULT_BUILDAH_PUSH_ARGS));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is(KafkaConnectResources.buildPodName(NAME)));
         // TODO: use configuration from the `ClusterOperatorConfig` rather than from env variables directly - https://github.com/strimzi/strimzi-kafka-operator/issues/11981
         assertThat(pod.getSpec().getContainers().get(0).getImage(), is(KafkaConnectBuild.DEFAULT_BUILDAH_IMAGE));
         assertThat(pod.getSpec().getContainers().get(0).getPorts(), is(nullValue()));
@@ -297,7 +244,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getResources().getRequests(), is(request));
         assertThat(pod.getSpec().getVolumes().size(), is(2));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
-        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
         assertThat(pod.getSpec().getVolumes().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getVolumes().get(1).getSecret().getSecretName(), is("my-docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(2));
@@ -305,103 +252,76 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/build/.docker"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getName(), is("REGISTRY_AUTH_FILE"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getValue(), is("/build/.docker/config.json"));
         io.strimzi.operator.cluster.TestUtils.checkOwnerReference(pod, kc);
     }
 
     @Test
     public void testKanikoDeploymentWithoutPushSecret()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                         .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
                     .endBuild()
                 .endSpec()
                 .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
         Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getSpec().getVolumes().size(), is(1));
-        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(defaultKanikoArgs));
+        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(EXPECTED_DEFAULT_KANIKO_OPTIONS));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
-        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(1));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(0));
     }
 
     @Test
     public void testBuildahDeploymentWithoutPushSecret()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                .endBuild()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                        .endDockerOutput()
+                    .endBuild()
+                .endSpec()
+                .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
 
         Pod pod = build.generateBuilderPod(true, true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         String[] commands = pod.getSpec().getContainers().get(0).getArgs().get(2).split("\n");
 
         assertThat(pod.getSpec().getVolumes().size(), is(1));
-        assertThat(commands[0], containsString(defaultBuildahBuildArgs));
-        assertThat(commands[1], containsString(defaultBuildahPushArgs));
+        assertThat(commands[0], containsString(EXPECTED_DEFAULT_BUILDAH_BUILD_ARGS));
+        assertThat(commands[1], containsString(EXPECTED_DEFAULT_BUILDAH_PUSH_ARGS));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
-        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(1));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(0));
     }
 
     @Test
     public void testConfigMap()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                    .endBuild()
-                .endSpec()
-                .build();
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), RESOURCE, VERSIONS, SHARED_ENV_PROVIDER, false);
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah);
-
-        KafkaConnectDockerfile dockerfile = new KafkaConnectDockerfile("my-image:latest", kc.getSpec().getBuild(), SHARED_ENV_PROVIDER);
+        KafkaConnectDockerfile dockerfile = new KafkaConnectDockerfile("my-image:latest", RESOURCE.getSpec().getBuild(), SHARED_ENV_PROVIDER);
         ConfigMap cm = build.generateDockerfileConfigMap(dockerfile);
 
-        assertThat(cm.getMetadata().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
-        assertThat(cm.getMetadata().getNamespace(), is(namespace));
+        assertThat(cm.getMetadata().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
+        assertThat(cm.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(cm.getData().get("Dockerfile"), is(dockerfile.getDockerfile()));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, kc);
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, RESOURCE);
     }
 
     @Test
@@ -414,39 +334,28 @@ public class KafkaConnectBuildTest {
         request.put("cpu", new Quantity("1000m"));
         request.put("memory", new Quantity("1Gi"));
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withResources(new ResourceRequirementsBuilder().withLimits(limit).withRequests(request).build())
                     .endBuild()
                 .endSpec()
                 .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
         KafkaConnectDockerfile dockerfile = new KafkaConnectDockerfile("my-image:latest", kc.getSpec().getBuild(), SHARED_ENV_PROVIDER);
         BuildConfig bc = build.generateBuildConfig(dockerfile);
-        assertThat(bc.getMetadata().getName(), is(KafkaConnectResources.buildConfigName(cluster)));
-        assertThat(bc.getMetadata().getNamespace(), is(namespace));
+        assertThat(bc.getMetadata().getName(), is(KafkaConnectResources.buildConfigName(NAME)));
+        assertThat(bc.getMetadata().getNamespace(), is(NAMESPACE));
 
-        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
-                Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, NAME,
+                Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(NAME),
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
                 Labels.KUBERNETES_NAME_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
-                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-                Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + this.cluster,
+                Labels.KUBERNETES_INSTANCE_LABEL, NAME,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + NAME,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
         assertThat(bc.getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(bc.getSpec().getSource().getDockerfile(), is(dockerfile.getDockerfile()));
@@ -462,73 +371,42 @@ public class KafkaConnectBuildTest {
     // Test to validate that .spec.image and spec.build.output.image in Kafka Connect are not pointing to the same image
     @Test
     public void testKafkaConnectBuildWithSpecImageSameAsDockerOutput() {
-        Map<String, Quantity> limit = new HashMap<>();
-        limit.put("cpu", new Quantity("500m"));
-        limit.put("memory", new Quantity("512Mi"));
-
-        Map<String, Quantity> request = new HashMap<>();
-        request.put("cpu", new Quantity("1000m"));
-        request.put("memory", new Quantity("1Gi"));
-
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
                     .withImage("my-image:latest")
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                            new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                        .withResources(new ResourceRequirementsBuilder().withLimits(limit).withRequests(request).build())
-                    .endBuild()
                 .endSpec()
                 .build();
 
-        InvalidResourceException thrown = assertThrows(InvalidResourceException.class, () -> {
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah);
-        }, "InvalidResourceException was expected");
+        InvalidResourceException thrown = assertThrows(InvalidResourceException.class, () -> KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false), "InvalidResourceException was expected");
         assertThat(thrown.getMessage(), is("KafkaConnect .spec.image cannot be the same as .spec.build.output.image"));
     }
 
     @Test
     public void testBuildconfigWithImageStreamOutput()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withNewImageStreamOutput()
                             .withImage("my-image:latest")
                         .endImageStreamOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
                     .endBuild()
                 .endSpec()
                 .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
         KafkaConnectDockerfile dockerfile = new KafkaConnectDockerfile("my-image:latest", kc.getSpec().getBuild(), SHARED_ENV_PROVIDER);
         BuildConfig bc = build.generateBuildConfig(dockerfile);
-        assertThat(bc.getMetadata().getName(), is(KafkaConnectResources.buildConfigName(cluster)));
-        assertThat(bc.getMetadata().getNamespace(), is(namespace));
+        assertThat(bc.getMetadata().getName(), is(KafkaConnectResources.buildConfigName(NAME)));
+        assertThat(bc.getMetadata().getNamespace(), is(NAMESPACE));
 
-        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
-                Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, NAME,
+                Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(NAME),
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
                 Labels.KUBERNETES_NAME_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
-                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-                Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + this.cluster,
+                Labels.KUBERNETES_INSTANCE_LABEL, NAME,
+                Labels.KUBERNETES_PART_OF_LABEL, Labels.APPLICATION_NAME + "-" + NAME,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
         assertThat(bc.getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(bc.getSpec().getSource().getDockerfile(), is(dockerfile.getDockerfile()));
@@ -564,21 +442,8 @@ public class KafkaConnectBuildTest {
                 .withSubPath("def")
                 .build();
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                        .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                    .endBuild()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
                     .withNewTemplate()
                         .withNewBuildPod()
                             .withNewMetadata()
@@ -611,9 +476,9 @@ public class KafkaConnectBuildTest {
                 .endSpec()
                 .build();
 
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, useBuildah);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
-        Pod pod = build.generateBuilderPod(true, useBuildah, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
+        Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getMetadata().getLabels().entrySet().containsAll(buildPodLabels.entrySet()), is(true));
         assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(buildPodAnnos.entrySet()), is(true));
         assertThat(pod.getSpec().getPriorityClassName(), is("top-priority"));
@@ -637,31 +502,23 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testValidKanikoOptions()   {
-        List<String> expectedArgs = new ArrayList<>(defaultKanikoArgs);
+        List<String> expectedArgs = new ArrayList<>(EXPECTED_DEFAULT_KANIKO_OPTIONS);
         expectedArgs.add("--reproducible");
         expectedArgs.add("--single-snapshot");
         expectedArgs.add("--log-format=json");
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withPushSecret("my-docker-credentials")
                             .withAdditionalKanikoOptions("--reproducible", "--single-snapshot", "--log-format=json")
                         .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
                     .endBuild()
                 .endSpec()
                 .build();
-
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
         Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
@@ -669,27 +526,20 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testInvalidKanikoOptions()   {
-        KafkaConnect kc = new KafkaConnectBuilder()
-                .withNewMetadata()
-                    .withName(cluster)
-                    .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                    .withBootstrapServers("my-kafka:9092")
-                    .withNewBuild()
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withPushSecret("my-docker-credentials")
                             .withAdditionalKanikoOptions("--reproducible", "--reproducible-something", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
                         .endDockerOutput()
-                        .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                                new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
                     .endBuild()
                 .endSpec()
                 .build();
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
         );
 
         assertThat(e.getMessage(), containsString(".spec.build.output.additionalKanikoOptions contains forbidden options: [--reproducible-something, --build-arg, --digest-file]"));
@@ -697,30 +547,22 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testValidBuildahBuildOptions() {
-        String expectedBuildOptions = defaultBuildahBuildArgs + " --retry=3";
-        String expectedPushOptions = defaultBuildahPushArgs + " --quiet";
+        String expectedBuildOptions = EXPECTED_DEFAULT_BUILDAH_BUILD_ARGS + " --retry=3";
+        String expectedPushOptions = EXPECTED_DEFAULT_BUILDAH_PUSH_ARGS + " --quiet";
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("my-docker-credentials")
-                        .withAdditionalBuildOptions("--retry=3")
-                        .withAdditionalPushOptions("--quiet")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                .endBuild()
-            .endSpec()
-            .build();
-
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withPushSecret("my-docker-credentials")
+                            .withAdditionalBuildOptions("--retry=3")
+                            .withAdditionalPushOptions("--quiet")
+                        .endDockerOutput()
+                    .endBuild()
+                .endSpec()
+                .build();
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
 
         Pod pod = build.generateBuilderPod(true, true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         String[] commands = pod.getSpec().getContainers().get(0).getArgs().get(2).split("\n");
@@ -730,28 +572,21 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testInvalidBuildahBuildOptions() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("my-docker-credentials")
-                        .withAdditionalBuildOptions("--logfile=my-file", "--file=/docker/Another", "--storage-driver=random")
-                        .withAdditionalPushOptions("--quiet")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                .endBuild()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withPushSecret("my-docker-credentials")
+                            .withAdditionalBuildOptions("--logfile=my-file", "--file=/docker/Another", "--storage-driver=random")
+                            .withAdditionalPushOptions("--quiet")
+                        .endDockerOutput()
+                    .endBuild()
+                .endSpec()
+                .build();
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true)
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true)
         );
 
         assertThat(e.getMessage(), containsString(".spec.build.output.additionalBuildOptions contains forbidden options: [--logfile, --file, --storage-driver]"));
@@ -759,28 +594,21 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testInvalidBuildahPushOptions() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("my-docker-credentials")
-                        .withAdditionalBuildOptions("--retry=3")
-                        .withAdditionalPushOptions("--digestfile=/tmp/random", "--sign-by=different", "--format=xy")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                .endBuild()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withPushSecret("my-docker-credentials")
+                            .withAdditionalBuildOptions("--retry=3")
+                            .withAdditionalPushOptions("--digestfile=/tmp/random", "--sign-by=different", "--format=xy")
+                        .endDockerOutput()
+                    .endBuild()
+                .endSpec()
+                .build();
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true)
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true)
         );
 
         assertThat(e.getMessage(), containsString(".spec.build.output.additionalPushOptions contains forbidden options: [--digestfile, --sign-by, --format]"));
@@ -788,31 +616,23 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testKanikoAdditionalOptionsConfiguredOnBothPlaces() {
-        List<String> expectedArgs = new ArrayList<>(defaultKanikoArgs);
+        List<String> expectedArgs = new ArrayList<>(EXPECTED_DEFAULT_KANIKO_OPTIONS);
         expectedArgs.add("--single-snapshot");
         expectedArgs.add("--log-format=json");
 
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("my-docker-credentials")
-                        .withAdditionalKanikoOptions("--reproducible")
-                        .withAdditionalBuildOptions("--single-snapshot", "--log-format=json")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                .endBuild()
-            .endSpec()
-            .build();
-
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withPushSecret("my-docker-credentials")
+                            .withAdditionalKanikoOptions("--reproducible")
+                            .withAdditionalBuildOptions("--single-snapshot", "--log-format=json")
+                        .endDockerOutput()
+                    .endBuild()
+                .endSpec()
+                .build();
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
         Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
@@ -821,316 +641,116 @@ public class KafkaConnectBuildTest {
 
     @Test
     public void testInvalidKanikoOptionsInAdditionalBuildOptions() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("my-docker-credentials")
-                        .withAdditionalBuildOptions("--reproducible", "--reproducible-something", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
-                    .endDockerOutput()
-                    .withPlugins(new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build())
-                .endBuild()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editBuild()
+                        .withNewDockerOutput()
+                           .withImage("my-image:latest")
+                           .withPushSecret("my-docker-credentials")
+                           .withAdditionalBuildOptions("--reproducible", "--reproducible-something", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
+                        .endDockerOutput()
+                    .endBuild()
+                .endSpec()
+                .build();
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () ->
-            KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
+            KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
         );
 
         assertThat(e.getMessage(), containsString(".spec.build.output.additionalBuildOptions contains forbidden options: [--reproducible-something, --build-arg, --digest-file]"));
     }
 
     @Test
-    public void testKanikoVolumesVolumeMountsAndEnvVariables() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                    .endDockerOutput()
-                    .withPlugins(
-                        new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build()
-                    )
-                .endBuild()
-            .endSpec()
-            .build();
-
-        KafkaConnectBuild kafkaConnectBuild = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
-
-        List<Volume> volumes = kafkaConnectBuild.getVolumes(false);
-
-        assertThat(volumes.size(), is(1));
-        assertThat(volumes.get(0).equals(
-            new VolumeBuilder()
-                .withName("dockerfile")
-                .withConfigMap(
-                    new ConfigMapVolumeSourceBuilder()
-                        .withName(KafkaConnectResources.dockerFileConfigMapName(cluster))
-                        .withItems(
-                            new KeyToPathBuilder()
-                                .withKey("Dockerfile")
-                                .withPath("Dockerfile")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ), is(true));
-
-        List<VolumeMount> volumeMounts = kafkaConnectBuild.getVolumeMounts(false);
-
-        assertThat(volumeMounts.size(), is(1));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("dockerfile").withMountPath("/dockerfile").build()), is(true));
-
-
-        List<EnvVar> envVars = kafkaConnectBuild.getBuildContainerEnvVars(false);
-
-        assertThat(envVars.size(), is(0));
-    }
-
-    @Test
     public void testKanikoWithAdditionalVolumesVolumeMountsAndEnvVariables() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("kaniko-push-secret")
-                    .endDockerOutput()
-                    .withPlugins(
-                        new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build()
-                    )
-                .endBuild()
-                .editOrNewTemplate()
-                    .withNewBuildContainer()
-                        .addToVolumeMounts(
-                            new VolumeMountBuilder()
-                                .withName("volume")
-                                .withMountPath("/mnt/my/path")
-                                .build()
-                        )
-                        .addNewEnv()
-                            .withName("MY_ENV")
-                            .withValue("value")
-                        .endEnv()
-                    .endBuildContainer()
-                .endTemplate()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editOrNewTemplate()
+                        .withNewBuildContainer()
+                            .addToVolumeMounts(
+                                new VolumeMountBuilder()
+                                    .withName("volume")
+                                    .withMountPath("/mnt/my/path")
+                                    .build()
+                            )
+                            .addNewEnv()
+                                .withName("MY_ENV")
+                                .withValue("value")
+                            .endEnv()
+                        .endBuildContainer()
+                    .endTemplate()
+                .endSpec()
+                .build();
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
 
-        KafkaConnectBuild kafkaConnectBuild = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
-
-        List<Volume> volumes = kafkaConnectBuild.getVolumes(false);
-
-        assertThat(volumes.size(), is(2));
-        assertThat(volumes.contains(
-            new VolumeBuilder()
-                .withName("dockerfile")
-                .withConfigMap(
-                    new ConfigMapVolumeSourceBuilder()
-                        .withName(KafkaConnectResources.dockerFileConfigMapName(cluster))
-                        .withItems(
-                            new KeyToPathBuilder()
-                                .withKey("Dockerfile")
-                                .withPath("Dockerfile")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ), is(true));
-        assertThat(volumes.contains(
-            new VolumeBuilder()
-                .withName("docker-credentials")
-                .withSecret(
-                    new SecretVolumeSourceBuilder()
-                        .withDefaultMode(292)
-                        .withSecretName("kaniko-push-secret")
-                        .withItems(
-                            new KeyToPathBuilder()
-                                .withKey(".dockerconfigjson")
-                                .withPath("config.json")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ), is(true));
-
-        List<VolumeMount> volumeMounts = kafkaConnectBuild.getVolumeMounts(false);
-
-        assertThat(volumeMounts.size(), is(3));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("volume").withMountPath("/mnt/my/path").build()), is(true));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("docker-credentials").withMountPath("/kaniko/.docker").build()), is(true));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("dockerfile").withMountPath("/dockerfile").build()), is(true));
-
-
-        List<EnvVar> envVars = kafkaConnectBuild.getBuildContainerEnvVars(false);
-
-        assertThat(envVars.size(), is(1));
-        assertThat(envVars.get(0).equals(new EnvVarBuilder().withName("MY_ENV").withValue("value").build()), is(true));
-    }
-
-    @Test
-    public void testBuildahVolumesVolumeMountsAndEnvVariables() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                    .endDockerOutput()
-                    .withPlugins(
-                        new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build()
-                    )
-                .endBuild()
-            .endSpec()
-            .build();
-
-        KafkaConnectBuild kafkaConnectBuild = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
-
-        List<Volume> volumes = kafkaConnectBuild.getVolumes(false);
-
-        assertThat(volumes.size(), is(1));
-        assertThat(volumes.get(0).equals(
-            new VolumeBuilder()
-                .withName("dockerfile")
-                .withConfigMap(
-                    new ConfigMapVolumeSourceBuilder()
-                        .withName(KafkaConnectResources.dockerFileConfigMapName(cluster))
-                        .withItems(
-                            new KeyToPathBuilder()
-                                .withKey("Dockerfile")
-                                .withPath("Dockerfile")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ), is(true));
-
-        List<VolumeMount> volumeMounts = kafkaConnectBuild.getVolumeMounts(true);
-
-        assertThat(volumeMounts.size(), is(1));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("dockerfile").withMountPath("/dockerfile").build()), is(true));
-
-
-        List<EnvVar> envVars = kafkaConnectBuild.getBuildContainerEnvVars(true);
-
-        assertThat(envVars.size(), is(0));
+        Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
+        assertThat(pod.getSpec().getVolumes().size(), is(2));
+        assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().size(), is(1));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().get(0).getKey(), is("Dockerfile"));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().get(0).getPath(), is("Dockerfile"));
+        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getSecretName(), is("my-docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().size(), is(1));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().get(0).getKey(), is(".dockerconfigjson"));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().get(0).getPath(), is("config.json"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(3));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/kaniko/.docker"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("volume"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/mnt/my/path"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getName(), is("MY_ENV"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getValue(), is("value"));
     }
 
     @Test
     public void testBuildahWithAdditionalVolumesVolumeMountsAndEnvVariables() {
-        KafkaConnect kc = new KafkaConnectBuilder()
-            .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
-            .endMetadata()
-            .withNewSpec()
-                .withBootstrapServers("my-kafka:9092")
-                .withNewBuild()
-                    .withNewDockerOutput()
-                        .withImage("my-image:latest")
-                        .withPushSecret("buildah-push-secret")
-                    .endDockerOutput()
-                    .withPlugins(
-                        new PluginBuilder().withName("my-connector").withArtifacts(jarArtifactWithChecksum).build(),
-                        new PluginBuilder().withName("my-connector2").withArtifacts(jarArtifactNoChecksum).build()
-                    )
-                .endBuild()
-                .editOrNewTemplate()
-                    .withNewBuildContainer()
-                        .addToVolumeMounts(
-                            new VolumeMountBuilder()
-                                .withName("volume")
-                                .withMountPath("/mnt/my/path")
-                                .build()
-                        )
-                        .addNewEnv()
-                            .withName("MY_ENV")
-                            .withValue("value")
-                        .endEnv()
-                    .endBuildContainer()
-                .endTemplate()
-            .endSpec()
-            .build();
+        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
+                .editSpec()
+                    .editOrNewTemplate()
+                        .withNewBuildContainer()
+                            .addToVolumeMounts(
+                                new VolumeMountBuilder()
+                                    .withName("volume")
+                                    .withMountPath("/mnt/my/path")
+                                    .build()
+                            )
+                            .addNewEnv()
+                                .withName("MY_ENV")
+                                .withValue("value")
+                            .endEnv()
+                        .endBuildContainer()
+                    .endTemplate()
+                .endSpec()
+                .build();
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
 
-        KafkaConnectBuild kafkaConnectBuild = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
-
-        List<Volume> volumes = kafkaConnectBuild.getVolumes(false);
-
-        assertThat(volumes.size(), is(2));
-        assertThat(volumes.contains(
-            new VolumeBuilder()
-                .withName("dockerfile")
-                .withConfigMap(
-                    new ConfigMapVolumeSourceBuilder()
-                        .withName(KafkaConnectResources.dockerFileConfigMapName(cluster))
-                        .withItems(
-                            new KeyToPathBuilder()
-                                .withKey("Dockerfile")
-                                .withPath("Dockerfile")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ), is(true));
-        assertThat(volumes.contains(
-            new VolumeBuilder()
-                .withName("docker-credentials")
-                .withSecret(
-                    new SecretVolumeSourceBuilder()
-                        .withDefaultMode(292)
-                        .withSecretName("buildah-push-secret")
-                        .withItems(
-                            new KeyToPathBuilder()
-                                .withKey(".dockerconfigjson")
-                                .withPath("config.json")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ), is(true));
-
-        List<VolumeMount> volumeMounts = kafkaConnectBuild.getVolumeMounts(true);
-
-        assertThat(volumeMounts.size(), is(3));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("volume").withMountPath("/mnt/my/path").build()), is(true));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("docker-credentials").withMountPath("/build/.docker").build()), is(true));
-        assertThat(volumeMounts.contains(new VolumeMountBuilder().withName("dockerfile").withMountPath("/dockerfile").build()), is(true));
-
-
-        List<EnvVar> envVars = kafkaConnectBuild.getBuildContainerEnvVars(true);
-
-        assertThat(envVars.size(), is(2));
-        assertThat(envVars.contains(new EnvVarBuilder().withName("MY_ENV").withValue("value").build()), is(true));
-        assertThat(envVars.contains(new EnvVarBuilder().withName("REGISTRY_AUTH_FILE").withValue("/build/.docker/config.json").build()), is(true));
+        Pod pod = build.generateBuilderPod(true, true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
+        assertThat(pod.getSpec().getVolumes().size(), is(2));
+        assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().size(), is(1));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().get(0).getKey(), is("Dockerfile"));
+        assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().get(0).getPath(), is("Dockerfile"));
+        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getSecretName(), is("my-docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().size(), is(1));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().get(0).getKey(), is(".dockerconfigjson"));
+        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().get(0).getPath(), is("config.json"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(3));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/build/.docker"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("volume"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/mnt/my/path"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(2));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getName(), is("REGISTRY_AUTH_FILE"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getValue(), is("/build/.docker/config.json"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(1).getName(), is("MY_ENV"));
+        assertThat(pod.getSpec().getContainers().get(0).getEnv().get(1).getValue(), is("value"));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors thre `KafkaConnectBuildTest` to make it more in-sync with other Connect and MM2 unit tests. It uses static variables to configure things in a single place, makes sure the Connect resources used in the tests are valid Connect resources, and merges some tests together where it made sense.

### Checklist

- [x] Make sure all tests pass