### PR TITLE
docs(mm2): updates connector properties section

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
@@ -23,7 +23,7 @@ MirrorMaker 2 consists of the following connectors:
 `MirrorHeartbeatConnector` is not configurable through the `KafkaMirrorMaker2` custom resource.
 To run a `MirrorHeartbeatConnector`, use a separate `KafkaConnect` and `KafkaConnector` custom resource.
 
-For a full list of supported MirrorMaker 2 connector properties, including common configuration and connector-specific options, see the Apache Kafka documentation.
+For a full list of supported MirrorMaker 2 connector properties, including common configuration and connector-specific options, see the {kafkaDoc}.
 
 WARNING: Configure the following properties with the *same values in both the source and checkpoint connectors*:
 `replication.policy.class`, `replication.policy.separator`, `offset-syncs.topic.location`, and `topic.filter.class`.


### PR DESCRIPTION
**Documentation**

Updates the Configuring MirrorMaker 2 connectors section.
Removes the out-of-date table and refers to the Kafka docs instead, as they now provide complete descriptions of the connector config properties available.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

