### PR TITLE
fix-testCreateOrUpdateCreatesCluster

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -183,7 +185,9 @@ public class KafkaBridgeAssemblyOperatorTest {
                 List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
                 assertThat(capturedStatuses.get(0).getStatus().getUrl(), is("http://foo-bridge-service.test.svc:8080"));
                 assertThat(capturedStatuses.get(0).getStatus().getReplicas(), is(bridge.getReplicas()));
-                assertThat(capturedStatuses.get(0).getStatus().getLabelSelector(), is(bridge.getSelectorLabels().toSelectorString()));
+                List<String> expectedParts = Arrays.asList(bridge.getSelectorLabels().toSelectorString().split(","));
+                List<String> actualParts   = Arrays.asList(capturedStatuses.get(0).getStatus().getLabelSelector().split(","));
+                assertThat(actualParts, containsInAnyOrder(expectedParts.toArray(new String[0])));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), is("Ready"));
 


### PR DESCRIPTION
- Bugfix

### Description

This PR fixes a flaky assertion in `KafkaBridgeAssemblyOperatorTest.java`, specifically in
`testCreateOrUpdateCreatesCluster`, which started failing intermittently when run with
[NonDex](https://github.com/TestingResearchIllinois/NonDex).

Previously, the test asserted strict string equality on the `labelSelector` stored in the
`KafkaBridge` status:

```
assertThat(capturedStatuses.get(0).getStatus().getLabelSelector(),
        is(bridge.getSelectorLabels().toSelectorString()));
```

Under NonDex, the iteration order of the underlying labels map can vary, which changes the
ordering of the key=value pairs in the selector string, even though the set of labels is
identical. A representative failure looks like:

```
Expected: is "strimzi.io/cluster=foo,strimzi.io/name=foo-bridge,strimzi.io/kind=KafkaBridge"
but: was "strimzi.io/cluster=foo,strimzi.io/kind=KafkaBridge,strimzi.io/name=foo-bridge"
```

Kubernetes label selectors are order-insensitive, so this test was asserting a stronger property
than the feature actually guarantees and became brittle under NonDex.

To make the test robust while preserving the original intent, this PR relaxes the assertion to
compare the selector as a set of labels instead of a single ordered string. The new assertion
splits both the expected and actual selectors and compares them order-independently:

```
List<String> expectedParts =
        Arrays.asList(bridge.getSelectorLabels().toSelectorString().split(","));
List<String> actualParts =
        Arrays.asList(capturedStatuses.get(0).getStatus().getLabelSelector().split(","));
assertThat(actualParts, containsInAnyOrder(expectedParts.toArray(new String[0])));
```


Checklist

- [ x]  Write tests
- [ x]  Make sure all tests pass