### PR TITLE
Bugfix for testUpdateWithFailure 

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -838,7 +838,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
                     assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
                     assertThat(mm2Status.getReplicas(), is(3));
-                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    // Compare as Sets to avoid order-dependent flakiness due to HashMap iteration order in labelSelector
+                    assertThat(Set.of(mm2Status.getLabelSelector().split(",")), is(Set.of("strimzi.io/cluster=my-mm2", "strimzi.io/name=my-mm2-mirrormaker2", "strimzi.io/kind=KafkaMirrorMaker2")));
                     assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
                     assertThat(mm2Status.getConditions().get(0).getType(), is("NotReady"));
 


### PR DESCRIPTION
### Type of change


- Bugfix


### Description

This PR fixes a flaky test in `KafkaMirrorMaker2AssemblyOperatorPodSetTest.java` where `testUpdateWithFailure` was failing intermittently due to non-deterministic ordering of the labelSelector string, generated from a HashMap. The flakiness took a little bit longer it was exposed by running the test around 300 times with NonDex, which revealed order-dependent failures similar to other flaky tests in the suite. Similar to the other flaky tests the fix updates the assertion to compare sets of labels instead of exact string matches, ensuring the test is order-independent while still validating the correct labels are present. Similar to the previous flaky tests.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

