### PR TITLE
Upgraded Strimzi OAuth to remediate CVE-2025-53864

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
-        <strimzi-oauth.version>0.15.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.17.0</strimzi-oauth.version>
         <netty.version>4.1.128.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Upgraded Strimzi OAuth from 0.15.1 to 0.17.0 to remediate CVE-2025-53864. This transitively upgrades nimbus-jose-jwt.

### Checklist


- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

