### PR TITLE
fixed testCreateCluster

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -71,6 +71,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -87,6 +88,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -286,7 +288,9 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
 
                     assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
                     assertThat(connectStatus.getReplicas(), is(3));
-                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    List<String> actualParts = Arrays.asList(connectStatus.getLabelSelector().split(","));
+                    List<String> expectedParts = List.of("strimzi.io/cluster=my-connect", "strimzi.io/name=my-connect-connect", "strimzi.io/kind=KafkaConnect");
+                    assertThat(actualParts, containsInAnyOrder(expectedParts.toArray(new String[0])));
                     assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
                     assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
 


### PR DESCRIPTION
* Bugfix
### Description

This PR fixes a flaky assertion in `KafkaConnectAssemblyOperatorPodSetTest.java`, specifically in
`testCreateCluster`, which started failing intermittently when run with
[NonDex](https://github.com/TestingResearchIllinois/NonDex).

Previously, the test asserted strict string equality on the `labelSelector` stored in the
`KafkaConnect` status:

    assertThat(connectStatus.getLabelSelector(),
            is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));

Under NonDex, the iteration order of the underlying labels map can vary, which changes the
ordering of the key=value pairs in the selector string, even though the set of labels is
identical. A representative failure looks like:

    Expected: is "strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"
    but: was "strimzi.io/cluster=my-connect,strimzi.io/kind=KafkaConnect,strimzi.io/name=my-connect-connect"

Kubernetes label selectors are order-insensitive, so this test was asserting a stronger property
than the feature actually guarantees and became brittle under NonDex.

To make the test robust while preserving the original intent, this PR relaxes the assertion to
compare the selector as a set of labels instead of a single ordered string. The new assertion
splits the selector and compares it order-independently:

    List<String> actualParts = Arrays.asList(connectStatus.getLabelSelector().split(","));
    List<String> expectedParts = List.of(
            "strimzi.io/cluster=my-connect",
            "strimzi.io/name=my-connect-connect",
            "strimzi.io/kind=KafkaConnect");
    assertThat(actualParts, containsInAnyOrder(expectedParts.toArray(new String[0])));

Checklist

  * [ x] Write tests
  * [ x] Make sure all tests pass
