### PR TITLE
Bugfix with testCreateCluster

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -243,7 +243,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
                     assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
                     assertThat(mm2Status.getReplicas(), is(3));
-                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    // Compare as Sets to avoid order-dependent flakiness due to HashMap iteration order in labelSelector
+                    assertThat(Set.of(mm2Status.getLabelSelector().split(",")), is(Set.of("strimzi.io/cluster=my-mm2", "strimzi.io/name=my-mm2-mirrormaker2", "strimzi.io/kind=KafkaMirrorMaker2")));
                     assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
                     assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a flaky test in `KafkaMirrorMaker2AssemblyOperatorPodSetTest.java` where `fix-testCreateCluster` was failing intermittently due to non-deterministic ordering of the labelSelector string, generated from a HashMap. The flakiness, similar to other tests in this suite, was revealed by running the test about 200 times with NonDex. The fix updates the assertion to compare sets of labels instead of exact string matches, making the test order-independent and consistent with previous fixes for similar flaky tests.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

