### PR TITLE
Upgraded GRPC Netty Shaded to remediate CVE-2025-55163

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -30,7 +30,7 @@
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
     </properties>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
@@ -30,7 +30,7 @@
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
     </properties>
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Upgraded GRPC Netty Shaded to remediate CVE-2025-55163

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

