### PR TITLE
Clean up KafkaRoller class

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -966,7 +966,7 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected Admin adminClient(Set<NodeRef> nodes, boolean b) throws ForceableProblem, FatalProblem {
+        protected Admin adminClient(Set<NodeRef> nodes, boolean b) throws ForceableProblem {
             if (delegateAdminClientCall) {
                 return super.adminClient(nodes, b);
             }


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Refactoring

### Description

* Use milliseconds as time unit throughout.
* Remove unused method getBrokersLogging.
* Remove throws that are never thrown.
* Remove ForceableProblem.forceNow boolean which is always false.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

