### PR TITLE
Clean image signatures before signing to avoid signature appending

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -123,7 +123,7 @@ docker_push_sbom_default:
 docker_gha_sign_manifest_default:
 	# Signs the manifest and its images using keyless signing (GitHub OIDC)
 	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --format '{{ json . }}' | jq -r .manifest.digest); \
-	cosign clean $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST || true; \
+	cosign clean -f --type signature $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST || true; \
 	cosign sign --yes --recursive --timeout 6m0s -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
 
 .PHONY: docker_gha_sbom_default


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We encountered an issue with too big signature OCI for kaniko exporter image. It seems the signatures were appending instead of creating new ones. This was probably caused by switching to keyless signing. This PR adds clean step before signing the images. 

There might be a race condition where clean step will remove `.sig` OCI images in quay even for releases as kaniko and buildah images won't change too much. In case we will receive any errors around signature verification from users we will add a mechanism that will add some hash into these images to make sure new digest will be generated every time whichw ill ensure that signatures won't be appended.


### Checklist

- [ ] Make sure all tests pass


