### PR TITLE
Update Strimzi to Java 21

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -4,8 +4,8 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'build_strimzi_java-17':
-          jdk_version: '17'
+        'build_strimzi_java-21':
+          jdk_version: '21'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/jobs/build/deploy_strimzi_java.yaml
+++ b/.azure/templates/jobs/build/deploy_strimzi_java.yaml
@@ -4,8 +4,8 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'deploy_strimzi_java-17':
-          jdk_version: '17'
+        'deploy_strimzi_java-21':
+          jdk_version: '21'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -4,8 +4,8 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'test_strimzi_java-17':
-          jdk_version: '17'
+        'test_strimzi_java-21':
+          jdk_version: '21'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 90

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -1,7 +1,7 @@
 # Step to configure JAVA on the agent
 parameters:
   - name: JDK_VERSION
-    default: '17'
+    default: '21'
 steps:
   - task: JavaToolInstaller@0
     inputs:

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -22,7 +22,7 @@ jobs:
   strategy:
     matrix:
       ${{ parameters.name }}:
-        jdk_version: '17'
+        jdk_version: '21'
   # Base system
   pool:
     vmImage: 'Ubuntu-22.04'

--- a/.github/actions/build/build-strimzi-binaries/action.yml
+++ b/.github/actions/build/build-strimzi-binaries/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/setup-java@v5
       with:
         distribution: "temurin"
-        java-version: "17"
+        java-version: "21"
 
     # Caches for Maven and Kafka
     - name: Restore Maven cache

--- a/.github/actions/build/deploy-java/action.yml
+++ b/.github/actions/build/deploy-java/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Restore Maven cache

--- a/.github/actions/build/release-artifacts/action.yml
+++ b/.github/actions/build/release-artifacts/action.yml
@@ -45,7 +45,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: Restore Maven cache
       uses: actions/cache/restore@v4

--- a/.github/actions/build/test-strimzi/action.yml
+++ b/.github/actions/build/test-strimzi/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Restore Maven cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,11 +50,11 @@ jobs:
           curl -L https://github.com/mikefarah/yq/releases/download/v4.2.1/yq_linux_amd64 > yq && chmod +x yq
           sudo cp -v yq /usr/bin/
 
-    # Setup OpenJDK 17
+    # Setup OpenJDK 21
     - uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     # Setup Maven cache
     - name: Restore Maven cache

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Install Helm
         uses: ./.github/actions/dependencies/install-helm

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -66,17 +66,17 @@ run `brew install bash` to install a compatible version of `bash`. If you wish t
 updated bash run `sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'` and `chsh -s /usr/local/bin/bash`
 
 The `mvn` tool might install the latest version of OpenJDK during the brew install. For builds on macOS to succeed,
-OpenJDK version 17 needs to be installed. This can be done by running `brew install openjdk@17`. For maven to read the
+OpenJDK version 21 needs to be installed. This can be done by running `brew install openjdk@21`. For maven to read the
 new Java version, you will need to edit the `~/.mavenrc` file and paste the following
-line `export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home`.
+line `export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-21.jdk/Contents/Home`.
 
 You may come across an issue of linking from the above step. To solve this run this command: 
-`sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk`.
+`sudo ln -sfn /usr/local/opt/openjdk@21/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-21.jdk`.
 If this throws an error that it cannot find the file or directory, navigate into `/Library/Java/` (or however deep you
-can) and create a new folder named `JavaVirtualMachines` followed by creating a file named `openjdk-17.jdk`. The folder
-structure after everything is said and done should look like `/Library/Java/JavaVirtualMachines/openjdk-17.jdk`. After
+can) and create a new folder named `JavaVirtualMachines` followed by creating a file named `openjdk-21.jdk`. The folder
+structure after everything is said and done should look like `/Library/Java/JavaVirtualMachines/openjdk-21.jdk`. After
 doing that run the command at the beginning again and this should link the file and allow you to use maven with OpenJDK
-version 17.
+version 21.
 
 When running the tests, you may encounter `OpenSSL` related errors for parts that you may not have even worked on, in 
 which case you need to make sure you are using `OpenSSL` and not LibreSSL which comes by default with macOS.
@@ -246,7 +246,7 @@ Commonly used Make targets:
 
 ### Java versions
 
-Strimzi currently developed and tested with Java 17.
+Strimzi currently developed and tested with Java 21.
 
 ### Building Docker images
 

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=21
 ARG TARGETOS
 ARG TARGETARCH
 ARG strimzi_version
@@ -21,7 +21,7 @@ RUN microdnf update -y \
     && microdnf reinstall -y tzdata \
     && microdnf clean all -y
 
-ENV JAVA_HOME=/usr/lib/jvm/jre-17
+ENV JAVA_HOME=/usr/lib/jvm/jre-21
 
 #####
 # Add Tini

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.24
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}</strimziRootDirectory>
@@ -54,7 +54,7 @@
         <maven.shade.version>3.4.1</maven.shade.version>
         <maven.javadoc.version>3.10.0</maven.javadoc.version>
         <maven.source.version>3.0.1</maven.source.version>
-        <maven.dependency.version>3.3.0</maven.dependency.version>
+        <maven.dependency.version>3.9.0</maven.dependency.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.checkstyle.version>3.5.0</maven.checkstyle.version>
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
@@ -106,7 +106,7 @@
 
         <!-- Test only dependencies -->
         <hamcrest.version>2.2</hamcrest.version>
-        <mockito.version>4.11.0</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <jupiter.version>6.0.0</jupiter.version>
         <strimzi-test-container.version>0.114.0</strimzi-test-container.version>
@@ -717,12 +717,6 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -30,7 +30,7 @@ prepare:
     how: install
     package:
       - wget
-      - java-17-openjdk-devel
+      - java-21-openjdk-devel
       - xz
       - make
       - git

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -118,11 +118,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>operator-common</artifactId>
         </dependency>
@@ -205,7 +200,6 @@
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline</ignoredUnusedDeclaredDependency>
                                 <!-- Needed for adding new appender JsonTemplateLayout support for logging, it's a runtime dep -->
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-layout-template-json</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates Strimzi to Java 21.

It is currently a Draft to see what other changes might be needed.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Update CHANGELOG.md