### PR TITLE
Refactored JSON model generator build script

### DIFF
--- a/config-model-generator/Makefile
+++ b/config-model-generator/Makefile
@@ -7,8 +7,6 @@ docker_tag:
 all: docker_build docker_push
 
 clean: java_clean
-	rm ../cluster-operator/src/main/resources/kafka-*-config-model.json || true
-	./build-config-models.sh clean
 
 include ../Makefile.maven
 

--- a/config-model-generator/build-config-models.sh
+++ b/config-model-generator/build-config-models.sh
@@ -3,16 +3,16 @@ set -e
 
 source $(dirname $(realpath $0))/../tools/kafka-versions-tools.sh
 
-# Parse the Kafka versions file and get a list of version strings in an array 
+# Parse the Kafka versions file and get a list of version strings in an array
 # called "versions"
 get_kafka_versions
 
+# Always delete existing files so when kafka-versions changes we remove
+# models for unsupported versions
+rm ../cluster-operator/src/main/resources/kafka-*-config-model.json || true
+
 if [ "$1" = "build" ]
 then
-    # Always delete existing files so when kafka-versions changes we remove
-    # models for unsupported versions
-    rm ../cluster-operator/src/main/resources/kafka-*-config-model.json || true
-
     for version in "${versions[@]}"
     do
         mvn ${MVN_ARGS} verify exec:java \


### PR DESCRIPTION
Within the "config-model-generator" project, the current Makefile "clean"  target deletes the model JSON files and the calls the `build-config-models.sh` script by passing the "clean" arg.
The `build-config-models.sh` itself still deletes the model JSON file but when it gets the "build" arg instead.
So it seems that in both cases "clean" or "build" arg, what we do is removing the JSON model files.

This PR cleans a little bit the logic.
The removal of the JSON model file is put at the top of the `build-config-models.sh` so that it's always done.
At the same time, calling the `build-config-models.sh` is removed from the Makefile "clean" target because we can just rely on the exec-maven-plugin usage within the config-model-generator pom file.
When using maven "compile" or "clean", the `build-config-models.sh` is called with right arg ("build" and "clean").
So with the Makefile "clean" target just referring to the "java_clean" target, we end calling "mvn clean" which still leverages the exec-maven-plugin and calls the `build-config-models.sh` with "clean" arg.

In general the calling of the `build-config-models.sh` script is driven through the exec-maven-plugin and the deletion of JSNO model files is something we always want with every run (with both "clean" or "build" args).

All the above is, of course, valid when we use `make clean` and `make build` which anyway ends to use "mvn" the way described above.