### PR TITLE
Do not show keystore passwords in the process table

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/tls_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/tls_utils.sh
@@ -11,15 +11,15 @@ set -e
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-  # Disable FIPS if needed
-  if [ "$FIPS_MODE" = "disabled" ]; then
-      KEYTOOL_OPTS="${KEYTOOL_OPTS} -J-Dcom.redhat.fips=false"
-  else
-      KEYTOOL_OPTS=""
-  fi
+    # Disable FIPS if needed
+    if [ "$FIPS_MODE" = "disabled" ]; then
+        KEYTOOL_OPTS="${KEYTOOL_OPTS} -J-Dcom.redhat.fips=false"
+    else
+        KEYTOOL_OPTS=""
+    fi
 
-   # shellcheck disable=SC2086
-   keytool ${KEYTOOL_OPTS} -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+    # shellcheck disable=SC2086
+    PASSWORD=$2 keytool ${KEYTOOL_OPTS} -keystore "$1" -storepass:env PASSWORD -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
 }
 
 # Parameters:
@@ -30,7 +30,7 @@ function create_truststore {
 # $5: CA public key to be imported
 # $6: Alias of the certificate
 function create_keystore {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -chain -CAfile "$5" -name "$6" -password pass:"$2" -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
+    PASSWORD=$2 RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -chain -CAfile "$5" -name "$6" -password env:PASSWORD -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
 }
 
 # Parameters:
@@ -40,7 +40,7 @@ function create_keystore {
 # $4: Private key to be imported
 # $5: Alias of the certificate
 function create_keystore_without_ca_file {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -name "$5" -password pass:"$2" -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
+    PASSWORD=$2 RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -name "$5" -password env:PASSWORD -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
 }
 
 # Searches the directory with the CAs and finds the CA matching our key.

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -16,7 +16,7 @@ function create_truststore {
     fi
 
     # shellcheck disable=SC2086
-    keytool ${KEYTOOL_OPTS} -keystore "$1" -storepass "$2" -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
+    PASSWORD=$2 keytool ${KEYTOOL_OPTS} -keystore "$1" -storepass:env PASSWORD -noprompt -alias "$4" -import -file "$3" -storetype PKCS12
 }
 
 # Parameters:
@@ -26,7 +26,7 @@ function create_truststore {
 # $4: Private key to be imported
 # $5: Alias of the certificate
 function create_keystore_without_ca_file {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -name "$5" -password pass:"$2" -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
+    PASSWORD=$2 RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -name "$5" -password env:PASSWORD -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
 }
 
 if [ "$STRIMZI_PUBLIC_CA" != "true" ]; then
@@ -34,21 +34,21 @@ if [ "$STRIMZI_PUBLIC_CA" != "true" ]; then
     STORE=/tmp/topic-operator/replication.truststore.p12
     rm -f "$STORE"
     for CRT in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
-      ALIAS=$(basename "$CRT" .crt)
-      echo "Adding $CRT to truststore $STORE with alias $ALIAS"
-      create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+        ALIAS=$(basename "$CRT" .crt)
+        echo "Adding $CRT to truststore $STORE with alias $ALIAS"
+        create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
     done
     echo "Preparing trust store certificates for internal communication is completed"
 fi
 
 if [ "$STRIMZI_TLS_AUTH_ENABLED" != "false" ]; then
-  echo "Preparing key store certificates for internal communication"
-  STORE=/tmp/topic-operator/replication.keystore.p12
-  rm -f "$STORE"
-  create_keystore_without_ca_file "$STORE" "$CERTS_STORE_PASSWORD" \
-      /etc/eto-certs/entity-operator.crt \
-      /etc/eto-certs/entity-operator.key \
-      /etc/tls-sidecar/cluster-ca-certs/ca.crt \
-      entity-operator
-  echo "Preparing key store certificates for internal communication is completed"
+    echo "Preparing key store certificates for internal communication"
+    STORE=/tmp/topic-operator/replication.keystore.p12
+    rm -f "$STORE"
+    create_keystore_without_ca_file "$STORE" "$CERTS_STORE_PASSWORD" \
+        /etc/eto-certs/entity-operator.crt \
+        /etc/eto-certs/entity-operator.key \
+        /etc/tls-sidecar/cluster-ca-certs/ca.crt \
+        entity-operator
+    echo "Preparing key store certificates for internal communication is completed"
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates our remaining calls to OpenSSL and to Java Keytool to read the store passwords directly from the environment variables instead of passing them through the command itself and possibly triggering warnings from a various security tools.

This requires the new variable `PASSWORD` to be defined before calling the command as this cannot be done with the function parameter variable directly.

This PR also fixes the indentation in the two modified files which were using a mix of different indentations (2 characters, 3 characters, 4 characters) and now uses 4 characters everywhere.

_(Given the passwords are any one-of passwords generated at container startup and are stored in the container, so anyone with access to the process table can see them quite easily anyway ... this is not really a security issue per-se. It is more about not causing alarms.)_

This should close #9957.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging