### PR TITLE
Remove some unused dependencies from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,12 +371,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-tools</artifactId>
-                <version>${kafka.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.13</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
@@ -392,22 +386,12 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>connect-json</artifactId>
-                <version>${kafka.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
                 <artifactId>connect-file</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>connect-api</artifactId>
-                <version>${kafka.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-streams</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR removes some dependencies referenced in the main `pom.xml` that are not used. This is likely because we stopped using them over time.

### Checklist

- [x] Make sure all tests pass