### PR TITLE
Add KafkaNodePool resource count metric and fix dashboard defaults

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
@@ -1586,6 +1586,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockKafkaOps.getAsync(eq(NAMESPACE), eq("bar"))).thenReturn(Future.succeededFuture(bar));
         when(mockKafkaOps.updateStatusAsync(any(), any(Kafka.class))).thenReturn(Future.succeededFuture());
 
+        CrdOperator<KubernetesClient, KafkaNodePool, KafkaNodePoolList> mockKafkaNodePoolOps = supplier.kafkaNodePoolOperator;
+        when(mockKafkaNodePoolOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockKafkaNodePoolOps.listAsync(eq(NAMESPACE), isNull(LabelSelector.class))).thenReturn(Future.succeededFuture(List.of()));
+
         AtomicBoolean fooReconciled = new AtomicBoolean(false);
         AtomicBoolean barReconciled = new AtomicBoolean(false);
 
@@ -1657,6 +1661,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockKafkaOps.getAsync(eq("namespace1"), eq("foo"))).thenReturn(Future.succeededFuture(foo));
         when(mockKafkaOps.getAsync(eq("namespace2"), eq("bar"))).thenReturn(Future.succeededFuture(bar));
         when(mockKafkaOps.updateStatusAsync(any(), any(Kafka.class))).thenReturn(Future.succeededFuture());
+
+        CrdOperator<KubernetesClient, KafkaNodePool, KafkaNodePoolList> mockKafkaNodePoolOps = supplier.kafkaNodePoolOperator;
+        when(mockKafkaNodePoolOps.listAsync(eq("*"), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockKafkaNodePoolOps.listAsync(eq("*"), isNull(LabelSelector.class))).thenReturn(Future.succeededFuture(List.of()));
 
         AtomicBoolean fooReconciled = new AtomicBoolean(false);
         AtomicBoolean barReconciled = new AtomicBoolean(false);


### PR DESCRIPTION
- Add nodePoolResourceCounter to KafkaAssemblyOperatorMetricsHolder
- Override reconcileThese() in KafkaAssemblyOperator to count NodePools
- Add unit tests for new metrics methods
- Fix Kafka panel default from N/A to 0 for consistency

Fixes #12138
