### PR TITLE
Refactor and clean-up various Entity Operator related classes

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -248,8 +248,8 @@ public class EntityTopicOperatorTest {
         assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(Map.of(
                 EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
-                EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
-                EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT)));
+                EntityTopicOperator.ETO_CA_CERTS_VOLUME_NAME, EntityTopicOperator.ETO_CA_CERTS_VOLUME_MOUNT,
+                EntityTopicOperator.ETO_CERTS_VOLUME_NAME, EntityTopicOperator.ETO_CERTS_VOLUME_MOUNT)));
     }
 
     @Test
@@ -316,9 +316,9 @@ public class EntityTopicOperatorTest {
         assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(Map.of(
             EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
             "entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
-            EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
-            EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT,
-            EntityOperator.ETO_CC_API_VOLUME_NAME, EntityOperator.ETO_CC_API_VOLUME_MOUNT
+            EntityTopicOperator.ETO_CA_CERTS_VOLUME_NAME, EntityTopicOperator.ETO_CA_CERTS_VOLUME_MOUNT,
+            EntityTopicOperator.ETO_CERTS_VOLUME_NAME, EntityTopicOperator.ETO_CERTS_VOLUME_MOUNT,
+            EntityTopicOperator.ETO_CC_API_VOLUME_NAME, EntityTopicOperator.ETO_CC_API_VOLUME_MOUNT
         )));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -227,9 +227,7 @@ public class EntityUserOperatorTest {
         assertThat(container.getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(Map.of(
                 EntityUserOperator.USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
-                "entity-user-operator-metrics-and-logging", "/opt/user-operator/custom-config/",
-                EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
-                EntityOperator.EUO_CERTS_VOLUME_NAME, EntityOperator.EUO_CERTS_VOLUME_MOUNT)));
+                "entity-user-operator-metrics-and-logging", "/opt/user-operator/custom-config/")));
     }
 
     @Test

--- a/documentation/modules/cruise-control/proc-cruise-control-topic-replication.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-topic-replication.adoc
@@ -134,5 +134,5 @@ spec:
 
 If you enable TLS authentication and authorization, mount the required certificates as follows:
 
-* Public certificates of the Cluster CA (certificate authority) in `/etc/tls-sidecar/cluster-ca-certs/ca.crt`
+* Public certificates of the Cluster CA (certificate authority) in `/etc/cluster-ca-certs/ca.crt`
 * Basic authorization credentials (user name and password) in `/etc/eto-cc-api/topic-operator.apiAdminName` and `/etc/eto-cc-api/topic-operator.apiAdminPassword`

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -256,23 +256,21 @@ class KafkaST extends AbstractST {
 
         String eoPod = eoPods.keySet().toArray()[0].toString();
         KubeResourceManager.get().kubeClient().getClient().pods().inNamespace(testStorage.getNamespaceName()).withName(eoPod).get().getSpec().getContainers().forEach(container -> {
-            if (!container.getName().equals("tls-sidecar")) {
-                LOGGER.info("Check if -D java options are present in {}", container.getName());
+            LOGGER.info("Check if -D java options are present in {}", container.getName());
 
-                String javaSystemProp = container.getEnv().stream().filter(envVar ->
-                    envVar.getName().equals("STRIMZI_JAVA_SYSTEM_PROPERTIES")).findFirst().orElseThrow().getValue();
-                String javaOpts = container.getEnv().stream().filter(envVar ->
-                    envVar.getName().equals("STRIMZI_JAVA_OPTS")).findFirst().orElseThrow().getValue();
+            String javaSystemProp = container.getEnv().stream().filter(envVar ->
+                envVar.getName().equals("STRIMZI_JAVA_SYSTEM_PROPERTIES")).findFirst().orElseThrow().getValue();
+            String javaOpts = container.getEnv().stream().filter(envVar ->
+                envVar.getName().equals("STRIMZI_JAVA_OPTS")).findFirst().orElseThrow().getValue();
 
-                assertThat(javaSystemProp, is("-Djavax.net.debug=verbose"));
+            assertThat(javaSystemProp, is("-Djavax.net.debug=verbose"));
 
-                if (container.getName().equals("topic-operator")) {
-                    assertThat(javaOpts, is("-Xms1024M -Xmx2G"));
-                }
+            if (container.getName().equals("topic-operator")) {
+                assertThat(javaOpts, is("-Xms1024M -Xmx2G"));
+            }
 
-                if (container.getName().equals("user-operator")) {
-                    assertThat(javaOpts, is("-Xms512M -Xmx1G"));
-                }
+            if (container.getName().equals("user-operator")) {
+                assertThat(javaOpts, is("-Xms512M -Xmx1G"));
             }
         });
 

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -33,7 +33,7 @@ if [ "$STRIMZI_PUBLIC_CA" != "true" ]; then
     echo "Preparing trust store certificates for internal communication"
     STORE=/tmp/topic-operator/replication.truststore.p12
     rm -f "$STORE"
-    for CRT in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
+    for CRT in /etc/cluster-ca-certs/*.crt; do
         ALIAS=$(basename "$CRT" .crt)
         echo "Adding $CRT to truststore $STORE with alias $ALIAS"
         create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
@@ -48,7 +48,7 @@ if [ "$STRIMZI_TLS_AUTH_ENABLED" != "false" ]; then
     create_keystore_without_ca_file "$STORE" "$CERTS_STORE_PASSWORD" \
         /etc/eto-certs/entity-operator.crt \
         /etc/eto-certs/entity-operator.key \
-        /etc/tls-sidecar/cluster-ca-certs/ca.crt \
+        /etc/cluster-ca-certs/ca.crt \
         entity-operator
     echo "Preparing key store certificates for internal communication is completed"
 fi

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -96,7 +96,7 @@ public class TopicOperatorConfig {
     /** Cruise Control: whether authentication is enabled. */
     public static final ConfigParameter<Boolean> CRUISE_CONTROL_AUTH_ENABLED = new ConfigParameter<>("STRIMZI_CRUISE_CONTROL_AUTH_ENABLED", ConfigParameterParser.BOOLEAN, "false", CONFIG_VALUES);
     /** Cruise Control: CA certificate file location. */
-    public static final ConfigParameter<String> CRUISE_CONTROL_CRT_FILE_PATH = new ConfigParameter<>("STRIMZI_CRUISE_CONTROL_CRT_FILE_PATH", ConfigParameterParser.STRING, "/etc/tls-sidecar/cluster-ca-certs/ca.crt", CONFIG_VALUES);
+    public static final ConfigParameter<String> CRUISE_CONTROL_CRT_FILE_PATH = new ConfigParameter<>("STRIMZI_CRUISE_CONTROL_CRT_FILE_PATH", ConfigParameterParser.STRING, "/etc/cluster-ca-certs/ca.crt", CONFIG_VALUES);
     /** Cruise Control: username file location. */
     public static final ConfigParameter<String> CRUISE_CONTROL_API_USER_PATH = new ConfigParameter<>("STRIMZI_CRUISE_CONTROL_API_USER_PATH", ConfigParameterParser.STRING, "/etc/eto-cc-api/" + CruiseControlApiProperties.TOPIC_OPERATOR_USERNAME_KEY, CONFIG_VALUES);
     /** Cruise Control: password file location. */


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors and cleans-up several classes related to the Entity Operator:
* Removes unnecessary Secret volumes and volume mounts in the Entity Operator Pod / User Operator container. These were not needed as the UO loads certs directly form Secrets.
* Provides a better separation of the volume-related logic between the `EntityOperator`, `EntityUserOperator` and `EntityTopicOperator` classes. This helps to provide better encapsulation, have naming constants where they belong, etc.
* Renames the `tls-sidecar` volume mount path as the `tls-sidecar` is  long gone and the path seems to be just historical oversight.
* Removes unnecessary TLS sidecar check from the `KafkaST` class
* Addresses various minor IDE warnings, mostly around comments, etc.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally