### PR TITLE
Updated Netty to 4.1.130.Final to resolve CVE-2025-67735

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
         <fasterxml.jackson-annotations.version>2.16.2</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.2</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.22</vertx.version>
-        <vertx-junit5.version>4.5.22</vertx-junit5.version>
+        <vertx.version>4.5.23</vertx.version>
+        <vertx-junit5.version>4.5.23</vertx-junit5.version>
         <kafka.version>3.9.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.5</zookeeper.version>
@@ -145,7 +145,7 @@
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.1</strimzi-oauth.version>
         <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
-        <netty.version>4.1.129.Final</netty.version>
+        <netty.version>4.1.130.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <jsonsmart.version>2.5.2</jsonsmart.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Updated Netty to 4.1.130.Final to resolve CVE-2025-67735
Updated Vert.x to 4.5.23 to fix compatibility issues with Netty

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

