### PR TITLE
Fix Request_Handler_Avg_Idle_Percent metric bug

### DIFF
--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json
@@ -2312,7 +2312,7 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "expr": "sum(irate(kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\"}[5m]) / 1e9 * 100) by (kubernetes_pod_name)",
+          "expr": "sum(irate(kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\"}[$__rate_interval]) / 1e9 * 100) by (kubernetes_pod_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

This PR addresses the follwoing issue:
https://github.com/strimzi/strimzi-kafka-operator/issues/12126

The `Request Handler Avg Idle Percent` dashboard is now showing a percentage average instead of an ever increasing counter.

<img width="1369" height="682" alt="GrafanaD" src="https://github.com/user-attachments/assets/29e2cfe3-943f-4ec9-a755-401ecd4a7daa" />


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

