### PR TITLE
Fix invalid deep-link to Bridge logging docs

### DIFF
--- a/documentation/modules/configuring/ref-configurable-loggers.adoc
+++ b/documentation/modules/configuring/ref-configurable-loggers.adoc
@@ -12,7 +12,7 @@ You can configure specific loggers for Kafka components and Strimzi operators.
 Kafka components::
 * link:{BookURLConfiguring}#property-kafka-logging-reference[Kafka loggers^]
 * link:{BookURLConfiguring}#property-kafka-connect-logging-reference[Kafka Connect and MirrorMaker 2 loggers^]
-* link:{BookURLConfiguring}#property-kafka-bridge-logging-reference[HTTP Bridge loggers^]
+* link:{BookURLConfiguring}#property-http-bridge-logging-reference[HTTP Bridge loggers^]
 * link:{BookURLConfiguring}#property-cruise-control-logging-reference[Cruise Control loggers^]
 
 Strimzi operators::


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

It looks like during the Kafka Bridge to HTTP Bridge renaming we forgot to rename this link to Bridge logging docs. This PR fixes it. I did not found any other links like this while looking at it.

### Checklist

- [x] Update documentation