### PR TITLE
Remove SLF4J and `rm` warning from the Strimzi build

### DIFF
--- a/config-model-generator/build-config-models.sh
+++ b/config-model-generator/build-config-models.sh
@@ -9,7 +9,7 @@ get_kafka_versions
 
 # Always delete existing files so when kafka-versions changes we remove
 # models for unsupported versions
-rm ../cluster-operator/src/main/resources/kafka-*-config-model.json || true
+rm -f ../cluster-operator/src/main/resources/kafka-*-config-model.json || true
 
 if [ "$1" = "build" ]
 then

--- a/config-model-generator/pom.xml
+++ b/config-model-generator/pom.xml
@@ -70,6 +70,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -98,6 +102,8 @@
                                     <ignoredUnusedDeclaredDependencies>
                                         <!-- Mot used directly because of differences between Kafka versions. But needed in the classpath. -->
                                         <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-raft</ignoredUnusedDeclaredDependency>
+                                        <!-- Needed for logging using the Kafka Clients (uses SLF4J) -->
+                                        <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
                                     </ignoredUnusedDeclaredDependencies>
                                 </configuration>
                             </execution>
@@ -154,6 +160,8 @@
                                     <ignoredUnusedDeclaredDependencies>
                                         <!-- Mot used directly because of differences between Kafka versions. But needed in the classpath. -->
                                         <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-raft</ignoredUnusedDeclaredDependency>
+                                        <!-- Needed for logging using the Kafka Clients (uses SLF4J) -->
+                                        <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
                                     </ignoredUnusedDeclaredDependencies>
                                 </configuration>
                             </execution>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -55,6 +55,14 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -68,6 +76,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.version}</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUnusedDeclaredDependencies>
+                                <!-- Needed for logging using the Kubernetes Client (uses SLF4J) -->
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR solves some more warnings from the Stirmzi build (this time unrelated to Java 21):
* Adds the SLF4J implementations to the CRD and Config Model generators to avoid the SLF4J warnings about the API being included without any provider
  ```
  SLF4J(W): No SLF4J providers were found.
  SLF4J(W): Defaulting to no-operation (NOP) logger implementation
  SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
  ```
* The `rm` command warning raised by repeated `mvn clean` or `make clean` runs

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally