### PR TITLE
Update Fabric8 Kubrnetes client to 7.5.0

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
@@ -16,9 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LeaderElectionManagerMockTest {
@@ -57,21 +55,25 @@ public class LeaderElectionManagerMockTest {
         le1.start();
         le1Leader.await();
         assertThat(getLease().getSpec().getHolderIdentity(), is("le-1"));
+        assertThat(getLease().getSpec().getLeaseDurationSeconds(), is(2));
 
         // Start the second member => leadership should not change
         le2.start();
         assertThat(getLease().getSpec().getHolderIdentity(), is("le-1"));
+        assertThat(getLease().getSpec().getLeaseDurationSeconds(), is(2));
 
         // Stop the first member => leadership should change
         le1.stop();
         le1NotLeader.await();
         le2Leader.await();
         assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+        assertThat(getLease().getSpec().getLeaseDurationSeconds(), is(2));
 
-        // Stop the second member => the leadership should be released
+        // Stop the second member => the holder identity remains set, but the lease duration is reset to 1
         le2.stop();
         le2NotLeader.await();
-        assertThat(getLease().getSpec().getHolderIdentity(), anyOf(is(""), nullValue()));
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+        assertThat(getLease().getSpec().getLeaseDurationSeconds(), is(1));
     }
 
     private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Consumer<Boolean> stopLeadershipCallback)   {
@@ -79,8 +81,8 @@ public class LeaderElectionManagerMockTest {
         envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME.key(), LEASE_NAME);
         envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE.key(), NAMESPACE);
         envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_IDENTITY.key(), identity);
-        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_DURATION_MS.key(), "1000");
-        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_RENEW_DEADLINE_MS.key(), "800");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_DURATION_MS.key(), "2000");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_RENEW_DEADLINE_MS.key(), "1000");
         envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_RETRY_PERIOD_MS.key(), "200");
 
         return new LeaderElectionManager(

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.4.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.4.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.4.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.5.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.5.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.5.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to new version 7.5.0. This version has some changes to the Lease election (e.g. https://github.com/fabric8io/kubernetes-client/issues/7160 and https://github.com/fabric8io/kubernetes-client/issues/7343). So this PR also contains some updates to our unit and integration tests to adapt to these changes (in particular, the lease duration is reset at shutdown and the last lease holder name is preserved).

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally