### PR TITLE
Fixed shellcheck warning SC2268 and updated version

### DIFF
--- a/.azure/scripts/setup_shellcheck.sh
+++ b/.azure/scripts/setup_shellcheck.sh
@@ -10,7 +10,7 @@ if [ "$ARCH" == "arm64" ]; then
     ARCH="aarch64"
 fi
 
-readonly VERSION="0.9.0"
+readonly VERSION="0.11.0"
 wget https://github.com/koalaman/shellcheck/releases/download/v$VERSION/shellcheck-v$VERSION.linux.$ARCH.tar.xz -O shellcheck.tar.xz
 tar xf shellcheck.tar.xz -C /tmp --strip-components 1
 chmod +x /tmp/shellcheck

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -41,7 +41,7 @@ if [ "$CRUISE_CONTROL_JMX_EXPORTER_ENABLED" = "true" ]; then
 fi
 
 # Set Debug options if enabled
-if [ "x$KAFKA_DEBUG" != "x" ]; then
+if [ -n "$KAFKA_DEBUG" ]; then
 
     # Use default ports
     DEFAULT_JAVA_DEBUG_PORT="5005"


### PR DESCRIPTION
While running the shellcheck locally I got the following error:

```shell
./.azure/scripts/shellcheck.sh

In docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh line 44:
if [ "x$KAFKA_DEBUG" != "x" ]; then
     ^-------------^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
if [ "$KAFKA_DEBUG" != "" ]; then

For more information:
  https://www.shellcheck.net/wiki/SC2268 -- Avoid x-prefix in comparisons as ...
make: *** [Makefile:139: shellcheck] Error 1
```

It seems being detected by the latest 0.11.0 shellcheck version I have locally while it's not detected with an older 0.9.0 used by our CIs.
This PR fixes the issue in the script by using a different way to do the check but also update shellcheck version to the latest 0.11.0 in our CIs.