### PR TITLE
Add flag for setting `hostUsers` on operator deployment

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -120,6 +120,7 @@ the documentation for more details.
 | `podSecurityContext`                             | Cluster Operator pod's security context                                         | `nil`                        |
 | `deploymentStrategy`                             | Adjust the Kubernetes rollout strategy of the Cluster Operator Deployment       | `nil`                        |
 | `priorityClassName`                              | Cluster Operator pod's priority class name                                      | `nil`                        |
+| `hostUsers`                                      | Set hostUsers value on the Cluster Operator container                           | `nil`                       |
 | `securityContext`                                | Cluster Operator container's security context                                   | `nil`                        |
 | `rbac.create`                                    | Whether to create RBAC related resources                                        | `yes`                        |
 | `serviceAccountCreate`                           | Whether to create a service account                                             | `yes`                        |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -50,6 +50,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if kindIs "bool" .Values.hostUsers }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
@@ -50,6 +50,23 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: 'quay.io/strimzi/operator:(latest|[0-9]+\.[0-9]+\.[0-9]+)'
 
+  - it: should not set hostUsers by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: should allow override of hostUsers to true
+    set:
+      hostUsers: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+
   - it: should have custom image if details are provided
     set:
       image:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -45,6 +45,7 @@ deploymentAnnotations: {}
 deploymentStrategy: {}
 priorityClassName: ""
 
+hostUsers: NULL
 podSecurityContext: {}
 securityContext: {}
 rbac:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This adds a flag where folks can explicitly set `hostUsers` if they desire on the operator itself.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

