### PR TITLE
Update Kubernetes Config Provider to 1.2.1

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -22,7 +22,7 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
-        <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.1</kafka-kubernetes-config-provider.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -22,7 +22,7 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
-        <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.1</kafka-kubernetes-config-provider.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kubernetes Config Provider version to 1.2.1-RC1. This is currently a Draft to test the RC1 before the actual GA release.

### Checklist

- [ ] Make sure all tests pass