### PR TITLE
Bumped Vert.x 5.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <fasterxml.jackson-annotations.version>2.18.3</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.18.3</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.18.3</fasterxml.jackson-jaxrs.version>
-        <vertx.version>5.0.6</vertx.version>
-        <vertx-junit5.version>5.0.6</vertx-junit5.version>
+        <vertx.version>5.0.7</vertx.version>
+        <vertx-junit5.version>5.0.7</vertx-junit5.version>
         <kafka.version>4.1.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>


### PR DESCRIPTION
This trivial PR bumps Vert.x to 5.0.7 with some bugs and CVE fixed https://vertx.io/blog/eclipse-vert-x-5-0-7/
The Netty version stays the same.