### PR TITLE
Improve quoting of numbers in `v1` API conversion

### DIFF
--- a/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertFileCommand.java
+++ b/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertFileCommand.java
@@ -85,7 +85,10 @@ public class ConvertFileCommand extends AbstractConversionCommand {
      */
     protected String run(byte[] data) throws IOException {
         YAMLFactory yamlFactory = new YAMLFactory();
-        YAMLMapper yamlMapper = new YAMLMapper(yamlFactory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES));
+        yamlFactory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+        yamlFactory.enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS);
+
+        YAMLMapper yamlMapper = new YAMLMapper(yamlFactory);
         YAMLParser yamlParser = yamlFactory.createParser(data);
         List<JsonNode> docs = yamlMapper.readValues(yamlParser, JSON_NODE_TYPE_REFERENCE).readAll();
 

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/kafka-all-out.out
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/kafka-all-out.out
@@ -47,10 +47,10 @@ spec:
       resources:
         limits:
           memory: 256Mi
-          cpu: 500m
+          cpu: "0.5"
         requests:
           memory: 256Mi
-          cpu: 200m
+          cpu: "0.2"
     userOperator:
       reconciliationIntervalMs: 30000
       resources:

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/kafka-all-out.yaml
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/kafka-all-out.yaml
@@ -100,10 +100,10 @@ spec:
       resources:
         requests:
           memory: 256Mi
-          cpu: 200m
+          cpu: "0.2"
         limits:
           memory: 256Mi
-          cpu: 500m
+          cpu: "0.5"
     userOperator:
       reconciliationIntervalSeconds: 30
       zookeeperSessionTimeoutSeconds: 15

--- a/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/multiple-resources.out
+++ b/v1-api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/v1/cli/multiple-resources.out
@@ -139,7 +139,7 @@ kind: ConfigMap
 metadata:
   name: game-demo
 data:
-  player_initial_lives: 3
+  player_initial_lives: "3"
   ui_properties_file_name: user-interface.properties
   game.properties: |
     enemy.types=aliens,monsters


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `v1` API conversion does not quote numbers currently which might lead to issues. For example, the following configuration:
```yaml
    userOperator:
      resources:
        requests:
          memory: 512Mi
          cpu: "0.2"
        limits:
          memory: 512Mi
          cpu: "0.5"
```

gets currently converted as:
```yaml
    userOperator:
      resources:
        requests:
          memory: 512Mi
          cpu: 0.2
        limits:
          memory: 512Mi
          cpu: 0.5
```

But this is not a valid Kubernetes resource:
```
The Kafka "my-cluster" is invalid:
* spec.entityOperator.userOperator.resources.limits.cpu: Invalid value: "number": spec.entityOperator.userOperator.resources.limits.cpu in body must be of type integer,string: "number"
* <nil>: Invalid value: "": "spec.entityOperator.userOperator.resources.limits.cpu" must validate at least one schema (anyOf)
* spec.entityOperator.userOperator.resources.limits.cpu: Invalid value: "number": spec.entityOperator.userOperator.resources.limits.cpu in body must be of type integer: "number"
* spec.entityOperator.userOperator.resources.requests.cpu: Invalid value: "number": spec.entityOperator.userOperator.resources.requests.cpu in body must be of type integer,string: "number"
* <nil>: Invalid value: "": "spec.entityOperator.userOperator.resources.requests.cpu" must validate at least one schema (anyOf)
* spec.entityOperator.userOperator.resources.requests.cpu: Invalid value: "number": spec.entityOperator.userOperator.resources.requests.cpu in body must be of type integer: "number"
* <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

While it is probably rare that this happens (it works fine for example if one uses the more common `200m` instead of `0.2`), similar problems might happen in other places as well.

This PR fixes the Jackson configuration we use in the conversion tool to properly quote the numbers. It also makes sure we have some tests covering this.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass