### PR TITLE
Update Fabric8 to 7.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.5.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.5.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.5.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.5.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.5.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.5.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR updates Fabric8 to 7.5.1 after patch release.

### Checklist

- [ ] Make sure all tests pass


