### PR TITLE
Update Cruise Control goal violations Grafana chart

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
@@ -464,7 +464,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Goal violations per anomaly detector execution. The 5-minute window matches the detector’s default run interval to preserve discrete per run counts",
+      "description": "Goal violations per anomaly detector execution. Because Cruise Control emits cumulative counts, the Prometheus query window must be set to the anomaly detector run interval to preserve discrete per run counts (5 minutes by default)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -544,7 +544,7 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "expr": "round(max_over_time(increase(kafka_cruisecontrol_anomalydetector_goal_violation_rate_count{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-cruise-control-.*\"}[5m])[5m:]))",
+          "expr": "round(max_over_time(increase(kafka_cruisecontrol_anomalydetector_goal_violation_rate_count{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-cruise-control-.*\"}[10m])[10m:]))",
           "hide": false,
           "instant": false,
           "interval": "",

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-cruise-control.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-cruise-control.json
@@ -464,7 +464,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Goal violations per anomaly detector execution. The 5-minute window matches the detector’s default run interval to preserve discrete per run counts",
+      "description": "Goal violations per anomaly detector execution. Because Cruise Control emits cumulative counts, the Prometheus query window must be set to the anomaly detector run interval to preserve discrete per run counts (5 minutes by default)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -544,7 +544,7 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "expr": "round(max_over_time(increase(kafka_cruisecontrol_anomalydetector_goal_violation_rate_count{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-cruise-control-.*\"}[5m])[5m:]))",
+          "expr": "round(max_over_time(increase(kafka_cruisecontrol_anomalydetector_goal_violation_rate_count{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-cruise-control-.*\"}[10m])[10m:]))",
           "hide": false,
           "instant": false,
           "interval": "",


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

#### Problem

The current Cruise Control Grafana dashboard displays goal violations using a rate-based expression (`irate()`), which results in periodic spikes that are mathematically correct but difficult to interpret. Since the anomaly detector runs at fixed intervals and reports discrete counts of goal violations per run, a rate-based visualization does not reflect the underlying behavior well.

When a single goal violation is present, the current “Goal Violation Rate” chart renders as shown below:

<img alt="old_goal_violation_chart_resized" height="300" src="https://github.com/user-attachments/assets/97a74261-cc91-4deb-b75d-93060983fe1a" width="100%" />

#### Solution

This PR updates the dashboard to show the number of goal violations detected per anomaly detector run providing a clearer and more intuitive view for administrators. This change affects only the dashboard and does not modify any Cruise Control metrics or behavior.

With this change, the current “Goal Violation Rate” chart is replaced by this proposed “Goal Violations” chart, which appears as shown below when a single goal violation is present.

<img alt="new_goal_violation_chart" height="300" src="https://github.com/user-attachments/assets/f3f0edf6-4f3b-4e1b-8660-8c61088bd4cf" width="100%" />


### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

