### PR TITLE
Log the kubernetes API server version

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -83,6 +83,9 @@ public class Main {
         MetricsProvider metricsProvider = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-cluster-operator", strimziVersion).build();
 
+        String kubeVersion = Util.getKubernetesVersion(client);
+        LOGGER.info("Connected to Kubernetes API server, version={}", kubeVersion);
+
         startHealthServer(vertx, metricsProvider)
                 .compose(i -> leaderElection(vertx, client, config, shutdownHook))
                 .compose(i -> createPlatformFeaturesAvailability(vertx, client))

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -5,6 +5,8 @@
 package io.strimzi.operator.common;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import org.quartz.CronExpression;
@@ -119,6 +121,23 @@ public class Util {
         }
 
         LOGGER.infoOp("Using config:\n" + sb);
+    }
+
+    /**
+     * Returns the Kubernetes API server Git version.
+     * Useful as a sanity check to confirm connectivity.
+     *
+     * @param client Fabric8 Kubernetes client
+     * @return Kubernetes Git version (e.g. v1.29.1)
+     */
+    public static String getKubernetesVersion(KubernetesClient client) {
+        VersionInfo version = client.getVersion();
+
+        if (version == null || version.getGitVersion() == null) {
+            throw new IllegalStateException("Failed to retrieve Kubernetes version from API server");
+        }
+
+        return version.getGitVersion();
     }
 
     /**
@@ -264,7 +283,7 @@ public class Util {
     public static String encodeToBase64(String data)  {
         return Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.US_ASCII));
     }
-    
+
     /**
      * Decodes a byte[] from Base64.
      *
@@ -275,7 +294,7 @@ public class Util {
     public static byte[] decodeBytesFromBase64(String data)  {
         return Base64.getDecoder().decode(data);
     }
-    
+
     /**
      * Decodes a byte[] from Base64.
      *
@@ -297,7 +316,7 @@ public class Util {
     public static String decodeFromBase64(String data)  {
         return decodeFromBase64(data, StandardCharsets.US_ASCII);
     }
-    
+
     /**
      * Decodes a String from Base64.
      *

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -84,6 +84,9 @@ public class Main {
         Admin adminClient = createAdminClient(config, secretOperator, new DefaultAdminClientProvider());
         var kafkaUserCrdOperator = new CrdOperator<>(kafkaUserOperatorExecutor, client, KafkaUser.class, KafkaUserList.class, "KafkaUser");
 
+        String kubeVersion = Util.getKubernetesVersion(client);
+        LOGGER.info("Connected to Kubernetes API server, version={}", kubeVersion);
+
         KafkaUserOperator kafkaUserOperator = new KafkaUserOperator(
                 config,
                 new OpenSslCertManager(),


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This provides a log entry with the API server version which can be used to determine if a strange version is used with strimzi as well as a quick failure of the API server version cannot be determined. The second case is probably a misconfiguration of the cluster resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

### Additional notes

I'm not a java programmer so I fear a fair bit of hand holding will be needed if I'm off target here.

If this check/log had been in place earlier I would have isolated a cluster configuration but on my end much more quickly. My attempt to build the changed source tree went poorly...

If it is less work to just discard my patch and do it yourself I'm not offended.