### PR TITLE
Git ignore Claude local configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ hs_err_pid*
 
 # Cluster operator config models
 **/cluster-operator/src/main/resources/kafka-*-config-model.json
+
+# Claude configuration
+.claude/
+CLAUDE.md
+.mcp.json


### PR DESCRIPTION
AI assistants use global and local project configuration on developers machine.
Every developer could like to have different configuration from the others, so the corresponding AI assistant configuration files local to the project root should be excluded by Git.
This PR adds exclusion for Claude configuration. It doesn't have anything about others (i.e. Copilot, ...) because I have not used it yet so not sure how it works and what's the content to be Git ignored for it. I would leave to other contributors who use other AI assistants adding such exclusion.