### PR TITLE
Update Kubernetes Config Provider to 1.2.2

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.0.x/pom.xml
@@ -22,7 +22,7 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
-        <kafka-kubernetes-config-provider.version>1.2.1</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.1.x/pom.xml
@@ -22,7 +22,7 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
-        <kafka-kubernetes-config-provider.version>1.2.1</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.5.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.5.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.5.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.5.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.5.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.5.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kubernetes Config Provider to 1.2.2 to fix a missed exclusion. It also bumps the Kubernetes Fabric8 client to 7.5.2 - this change has no real impact on us, but it makes sense to have the versions aligned.

_This is currently a Draft using the 1.2.2-rc1 version._

### Checklist

- [ ] Make sure all tests pass