### PR TITLE
Remove `deleteClaim: false` from examples and docs - Closes #12312

### DIFF
--- a/documentation/modules/configuring/con-config-node-pools.adoc
+++ b/documentation/modules/configuring/con-config-node-pools.adoc
@@ -67,7 +67,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # Resources requests and limits (recommended)
   resources: # <6>
     requests:

--- a/documentation/modules/configuring/con-config-storage-kraft-metadata.adoc
+++ b/documentation/modules/configuring/con-config-storage-kraft-metadata.adoc
@@ -35,11 +35,9 @@ spec:
     - id: 0
       type: persistent-claim
       size: 100Gi
-      deleteClaim: false
     - id: 1
       type: persistent-claim
       size: 100Gi
       kraftMetadata: shared
-      deleteClaim: false
   # ...
 ----

--- a/documentation/modules/configuring/con-config-storage-kraft.adoc
+++ b/documentation/modules/configuring/con-config-storage-kraft.adoc
@@ -131,15 +131,12 @@ spec:
       - id: 0
         type: persistent-claim
         size: 2000Gi
-        deleteClaim: false
       - id: 1
         type: persistent-claim
         size: 2000Gi
-        deleteClaim: false
       - id: 2
         type: persistent-claim
         size: 2000Gi
-        deleteClaim: false
   # ...
 ----
 
@@ -189,15 +186,12 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
       - id: 1
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
       - id: 2
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # ...
 ----
 

--- a/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
@@ -33,7 +33,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # ...
 ---
 apiVersion: {KafkaNodePoolApiVersion}
@@ -52,7 +51,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # ...
 ----
 
@@ -104,7 +102,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # ...
 ----
 

--- a/documentation/modules/configuring/proc-splitting-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-splitting-node-pool-roles.adoc
@@ -34,7 +34,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 20Gi
-        deleteClaim: false
   # ...
 ----
 
@@ -82,7 +81,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # ...
 ----
 +
@@ -152,7 +150,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 20Gi
-        deleteClaim: false
   # ...
 ----
 

--- a/documentation/modules/cruise-control/proc-automating-rebalances.adoc
+++ b/documentation/modules/cruise-control/proc-automating-rebalances.adoc
@@ -142,7 +142,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
   # ...
 ----
 +

--- a/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
@@ -60,15 +60,12 @@ spec:
       - id: 0
         type: persistent-claim
         size: 2000Gi
-        deleteClaim: false
       - id: 1
         type: persistent-claim
         size: 2000Gi
-        deleteClaim: false
       - id: 2
         type: persistent-claim
         size: 2000Gi
-        deleteClaim: false
   # ...
 ----
 

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -15,7 +15,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1
@@ -36,11 +35,9 @@ spec:
         size: 100Gi
         # Indicates that this directory will be used to store Kraft metadata log
         kraftMetadata: shared
-        deleteClaim: false
       - id: 1
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -15,7 +15,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1
@@ -35,7 +34,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1

--- a/packaging/examples/kafka/kafka-single-node.yaml
+++ b/packaging/examples/kafka/kafka-single-node.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/kafka/kafka-with-dual-role-nodes.yaml
+++ b/packaging/examples/kafka/kafka-with-dual-role-nodes.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -15,7 +15,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1
@@ -35,7 +34,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-metrics.yaml
@@ -15,7 +15,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
@@ -34,7 +33,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: Kafka

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -15,7 +15,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1
@@ -35,7 +34,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 
@@ -64,7 +63,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -15,7 +15,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1
@@ -35,7 +34,6 @@ spec:
         type: persistent-claim
         size: 100Gi
         kraftMetadata: shared
-        deleteClaim: false
 ---
 
 apiVersion: kafka.strimzi.io/v1

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -15,7 +15,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 
@@ -64,7 +63,6 @@ spec:
       - id: 0
         type: persistent-claim
         size: 100Gi
-        deleteClaim: false
         kraftMetadata: shared
 ---
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

As discussed on the triage call and in #12312, we should remove the `deleteClaim: false` flag from the examples and docs as the `false` values is default and is confusing users when they don't set it.

This should close #12312.

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging