### PR TITLE
Use shallow clone when publishing docs to the website

### DIFF
--- a/.azure/scripts/docu-push-to-website.sh
+++ b/.azure/scripts/docu-push-to-website.sh
@@ -7,7 +7,7 @@ chmod 600 github_deploy_key
 eval `ssh-agent -s`
 ssh-add github_deploy_key
 
-git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website
+git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website --depth 1
 
 # Operator docs
 rm -rf  /tmp/website/docs/operators/in-development/images


### PR DESCRIPTION
### Type of change

- Task

### Description

Currently, when publishing the docs to the website, we clone the whole history of the website repo. We should be able to do it with a shallow clone only. This PR updates the cloning logic to do a shallow clone only.