### PR TITLE
doc: rename Kafka Bridge to HTTP Bridge in SuiteDoc and system test docs

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.bridge.HttpBridgeST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.bridge.HttpBridgeST.md
@@ -1,6 +1,6 @@
 # HttpBridgeST
 
-**Description:** Test suite for various Kafka Bridge operations.
+**Description:** Test suite for various HTTP Bridge operations.
 
 **Before test execution steps:**
 

--- a/development-docs/systemtests/io.strimzi.systemtest.bridge.HttpBridgeScramShaST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.bridge.HttpBridgeScramShaST.md
@@ -1,6 +1,6 @@
 # HttpBridgeScramShaST
 
-**Description:** Test suite for validating Kafka Bridge functionality with TLS and SCRAM-SHA authentication
+**Description:** Test suite for validating HTTP Bridge functionality with TLS and SCRAM-SHA authentication
 
 **Before test execution steps:**
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.containsString;
 @Tag(REGRESSION)
 @Tag(BRIDGE)
 @SuiteDoc(
-    description = @Desc("Test suite for various Kafka Bridge operations."),
+    description = @Desc("Test suite for various HTTP Bridge operations."),
     beforeTestSteps = {
         @Step(value = "Initialize Test Storage and deploy Kafka and Kafka Bridge.", expected = "Kafka and Kafka Bridge are deployed with necessary configuration.")
     },

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -45,7 +45,7 @@ import static io.strimzi.systemtest.TestTags.REGRESSION;
 @Tag(BRIDGE)
 @Tag(REGRESSION)
 @SuiteDoc(
-    description = @Desc("Test suite for validating Kafka Bridge functionality with TLS and SCRAM-SHA authentication"),
+    description = @Desc("Test suite for validating HTTP Bridge functionality with TLS and SCRAM-SHA authentication"),
     beforeTestSteps = {
         @Step(value = "Create TestStorage instance.", expected = "TestStorage instance is created."),
         @Step(value = "Create BridgeClients instance.", expected = "BridgeClients instance is created."),


### PR DESCRIPTION

### Type of change
- [x] Documentation

### Description
Fixes #12120

Renames "Kafka Bridge" to "HTTP Bridge" in the high-level `@SuiteDoc` descriptions and corresponding `.md` documentation files.

Following the feedback in #12379, I've kept `KafkaBridge` everywhere else to maintain consistency with the Custom Resource name.

**Changes:**
- `HttpBridgeST.java` / `HttpBridgeST.md` - Updated suite description
- `HttpBridgeScramShaST.java` / `HttpBridgeScramShaST.md` - Updated suite description

### Checklist
- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards
