### PR TITLE
Implement selective pod metadata patching in StrimziPodSetController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.51.0
 
 * Allow setting the following configurations with the listener prefix (e.g. `listener.name.listener1-9900.`): `connections.max.reauth.ms`, `max.connections*` and `max.connection.creation.rate`.
+* Add support for in-place patching of Pod metadata (labels and annotations) without requiring a rolling restart.
+  Previously, any change to a Pod managed by the `StrimziPodSetController` would trigger a rolling update.
+  Now, metadata-only changes are applied via Strategic Merge Patch, improving operational efficiency.
 
 ### Major changes, deprecations, and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodDiff.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Utility class for computing differences between pods and determining if changes
+ * can be applied in-place (patched) without requiring a pod restart.
+ *
+ * <p>In Kubernetes, most pod spec fields are immutable after creation. However,
+ * certain metadata fields (labels and annotations) can be modified on a running pod
+ * without triggering a restart.</p>
+ *
+ * <p>This class is immutable and thread-safe once constructed.</p>
+ */
+public final class PodDiff {
+
+    /**
+     * Enum representing the type of change detected between two pods.
+     */
+    public enum ChangeType {
+        /** No changes detected */
+        NONE,
+        /** Only metadata (labels/annotations) changed - can be patched in-place */
+        METADATA_ONLY,
+        /** Spec or other immutable fields changed - requires pod restart */
+        REQUIRES_RESTART
+    }
+
+    /** Singleton instance representing no changes */
+    private static final PodDiff NO_CHANGE = new PodDiff(
+            ChangeType.NONE, 
+            Collections.emptyMap(), 
+            Collections.emptyMap(), 
+            Collections.emptyMap(), 
+            Collections.emptyMap()
+    );
+
+    private final ChangeType changeType;
+    private final Map<String, String> labelChanges;
+    private final Map<String, String> annotationChanges;
+    private final Map<String, String> labelsToRemove;
+    private final Map<String, String> annotationsToRemove;
+
+    /**
+     * Private constructor. Use {@link #diff(Pod, Pod)} to create instances.
+     *
+     * @param changeType          The type of change detected
+     * @param labelChanges        Labels to add or update
+     * @param annotationChanges   Annotations to add or update
+     * @param labelsToRemove      Labels to remove
+     * @param annotationsToRemove Annotations to remove
+     */
+    private PodDiff(ChangeType changeType,
+                    Map<String, String> labelChanges,
+                    Map<String, String> annotationChanges,
+                    Map<String, String> labelsToRemove,
+                    Map<String, String> annotationsToRemove) {
+        this.changeType = changeType;
+        // Store immutable copies to ensure thread-safety
+        this.labelChanges = Collections.unmodifiableMap(new HashMap<>(labelChanges));
+        this.annotationChanges = Collections.unmodifiableMap(new HashMap<>(annotationChanges));
+        this.labelsToRemove = Collections.unmodifiableMap(new HashMap<>(labelsToRemove));
+        this.annotationsToRemove = Collections.unmodifiableMap(new HashMap<>(annotationsToRemove));
+    }
+
+    /**
+     * Computes the difference between the current pod and the desired pod.
+     *
+     * @param current The current pod state (from the cluster)
+     * @param desired The desired pod state (from the StrimziPodSet)
+     * @return A PodDiff describing the changes
+     * @throws IllegalArgumentException if either pod is null
+     */
+    public static PodDiff diff(Pod current, Pod desired) {
+        if (current == null || desired == null) {
+            throw new IllegalArgumentException("Current and desired pods must not be null");
+        }
+
+        boolean specChanged = PodRevision.hasChanged(current, desired);
+
+        Map<String, String> currentLabels = nullSafeMap(current.getMetadata().getLabels());
+        Map<String, String> desiredLabels = nullSafeMap(desired.getMetadata().getLabels());
+        Map<String, String> currentAnnotations = nullSafeMap(current.getMetadata().getAnnotations());
+        Map<String, String> desiredAnnotations = nullSafeMap(desired.getMetadata().getAnnotations());
+
+        Map<String, String> labelChanges = computeAdditions(currentLabels, desiredLabels);
+        Map<String, String> labelsToRemove = computeRemovals(currentLabels, desiredLabels);
+        Map<String, String> annotationChanges = computeAdditions(currentAnnotations, desiredAnnotations);
+        Map<String, String> annotationsToRemove = computeRemovals(currentAnnotations, desiredAnnotations);
+
+        boolean hasMetadataChanges = !labelChanges.isEmpty() || !annotationChanges.isEmpty() 
+                || !labelsToRemove.isEmpty() || !annotationsToRemove.isEmpty();
+
+        // Return singleton for no-change case to reduce allocations
+        if (!specChanged && !hasMetadataChanges) {
+            return NO_CHANGE;
+        }
+
+        ChangeType changeType = determineChangeType(specChanged, hasMetadataChanges);
+
+        return new PodDiff(changeType, labelChanges, annotationChanges, labelsToRemove, annotationsToRemove);
+    }
+
+    /**
+     * Gets a non-null map, returning empty map if input is null.
+     *
+     * @param map The input map (may be null)
+     * @return The input map or an empty immutable map if null
+     */
+    private static Map<String, String> nullSafeMap(Map<String, String> map) {
+        return map != null ? map : Collections.emptyMap();
+    }
+
+    /**
+     * Computes entries that need to be added or updated.
+     *
+     * @param current The current map state
+     * @param desired The desired map state
+     * @return Map containing entries to add or update
+     */
+    private static Map<String, String> computeAdditions(Map<String, String> current, Map<String, String> desired) {
+        Map<String, String> changes = new HashMap<>();
+        for (Map.Entry<String, String> entry : desired.entrySet()) {
+            if (!Objects.equals(current.get(entry.getKey()), entry.getValue())) {
+                changes.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return changes;
+    }
+
+    /**
+     * Computes entries that need to be removed.
+     *
+     * @param current The current map state
+     * @param desired The desired map state
+     * @return Map containing entries to remove
+     */
+    private static Map<String, String> computeRemovals(Map<String, String> current, Map<String, String> desired) {
+        Map<String, String> removals = new HashMap<>();
+        for (Map.Entry<String, String> entry : current.entrySet()) {
+            if (!desired.containsKey(entry.getKey())) {
+                removals.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return removals;
+    }
+
+    /**
+     * Determines the change type based on spec and metadata changes.
+     *
+     * @param specChanged        Whether the pod spec has changed
+     * @param hasMetadataChanges Whether there are metadata changes
+     * @return The appropriate ChangeType
+     */
+    private static ChangeType determineChangeType(boolean specChanged, boolean hasMetadataChanges) {
+        if (specChanged) {
+            return ChangeType.REQUIRES_RESTART;
+        } else if (hasMetadataChanges) {
+            return ChangeType.METADATA_ONLY;
+        } else {
+            return ChangeType.NONE;
+        }
+    }
+
+    /**
+     * Returns the type of change detected.
+     *
+     * @return The change type
+     */
+    public ChangeType getChangeType() {
+        return changeType;
+    }
+
+    /**
+     * Checks if the changes can be applied via an in-place patch (no restart required).
+     *
+     * @return true if only patchable (metadata) changes were detected
+     */
+    public boolean isPatchable() {
+        return changeType == ChangeType.METADATA_ONLY;
+    }
+
+    /**
+     * Checks if there are any changes at all.
+     *
+     * @return true if changes were detected
+     */
+    public boolean hasChanges() {
+        return changeType != ChangeType.NONE;
+    }
+
+    /**
+     * Returns the total count of metadata changes (additions, updates, and removals).
+     *
+     * @return The total number of metadata changes
+     */
+    public int getTotalChangeCount() {
+        return labelChanges.size() + annotationChanges.size() 
+                + labelsToRemove.size() + annotationsToRemove.size();
+    }
+
+    /**
+     * Returns the labels that need to be added or updated.
+     *
+     * @return Immutable map of label changes
+     */
+    public Map<String, String> getLabelChanges() {
+        return labelChanges;
+    }
+
+    /**
+     * Returns the annotations that need to be added or updated.
+     *
+     * @return Immutable map of annotation changes
+     */
+    public Map<String, String> getAnnotationChanges() {
+        return annotationChanges;
+    }
+
+    /**
+     * Returns the labels that should be removed.
+     *
+     * @return Immutable map of labels to remove
+     */
+    public Map<String, String> getLabelsToRemove() {
+        return labelsToRemove;
+    }
+
+    /**
+     * Returns the annotations that should be removed.
+     *
+     * @return Immutable map of annotations to remove
+     */
+    public Map<String, String> getAnnotationsToRemove() {
+        return annotationsToRemove;
+    }
+
+    /**
+     * Creates a minimal Pod object suitable for patching the current pod's metadata.
+     * This creates a pod with only the essential fields for a strategic merge patch.
+     *
+     * @param currentPod The current pod to base the patch on
+     * @return A Pod object containing only the metadata changes
+     * @throws IllegalStateException if this diff is not patchable
+     * @throws IllegalArgumentException if currentPod is null
+     */
+    public Pod createPatchPod(Pod currentPod) {
+        if (!isPatchable()) {
+            throw new IllegalStateException("Cannot create patch pod for non-patchable changes (changeType=" + changeType + ")");
+        }
+        if (currentPod == null) {
+            throw new IllegalArgumentException("Current pod must not be null");
+        }
+
+        Map<String, String> newLabels = new HashMap<>(nullSafeMap(currentPod.getMetadata().getLabels()));
+        Map<String, String> newAnnotations = new HashMap<>(nullSafeMap(currentPod.getMetadata().getAnnotations()));
+
+        // Apply additions/updates
+        newLabels.putAll(labelChanges);
+        newAnnotations.putAll(annotationChanges);
+
+        // Apply removals
+        labelsToRemove.keySet().forEach(newLabels::remove);
+        annotationsToRemove.keySet().forEach(newAnnotations::remove);
+
+        ObjectMeta patchMeta = new ObjectMetaBuilder()
+                .withName(currentPod.getMetadata().getName())
+                .withNamespace(currentPod.getMetadata().getNamespace())
+                .withLabels(newLabels.isEmpty() ? null : newLabels)
+                .withAnnotations(newAnnotations.isEmpty() ? null : newAnnotations)
+                .build();
+
+        return new PodBuilder()
+                .withMetadata(patchMeta)
+                .build();
+    }
+
+    /**
+     * Returns a human-readable summary of the changes for logging purposes.
+     *
+     * @return A summary string describing the changes
+     */
+    public String getSummary() {
+        if (!hasChanges()) {
+            return "no changes";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (!labelChanges.isEmpty()) {
+            sb.append("labels to update: ").append(labelChanges.keySet());
+        }
+        if (!labelsToRemove.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append("labels to remove: ").append(labelsToRemove.keySet());
+        }
+        if (!annotationChanges.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append("annotations to update: ").append(annotationChanges.keySet());
+        }
+        if (!annotationsToRemove.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append("annotations to remove: ").append(annotationsToRemove.keySet());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PodDiff podDiff = (PodDiff) o;
+        return changeType == podDiff.changeType 
+                && Objects.equals(labelChanges, podDiff.labelChanges) 
+                && Objects.equals(annotationChanges, podDiff.annotationChanges) 
+                && Objects.equals(labelsToRemove, podDiff.labelsToRemove) 
+                && Objects.equals(annotationsToRemove, podDiff.annotationsToRemove);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(changeType, labelChanges, annotationChanges, labelsToRemove, annotationsToRemove);
+    }
+
+    @Override
+    public String toString() {
+        return "PodDiff{" +
+                "changeType=" + changeType +
+                ", labelChanges=" + labelChanges.size() +
+                ", annotationChanges=" + annotationChanges.size() +
+                ", labelsToRemove=" + labelsToRemove.size() +
+                ", annotationsToRemove=" + annotationsToRemove.size() +
+                '}';
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PodDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PodDiffTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@link PodDiff} utility class.
+ */
+public class PodDiffTest {
+
+    private static final String NAMESPACE = "test-namespace";
+    private static final String POD_NAME = "test-pod";
+    private static final String REVISION_ANNOTATION = PodRevision.STRIMZI_REVISION_ANNOTATION;
+
+    private Pod createPod(Map<String, String> labels, Map<String, String> annotations, String revision) {
+        return new PodBuilder()
+                .withNewMetadata()
+                    .withName(POD_NAME)
+                    .withNamespace(NAMESPACE)
+                    .withLabels(labels)
+                    .withAnnotations(annotations != null 
+                        ? mergeMaps(annotations, Map.of(REVISION_ANNOTATION, revision))
+                        : Map.of(REVISION_ANNOTATION, revision))
+                .endMetadata()
+                .withNewSpec()
+                    .addNewContainer()
+                        .withName("kafka")
+                        .withImage("quay.io/strimzi/kafka:latest")
+                    .endContainer()
+                .endSpec()
+                .build();
+    }
+
+    private Map<String, String> mergeMaps(Map<String, String> m1, Map<String, String> m2) {
+        java.util.Map<String, String> result = new java.util.HashMap<>(m1);
+        result.putAll(m2);
+        return result;
+    }
+
+    @Test
+    public void testNoChanges() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of("custom", "value"), revision);
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of("custom", "value"), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getChangeType(), is(PodDiff.ChangeType.NONE));
+        assertFalse(diff.hasChanges());
+        assertFalse(diff.isPatchable());
+        assertThat(diff.getTotalChangeCount(), is(0));
+        assertTrue(diff.getLabelChanges().isEmpty());
+        assertTrue(diff.getAnnotationChanges().isEmpty());
+    }
+
+    @Test
+    public void testNoChangesSingletonReuse() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of("custom", "value"), revision);
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of("custom", "value"), revision);
+
+        PodDiff diff1 = PodDiff.diff(current, desired);
+        PodDiff diff2 = PodDiff.diff(current, desired);
+
+        // Should return same singleton instance for no-change case
+        assertThat(diff1, sameInstance(diff2));
+    }
+
+    @Test
+    public void testLabelAdded() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "environment", "prod"), Map.of(), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getChangeType(), is(PodDiff.ChangeType.METADATA_ONLY));
+        assertTrue(diff.hasChanges());
+        assertTrue(diff.isPatchable());
+        assertThat(diff.getTotalChangeCount(), is(1));
+        assertThat(diff.getLabelChanges(), is(Map.of("environment", "prod")));
+        assertTrue(diff.getAnnotationChanges().isEmpty());
+    }
+
+    @Test
+    public void testLabelModified() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka", "version", "1.0"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "version", "2.0"), Map.of(), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getChangeType(), is(PodDiff.ChangeType.METADATA_ONLY));
+        assertTrue(diff.isPatchable());
+        assertThat(diff.getLabelChanges(), is(Map.of("version", "2.0")));
+    }
+
+    @Test
+    public void testLabelRemoved() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka", "deprecated", "true"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of(), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getChangeType(), is(PodDiff.ChangeType.METADATA_ONLY));
+        assertTrue(diff.isPatchable());
+        assertThat(diff.getLabelsToRemove(), is(Map.of("deprecated", "true")));
+    }
+
+    @Test
+    public void testAnnotationAdded() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of("prometheus.io/scrape", "true"), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getChangeType(), is(PodDiff.ChangeType.METADATA_ONLY));
+        assertTrue(diff.isPatchable());
+        assertThat(diff.getAnnotationChanges(), is(Map.of("prometheus.io/scrape", "true")));
+    }
+
+    @Test
+    public void testSpecChangedRequiresRestart() {
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), "revision-v1");
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of(), "revision-v2");
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getChangeType(), is(PodDiff.ChangeType.REQUIRES_RESTART));
+        assertTrue(diff.hasChanges());
+        assertFalse(diff.isPatchable());
+    }
+
+    @Test
+    public void testCreatePatchPod() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "environment", "prod"), Map.of("description", "Production"), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+        Pod patchPod = diff.createPatchPod(current);
+
+        assertThat(patchPod.getMetadata().getName(), is(POD_NAME));
+        assertThat(patchPod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(patchPod.getMetadata().getLabels().get("environment"), is("prod"));
+        assertThat(patchPod.getMetadata().getAnnotations().get("description"), is("Production"));
+    }
+
+    @Test
+    public void testCreatePatchPodThrowsForNonPatchable() {
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), "revision-v1");
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of(), "revision-v2");
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThrows(IllegalStateException.class, () -> diff.createPatchPod(current));
+    }
+
+    @Test
+    public void testCreatePatchPodThrowsForNullPod() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "env", "prod"), Map.of(), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThrows(IllegalArgumentException.class, () -> diff.createPatchPod(null));
+    }
+
+    @Test
+    public void testNullPodsThrowsException() {
+        Pod pod = createPod(Map.of("app", "kafka"), Map.of(), "abc123");
+
+        assertThrows(IllegalArgumentException.class, () -> PodDiff.diff(null, pod));
+        assertThrows(IllegalArgumentException.class, () -> PodDiff.diff(pod, null));
+    }
+
+    @Test
+    public void testGetSummaryNoChanges() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka"), Map.of(), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThat(diff.getSummary(), is("no changes"));
+    }
+
+    @Test
+    public void testGetSummaryWithChanges() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka", "old", "label"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "new", "label"), Map.of("ann", "value"), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+        String summary = diff.getSummary();
+
+        assertThat(summary, containsString("labels to update"));
+        assertThat(summary, containsString("labels to remove"));
+        assertThat(summary, containsString("annotations to update"));
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "env", "prod"), Map.of(), revision);
+
+        PodDiff diff1 = PodDiff.diff(current, desired);
+        PodDiff diff2 = PodDiff.diff(current, desired);
+
+        assertThat(diff1, is(diff2));
+        assertThat(diff1.hashCode(), is(diff2.hashCode()));
+    }
+
+    @Test
+    public void testEqualsWithDifferentChanges() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired1 = createPod(Map.of("app", "kafka", "env", "prod"), Map.of(), revision);
+        Pod desired2 = createPod(Map.of("app", "kafka", "env", "staging"), Map.of(), revision);
+
+        PodDiff diff1 = PodDiff.diff(current, desired1);
+        PodDiff diff2 = PodDiff.diff(current, desired2);
+
+        assertThat(diff1, is(not(diff2)));
+    }
+
+    @Test
+    public void testMapsAreImmutable() {
+        String revision = "abc123";
+        Pod current = createPod(Map.of("app", "kafka"), Map.of(), revision);
+        Pod desired = createPod(Map.of("app", "kafka", "env", "prod"), Map.of(), revision);
+
+        PodDiff diff = PodDiff.diff(current, desired);
+
+        assertThrows(UnsupportedOperationException.class, () -> diff.getLabelChanges().put("test", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> diff.getAnnotationChanges().put("test", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> diff.getLabelsToRemove().put("test", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> diff.getAnnotationsToRemove().put("test", "value"));
+    }
+}

--- a/documentation/modules/configuring/con-pod-management.adoc
+++ b/documentation/modules/configuring/con-pod-management.adoc
@@ -14,4 +14,13 @@ You must not create, update, or delete `StrimziPodSet` resources.
 The `StrimziPodSet` custom resource is used internally and resources are managed solely by the Cluster Operator.
 As a consequence, the Cluster Operator must be running properly to avoid the possibility of pods not starting and Kafka clusters not being available.
 
+== Selective pod metadata patching
+
+The `StrimziPodSetController` supports in-place patching of pod metadata (labels and annotations) without requiring a rolling restart.
+When you update labels or annotations in your Kafka, Kafka Connect, or MirrorMaker 2 custom resources, the Cluster Operator detects whether these are metadata-only changes.
+If a change affects only the pod metadata and not the pod specification, the controller applies the update directly using a strategic merge patch instead of triggering a rolling update.
+This optimization improves operational efficiency by avoiding unnecessary pod restarts for common operational changes like adding monitoring labels or updating annotations.
+
+NOTE: Changes to the pod specification (such as container images, resource limits, or volumes) still require a rolling restart to apply.
+
 NOTE: Kubernetes `Deployment` resources are used for creating and managing the pods of other components.


### PR DESCRIPTION
This change adds support for in-place patching of Pod metadata (labels and annotations) without requiring a rolling restart. Previously, any change to a Pod would trigger a rolling update; now metadata-only changes are applied via Strategic Merge Patch.

Changes:
- Add PodDiff utility class to categorize changes as NONE, METADATA_ONLY, or REQUIRES_RESTART
- Add patchPodMetadata() helper method to StrimziPodSetController
- Modify maybeCreateOrPatchPod() to use PodDiff for detecting changes
- Add comprehensive unit tests for PodDiff
- Remove TODO comment at line 466
- Update documentation 

### Type of change

- Enhancement / new feature
- Documentation

### Description

The `StrimziPodSetController` supports in-place patching of pod metadata (labels and annotations) without requiring a rolling restart.

When you update labels or annotations in your Kafka, Kafka Connect, or MirrorMaker 2 custom resources, the Cluster Operator detects whether these are metadata-only changes.

If a change affects only the pod metadata and not the pod specification, the controller applies the update directly using a strategic merge patch instead of triggering a rolling update.

This optimization improves operational efficiency by avoiding unnecessary pod restarts for common operational changes like adding monitoring labels or updating annotations.


### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

