### PR TITLE
Upgraded JSON Path to 2.10.0 to remediate CVE-2024-57699

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
         <netty.version>4.2.9.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
-        <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
+        <jayway-jsonpath.version>2.10.0</jayway-jsonpath.version>
         <commons-codec.version>1.13</commons-codec.version>
         <commons-io.version>2.18.0</commons-io.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Upgraded JSON Path to 2.10.0 to remediate CVE-2024-57699

### Checklist

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

