### PR TITLE
Remove the Jayway JsonPath dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
         <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
         <netty.version>4.2.9.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
-        <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <commons-codec.version>1.13</commons-codec.version>
         <commons-io.version>2.18.0</commons-io.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
@@ -620,11 +619,6 @@
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
                 <version>${opentelemetry.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${jayway-jsonpath.version}</version>
             </dependency>
             <dependency>
                 <groupId>info.picocli</groupId>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -128,11 +128,6 @@
             <version>${fabric8.kubernetes-model.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Event;
@@ -182,28 +181,6 @@ public class StUtils {
         } catch (IOException e) {
             throw new AssertionError("Invalid Properties definition", e);
         }
-    }
-
-    /**
-     * Get a Map of properties from an environment variable in json.
-     * @param containerIndex name of the container
-     * @param json The json from which to extract properties
-     * @param envVar The environment variable name
-     * @return The properties which the variable contains
-     */
-    public static Map<String, Object> getPropertiesFromJson(int containerIndex, String json, String envVar) {
-        List<String> array = JsonPath.parse(json).read(globalVariableJsonPathBuilder(containerIndex, envVar));
-        return StUtils.loadProperties(array.get(0));
-    }
-
-    /**
-     * Get a jsonPath which can be used to extract envariable variables from a spec
-     * @param containerIndex index of the container
-     * @param envVar The environment variable name
-     * @return The json path
-     */
-    public static String globalVariableJsonPathBuilder(int containerIndex, String envVar) {
-        return "$.spec.containers[" + containerIndex + "].env[?(@.name=='" + envVar + "')].value";
     }
 
     public static Properties stringToProperties(String str) {

--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -28,5 +28,3 @@ logger.clients.level = INFO
 
 logger.fabric8.name = io.fabric8.kubernetes.client
 logger.fabric8.level = OFF
-logger.jayway.name = com.jayway.jsonpath.internal.path.CompiledPath
-logger.jayway.level = OFF


### PR DESCRIPTION
### Type of change

- Task

### Description

The Jwayway JsonPath dependency was used in STs, but it is not used there anymore. This PR removes it. (It still remains as a dependency of Strimzi Oauth, but that is a different story not directly related to operators)

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally