### PR TITLE
Bump Test-Frame to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <testcontainer.version>2.0.2</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
         <junit4.version>4.13.2</junit4.version>
-        <skodjob.test-frame.version>1.3.0</skodjob.test-frame.version>
+        <skodjob.test-frame.version>1.4.0</skodjob.test-frame.version>
         <skodjob-doc.version>0.6.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
         <access-operator.version>0.2.0</access-operator.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This small PR updates version of Test-Frame to 1.4.0 after the release.

### Checklist

- [x] Make sure all tests pass
