### PR TITLE
doc: Update how the change to Namespace handling in Access Operator is documented

### DIFF
--- a/documentation/modules/deploying/proc-deploy-access-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-access-operator-watch-multiple-namespaces.adoc
@@ -1,0 +1,76 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// deploying/assembly_deploy-access-operator.adoc
+
+[id='deploying-access-operator-to-watch-multiple-namespaces-{context}']
+= Deploying the Access Operator to watch multiple namespaces
+
+[role="_abstract"]
+This procedure shows how to deploy the Access Operator to watch Strimzi resources across multiple namespaces in your Kubernetes cluster.
+
+.Prerequisites
+
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
+
+.Procedure
+
+. Edit the installation files to use the namespace the Access Operator is going to be installed into.
++
+For example, in this procedure the Access Operator is installed into the namespace `my-access-operator-namespace`.
++
+include::../../shared/snip-access-operator-namespace-sed.adoc[]
+
+. Edit the `install/050-Deployment.yaml` file
+to add a list of all the namespaces the Cluster Operator will watch to the `STRIMZI_NAMESPACE` environment variable.
++
+For example, in this  procedure the Access Operator will watch the namespaces `watched-namespace-1`, `watched-namespace-2`, `watched-namespace-3`.
++
+[source,yaml,subs="attributes"]
+----
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  # ...
+  template:
+    spec:
+      serviceAccountName: strimzi-access-operator
+      containers:
+      - name: strimzi-access-operator
+        image: {DockerAccessOperator}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: STRIMZI_NAMESPACE
+          value: watched-namespace-1,watched-namespace-2,watched-namespace-3
+----
+
+. For each namespace listed, install the `RoleBindings`.
++
+In this example, we replace `watched-namespace` in these commands with the namespaces listed in the previous step,
+repeating them for `watched-namespace-1`, `watched-namespace-2`, `watched-namespace-3`:
++
+[source,shell]
+kubectl create -f install/060-RoleBinding-strimzi-acces-operator.yaml -n <watched_namespace>
+
+. Deploy the Access Operator:
++
+[source,shell,subs="+quotes,attributes+"]
+kubectl create -f install -n my-access-operator-namespace
+
+. Check the status of the deployment:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get deployments -n my-access-operator-namespace
+----
++
+.Output shows the deployment name and readiness
+[source,shell,subs="+quotes"]
+----
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-access-operator  1/1    1           1
+----
++
+`READY` shows the number of replicas that are ready/expected.
+The deployment is successful when the `AVAILABLE` output shows `1`.

--- a/documentation/modules/deploying/proc-deploy-access-operator-watch-single-namespace.adoc
+++ b/documentation/modules/deploying/proc-deploy-access-operator-watch-single-namespace.adoc
@@ -1,0 +1,45 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// deploying/assembly_deploy-access-operator.adoc
+
+[id='deploying-access-operator-{context}']
+= Deploying the Access Operator to watch a single namespace
+
+[role="_abstract"]
+This procedure shows how to deploy the Access Operator to watch Strimzi resources in a single namespace in your Kubernetes cluster.
+
+.Prerequisites
+
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
+
+.Procedure
+
+. Edit the installation files to use the namespace the Access Operator is going to be installed into.
++
+For example, in this procedure the Access Operator is installed into the namespace `my-access-operator-namespace`.
++
+include::../../shared/snip-access-operator-namespace-sed.adoc[]
+
+. Deploy the Access Operator:
++
+[source,shell,subs="+quotes,attributes+"]
+kubectl create -f install -n my-access-operator-namespace
+
+. Check the status of the deployment:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get deployments -n my-access-operator-namespace
+----
++
+.Output shows the deployment name and readiness
+[source,shell,subs="+quotes"]
+----
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-access-operator  1/1    1           1
+----
++
+`READY` shows the number of replicas that are ready/expected.
+The deployment is successful when the `AVAILABLE` output shows `1`.

--- a/documentation/modules/deploying/proc-deploy-access-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-access-operator-watch-whole-cluster.adoc
@@ -1,0 +1,74 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// deploying/assembly_deploy-access-operator.adoc
+
+[id='deploying-access-operator-to-watch-whole-cluster-{context}']
+= Deploying the Access Operator to watch all namespaces
+
+[role="_abstract"]
+This procedure shows how to deploy the Access Operator to watch Strimzi resources across all namespaces in your Kubernetes cluster.
+
+When running in this mode, the Access Operator automatically manages clusters in any new namespaces that are created.
+
+.Prerequisites
+
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
+
+.Procedure
+
+. Edit the installation files to use the namespace the Access Operator is going to be installed into.
++
+For example, in this procedure the Access Operator is installed into the namespace `my-access-operator-namespace`.
++
+include::../../shared/snip-access-operator-namespace-sed.adoc[]
+
+. Edit the `install/050-Deployment.yaml` file to set the value of the `STRIMZI_NAMESPACE` environment variable to `*`.
++
+[source,yaml,subs="attributes"]
+----
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  # ...
+  template:
+    spec:
+      # ...
+      serviceAccountName: strimzi-access-operator
+      containers:
+      - name: strimzi-access-operator
+        image: {DockerAccessOperator}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: STRIMZI_NAMESPACE
+          value: "*"
+        # ...
+----
+
+. Create `ClusterRoleBindings` that grant cluster-wide access for all namespaces to the Access Operator.
++
+[source,shell,subs="+quotes,attributes+"]
+kubectl create clusterrolebinding strimzi-access-operator --clusterrole=strimzi-access-operator --serviceaccount my-access-operator-namespace:strimzi-access-operator
+
+. Deploy the Access Operator to your Kubernetes cluster.
++
+[source,shell,subs="+quotes,attributes+"]
+kubectl create -f install -n my-access-operator-namespace
+
+. Check the status of the deployment:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get deployments -n my-access-operator-namespace
+----
++
+.Output shows the deployment name and readiness
+[source,shell,subs="+quotes"]
+----
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-access-operator  1/1    1           1
+----
++
+`READY` shows the number of replicas that are ready/expected.
+The deployment is successful when the `AVAILABLE` output shows `1`.

--- a/documentation/modules/deploying/proc-deploy-access-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-access-operator.adoc
@@ -19,27 +19,11 @@ The installation files are contained in the `./install` directory.
 
 By default, the Access Operator is deployed in the `strimzi-access-operator` namespace. 
 To deploy the operator in a different namespace, update the `namespace` property in the installation files.
+For instructions on the various namespace deployment options, see below:
 
-.Procedure
-
-. Deploy the Access Operator using the installation files from the `install` directory:
-+
-[source,shell]
-kubectl create -f ./install/access-operator
-
-. Check the status of the deployment:
-+
-[source,shell,subs="+quotes"]
-----
-kubectl get deployments
-----
-+
-.Output shows the deployment name and readiness
-[source,shell,subs="+quotes"]
-----
-NAME                     READY  UP-TO-DATE  AVAILABLE
-strimzi-access-operator  1/1    1           1
-----
-+
-`READY` shows the number of replicas that are ready/expected.
-The deployment is successful when the `AVAILABLE` output shows `1`.
+//Deploy the Cluster Operator to watch a single namespace
+include::../../modules/deploying/proc-deploy-access-operator-watch-single-namespace.adoc[leveloffset=+1]
+//Deploy the Cluster Operator to watch multiple namespaces
+include::../../modules/deploying/proc-deploy-access-operator-watch-multiple-namespaces.adoc[leveloffset=+1]
+//Deploy the Cluster Operator to watch all namespaces
+include::../../modules/deploying/proc-deploy-access-operator-watch-whole-cluster.adoc[leveloffset=+1]

--- a/documentation/shared/snip-access-operator-namespace-sed.adoc
+++ b/documentation/shared/snip-access-operator-namespace-sed.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: SNIPPET
+
+On Linux, use:
++
+[source, subs="+quotes"]
+----
+sed -i 's/namespace: .\*/namespace: my-access-operator-namespace/' install/*RoleBinding*.yaml
+----
++
+On MacOS, use:
++
+[source, subs="+quotes"]
+----
+sed -i '' 's/namespace: .\*/namespace: my-access-operator-namespace/' install/*RoleBinding*.yaml
+----


### PR DESCRIPTION
### Type of change
- Documentation

### Description

This PR updates the modules documentation to reflect the changes made in PR https://github.com/strimzi/kafka-access-operator/pull/112 where we allow the Kafka Access Operator to deploy in single namespaces, multiple namespaces and all namespaces.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

