### PR TITLE
Fix typo in Ca class unit test

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
@@ -120,7 +120,7 @@ class CaTest {
         String pem = Ca.x509CertificateToPem(x509);
         assertThat(pem, is(cert));
 
-        X509Certificate nextX509 = Ca.x509Certificate(cert.getBytes());
+        X509Certificate nextX509 = Ca.x509Certificate(pem.getBytes());
         assertThat(nextX509.getSubjectX500Principal().getName(), is("CN=cluster-ca,O=Default Company Ltd,L=Default City,C=XX"));
         assertThat(nextX509.getSignature(), is(x509.getSignature()));
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I made a typo in #12420 in one of the unit tests. This PR fixes it. It does not really change anything on the production code.

Credit to @tinaselenge for spotting it!

### Checklist

- [x] Make sure all tests pass