### PR TITLE
Add timeouts to jobs and migrate from container to VM usage

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -5,7 +5,7 @@ All the steps mentioned bellow re-use scripts from our [azure](../../.azure) dir
 ## Build jar artifacts
 Building Strimzi is exactly the same as we have in Azure pipelines.
 Only difference is in used runners for each step.
-Strimzi jars are built on `oracle-2cpu-8gb-arm64` runner as part of [build-strimzi-binaries](../actions/build/build-strimzi-binaries) action.
+Strimzi jars are built on `ubuntu-latest` runner as part of [build-strimzi-binaries](../actions/build/build-strimzi-binaries) action.
 This runner is basically a Kubernetes pod that runs all the commands defined in the action.
 
 Action output is tar-ball with Strimzi jars that can be used by other actions and workflows.
@@ -15,7 +15,7 @@ Usage example can be like this:
 ```yaml
   build-artifacts:
     name: build-artifacts
-    runs-on: oracle-2cpu-8gb-arm64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/build-strimzi-binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
   build-strimzi:
     name: Build Strimzi
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 
@@ -49,6 +50,7 @@ jobs:
     needs:
       - build-strimzi
     runs-on: ubuntu-latest
+    timeout-minutes: 80
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/test-strimzi
@@ -64,6 +66,7 @@ jobs:
     needs:
       - build-strimzi
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/build-docs
@@ -84,6 +87,7 @@ jobs:
           - s390x
           - ppc64le
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/build-containers
@@ -101,6 +105,7 @@ jobs:
       - build-docs
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       # Required for keyless signing with GitHub OIDC
@@ -128,6 +133,7 @@ jobs:
       - build-docs
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/publish-docs
@@ -145,6 +151,7 @@ jobs:
       - build-docs
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/deploy-java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
     name: Prepare Release Artifacts
     if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/release-artifacts
@@ -48,6 +49,7 @@ jobs:
     name: Push Java artifacts to GHCR
     if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       packages: write
     steps:
@@ -81,6 +83,7 @@ jobs:
       - push-java-artifacts-to-ghcr
     if: ${{ startsWith(github.ref, 'refs/heads/release-') && inputs.useSuffix == true }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
@@ -114,6 +117,7 @@ jobs:
         needs.push-containers-with-suffix.result == 'skipped')
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
@@ -143,6 +147,7 @@ jobs:
         needs.push-containers.result == 'success'
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build/publish-helm-chart

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -34,6 +34,7 @@ jobs:
   # Parse and build parameters from comment or from workflow params
   parse-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -73,6 +74,7 @@ jobs:
       - parse-params
     if: ${{ needs.parse-params.outputs.shouldRun == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -94,6 +96,7 @@ jobs:
         needs.parse-params.outputs.shouldRun == 'true'
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
       pull-requests: write
@@ -139,6 +142,7 @@ jobs:
         needs.check-build.result == 'success'
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -208,7 +212,8 @@ jobs:
         needs.parse-params.outputs.releaseVersion == 'latest' &&
         needs.check-build.outputs.buildRunId == ''
       }}
-    runs-on: oracle-2cpu-8gb-arm64
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
@@ -216,7 +221,7 @@ jobs:
       - uses: ./.github/actions/build/build-strimzi-binaries
         with:
           mvnArgs: "-B -DskipTests -Dmaven.javadoc.skip=true"
-          runnerArch: "arm64"
+          runnerArch: "amd64"
 
   build-images:
     name: build-images
@@ -240,6 +245,7 @@ jobs:
       matrix:
         architecture: [amd64, arm64]
     runs-on: oracle-vm-2cpu-8gb-arm64
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -301,6 +307,7 @@ jobs:
         needs.generate-matrix.outputs.isValid == 'true'
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -343,6 +350,7 @@ jobs:
         (contains(needs.parse-params.outputs.profileList, 'performance') || contains(needs.parse-params.outputs.pipelineList, 'performance'))
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds timeouts to all jobs on GitHub Actions to prevent to be stuck on smaller steps like publish-docs, etc.

It also changes usage of one container runner to VM as it was advised by CNCF due to underlying infra issues with containers.

### Checklist

- [ ] Make sure all tests pass

