### PR TITLE
Replaces singletonList with List.of in ConfigModel classes

### DIFF
--- a/config-model/src/main/java/io/strimzi/kafka/config/model/ConfigModel.java
+++ b/config-model/src/main/java/io/strimzi/kafka/config/model/ConfigModel.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 /**
  * A model of a particular configuration parameter.
@@ -236,7 +235,7 @@ public class ConfigModel {
 
     private List<String> validateBoolean(String configName, String value) {
         if (!value.matches("true|false")) {
-            return singletonList(configName + " has value '" + value + "' which is not a boolean");
+            return List.of(configName + " has value '" + value + "' which is not a boolean");
         }
         return emptyList();
     }
@@ -246,13 +245,13 @@ public class ConfigModel {
 
         // Check for duplicate values as within Kafka ConfigDef.ValidList
         if (Set.copyOf(l).size() != l.size()) {
-            return singletonList(configName + " contains duplicate values");
+            return List.of(configName + " contains duplicate values");
         }
 
         // Check for empty individual values as within Kafka ConfigDef.ValidList
         for (String item : l) {
             if (item.isEmpty()) {
-                return singletonList(configName + " contains empty values");
+                return List.of(configName + " contains empty values");
             }
         }
 
@@ -261,7 +260,7 @@ public class ConfigModel {
             HashSet<String> items = new HashSet<>(l);
             items.removeAll(getItems());
             if (!items.isEmpty()) {
-                return singletonList(configName + " contains values " + items + " which are not in the allowed items " + getItems());
+                return List.of(configName + " contains values " + items + " which are not in the allowed items " + getItems());
             }
         }
         return emptyList();
@@ -284,7 +283,7 @@ public class ConfigModel {
                 errors.add(maximumErrorMsg(configName, value));
             }
         } catch (NumberFormatException e) {
-            errors = singletonList(numFormatMsg(configName, value, "a double"));
+            errors = List.of(numFormatMsg(configName, value, "a double"));
         }
         return errors;
     }
@@ -306,7 +305,7 @@ public class ConfigModel {
                 errors.add(maximumErrorMsg(configName, value));
             }
         } catch (NumberFormatException e) {
-            errors = singletonList(numFormatMsg(configName, value, "a long"));
+            errors = List.of(numFormatMsg(configName, value, "a long"));
         }
         return errors;
     }
@@ -328,7 +327,7 @@ public class ConfigModel {
                 errors.add(maximumErrorMsg(configName, value));
             }
         } catch (NumberFormatException e) {
-            errors = singletonList(numFormatMsg(configName, value, "a short"));
+            errors = List.of(numFormatMsg(configName, value, "a short"));
         }
         return errors;
     }
@@ -357,7 +356,7 @@ public class ConfigModel {
                 errors.add(configName + " has value '" + value + "' which does not match the required pattern: " + getPattern());
             }
         } catch (NumberFormatException e) {
-            errors = singletonList(numFormatMsg(configName, value, "an int"));
+            errors = List.of(numFormatMsg(configName, value, "an int"));
         }
         return errors;
     }

--- a/config-model/src/test/java/ConfigModelTest.java
+++ b/config-model/src/test/java/ConfigModelTest.java
@@ -7,9 +7,10 @@ import io.strimzi.kafka.config.model.ConfigModel;
 import io.strimzi.kafka.config.model.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -24,13 +25,13 @@ public class ConfigModelTest {
         assertThat(cm.validate("test",  "foo"), is(emptyList()));
         assertThat(cm.validate("test",  "bar"), is(emptyList()));
         assertThat(cm.validate("test",  "baz"),
-                is(singletonList("test has value 'baz' which is not one of the allowed values: [foo, bar]")));
+                is(List.of("test has value 'baz' which is not one of the allowed values: [foo, bar]")));
         cm.setValues(null);
         cm.setPattern("foo|bar");
         assertThat(cm.validate("test",  "foo"), is(emptyList()));
         assertThat(cm.validate("test",  "bar"), is(emptyList()));
         assertThat(cm.validate("test",  "baz"),
-                is(singletonList("test has value 'baz' which does not match the required pattern: foo|bar")));
+                is(List.of("test has value 'baz' which does not match the required pattern: foo|bar")));
     }
 
     @Test
@@ -39,7 +40,7 @@ public class ConfigModelTest {
         cm.setType(Type.BOOLEAN);
         assertThat(cm.validate("test",  "true"), is(emptyList()));
         assertThat(cm.validate("test",  "false"), is(emptyList()));
-        assertThat(cm.validate("test",  "dog"), is(singletonList("test has value 'dog' which is not a boolean")));
+        assertThat(cm.validate("test",  "dog"), is(List.of("test has value 'dog' which is not a boolean")));
     }
 
     @Test
@@ -49,12 +50,12 @@ public class ConfigModelTest {
         assertThat(cm.validate("test",  "1"), is(emptyList()));
         assertThat(cm.validate("test",  Short.valueOf(Short.MAX_VALUE).toString()), is(emptyList()));
         assertThat(cm.validate("test",  Short.valueOf(Short.MIN_VALUE).toString()), is(emptyList()));
-        assertThat(cm.validate("test", Integer.valueOf((int) Short.MAX_VALUE + 1).toString()), is(singletonList("test has value '32768' which is not a short")));
-        assertThat(cm.validate("test", Integer.valueOf((int) Short.MIN_VALUE - 1).toString()), is(singletonList("test has value '-32769' which is not a short")));
+        assertThat(cm.validate("test", Integer.valueOf((int) Short.MAX_VALUE + 1).toString()), is(List.of("test has value '32768' which is not a short")));
+        assertThat(cm.validate("test", Integer.valueOf((int) Short.MIN_VALUE - 1).toString()), is(List.of("test has value '-32769' which is not a short")));
         cm.setMinimum(0);
-        assertThat(cm.validate("test", "-1"), is(singletonList("test has value -1 which less than the minimum value 0")));
+        assertThat(cm.validate("test", "-1"), is(List.of("test has value -1 which less than the minimum value 0")));
         cm.setMaximum(1);
-        assertThat(cm.validate("test", "2"), is(singletonList("test has value 2 which greater than the maximum value 1")));
+        assertThat(cm.validate("test", "2"), is(List.of("test has value 2 which greater than the maximum value 1")));
     }
 
     @Test
@@ -64,12 +65,12 @@ public class ConfigModelTest {
         assertThat(cm.validate("test", "1"), is(emptyList()));
         assertThat(cm.validate("test", Integer.valueOf(Integer.MAX_VALUE).toString()), is(emptyList()));
         assertThat(cm.validate("test", Integer.valueOf(Integer.MIN_VALUE).toString()), is(emptyList()));
-        assertThat(cm.validate("test", Long.valueOf((long) Integer.MAX_VALUE + 1L).toString()), is(singletonList("test has value '2147483648' which is not an int")));
-        assertThat(cm.validate("test", Long.valueOf((long) Integer.MIN_VALUE - 1L).toString()), is(singletonList("test has value '-2147483649' which is not an int")));
+        assertThat(cm.validate("test", Long.valueOf((long) Integer.MAX_VALUE + 1L).toString()), is(List.of("test has value '2147483648' which is not an int")));
+        assertThat(cm.validate("test", Long.valueOf((long) Integer.MIN_VALUE - 1L).toString()), is(List.of("test has value '-2147483649' which is not an int")));
         cm.setMinimum(0);
-        assertThat(cm.validate("test", "-1"), is(singletonList("test has value -1 which less than the minimum value 0")));
+        assertThat(cm.validate("test", "-1"), is(List.of("test has value -1 which less than the minimum value 0")));
         cm.setMaximum(1);
-        assertThat(cm.validate("test", "2"), is(singletonList("test has value 2 which greater than the maximum value 1")));
+        assertThat(cm.validate("test", "2"), is(List.of("test has value 2 which greater than the maximum value 1")));
     }
 
     @Test
@@ -79,12 +80,12 @@ public class ConfigModelTest {
         assertThat(cm.validate("test", "1"), is(emptyList()));
         assertThat(cm.validate("test", Long.valueOf(Long.MAX_VALUE).toString()), is(emptyList()));
         assertThat(cm.validate("test", Long.valueOf(Long.MIN_VALUE).toString()), is(emptyList()));
-        assertThat(cm.validate("test", "9223372036854775808"), is(singletonList("test has value '9223372036854775808' which is not a long")));
-        assertThat(cm.validate("test", "-9223372036854775809"), is(singletonList("test has value '-9223372036854775809' which is not a long")));
+        assertThat(cm.validate("test", "9223372036854775808"), is(List.of("test has value '9223372036854775808' which is not a long")));
+        assertThat(cm.validate("test", "-9223372036854775809"), is(List.of("test has value '-9223372036854775809' which is not a long")));
         cm.setMinimum(0);
-        assertThat(cm.validate("test", "-1"), is(singletonList("test has value -1 which less than the minimum value 0")));
+        assertThat(cm.validate("test", "-1"), is(List.of("test has value -1 which less than the minimum value 0")));
         cm.setMaximum(1);
-        assertThat(cm.validate("test", "2"), is(singletonList("test has value 2 which greater than the maximum value 1")));
+        assertThat(cm.validate("test", "2"), is(List.of("test has value 2 which greater than the maximum value 1")));
     }
 
     @Test
@@ -92,11 +93,11 @@ public class ConfigModelTest {
         ConfigModel cm = new ConfigModel();
         cm.setType(Type.DOUBLE);
         assertThat(cm.validate("test", "1"), is(emptyList()));
-        assertThat(cm.validate("test", "dog"), is(singletonList("test has value 'dog' which is not a double")));
+        assertThat(cm.validate("test", "dog"), is(List.of("test has value 'dog' which is not a double")));
         cm.setMinimum(0.0);
-        assertThat(cm.validate("test", "-0.1"), is(singletonList("test has value -0.1 which less than the minimum value 0.0")));
+        assertThat(cm.validate("test", "-0.1"), is(List.of("test has value -0.1 which less than the minimum value 0.0")));
         cm.setMaximum(1.0);
-        assertThat(cm.validate("test", "1.1"), is(singletonList("test has value 1.1 which greater than the maximum value 1.0")));
+        assertThat(cm.validate("test", "1.1"), is(List.of("test has value 1.1 which greater than the maximum value 1.0")));
     }
 
     @Test
@@ -109,14 +110,14 @@ public class ConfigModelTest {
         assertThat(cm.validate("test", "foo"), is(emptyList()));
         assertThat(cm.validate("test", "foo,bar"), is(emptyList()));
         assertThat(cm.validate("test", "foo,bar,baz"),
-                is(singletonList("test contains values [baz] which are not in the allowed items [foo, bar]")));
+                is(List.of("test contains values [baz] which are not in the allowed items [foo, bar]")));
         assertThat(cm.validate("test", "foo, bar, baz"),
-                is(singletonList("test contains values [baz] which are not in the allowed items [foo, bar]")));
+                is(List.of("test contains values [baz] which are not in the allowed items [foo, bar]")));
         assertThat(cm.validate("test", " foo , bar, baz "),
-                is(singletonList("test contains values [baz] which are not in the allowed items [foo, bar]")));
+                is(List.of("test contains values [baz] which are not in the allowed items [foo, bar]")));
         // " foo , bar,," contains duplicate empty strings, so duplicate check triggers first
         assertThat(cm.validate("test", " foo , bar,,"),
-                is(singletonList("test contains duplicate values")));
+                is(List.of("test contains duplicate values")));
         // Test empty items list, should allow any values (Kafka 4.2.0+ behavior with ValidList.anyNonDuplicateValues)
         cm.setItems(emptyList());
         assertThat(cm.validate("test", "foo"), is(emptyList()));
@@ -124,14 +125,14 @@ public class ConfigModelTest {
         assertThat(cm.validate("test", "TLSv1.1,TLSv1.2,TLSv1.3"), is(emptyList()));
         // Test duplicate values, should be rejected (Kafka 4.2.0+ behavior with ValidList.anyNonDuplicateValues rejects duplicates)
         assertThat(cm.validate("test", "foo,bar,foo"),
-                is(singletonList("test contains duplicate values")));
+                is(List.of("test contains duplicate values")));
         assertThat(cm.validate("test", "TLSv1.2,TLSv1.2"),
-                is(singletonList("test contains duplicate values")));
+                is(List.of("test contains duplicate values")));
         // Test empty individual values, should be rejected (Kafka's ValidList rejects empty values)
         assertThat(cm.validate("test", "foo,,bar"),
-                is(singletonList("test contains empty values")));
+                is(List.of("test contains empty values")));
         assertThat(cm.validate("test", "TLSv1.2,,TLSv1.3"),
-                is(singletonList("test contains empty values")));
+                is(List.of("test contains empty values")));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

As agreed on a discussion on the #12315, this trivial PR just replace the usage of `singletoList` with `List.of` within the ConfigModel related classes.

### Checklist

- [x] Make sure all tests pass