### PR TITLE
Updated CHANGELOG about Apache Kafka 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.51.0
 
+* Add support for Kafka 4.2.0 and remove support for Kafka 4.0.0 and 4.0.1
 * Allow setting the following configurations with the listener prefix (e.g. `listener.name.listener1-9900.`): `connections.max.reauth.ms`, `max.connections*` and `max.connection.creation.rate`.
 * The `ServerSideApplyPhase1` feature gate moves to beta stage and is enabled by default.
   If needed, `ServerSideApplyPhase1` can be disabled in the feature gates configuration in the Cluster Operator.


### PR DESCRIPTION
I forgot to update the CHANGELOG with the Apache Kafka 4.2.0 support and 4.0.x drop when merging the #12315.
This PR fixed it.