### PR TITLE
[ST] Don't change image in case we are using SHA digest in Deployment file

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -112,6 +112,12 @@ public class StUtils {
      * @return Updated docker image with a proper registry, org, tag
      */
     public static String changeOrgAndTag(String image) {
+        // in case that the image in the file contains `@sha256:`, we want to test exactly some digest and we
+        // will skip configuring the other parts, so returning the image as is
+        if (image.contains("@sha256:")) {
+            return image;
+        }
+
         Matcher m = IMAGE_PATTERN_FULL_PATH.matcher(image);
         if (m.find()) {
             String registry = setImageProperties(m.group("registry"), Environment.STRIMZI_REGISTRY);


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This small PR changes the behavior of `changeOrgAndTag` method which we are using for changing the image based on other env variables. In case that we are using image with SHA digest in the Deployment file, we are typically want to run the tests with exactly this image, so it doesn't make sense to change it in any way. Without this change, the image returned from this method looks like this:

```
/quay.io/lkral/operator@sha256:9aa0e08f91d9dd566586d5875d4c97d4a5addc7cc927352a7051d8d6c1336a78
```
which then fails during the deployment of the CO, as it is wrong format of the image.

### Checklist

- [x] Make sure all tests pass
