### PR TITLE
docs(pdb): clarifies pdb applies to brokers and controller in cluster

### DIFF
--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -23,7 +23,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 `<kafka_cluster_name>-kafka`:: Name given to the following Kafka resources:
 +
 - Service account used by the Kafka pods.
-- PodDisruptionBudget that applies to all Kafka cluster node pool pods.
+- PodDisruptionBudget that applies to all Kafka pods in the cluster, including broker-only, controller-only, and mixed-role (broker/controller) pods.
 - Role granting the Kafka brokers and controllers access to read their certificates and credentials.
 
 `<kafka_cluster_name>-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.


### PR DESCRIPTION
**Documentation**

Clarifies that the Kafka PodDisruptionBudget created by the Cluster Operator applies to all Kafka pods in the cluster, including broker-only, controller-only, and mixed-role pods.

This removes ambiguity in the doc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

