### PR TITLE
docs(bridge): corrects property description

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
@@ -44,7 +44,7 @@ public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving {
         this.port = port;
     }
 
-    @Description("The port which is the server listening on.")
+    @Description("Port the server listens on.")
     @JsonProperty(defaultValue = "8080")
     @Minimum(1023)
     public int getPort() {

--- a/api/src/test/resources/crds/v1/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/crds/v1/046-Crd-kafkabridge.yaml
@@ -159,7 +159,7 @@ spec:
                   port:
                     type: integer
                     minimum: 1023
-                    description: The port which is the server listening on.
+                    description: Port the server listens on.
                   cors:
                     type: object
                     properties:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3923,7 +3923,7 @@ include::../api/io.strimzi.api.kafka.model.bridge.KafkaBridgeHttpConfig.adoc[lev
 |Property |Property type |Description
 |port
 |integer
-|The port which is the server listening on.
+|Port the server listens on.
 |cors
 |xref:type-KafkaBridgeHttpCors-{context}[`KafkaBridgeHttpCors`]
 |CORS configuration for the HTTP Bridge.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -160,7 +160,7 @@ spec:
                     port:
                       type: integer
                       minimum: 1023
-                      description: The port which is the server listening on.
+                      description: Port the server listens on.
                     cors:
                       type: object
                       properties:
@@ -1786,7 +1786,7 @@ spec:
                     port:
                       type: integer
                       minimum: 1023
-                      description: The port which is the server listening on.
+                      description: Port the server listens on.
                     cors:
                       type: object
                       properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -159,7 +159,7 @@ spec:
                   port:
                     type: integer
                     minimum: 1023
-                    description: The port which is the server listening on.
+                    description: Port the server listens on.
                   cors:
                     type: object
                     properties:
@@ -1785,7 +1785,7 @@ spec:
                   port:
                     type: integer
                     minimum: 1023
-                    description: The port which is the server listening on.
+                    description: Port the server listens on.
                   cors:
                     type: object
                     properties:


### PR DESCRIPTION
**Documentation**

Corrects the description of the `port` property in the `KafkaBridgeHttpConfig` schema for clarity and grammar.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

