### PR TITLE
Alternative approach to fix the SSA issues in Rebalances and offset listing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -873,6 +873,9 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                     labels.putAll(resource.getMetadata().getLabels());
                     ObjectMeta objectMeta = existingConfigMap.getMetadata();
                     objectMeta.setLabels(labels);
+                    // We need to remove the managedFields from the metadata, as we can use server-side-apply.
+                    // This should be fixed properly as part of https://github.com/strimzi/strimzi-kafka-operator/issues/12462
+                    objectMeta.setManagedFields(null);
                     existingConfigMap.setMetadata(objectMeta);
 
                     if (existingConfigMap.getMetadata().getOwnerReferences().isEmpty()) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR is an alternative approach to #12451, which aims to provide a quick fix to unblock the 0.51.0 release. It fixes #12447 and #12462 by simply reseting the managed fields without touching the labels, owner references or how the Config Maps are managed. The reason for it is that #12451 seems to be getting more complex than originally assumed. This PR does not aim to replace #12451 -> that should still be used to provide a better solution for 1.0.0.

This should be backported to 0.51 release branch.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally