### PR TITLE
Use only `v1` API in generated docs

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -436,7 +436,7 @@ class DocGenerator {
                     .append("` property is a discriminator that distinguishes use of the `")
                     .append(cls.getSimpleName()).append("` type from ");
             if (subtypeLinks.trim().isEmpty()) {
-                out.append("other subtypes which may be added in the future.");
+                out.append("other subtypes that may be added in the future.");
             } else {
                 out.append(subtypeLinks).append(".");
             }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -154,7 +154,7 @@ Example of complex type.
 Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 
 
-The `discrim` property is a discriminator that distinguishes use of the `PolymorphicLeft` type from other subtypes which may be added in the future.
+The `discrim` property is a discriminator that distinguishes use of the `PolymorphicLeft` type from other subtypes that may be added in the future.
 It must have the value `left` for the type `PolymorphicLeft`.
 [cols="2,2,3a",options="header"]
 |====

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -609,7 +609,7 @@ include::../api/io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions.adoc[level
 Used in: xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaJmxAuthenticationPassword` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `KafkaJmxAuthenticationPassword` type from other subtypes that may be added in the future.
 It must have the value `password` for the type `KafkaJmxAuthenticationPassword`.
 [cols="2,2,3a",options="header"]
 |====
@@ -1062,7 +1062,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorageCust
 == `TieredStorageCustom` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `TieredStorageCustom` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `TieredStorageCustom` type from other subtypes that may be added in the future.
 It must have the value `custom` for the type `TieredStorageCustom`.
 [cols="2,2,3a",options="header"]
 |====
@@ -1488,7 +1488,7 @@ Used in: xref:type-BrokerCapacity-{context}[`BrokerCapacity`]
 Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 
 
-The `type` property is a discriminator that distinguishes use of the `HashLoginServiceApiUsers` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `HashLoginServiceApiUsers` type from other subtypes that may be added in the future.
 It must have the value `hashLoginService` for the type `HashLoginServiceApiUsers`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2095,7 +2095,7 @@ It must have the value `custom` for the type `KafkaClientAuthenticationCustom`.
 Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 
 
-The `type` property is a discriminator that distinguishes use of the `OpenTelemetryTracing` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `OpenTelemetryTracing` type from other subtypes that may be added in the future.
 It must have the value `opentelemetry` for the type `OpenTelemetryTracing`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2422,7 +2422,7 @@ include::../api/io.strimzi.api.kafka.model.connect.MountedPlugin.adoc[leveloffse
 Used in: xref:type-MountedPlugin-{context}[`MountedPlugin`]
 
 
-The `type` property is a discriminator that distinguishes use of the `ImageArtifact` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `ImageArtifact` type from other subtypes that may be added in the future.
 It must have the value `image` for the type `ImageArtifact`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2698,7 +2698,7 @@ Used in: xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUser
 Used in: xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaUserAuthorizationSimple` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `KafkaUserAuthorizationSimple` type from other subtypes that may be added in the future.
 It must have the value `simple` for the type `KafkaUserAuthorizationSimple`.
 [cols="2,2,3a",options="header"]
 |====


### PR DESCRIPTION
### Type of change

- Task
- Documentation

### Description

This PR updates the documentation generator to generate the docs only for `v1` API fields. That means it will leave out all the fields deprecated and removed in `v1beta2`. 

While we have the `v1beta2` API still in the main branch CRDs, updating the generated API docs makes it easier to work on the tasks such as #12465 as it makes it easier to search for the actual documentation parts that need manual updates.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation