### PR TITLE
Bump Jackson to 2.18.6 to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
         <fabric8.openshift-client.version>7.5.2</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>7.5.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.18.3</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.18.3</fasterxml.jackson-annotations.version>
-        <fasterxml.jackson-datatype.version>2.18.3</fasterxml.jackson-datatype.version>
-        <fasterxml.jackson-jaxrs.version>2.18.3</fasterxml.jackson-jaxrs.version>
+        <fasterxml.jackson-core.version>2.18.6</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.18.6</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.18.6</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.18.6</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-datatype.version>2.18.6</fasterxml.jackson-datatype.version>
+        <fasterxml.jackson-jaxrs.version>2.18.6</fasterxml.jackson-jaxrs.version>
         <vertx.version>5.0.8</vertx.version>
         <vertx-junit5.version>5.0.8</vertx-junit5.version>
         <kafka.version>4.2.0</kafka.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR bumps the Jackson libraries to 2.18.6 to address a [CVE reported by Dependabot](https://github.com/strimzi/strimzi-kafka-operator/security/dependabot/50). This replaces the Depaendabot's own PR, which bumped only one of the Jackson libraries.

### Checklist

- [x] Reference relevant issue(s) and close them after merging