### PR TITLE
Remove Keycloak authorization from Cluster Operator

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -40,8 +40,6 @@ import java.util.List;
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     public static final String TYPE_KEYCLOAK = "keycloak";
 
-    public static final String AUTHORIZER_CLASS_NAME = "io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer";
-
     private String clientId;
     private String tokenEndpointUri;
     private List<CertSecretSource> tlsTrustedCertificates;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.common.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.common.Rack;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationCustom;
-import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloak;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationSimple;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
@@ -635,7 +634,7 @@ public class KafkaBrokerConfigurationBuilder {
             superUsers.add(String.format("User:CN=%s,O=io.strimzi", "cluster-operator"));
 
             printSectionHeader("Authorization");
-            configureAuthorization(clusterName, superUsers, authorization);
+            configureAuthorization(superUsers, authorization);
             writer.println("super.users=" + String.join(";", superUsers));
             writer.println();
         }
@@ -646,16 +645,12 @@ public class KafkaBrokerConfigurationBuilder {
     /**
      * Configures authorization for the Kafka brokers. This method is used only internally.
      *
-     * @param clusterName       Name of the cluster
      * @param superUsers        Super-users list who have all the rights on the cluster
      * @param authorization     The authorization configuration from the Kafka CR
      */
-    @SuppressWarnings("deprecation") // Keycloak Authorization is deprecated
-    private void configureAuthorization(String clusterName, List<String> superUsers, KafkaAuthorization authorization) {
+    private void configureAuthorization(List<String> superUsers, KafkaAuthorization authorization) {
         if (authorization instanceof KafkaAuthorizationSimple simpleAuthz) {
             configureSimpleAuthorization(simpleAuthz, superUsers);
-        } else if (authorization instanceof KafkaAuthorizationKeycloak keycloakAuthz) {
-            configureKeycloakAuthorization(clusterName, keycloakAuthz, superUsers);
         } else if (authorization instanceof KafkaAuthorizationCustom customAuthz) {
             configureCustomAuthorization(customAuthz, superUsers);
         }
@@ -669,52 +664,6 @@ public class KafkaBrokerConfigurationBuilder {
      */
     private void configureSimpleAuthorization(KafkaAuthorizationSimple authorization, List<String> superUsers) {
         writer.println("authorizer.class.name=" + KafkaAuthorizationSimple.KRAFT_AUTHORIZER_CLASS_NAME);
-
-        // User configured super-users
-        if (authorization.getSuperUsers() != null && !authorization.getSuperUsers().isEmpty()) {
-            superUsers.addAll(authorization.getSuperUsers().stream().map(e -> String.format("User:%s", e)).toList());
-        }
-    }
-
-    /**
-     * Configures Keycloak authorization
-     *
-     * @param clusterName       Name of the cluster
-     * @param authorization     Custom authorization configuration
-     * @param superUsers        Super-users list who have all the rights on the cluster
-     */
-    @SuppressWarnings("deprecation") // Keycloak Authorization is deprecated
-    private void configureKeycloakAuthorization(String clusterName, KafkaAuthorizationKeycloak authorization, List<String> superUsers) {
-        writer.println("authorizer.class.name=" + KafkaAuthorizationKeycloak.AUTHORIZER_CLASS_NAME);
-        writer.println("strimzi.authorization.token.endpoint.uri=" + authorization.getTokenEndpointUri());
-        writer.println("strimzi.authorization.client.id=" + authorization.getClientId());
-        writer.println("strimzi.authorization.delegate.to.kafka.acl=" + authorization.isDelegateToKafkaAcls());
-        addOptionIfNotNull(writer, "strimzi.authorization.grants.refresh.period.seconds", authorization.getGrantsRefreshPeriodSeconds());
-        addOptionIfNotNull(writer, "strimzi.authorization.grants.refresh.pool.size", authorization.getGrantsRefreshPoolSize());
-        addOptionIfNotNull(writer, "strimzi.authorization.grants.max.idle.time.seconds", authorization.getGrantsMaxIdleTimeSeconds());
-        addOptionIfNotNull(writer, "strimzi.authorization.grants.gc.period.seconds", authorization.getGrantsGcPeriodSeconds());
-        addOptionIfNotNull(writer, "strimzi.authorization.connect.timeout.seconds", authorization.getConnectTimeoutSeconds());
-        addOptionIfNotNull(writer, "strimzi.authorization.read.timeout.seconds", authorization.getReadTimeoutSeconds());
-        addOptionIfNotNull(writer, "strimzi.authorization.http.retries", authorization.getHttpRetries());
-        if (authorization.isGrantsAlwaysLatest()) {
-            writer.println("strimzi.authorization.reuse.grants=false");
-        }
-        if (authorization.isEnableMetrics()) {
-            writer.println("strimzi.authorization.enable.metrics=true");
-        }
-        if (!authorization.isIncludeAcceptHeader()) {
-            writer.println("strimzi.authorization.include.accept.header=false");
-        }
-
-        writer.println("strimzi.authorization.kafka.cluster.name=" + clusterName);
-
-        if (authorization.getTlsTrustedCertificates() != null && !authorization.getTlsTrustedCertificates().isEmpty())    {
-            writer.println("strimzi.authorization.ssl.truststore.location=/tmp/kafka/authz-keycloak.truststore.p12");
-            writer.println("strimzi.authorization.ssl.truststore.password=" + PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR);
-            writer.println("strimzi.authorization.ssl.truststore.type=PKCS12");
-            String endpointIdentificationAlgorithm = authorization.isDisableTlsHostnameVerification() ? "" : "HTTPS";
-            writer.println("strimzi.authorization.ssl.endpoint.identification.algorithm=" + endpointIdentificationAlgorithm);
-        }
 
         // User configured super-users
         if (authorization.getSuperUsers() != null && !authorization.getSuperUsers().isEmpty()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -52,7 +52,6 @@ import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
-import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloak;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -145,7 +144,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     protected static final String ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS = "EXTERNAL_ADDRESS";
     private static final String ENV_VAR_KAFKA_JMX_EXPORTER_ENABLED = "KAFKA_JMX_EXPORTER_ENABLED";
     private static final String ENV_VAR_KAFKA_CLUSTER_NAME = "KAFKA_CLUSTER_NAME";
-    private static final String ENV_VAR_STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS = "STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS";
 
     // For port names in services, a 'tcp-' prefix is added to support Istio protocol selection
     // This helps Istio to avoid using a wildcard listener and instead present IP:PORT pairs which effects
@@ -282,7 +280,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return Kafka cluster instance
      */
-    @SuppressWarnings({"NPathComplexity", "deprecation"}) // Keycloak Authorization is deprecated; resource configuration in Kafka CR (.spec.kafka.resources) is deprecated
+    @SuppressWarnings({"NPathComplexity", "deprecation"}) // Resource configuration in Kafka CR (.spec.kafka.resources) is deprecated
     public static KafkaCluster fromCrd(Reconciliation reconciliation,
                                        Kafka kafka,
                                        List<KafkaPool> pools,
@@ -364,19 +362,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
         ListenersValidator.validate(reconciliation, result.brokerNodes(), listeners);
         result.listeners = listeners;
-
-        // Set authorization
-        if (kafkaClusterSpec.getAuthorization() instanceof KafkaAuthorizationKeycloak) {
-            if (!ListenersUtils.hasListenerWithOAuth(listeners)) {
-                throw new InvalidResourceException("You cannot configure Keycloak Authorization without any listener with OAuth based authentication");
-            } else {
-                KafkaAuthorizationKeycloak authorizationKeycloak = (KafkaAuthorizationKeycloak) kafkaClusterSpec.getAuthorization();
-                if (authorizationKeycloak.getClientId() == null || authorizationKeycloak.getTokenEndpointUri() == null) {
-                    LOGGER.errorCr(reconciliation, "Keycloak Authorization: Token Endpoint URI and clientId are both required");
-                    throw new InvalidResourceException("Keycloak Authorization: Token Endpoint URI and clientId are both required");
-                }
-            }
-        }
 
         result.authorization = kafkaClusterSpec.getAuthorization();
 
@@ -1391,10 +1376,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             }
         }
 
-        if (authorization instanceof KafkaAuthorizationKeycloak keycloakAuthz) {
-            CertUtils.createTrustedCertificatesVolumes(volumeList, keycloakAuthz.getTlsTrustedCertificates(), isOpenShift, "authz-keycloak");
-        }
-
         TemplateUtils.addAdditionalVolumes(templatePod, volumeList);
 
         return volumeList;
@@ -1457,10 +1438,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     volumeMountList.addAll(AuthenticationUtils.configureGenericSecretVolumeMounts("custom-listener-" + identifier, custom.getSecrets(), CUSTOM_AUTHN_SECRETS_VOLUME_MOUNT + "/custom-listener-" + identifier));
                 }
             }
-        }
-
-        if (authorization instanceof KafkaAuthorizationKeycloak keycloakAuthz) {
-            CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, keycloakAuthz.getTlsTrustedCertificates(), TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/", "authz-keycloak");
         }
 
         TemplateUtils.addAdditionalVolumeMounts(volumeMountList, containerTemplate);
@@ -1574,12 +1551,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     }
                 }
             }
-        }
-
-        if (authorization instanceof KafkaAuthorizationKeycloak keycloakAuthz
-                && keycloakAuthz.getTlsTrustedCertificates() != null
-                && !keycloakAuthz.getTlsTrustedCertificates().isEmpty()) {
-            varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS, CertUtils.trustedCertsEnvVar(keycloakAuthz.getTlsTrustedCertificates())));
         }
 
         varList.addAll(jmx.envVars());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -33,18 +33,6 @@ public class ListenersUtils {
     private ListenersUtils() { }
 
     /**
-     * Finds out if any of the listeners has OAuth authentication enabled
-     *
-     * @param listeners List of all listeners
-     *
-     * @return          True if any listener in the list is using OAuth authentication. False otherwise.
-     */
-    public static boolean hasListenerWithOAuth(List<GenericKafkaListener> listeners)    {
-        return listeners.stream()
-                .anyMatch(ListenersUtils::isListenerWithOAuth);
-    }
-
-    /**
      * Checks whether the listener is using OAuth authentication
      *
      * @param listener  Listener to check

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -15,7 +15,6 @@ import io.strimzi.api.kafka.model.common.SystemPropertyBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationCustomBuilder;
-import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationSimple;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -302,8 +301,6 @@ public class EntityUserOperatorTest {
     @Test
     public void testAclsAdminApiSupported() {
         testAclsAdminApiSupported(new KafkaAuthorizationSimple());
-        testAclsAdminApiSupported(new KafkaAuthorizationKeycloakBuilder().withDelegateToKafkaAcls(true).build());
-        testAclsAdminApiSupported(new KafkaAuthorizationKeycloakBuilder().withDelegateToKafkaAcls(false).build());
         testAclsAdminApiSupported(new KafkaAuthorizationCustomBuilder().withSupportsAdminApi(true).build());
         testAclsAdminApiSupported(new KafkaAuthorizationCustomBuilder().withSupportsAdminApi(false).build());
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
-import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationSimpleBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
@@ -314,91 +313,6 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("node.id=2",
                 "authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer",
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jakub;User:CN=kuba"));
-    }
-
-    @Test
-    public void testKeycloakAuthorization() {
-        CertSecretSource cert = new CertSecretSourceBuilder()
-                .withSecretName("my-secret")
-                .withCertificate("my.crt")
-                .build();
-
-        KafkaAuthorization auth = new KafkaAuthorizationKeycloakBuilder()
-                .withTokenEndpointUri("http://token-endpoint-uri")
-                .withClientId("my-client-id")
-                .withDelegateToKafkaAcls(false)
-                .withGrantsRefreshPeriodSeconds(120)
-                .withGrantsRefreshPoolSize(10)
-                .withGrantsMaxIdleTimeSeconds(600)
-                .withGrantsGcPeriodSeconds(120)
-                .withGrantsAlwaysLatest(true)
-                .withTlsTrustedCertificates(cert)
-                .withDisableTlsHostnameVerification(true)
-                .addToSuperUsers("giada", "CN=paccu")
-                .withConnectTimeoutSeconds(30)
-                .withReadTimeoutSeconds(10)
-                .withHttpRetries(2)
-                .withEnableMetrics(true)
-                .withIncludeAcceptHeader(false)
-                .build();
-
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
-                .withAuthorization("my-cluster", auth)
-                .build();
-
-        assertThat(configuration, isEquivalent("node.id=2",
-                "authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer",
-                "strimzi.authorization.token.endpoint.uri=http://token-endpoint-uri",
-                "strimzi.authorization.client.id=my-client-id",
-                "strimzi.authorization.delegate.to.kafka.acl=false",
-                "strimzi.authorization.kafka.cluster.name=my-cluster",
-                "strimzi.authorization.ssl.truststore.location=/tmp/kafka/authz-keycloak.truststore.p12",
-                "strimzi.authorization.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "strimzi.authorization.ssl.truststore.type=PKCS12",
-                "strimzi.authorization.ssl.endpoint.identification.algorithm=",
-                "strimzi.authorization.grants.refresh.period.seconds=120",
-                "strimzi.authorization.grants.refresh.pool.size=10",
-                "strimzi.authorization.grants.max.idle.time.seconds=600",
-                "strimzi.authorization.grants.gc.period.seconds=120",
-                "strimzi.authorization.reuse.grants=false",
-                "strimzi.authorization.connect.timeout.seconds=30",
-                "strimzi.authorization.read.timeout.seconds=10",
-                "strimzi.authorization.http.retries=2",
-                "strimzi.authorization.enable.metrics=true",
-                "strimzi.authorization.include.accept.header=false",
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:giada;User:CN=paccu"));
-    }
-
-    @Test
-    public void testKeycloakAuthorizationWithDefaults() {
-        CertSecretSource cert = new CertSecretSourceBuilder()
-                .withSecretName("my-secret")
-                .withCertificate("my.crt")
-                .build();
-
-        KafkaAuthorization auth = new KafkaAuthorizationKeycloakBuilder()
-                .withTokenEndpointUri("http://token-endpoint-uri")
-                .withClientId("my-client-id")
-                .withTlsTrustedCertificates(cert)
-                .withReadTimeoutSeconds(30)
-                .build();
-
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
-                .withAuthorization("my-cluster", auth)
-                .build();
-
-        assertThat(configuration, isEquivalent("node.id=2",
-                "authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer",
-                "strimzi.authorization.token.endpoint.uri=http://token-endpoint-uri",
-                "strimzi.authorization.client.id=my-client-id",
-                "strimzi.authorization.delegate.to.kafka.acl=false",
-                "strimzi.authorization.kafka.cluster.name=my-cluster",
-                "strimzi.authorization.ssl.truststore.location=/tmp/kafka/authz-keycloak.truststore.p12",
-                "strimzi.authorization.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "strimzi.authorization.ssl.truststore.type=PKCS12",
-                "strimzi.authorization.ssl.endpoint.identification.algorithm=HTTPS",
-                "strimzi.authorization.read.timeout.seconds=30",
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
-import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
@@ -22,7 +21,6 @@ import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,7 +29,6 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaClusterOAuthTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
@@ -374,91 +371,5 @@ public class KafkaClusterOAuthTest {
                 assertThat(volumes.stream().filter(vol -> "oauth-external-9094-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
             }
         }));
-    }
-
-    @Test
-    public void testGenerateDeploymentWithKeycloakAuthorization() {
-        CertSecretSource cert1 = new CertSecretSourceBuilder()
-                .withSecretName("first-certificate")
-                .withCertificate("ca.crt")
-                .build();
-
-        CertSecretSource cert2 = new CertSecretSourceBuilder()
-                .withSecretName("second-certificate")
-                .withCertificate("tls.crt")
-                .build();
-
-        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editKafka()
-                        .withListeners(new GenericKafkaListenerBuilder()
-                                .withName("plain")
-                                .withPort(9092)
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withTls(false)
-                                .withAuth(
-                                        new KafkaListenerAuthenticationOAuthBuilder()
-                                                .withClientId("my-client-id")
-                                                .withValidIssuerUri("http://valid-issuer")
-                                                .withIntrospectionEndpointUri("http://introspection")
-                                                .withMaxSecondsWithoutReauthentication(3600)
-                                                .withNewClientSecret()
-                                                .withSecretName("my-secret-secret")
-                                                .withKey("my-secret-key")
-                                                .endClientSecret()
-                                                .withDisableTlsHostnameVerification(true)
-                                                .withTlsTrustedCertificates(cert1, cert2)
-                                                .build())
-                                .build())
-                    .withAuthorization(
-                            new KafkaAuthorizationKeycloakBuilder()
-                                    .withClientId("my-client-id")
-                                    .withTokenEndpointUri("http://token-endpoint-uri")
-                                    .withDisableTlsHostnameVerification(true)
-                                    .withDelegateToKafkaAcls(false)
-                                    .withGrantsRefreshPeriodSeconds(90)
-                                    .withGrantsRefreshPoolSize(4)
-                                    .withTlsTrustedCertificates(cert1, cert2)
-                                    .build())
-                    .endKafka()
-                .endSpec()
-                .build();
-        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
-
-        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, node -> Map.of());
-        assertThat(podSets.size(), is(3));
-
-        podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).forEach(pod -> {
-            Container cont = pod.getSpec().getContainers().stream().findAny().orElseThrow();
-            // Volume mounts
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "authz-keycloak-first-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/first-certificate"));
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "authz-keycloak-second-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/second-certificate"));
-
-            // Environment variable
-            assertThat(cont.getEnv().stream().filter(e -> "STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS".equals(e.getName())).findFirst().orElseThrow().getValue(), is("first-certificate/ca.crt;second-certificate/tls.crt"));
-
-            // Volumes
-            List<Volume> volumes = pod.getSpec().getVolumes();
-            assertThat(volumes.stream().filter(vol -> "authz-keycloak-first-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
-            assertThat(volumes.stream().filter(vol -> "authz-keycloak-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
-        }));
-    }
-
-    @Test
-    public void testGenerateDeploymentWithKeycloakAuthorizationMissingOAuthListeners() {
-        assertThrows(InvalidResourceException.class, () -> {
-            Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
-                    .editSpec()
-                    .editKafka()
-                    .withAuthorization(
-                            new KafkaAuthorizationKeycloakBuilder().build())
-                    .endKafka()
-                    .endSpec()
-                    .build();
-
-            List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
-        });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -4,63 +4,21 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.strimzi.api.kafka.model.kafka.Kafka;
-import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
-import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAuthBuilder;
-import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationScramSha512Builder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
-import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
-import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
-import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
-import io.strimzi.operator.cluster.KafkaVersionTestUtils;
-import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
-import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaClusterOAuthValidationTest {
-    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
-    private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
-    private static final String NAMESPACE = "my-namespace";
-    private static final String CLUSTER_NAME = "my-cluster";
-    private final static Kafka KAFKA = new KafkaBuilder()
-            .withNewMetadata()
-                .withName(CLUSTER_NAME)
-                .withNamespace(NAMESPACE)
-            .endMetadata()
-            .withNewSpec()
-                .withNewKafka()
-                    .withListeners(getListeners(null))
-                .endKafka()
-            .endSpec()
-            .build();
-    private final static KafkaNodePool MIXED = new KafkaNodePoolBuilder()
-            .withNewMetadata()
-                .withName("mixed")
-                .withNamespace(NAMESPACE)
-                .withGeneration(1L)
-                .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME))
-            .endMetadata()
-            .withNewSpec()
-                .withReplicas(3)
-                .withNewJbodStorage()
-                    .withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build())
-                .endJbodStorage()
-                .withRoles(ProcessRoles.CONTROLLER, ProcessRoles.BROKER)
-            .endSpec()
-            .build();
     private final static Set<NodeRef> THREE_NODES = Set.of(
             new NodeRef("my-cluster-mixed-0", 0, "mixed", true, true),
             new NodeRef("my-cluster-mixed-1", 1, "mixed", true, true),
@@ -92,84 +50,6 @@ public class KafkaClusterOAuthValidationTest {
                 .build();
 
         ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
-    }
-
-    @Test
-    public void testOAuthAuthnAuthz() {
-        List<GenericKafkaListener> listeners = List.of(new GenericKafkaListenerBuilder()
-                .withName("listener1")
-                .withPort(9900)
-                .withType(KafkaListenerType.INTERNAL)
-                .withAuth(new KafkaListenerAuthenticationOAuthBuilder()
-                        .withClientId("my-client-id")
-                        .withValidIssuerUri("http://valid-issuer")
-                        .withJwksEndpointUri("http://jwks-endpoint")
-                        .withJwksRefreshSeconds(30)
-                        .withJwksExpirySeconds(90)
-                        .withJwksMinRefreshPauseSeconds(5)
-                        .withConnectTimeoutSeconds(20)
-                        .withReadTimeoutSeconds(20)
-                        .withGroupsClaim("$.groups")
-                        .withMaxSecondsWithoutReauthentication(1800)
-                        .withNewClientSecret()
-                            .withSecretName("my-secret-secret")
-                            .withKey("my-secret-key")
-                        .endClientSecret()
-                        .build())
-                .build());
-
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editKafka()
-                        .withListeners(listeners)
-                        .withAuthorization(new KafkaAuthorizationKeycloakBuilder()
-                                .withTokenEndpointUri("http://token-endpoint")
-                                .withClientId("my-client-id")
-                                .withDelegateToKafkaAcls(true)
-                                .withGrantsRefreshPeriodSeconds(60)
-                                .withGrantsRefreshPoolSize(5)
-                                .withSuperUsers("alice",
-                                        "CN=alice")
-                                .build())
-                    .endKafka()
-                .endSpec()
-                .build();
-
-        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(MIXED), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
-        KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
-    }
-
-    @Test
-    public void testOAuthAuthzWithoutAuthn() {
-        assertThrows(InvalidResourceException.class, () -> {
-            List<GenericKafkaListener> listeners = List.of(new GenericKafkaListenerBuilder()
-                    .withName("listener1")
-                    .withPort(9900)
-                    .withType(KafkaListenerType.INTERNAL)
-                    .withAuth(new KafkaListenerAuthenticationScramSha512Builder()
-                            .build())
-                    .build());
-
-            Kafka kafka = new KafkaBuilder(KAFKA)
-                    .editSpec()
-                        .editKafka()
-                            .withListeners(listeners)
-                            .withAuthorization(new KafkaAuthorizationKeycloakBuilder()
-                                    .withTokenEndpointUri("http://token-endpoint")
-                                    .withClientId("my-client-id")
-                                    .withDelegateToKafkaAcls(true)
-                                    .withGrantsRefreshPeriodSeconds(60)
-                                    .withGrantsRefreshPoolSize(5)
-                                    .withSuperUsers("alice",
-                                            "CN=alice")
-                                    .build())
-                        .endKafka()
-                    .endSpec()
-                    .build();
-
-            List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(MIXED), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
-        });
     }
 
     @SuppressWarnings("deprecation") // OAuth authentication is deprecated

--- a/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -18,8 +18,3 @@ for CERT_DIR in /opt/kafka/certificates/*; do
     echo "Preparing store for ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} listener is complete"  
   fi
 done
-
-if [ -n "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS" ]; then
-  echo "Preparing Keycloak authorization truststore"
-  prepare_truststore "/tmp/kafka/authz-keycloak.truststore.p12" "$CERTS_STORE_PASSWORD" "/opt/kafka/certificates/authz-keycloak-certs" "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS"
-fi


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the `type: keycloak` authorization support from the CLuster operator as it is being dropped by the `v1` API. Keycloak authorization can continue to be used through the `type: custom` API.

This PR contributes to #12467.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging