### PR TITLE
feat: add UIDs to Grafana dashboards

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-cruise-control.json
@@ -2069,6 +2069,7 @@
   },
   "timezone": "",
   "title": "Strimzi Cruise Control",
+  "uid": "fb7da220847d2e2c",
   "version": 4,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -3020,6 +3020,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Bridge",
+  "uid": "069669ed52041ef4",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -1803,6 +1803,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Connect",
+  "uid": "646c07d84adaf50d",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -1627,6 +1627,7 @@
   },
   "timezone": "browser",
   "title": "Strimzi Kafka Exporter",
+  "uid": "52a9e2042fa225a2",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -2356,6 +2356,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Mirror Maker 2",
+  "uid": "6e9806b052af8d25",
   "version": 10,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-oauth.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-oauth.json
@@ -764,6 +764,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka OAuth",
+  "uid": "3797efba280f9ed6",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka.json
@@ -2883,6 +2883,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka",
+  "uid": "7ddce8bf9ea7ddb5",
   "version": 4,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kraft.json
@@ -2115,6 +2115,7 @@
   },
   "timezone": "",
   "title": "Strimzi KRaft",
+  "uid": "d1b98e4d984de29d",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-operators.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-operators.json
@@ -1771,6 +1771,7 @@
   },
   "timezone": "",
   "title": "Strimzi Operators",
+  "uid": "31545fecf446bf88",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-bridge.json
@@ -3020,6 +3020,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Bridge",
+  "uid": "e9ff8938f1dfeb1b",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-connect.json
@@ -1803,6 +1803,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Connect",
+  "uid": "2d3b3918d6150cef",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -2356,6 +2356,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Mirror Maker 2",
+  "uid": "da8f0746ca50ea62",
   "version": 10,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json
@@ -2883,6 +2883,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka",
+  "uid": "0fba080180e35871",
   "version": 4,
   "weekStart": ""
 }

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kraft.json
@@ -2115,6 +2115,7 @@
   },
   "timezone": "",
   "title": "Strimzi KRaft",
+  "uid": "117edf7709fd86a1",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-cruise-control.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-cruise-control.json
@@ -2069,6 +2069,7 @@
   },
   "timezone": "",
   "title": "Strimzi Cruise Control",
+  "uid": "fb7da220847d2e2c",
   "version": 4,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-bridge.json
@@ -3020,6 +3020,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Bridge",
+  "uid": "069669ed52041ef4",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-connect.json
@@ -1803,6 +1803,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Connect",
+  "uid": "646c07d84adaf50d",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
@@ -1627,6 +1627,7 @@
   },
   "timezone": "browser",
   "title": "Strimzi Kafka Exporter",
+  "uid": "52a9e2042fa225a2",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -2356,6 +2356,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka Mirror Maker 2",
+  "uid": "6e9806b052af8d25",
   "version": 10,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-oauth.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-oauth.json
@@ -764,6 +764,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka OAuth",
+  "uid": "3797efba280f9ed6",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka.json
@@ -2883,6 +2883,7 @@
   },
   "timezone": "",
   "title": "Strimzi Kafka",
+  "uid": "7ddce8bf9ea7ddb5",
   "version": 4,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kraft.json
@@ -2115,6 +2115,7 @@
   },
   "timezone": "",
   "title": "Strimzi KRaft",
+  "uid": "d1b98e4d984de29d",
   "version": 6,
   "weekStart": ""
 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-operators.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-operators.json
@@ -1771,6 +1771,7 @@
   },
   "timezone": "",
   "title": "Strimzi Operators",
+  "uid": "31545fecf446bf88",
   "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This adds a UID to all Grafana dashboards. The values were derived from the dashboard JSON file names by taking their SHA256 hash and truncating it to 16 characters.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Reference relevant issue(s) and close them after merging

This closes #10886.