### PR TITLE
Stop using the `operation` field in KafkaUser ACLs in the UO

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.user.model.acl;
 import io.strimzi.api.kafka.model.user.acl.AclOperation;
 import io.strimzi.api.kafka.model.user.acl.AclRule;
 import io.strimzi.api.kafka.model.user.acl.AclRuleType;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclPermissionType;
@@ -141,20 +140,17 @@ public class SimpleAclRule {
      * @param rule AclRule object from KafkaUser CR
      * @return The SimpleAclRule.
      */
-    @SuppressWarnings("deprecation")
     public static List<SimpleAclRule> fromCrd(AclRule rule) {
-        if (rule.getOperations() != null && rule.getOperation() != null) {
-            throw new InvalidResourceException("Both fields `operations` and `operation` cannot be filled in at the same time");
-        } else if (rule.getOperations() == null && rule.getOperation() == null) {
-            throw new InvalidResourceException("Both fields `operations` and `operation` are null. At least one of them must be specified.");
-        } else if (rule.getOperations() != null) {
+        if (rule.getOperations() != null) {
             List<SimpleAclRule> simpleAclRules = new ArrayList<>();
             for (AclOperation operation : rule.getOperations()) {
                 simpleAclRules.add(new SimpleAclRule(rule.getType(), SimpleAclRuleResource.fromCrd(rule.getResource()), rule.getHost(), operation));
             }
             return simpleAclRules;
         } else {
-            return List.of(new SimpleAclRule(rule.getType(), SimpleAclRuleResource.fromCrd(rule.getResource()), rule.getHost(), rule.getOperation()));
+            // Should not happen, because in v1 CRD the operations field is required.
+            // But you never know, so we better handle it to be sure.
+            return List.of();
         }
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.user.acl.AclRuleBuilder;
 import io.strimzi.api.kafka.model.user.acl.AclRuleResource;
 import io.strimzi.api.kafka.model.user.acl.AclRuleTopicResourceBuilder;
 import io.strimzi.api.kafka.model.user.acl.AclRuleType;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclPermissionType;
@@ -27,7 +26,6 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SimpleAclRuleTest {
     private static final AclRuleResource ACL_RULE_TOPIC_RESOURCE;
@@ -48,7 +46,7 @@ public class SimpleAclRuleTest {
             .withType(AclRuleType.ALLOW)
             .withResource(ACL_RULE_TOPIC_RESOURCE)
             .withHost("127.0.0.1")
-            .withOperation(AclOperation.READ)
+            .withOperations(AclOperation.READ)
             .build();
 
         List<SimpleAclRule> simpleAclRules = SimpleAclRule.fromCrd(rule);
@@ -59,33 +57,14 @@ public class SimpleAclRuleTest {
     }
 
     @Test
-    public void testFromCrdWithBothOperationsAndOperationSetAtTheSameTime()   {
-        assertThrows(InvalidResourceException.class, () -> {
-            AclRule rule = new AclRuleBuilder()
-                .withType(AclRuleType.ALLOW)
-                .withResource(ACL_RULE_TOPIC_RESOURCE)
-                .withHost("127.0.0.1")
-                .withOperation(AclOperation.READ)
-                .withOperations(AclOperation.READ, AclOperation.WRITE, AclOperation.DESCRIBECONFIGS)
-                .build();
+    public void testFromCrdWithNoOperations()   {
+        AclRule rule = new AclRuleBuilder()
+            .withType(AclRuleType.ALLOW)
+            .withResource(ACL_RULE_TOPIC_RESOURCE)
+            .withHost("127.0.0.1")
+            .build();
 
-            SimpleAclRule.fromCrd(rule);
-        });
-    }
-
-    @Test
-    public void testFromCrdWithNoOperationsAndOperationSet()   {
-        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
-            AclRule rule = new AclRuleBuilder()
-                .withType(AclRuleType.ALLOW)
-                .withResource(ACL_RULE_TOPIC_RESOURCE)
-                .withHost("127.0.0.1")
-                .build();
-
-            SimpleAclRule.fromCrd(rule);
-        });
-
-        assertThat(ex.getMessage(), is("Both fields `operations` and `operation` are null. At least one of them must be specified."));
+        assertThat(SimpleAclRule.fromCrd(rule).size(), is(0));
     }
 
     @Test
@@ -145,7 +124,7 @@ public class SimpleAclRuleTest {
             .withType(AclRuleType.ALLOW)
             .withResource(ACL_RULE_TOPIC_RESOURCE)
             .withHost("127.0.0.1")
-            .withOperation(AclOperation.READ)
+            .withOperations(AclOperation.READ)
             .build();
 
         AclBinding expectedKafkaAclBinding = new AclBinding(


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR continues the work towards https://github.com/strimzi/strimzi-kafka-operator/issues/12467 and removes the use of the `operation` field in the useer ACLs when processing them in the User Operator. This field is not part of the `v1` API anymore and is not used.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging