### PR TITLE
Remove the old Bridge `enableMetrics` flag from CO

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -119,7 +119,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
     private KafkaBridgeAdminClientSpec kafkaBridgeAdminClient;
     private KafkaBridgeConsumerSpec kafkaBridgeConsumer;
     private KafkaBridgeProducerSpec kafkaBridgeProducer;
-    private boolean isLegacyMetricsConfigEnabled = false;
     private LoggingModel logging;
     private MetricsModel metrics;
 
@@ -165,7 +164,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
      * @param sharedEnvironmentProvider Shared environment provider
      * @return KafkaBridgeCluster instance
      */
-    @SuppressWarnings({"checkstyle:NPathComplexity", "deprecation"})
+    @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static KafkaBridgeCluster fromCrd(Reconciliation reconciliation,
                                              KafkaBridge kafkaBridge,
                                              SharedEnvironmentProvider sharedEnvironmentProvider) {
@@ -201,8 +200,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
             result.metrics = new JmxPrometheusExporterModel(spec);
         } else if (spec.getMetricsConfig() instanceof StrimziMetricsReporter) {
             result.metrics = new StrimziMetricsReporterModel(spec, DEFAULT_METRICS_ALLOW_LIST);
-        } else {
-            result.isLegacyMetricsConfigEnabled = Boolean.TRUE.equals(spec.getEnableMetrics());
         }
 
         result.setTls(spec.getTls() != null ? spec.getTls() : null);
@@ -579,10 +576,10 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
                         .withKafkaConsumer(kafkaBridgeConsumer)
                         .withHttp(http, kafkaBridgeProducer, kafkaBridgeConsumer);
 
-        if ((metrics instanceof JmxPrometheusExporterModel) || isLegacyMetricsConfigEnabled) {
-            builder.withJmxPrometheusExporter((JmxPrometheusExporterModel) metrics, isLegacyMetricsConfigEnabled);
-        } else if (metrics instanceof StrimziMetricsReporterModel) {
-            builder.withStrimziMetricsReporter((StrimziMetricsReporterModel) metrics);
+        if (metrics instanceof JmxPrometheusExporterModel jmxPrometheusExporterModel) {
+            builder.withJmxPrometheusExporter(jmxPrometheusExporterModel);
+        } else if (metrics instanceof StrimziMetricsReporterModel strimziMetricsReporterModel) {
+            builder.withStrimziMetricsReporter(strimziMetricsReporterModel);
         }
 
         data.put(BRIDGE_CONFIGURATION_FILENAME, builder.build());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
@@ -395,22 +395,14 @@ public class KafkaBridgeConfigurationBuilder {
      * Configures the JMX Prometheus Metrics Exporter.
      *
      * @param model JMX Prometheus Metrics Exporter configuration
-     * @param isLegacyMetricsConfigEnabled Flag which indicates whether the metrics are enabled or not in legacy mode.
      *
      * @return Returns the builder instance
      */
-    public KafkaBridgeConfigurationBuilder withJmxPrometheusExporter(
-            JmxPrometheusExporterModel model, boolean isLegacyMetricsConfigEnabled) {
-        if (model != null || isLegacyMetricsConfigEnabled) {
+    public KafkaBridgeConfigurationBuilder withJmxPrometheusExporter(JmxPrometheusExporterModel model) {
+        if (model != null) {
             printSectionHeader("Prometheus JMX Exporter configuration");
             writer.println("bridge.metrics=" + JmxPrometheusExporterMetrics.TYPE_JMX_EXPORTER);
-
-            // if isLegacyMetricsConfigEnabled is not used, we pass the path of the config file.
-            // If it is used, the Bridge will use the fallback config.
-            if (!isLegacyMetricsConfigEnabled) {
-                writer.println("bridge.metrics.exporter.config.path="
-                        + KAFKA_BRIDGE_CONFIG_VOLUME_MOUNT + JmxPrometheusExporterModel.CONFIG_MAP_KEY);
-            }
+            writer.println("bridge.metrics.exporter.config.path=" + KAFKA_BRIDGE_CONFIG_VOLUME_MOUNT + JmxPrometheusExporterModel.CONFIG_MAP_KEY);
 
             writer.println();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -181,7 +181,11 @@ public class ResourceUtils {
                     .withBootstrapServers(bootstrapServers)
                     .withProducer(producer)
                     .withConsumer(consumer)
-                    .withEnableMetrics(enableMetrics)
+                    .withNewJmxPrometheusExporterMetricsConfig()
+                        .withNewValueFrom()
+                            .withNewConfigMapKeyRef("metrics.yaml", "my-metrics-config", false)
+                        .endValueFrom()
+                    .endJmxPrometheusExporterMetricsConfig()
                     .withHttp(http)
                 .endSpec()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
@@ -664,20 +664,6 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.security.protocol=PLAINTEXT"
         ));
     }
-    
-    @Test
-    public void testWithPrometheusJmxExporterLegacyMode() {
-        String configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withJmxPrometheusExporter(null, true)
-                .build();
-
-        assertThat(configuration, isEquivalent(
-                "bridge.id=my-bridge",
-                "bridge.metrics=" + JmxPrometheusExporterMetrics.TYPE_JMX_EXPORTER,
-                "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
-                "kafka.security.protocol=PLAINTEXT"
-        ));
-    }
 
     @Test
     public void testWithPrometheusJmxExporter() {
@@ -691,7 +677,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                         .build());
 
         String configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withJmxPrometheusExporter(model, false)
+                .withJmxPrometheusExporter(model)
                 .build();
 
         assertThat(configuration, isEquivalent(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -143,6 +144,8 @@ public class KafkaBridgeAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture());
+        // Metrics configuration map
+        when(mockCmOps.getAsync(any(), eq("my-metrics-config"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withData(Map.of("metrics.yaml", "metrics-config")).build()));
 
         ArgumentCaptor<KafkaBridge> bridgeCaptor = ArgumentCaptor.forClass(KafkaBridge.class);
         when(mockBridgeOps.updateStatusAsync(any(), bridgeCaptor.capture())).thenReturn(Future.succeededFuture());
@@ -171,7 +174,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 assertThat(dc.getMetadata().getName(), is(bridge.getComponentName()));
                 assertThat(dc, is(bridge.generateDeployment(Map.of(
                         Annotations.ANNO_STRIMZI_AUTH_HASH, "0",
-                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "eeacc2f1"
+                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "9fd6bb72"
                         ), true, null, null)));
 
                 // Verify PodDisruptionBudget
@@ -239,6 +242,9 @@ public class KafkaBridgeAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+        // Metrics configuration map
+        when(mockCmOps.getAsync(any(), eq("my-metrics-config"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withData(Map.of("metrics.yaml", "metrics-config")).build()));
+
         KafkaBridgeAssemblyOperator ops = new KafkaBridgeAssemblyOperator(vertx,
                 new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"),
@@ -317,6 +323,8 @@ public class KafkaBridgeAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture());
+        // Metrics configuration map
+        when(mockCmOps.getAsync(any(), eq("my-metrics-config"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withData(Map.of("metrics.yaml", "metrics-config")).build()));
 
         KafkaBridgeAssemblyOperator ops = new KafkaBridgeAssemblyOperator(vertx,
                 new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -344,7 +352,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 assertThat(dc.getMetadata().getName(), is(compareTo.getComponentName()));
                 assertThat(dc, is(compareTo.generateDeployment(Map.of(
                         Annotations.ANNO_STRIMZI_AUTH_HASH, "0",
-                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "eeacc2f1"
+                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "9fd6bb72"
                 ), true, null, null)));
 
                 // Verify PodDisruptionBudget
@@ -707,15 +715,22 @@ public class KafkaBridgeAssemblyOperatorTest {
         when(mockBridgeOps.get(kbNamespace, kbName)).thenReturn(kb);
         when(mockBridgeOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kb));
         when(mockBridgeOps.get(anyString(), anyString())).thenReturn(kb);
+        ArgumentCaptor<KafkaBridge> bridgeCaptor = ArgumentCaptor.forClass(KafkaBridge.class);
+        when(mockBridgeOps.updateStatusAsync(any(), bridgeCaptor.capture())).thenReturn(Future.succeededFuture());
+
         when(mockServiceOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
         when(mockDcOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(mockDcOps.scaleUp(any(), anyString(), anyString(), anyInt(), anyLong())).thenReturn(Future.succeededFuture(42));
         when(mockDcOps.scaleDown(any(), anyString(), anyString(), anyInt(), anyLong())).thenReturn(Future.succeededFuture(42));
         when(mockDcOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
         when(mockPdbOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture());
+
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
-        ArgumentCaptor<KafkaBridge> bridgeCaptor = ArgumentCaptor.forClass(KafkaBridge.class);
-        when(mockBridgeOps.updateStatusAsync(any(), bridgeCaptor.capture())).thenReturn(Future.succeededFuture());
+        // Metrics configuration map
+        when(mockCmOps.getAsync(any(), eq("my-metrics-config"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withData(Map.of("metrics.yaml", "metrics-config")).build()));
+
         KafkaBridgeAssemblyOperator ops = new KafkaBridgeAssemblyOperator(vertx,
                 new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"),


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the use of the old HTTP Bridge `enableMetrics` flag from the Cluster Operator, as it will be gone in the `v1` API.

This contributes to #12467 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging