### PR TITLE
Stop using the Kaniko additional options

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -104,7 +104,7 @@ public class KafkaConnectBuild extends AbstractModel {
      * @param useConnectBuildWithBuildah    determines if Buildah should be used for the Connect Build
      * @return              Instance of KafkaConnectBuild class
      */
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "deprecation"})
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     public static KafkaConnectBuild fromCrd(Reconciliation reconciliation,
                                             KafkaConnect kafkaConnect,
                                             KafkaVersion.Lookup versions,
@@ -120,7 +120,6 @@ public class KafkaConnectBuild extends AbstractModel {
         if (spec.getBuild() != null)    {
             validateBuildConfiguration(spec.getBuild());
 
-            // The additionalKanikoOptions are validated separately to avoid parsing the list twice
             if (spec.getBuild().getOutput() != null
                     && spec.getBuild().getOutput() instanceof DockerOutput dockerOutput) {
 
@@ -142,14 +141,8 @@ public class KafkaConnectBuild extends AbstractModel {
                 } else {
                     if (dockerOutput.getAdditionalBuildOptions() != null
                             && !dockerOutput.getAdditionalBuildOptions().isEmpty()) {
-                        // in case that we are using Kaniko and `.additionalBuildOptions` field contains some options, we want to check them
-                        // because `.additionalKanikoOptions` is deprecated and `.additionalBuildOptions` is replacement
                         validateAdditionalOptions(DockerOutput.ALLOWED_KANIKO_OPTIONS, dockerOutput.getAdditionalBuildOptions(), ".spec.build.output.additionalBuildOptions");
                         result.additionalBuildOptions = dockerOutput.getAdditionalBuildOptions();
-                    } else if (dockerOutput.getAdditionalKanikoOptions() != null
-                            && !dockerOutput.getAdditionalKanikoOptions().isEmpty()) {
-                        validateAdditionalOptions(DockerOutput.ALLOWED_KANIKO_OPTIONS, dockerOutput.getAdditionalKanikoOptions(), ".spec.build.output.additionalKanikoOptions");
-                        result.additionalBuildOptions = dockerOutput.getAdditionalKanikoOptions();
                     }
                 }
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -517,7 +517,7 @@ public class KafkaConnectBuildTest {
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withPushSecret("my-docker-credentials")
-                            .withAdditionalKanikoOptions("--reproducible", "--single-snapshot", "--log-format=json")
+                            .withAdditionalBuildOptions("--reproducible", "--single-snapshot", "--log-format=json")
                         .endDockerOutput()
                     .endBuild()
                 .endSpec()
@@ -536,7 +536,7 @@ public class KafkaConnectBuildTest {
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
                             .withPushSecret("my-docker-credentials")
-                            .withAdditionalKanikoOptions("--reproducible", "--reproducible-something", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
+                            .withAdditionalBuildOptions("--reproducible", "--reproducible-something", "--build-arg", "--single-snapshot", "--digest-file=/dev/null", "--log-format=json")
                         .endDockerOutput()
                     .endBuild()
                 .endSpec()
@@ -546,7 +546,7 @@ public class KafkaConnectBuildTest {
             KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false)
         );
 
-        assertThat(e.getMessage(), containsString(".spec.build.output.additionalKanikoOptions contains forbidden options: [--reproducible-something, --build-arg, --digest-file]"));
+        assertThat(e.getMessage(), containsString(".spec.build.output.additionalBuildOptions contains forbidden options: [--reproducible-something, --build-arg, --digest-file]"));
     }
 
     @Test
@@ -616,31 +616,6 @@ public class KafkaConnectBuildTest {
         );
 
         assertThat(e.getMessage(), containsString(".spec.build.output.additionalPushOptions contains forbidden options: [--digestfile, --sign-by, --format]"));
-    }
-
-    @Test
-    public void testKanikoAdditionalOptionsConfiguredOnBothPlaces() {
-        List<String> expectedArgs = new ArrayList<>(EXPECTED_DEFAULT_KANIKO_OPTIONS);
-        expectedArgs.add("--single-snapshot");
-        expectedArgs.add("--log-format=json");
-
-        KafkaConnect kc = new KafkaConnectBuilder(RESOURCE)
-                .editSpec()
-                    .editBuild()
-                        .withNewDockerOutput()
-                            .withImage("my-image:latest")
-                            .withPushSecret("my-docker-credentials")
-                            .withAdditionalKanikoOptions("--reproducible")
-                            .withAdditionalBuildOptions("--single-snapshot", "--log-format=json")
-                        .endDockerOutput()
-                    .endBuild()
-                .endSpec()
-                .build();
-        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, false);
-
-        Pod pod = build.generateBuilderPod(true, false, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
-        assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
-        assertThat(pod.getSpec().getContainers().get(0).getArgs().contains("--reproducible"), is(false));
     }
 
     @Test

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -186,7 +186,7 @@ public class KafkaConnectTemplates {
             dockerOutputBuilder.withAdditionalPushOptions("--tls-verify=false");
         } else if (!Environment.isConnectBuildWithBuildahEnabled() && KubeClusterResource.getInstance().isKind()) {
             // if we use Kind we add insecure option
-            dockerOutputBuilder.withAdditionalKanikoOptions(
+            dockerOutputBuilder.withAdditionalBuildOptions(
                 // --insecure for PUSH via HTTP instead of HTTPS
                 "--insecure");
         }


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the use of the Kaniko additional options field from the Cluster operator and from the tests.

This contributes to https://github.com/strimzi/strimzi-kafka-operator/issues/12467

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging