### PR TITLE
Update Jetty to 12.1.7 to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <quartz.version>2.5.0</quartz.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
-        <jetty.version>12.0.22</jetty.version>
+        <jetty.version>12.1.7</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
         <netty.version>4.2.10.Final</netty.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Jetty to 12.1.7 and replaces https://github.com/strimzi/strimzi-kafka-operator/pull/12493 and https://github.com/strimzi/strimzi-kafka-operator/pull/12492.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally