### PR TITLE
Remove the remains of storage overrides from Cluster Operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -165,7 +165,6 @@ public class KafkaPool extends AbstractModel {
                         "changing the kraftMetadata flag (but only one volume can be marked to store the KRaft metadata log at a time), " +
                         "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
                         "each volume in Jbod storage should have an unique ID, " +
-                        "changing overrides to nodes which do not exist yet, " +
                         "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 LOGGER.warnCr(reconciliation, "The desired Kafka storage configuration in the KafkaNodePool resource {}/{} contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -28,7 +28,7 @@ public class StorageDiff extends AbstractJsonDiff {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StorageDiff.class.getName());
 
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
-            "^(/deleteClaim|/kraftMetadata|/overrides.*|/volumeAttributesClass|)$");
+            "^(/deleteClaim|/kraftMetadata|/volumeAttributesClass|)$");
 
     private final boolean isEmpty;
     private final boolean changesType;
@@ -38,8 +38,8 @@ public class StorageDiff extends AbstractJsonDiff {
     private final boolean duplicateVolumeIds;
 
     /**
-     * Diffs the storage for allowed or not allowed changes. Examples of allowed changes is increasing volume size or
-     * adding overrides for nodes before scale-up / removing them after scale-down.
+     * Diffs the storage for allowed or not allowed changes. Examples of allowed changes are increasing volume size or
+     * volumeAttributesClass changes.
      *
      * @param reconciliation    The reconciliation
      * @param current           Current Storage configuration
@@ -52,9 +52,8 @@ public class StorageDiff extends AbstractJsonDiff {
     }
 
     /**
-     * Diffs the storage for allowed or not allowed changes. Examples of allowed changes is increasing volume size or
-     * adding overrides for nodes before scale-up / removing them after scale-down. This constructor is used internally
-     * only.
+     * Diffs the storage for allowed or not allowed changes. Example of allowed changes are increasing volume size or
+     * volumeAttributesClass changes. This constructor is used internally only.
      *
      * @param reconciliation    The reconciliation
      * @param current           Current Storage configuration

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStorageTest.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
-import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
@@ -219,53 +218,6 @@ public class KafkaClusterStorageTest {
                                         .withDeleteClaim(true)
                                         .withId(1)
                                         .withSize("1000Gi")
-                                        .build())
-                    .endJbodStorage()
-                .endSpec()
-                .build();
-        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(POOL_CONTROLLERS, POOL_MIXED, brokers), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
-
-        // Check PVCs
-        List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
-        assertThat(pvcs.size(), is(11));
-
-        for (PersistentVolumeClaim pvc : pvcs) {
-            if (pvc.getMetadata().getName().contains("brokers")) {
-                if (pvc.getMetadata().getName().contains("data-0")) {
-                    assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
-                    assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
-                    assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-                    assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
-                    assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-                } else if (pvc.getMetadata().getName().contains("data-1")) {
-                    assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("1000Gi")));
-                    assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
-                    assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
-                    assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
-                    assertThat(pvc.getSpec().getStorageClassName(), is("gp2-st1"));
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testGeneratePersistentVolumeClaimsJbodWithOverrides() {
-        KafkaNodePool brokers = new KafkaNodePoolBuilder(POOL_BROKERS)
-                .editSpec()
-                    .withNewJbodStorage()
-                        .withVolumes(new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd")
-                                        .withDeleteClaim(false)
-                                        .withId(0)
-                                        .withSize("100Gi")
-                                        .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(6).withStorageClass("gp2-ssd-az1").build()) // The override is set, but the test checks that it is ignored
-                                        .build(),
-                                new PersistentClaimStorageBuilder()
-                                        .withStorageClass("gp2-st1")
-                                        .withDeleteClaim(true)
-                                        .withId(1)
-                                        .withSize("1000Gi")
-                                        .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(6).withStorageClass("gp2-st1-az1").build()) // The override is set, but the test checks that it is ignored
                                         .build())
                     .endJbodStorage()
                 .endSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.kafka.JbodStorage;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
-import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
@@ -232,85 +231,5 @@ public class PersistentVolumeClaimUtilsTest {
         assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
         assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
         assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
-    }
-
-    @Test
-    public void testWithStorageClassOverrides()  {
-        JbodStorage jbod = new JbodStorageBuilder()
-                .withVolumes(new PersistentClaimStorageBuilder()
-                        .withId(0)
-                        .withStorageClass("my-storage-class")
-                        .withSize("100Gi")
-                        .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build()) // The override is set, but the test checks that it is ignored
-                        .build())
-                .build();
-
-        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, SINGLE_NODE, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
-
-        assertThat(pvcs.size(), is(1));
-
-        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
-        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
-        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
-        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
-        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
-        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
-        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
-        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
-        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
-        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
-    }
-
-    @Test
-    public void testJbodWithClassOverridesAndDeleteClaims()  {
-        JbodStorage jbod = new JbodStorageBuilder()
-                .withVolumes(
-                        new PersistentClaimStorageBuilder()
-                                .withId(0)
-                                .withStorageClass("my-storage-class")
-                                .withSize("100Gi")
-                                .withDeleteClaim(false)
-                                .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build()) // The override is set, but the test checks that it is ignored
-                                .build(),
-                        new PersistentClaimStorageBuilder()
-                                .withId(1)
-                                .withStorageClass("my-storage-class2")
-                                .withSize("200Gi")
-                                .withDeleteClaim(true)
-                                .build(),
-                        new EphemeralStorage())
-                .build();
-
-        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAMESPACE, THREE_NODES, jbod, false, LABELS, ResourceUtils.DUMMY_OWNER_REFERENCE, null);
-
-        assertThat(pvcs.size(), is(6));
-
-        for (int i = 0; i < 3; i++)  {
-            assertThat(pvcs.get(i).getMetadata().getName(), is("data-0-my-cluster-kafka-" + i));
-            assertThat(pvcs.get(i).getMetadata().getNamespace(), is(NAMESPACE));
-            assertThat(pvcs.get(i).getMetadata().getLabels(), is(LABELS.toMap()));
-            assertThat(pvcs.get(i).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
-            assertThat(pvcs.get(i).getMetadata().getOwnerReferences(), is(List.of()));
-            assertThat(pvcs.get(i).getSpec().getVolumeMode(), is("Filesystem"));
-            assertThat(pvcs.get(i).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
-            assertThat(pvcs.get(i).getSpec().getSelector(), is(nullValue()));
-            assertThat(pvcs.get(i).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
-            assertThat(pvcs.get(i).getSpec().getStorageClassName(), is("my-storage-class"));
-        }
-
-        for (int i = 3; i < 6; i++)  {
-            assertThat(pvcs.get(i).getMetadata().getName(), is("data-1-my-cluster-kafka-" + i % 3));
-            assertThat(pvcs.get(i).getMetadata().getNamespace(), is(NAMESPACE));
-            assertThat(pvcs.get(i).getMetadata().getLabels(), is(LABELS.toMap()));
-            assertThat(pvcs.get(i).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "true")));
-            assertThat(pvcs.get(i).getMetadata().getOwnerReferences(), is(List.of(ResourceUtils.DUMMY_OWNER_REFERENCE)));
-            assertThat(pvcs.get(i).getSpec().getVolumeMode(), is("Filesystem"));
-            assertThat(pvcs.get(i).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
-            assertThat(pvcs.get(i).getSpec().getSelector(), is(nullValue()));
-            assertThat(pvcs.get(i).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("200Gi", null))));
-            assertThat(pvcs.get(i).getSpec().getStorageClassName(), is("my-storage-class2"));
-        }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.KRaftMetadataStorage;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
-import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.operator.common.Reconciliation;
 import org.junit.jupiter.api.Test;
@@ -60,51 +59,6 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(true));
-    }
-
-    @Test
-    public void testOverridesAreIgnoredInDiff()    {
-        Storage persistent = new PersistentClaimStorageBuilder()
-                .withStorageClass("gp2-ssd")
-                .withDeleteClaim(false)
-                .withId(0)
-                .withSize("100Gi")
-                .build();
-        Storage persistent2 = new PersistentClaimStorageBuilder()
-                .withStorageClass("gp2-ssd")
-                .withDeleteClaim(false)
-                .withId(0)
-                .withSize("100Gi")
-                .withOverrides(new PersistentClaimStorageOverrideBuilder()
-                        .withBroker(1)
-                        .withStorageClass("gp2-ssd-az1")
-                        .build())
-                .build();
-        Storage persistent3 = new PersistentClaimStorageBuilder()
-                .withStorageClass("gp2-ssd")
-                .withDeleteClaim(false)
-                .withId(0)
-                .withSize("100Gi")
-                .withOverrides(new PersistentClaimStorageOverrideBuilder()
-                        .withBroker(1)
-                        .withStorageClass("gp2-ssd-az2")
-                        .build())
-                .build();
-
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
-
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
-
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
-        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR removes the remains of the Storage overrides that allows to use different storage classes on a per-broker basis. Most of it was already removed in 0.46.0. This PR removes some Javadocs, tests, and so on.

This contributes to https://github.com/strimzi/strimzi-kafka-operator/issues/12467.

### Checklist

- [x] Make sure all tests pass