### PR TITLE
Remove Jaeger tracing checks from Cluster Operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -44,7 +44,6 @@ import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
-import io.strimzi.api.kafka.model.common.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
 import io.strimzi.api.kafka.model.connect.ImageArtifact;
@@ -258,13 +257,10 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
 
         // Tracing configuration
         result.tracing = spec.getTracing();
-        if (result.tracing != null)   {
-            if (JaegerTracing.TYPE_JAEGER.equals(result.tracing.getType())) {
-                LOGGER.warnCr(reconciliation, "Tracing type \"{}\" is not supported anymore and will be ignored", JaegerTracing.TYPE_JAEGER);
-            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(result.tracing.getType())) {
-                config.setConfigOption("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
-                config.setConfigOption("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
-            }
+        if (result.tracing != null
+                && OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(result.tracing.getType()))   {
+            config.setConfigOption("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+            config.setConfigOption("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
         }
 
         if (result.getImage() == null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -11,7 +11,6 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha256;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
-import io.strimzi.api.kafka.model.common.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
@@ -170,16 +169,10 @@ public class KafkaMirrorMaker2Connectors {
         }
 
         // Tracing
-        if (tracing != null)   {
-            @SuppressWarnings("deprecation") // JaegerTracing is deprecated
-            String jaegerType = JaegerTracing.TYPE_JAEGER;
-
-            if (jaegerType.equals(tracing.getType())) {
-                LOGGER.warnCr(reconciliation, "Tracing type \"{}\" is not supported anymore and will be ignored", jaegerType);
-            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(tracing.getType())) {
-                config.put("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
-                config.put("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
-            }
+        if (tracing != null
+                && OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(tracing.getType()))   {
+            config.put("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+            config.put("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
         }
 
         // Rack awareness (client.rack has to be configured in the connector because the consumer is created by the connector)


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the Jaeger tracing checks from the Cluster Operator. Jaeger tracing is not supported for a long time. But since it was part of the API, we used to raise warning messages when it was specified there. As it is not present anymore in the `v1` API, the checks are nto needed anymore and can be removed.

This contributes to https://github.com/strimzi/strimzi-kafka-operator/issues/12467.

### Checklist

- [x] Reference relevant issue(s) and close them after merging