### PR TITLE
Replace hardcoded JKS keystore type with KeyStore.getDefaultType()

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -80,14 +80,14 @@ public class KafkaAgentClient {
             }
             String trustManagerFactoryAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
             TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm);
-            trustManagerFactory.init(tlsPemIdentity.pemTrustSet().jksTrustStore());
+            trustManagerFactory.init(tlsPemIdentity.pemTrustSet().trustStore());
 
             if (tlsPemIdentity.pemAuthIdentity() == null) {
                 throw new RuntimeException("Missing cluster operator authentication identity certificates required to create connection to Kafka Agent");
             }
             String keyManagerFactoryAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(keyManagerFactoryAlgorithm);
-            keyManagerFactory.init(tlsPemIdentity.pemAuthIdentity().jksKeyStore(KEYSTORE_PASSWORD), KEYSTORE_PASSWORD);
+            keyManagerFactory.init(tlsPemIdentity.pemAuthIdentity().keyStore(KEYSTORE_PASSWORD), KEYSTORE_PASSWORD);
 
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -145,7 +145,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             if (apiSslEnabled) {
                 String trustManagerFactoryAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm);
-                trustManagerFactory.init(pemTrustSet.jksTrustStore());
+                trustManagerFactory.init(pemTrustSet.trustStore());
 
                 SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(null, trustManagerFactory.getTrustManagers(), null);

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -268,13 +268,13 @@ public class KafkaAgent {
 
     static SslContextFactory.Server getSSLContextFactory(Secret caCertSecret, Secret nodeCertSecret) throws GeneralSecurityException, IOException {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-        sslContextFactory.setTrustStore(KafkaAgentUtils.jksTrustStore(caCertSecret));
+        sslContextFactory.setTrustStore(KafkaAgentUtils.trustStore(caCertSecret));
 
         byte[] random = new byte[24];
         RANDOM.nextBytes(random);
         String password = Base64.getUrlEncoder().withoutPadding().encodeToString(random).substring(0, 32);
 
-        sslContextFactory.setKeyStore(KafkaAgentUtils.jksKeyStore(nodeCertSecret, password.toCharArray()));
+        sslContextFactory.setKeyStore(KafkaAgentUtils.keyStore(nodeCertSecret, password.toCharArray()));
         sslContextFactory.setKeyStorePassword(password);
         sslContextFactory.setNeedClientAuth(true);
         return  sslContextFactory;

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgentUtils.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgentUtils.java
@@ -35,13 +35,13 @@ public class KafkaAgentUtils {
      * throws an exception if it is not.
      *
      * @param secret Secret containing the TrustStore certificates
-     * @return TrustStore file in JKS format
+     * @return In-memory TrustStore using the JVM's default keystore type
      * @throws GeneralSecurityException if something goes wrong when creating the truststore
      * @throws IOException if there is an I/O or format problem with the data used to load the truststore.
      * This is not expected as the truststore is loaded with null parameter.
      */
-    static KeyStore jksTrustStore(Secret secret) throws GeneralSecurityException, IOException {
-        KeyStore trustStore = KeyStore.getInstance("JKS");
+    static KeyStore trustStore(Secret secret) throws GeneralSecurityException, IOException {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
         trustStore.load(null);
         int aliasIndex = 0;
         for (X509Certificate certificate : asX509Certificates(extractCerts(secret), secret.getMetadata().getName(), secret.getMetadata().getNamespace()).values()) {
@@ -56,11 +56,11 @@ public class KafkaAgentUtils {
      *
      * @param secret Secret containing private key and certificate
      *
-     * @return KeyStore file in JKS format
+     * @return In-memory KeyStore using the JVM's default keystore type
      * @throws GeneralSecurityException if something goes wrong when creating the truststore
      * @throws IOException if there is an I/O or format problem with the data used to load the truststore.
      */
-    static KeyStore jksKeyStore(Secret secret, char[] password) throws GeneralSecurityException, IOException {
+    static KeyStore keyStore(Secret secret, char[] password) throws GeneralSecurityException, IOException {
         String secretName = secret.getMetadata().getName();
         String strippedPrivateKey = new String(decodeBase64FieldFromSecret(secret, secretName + ".key"), StandardCharsets.US_ASCII)
                 .replace("-----BEGIN PRIVATE KEY-----", "")
@@ -72,7 +72,7 @@ public class KafkaAgentUtils {
         final PrivateKey key = keyFactory.generatePrivate(keySpec);
 
         X509Certificate certificateChain = x509Certificate(decodeBase64FieldFromSecret(secret, secretName + ".crt"));
-        KeyStore nodeKeyStore = KeyStore.getInstance("JKS");
+        KeyStore nodeKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         nodeKeyStore.load(null);
         nodeKeyStore.setKeyEntry(secret.getMetadata().getName(), key, password, new Certificate[]{certificateChain});
         return nodeKeyStore;

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -96,13 +96,13 @@ public class KafkaAgentTest {
 
     private SSLContext getClientSSLContext(Secret caCertSecret, Secret nodeCertSecret) throws GeneralSecurityException, IOException {
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        tmf.init(KafkaAgentUtils.jksTrustStore(caCertSecret));
+        tmf.init(KafkaAgentUtils.trustStore(caCertSecret));
 
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         byte[] random = new byte[24];
         RANDOM.nextBytes(random);
         String password = Base64.getUrlEncoder().withoutPadding().encodeToString(random).substring(0, 32);
-        kmf.init(KafkaAgentUtils.jksKeyStore(nodeCertSecret, password.toCharArray()), password.toCharArray());
+        kmf.init(KafkaAgentUtils.keyStore(nodeCertSecret, password.toCharArray()), password.toCharArray());
 
         SSLContext sslContext = SSLContext.getInstance("TLS");
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), RANDOM);

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/PemAuthIdentity.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/PemAuthIdentity.java
@@ -127,11 +127,11 @@ public class PemAuthIdentity {
      *
      * @param password to use to secure the KeyStore
      *
-     * @return KeyStore file in JKS format
+     * @return In-memory KeyStore using the JVM's default keystore type
      * @throws GeneralSecurityException if something goes wrong when creating the truststore
      * @throws IOException if there is an I/O or format problem with the data used to load the truststore.
      */
-    public KeyStore jksKeyStore(char[] password) throws GeneralSecurityException, IOException {
+    public KeyStore keyStore(char[] password) throws GeneralSecurityException, IOException {
         String strippedPrivateKey = privateKeyAsPem()
                 .replace("-----BEGIN PRIVATE KEY-----", "")
                 .replaceAll(System.lineSeparator(), "")
@@ -141,7 +141,7 @@ public class PemAuthIdentity {
         final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         final PrivateKey key = keyFactory.generatePrivate(keySpec);
 
-        KeyStore coKeyStore = KeyStore.getInstance("JKS");
+        KeyStore coKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         coKeyStore.load(null);
         coKeyStore.setKeyEntry("cluster-operator", key, password, new Certificate[]{certificateChain()});
         return coKeyStore;

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/PemTrustSet.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/PemTrustSet.java
@@ -61,15 +61,15 @@ public class PemTrustSet {
      * TrustStore to use for TLS connections. This also validates each one is a valid certificate and
      * throws an exception if it is not.
      *
-     * @return  TrustStore file in JKS format
+     * @return  In-memory TrustStore using the JVM's default keystore type
      *
      * @throws GeneralSecurityException     If something goes wrong when creating the truststore
      *
      * @throws IOException  If there is an I/O or format problem with the data used to load the truststore.
      *                      This is not expected as the truststore is loaded with null parameter.
      */
-    public KeyStore jksTrustStore() throws GeneralSecurityException, IOException {
-        KeyStore trustStore = KeyStore.getInstance("JKS");
+    public KeyStore trustStore() throws GeneralSecurityException, IOException {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
         trustStore.load(null);
         int aliasIndex = 0;
         for (X509Certificate certificate : asX509Certificates()) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/auth/PemAuthIdentityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/auth/PemAuthIdentityTest.java
@@ -60,7 +60,7 @@ public class PemAuthIdentityTest {
                         "cluster-operator.password", "bm90YXBhc3N3b3Jk")) //notapassword
                 .build();
         PemAuthIdentity pemAuthIdentity = PemAuthIdentity.clusterOperator(secretWithBadCertificate);
-        Exception e = assertThrows(RuntimeException.class, () -> pemAuthIdentity.jksKeyStore(new char[]{}));
+        Exception e = assertThrows(RuntimeException.class, () -> pemAuthIdentity.keyStore(new char[]{}));
         assertThat(e.getMessage(), is("Bad/corrupt certificate found in data.cluster-operator.crt of Secret testcluster-cluster-operator-certs in namespace testns"));
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/auth/PemTrustSetTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/auth/PemTrustSetTest.java
@@ -34,7 +34,7 @@ public class PemTrustSetTest {
                 .withData(Map.of("ca.crt", "notacert"))
                 .build();
         PemTrustSet pemTrustSet = new PemTrustSet(secretWithBadCertificate);
-        Exception e = assertThrows(RuntimeException.class, pemTrustSet::jksTrustStore);
+        Exception e = assertThrows(RuntimeException.class, pemTrustSet::trustStore);
         assertThat(e.getMessage(), is("Bad/corrupt certificate found in data.ca.crt of Secret testcluster-cluster-operator-certs in namespace testns"));
     }
 
@@ -149,10 +149,10 @@ public class PemTrustSetTest {
 
         PemTrustSet pemTrustSet = new PemTrustSet(secretWithCAChain);
 
-        // Test JKS conversion
-        KeyStore jks = pemTrustSet.jksTrustStore();
-        assertThat(jks.size(), is(1));
-        X509Certificate cert = (X509Certificate) jks.getCertificate(jks.aliases().nextElement());
+        // Test KeyStore conversion
+        KeyStore trustStore = pemTrustSet.trustStore();
+        assertThat(trustStore.size(), is(1));
+        X509Certificate cert = (X509Certificate) trustStore.getCertificate(trustStore.aliases().nextElement());
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=ClusterCA,O=Strimzi\\, Inc.,L=Prague,C=CZ"));
 
         // Test PEM conversion


### PR DESCRIPTION
### Type of change

_Select the type of your PR_
- Refactoring

### Description

In-memory keystores used for TrustManagerFactory/KeyManagerFactory do not need a specific type. Using the JVM's default allows FIPS-configured JVMs to use their preferred keystore type (e.g. BCFKS) instead of failing on JKS.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

