### PR TITLE
[ST] CustomCaST: use controller pod snapshot when waiting for controller rolling update

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -197,7 +197,7 @@ public class CustomCaST extends AbstractST {
         // generate new server certificates signed by the new CA key.
 
         // Kafka has to roll
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getControllerSelector(), 3, brokerPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getControllerSelector(), 3, controllerPods);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), 3, brokerPods);
 
         // EO must not roll


### PR DESCRIPTION
Use controllerPods instead of brokerPods when waiting for the controller component to roll after CA renewal. Fixes #12489.

### Type of change

_Select the type of your PR_

- Bugfix

### Description

In CustomCaST, after CA renewal the test waits for Kafka controller and broker pods to roll. The wait for the controller component was using the broker pod snapshot (brokerPods) instead of the controller snapshot (controllerPods).

waitTillComponentHasRolledAndPodsReady needs the snapshot of the same component it is waiting for so it can detect when those pods have been replaced. Using brokerPods for the controller wait could cause the test to pass before controller pods had actually rolled.

This change uses controllerPods when waiting for the controller selector and keeps brokerPods for the broker selector.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

