### PR TITLE
Use Kafka's Admin instead of AdminClient

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -52,7 +52,6 @@ import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
 import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
@@ -158,7 +157,7 @@ public class ResourceUtils {
     }
 
     public static Admin adminClient()   {
-        Admin mock = mock(AdminClient.class);
+        Admin mock = mock(Admin.class);
         DescribeClusterResult dcr;
         try {
             Constructor<DescribeClusterResult> declaredConstructor = DescribeClusterResult.class.getDeclaredConstructor(KafkaFuture.class, KafkaFuture.class, KafkaFuture.class, KafkaFuture.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.cluster.operator.resource;
 
 import io.strimzi.operator.common.Reconciliation;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
@@ -245,7 +244,7 @@ public class KafkaAvailabilityTest {
         }
 
         Admin ac() {
-            Admin ac = mock(AdminClient.class);
+            Admin ac = mock(Admin.class);
 
             ListTopicsResult ltr = mockListTopics();
             when(ac.listTopics(any())).thenReturn(ltr);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -21,7 +21,6 @@ import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeMetadataQuorumResult;
 import org.apache.kafka.clients.admin.QuorumInfo;
@@ -936,7 +935,7 @@ public class KafkaRollerTest {
             if (exception != null) {
                 throw new ForceableProblem("An error while try to create the admin client", exception);
             }
-            Admin ac = mock(AdminClient.class, invocation -> {
+            Admin ac = mock(Admin.class, invocation -> {
                 if ("close".equals(invocation.getMethod().getName())) {
                     Admin mock = (Admin) invocation.getMock();
                     unclosedAdminClients.remove(mock);

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.user.operator;
 import io.strimzi.operator.user.ResourceUtils;
 import io.strimzi.operator.user.UserOperatorConfig;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -64,7 +63,7 @@ public class QuotasOperatorTest {
     }
 
     private static Admin mockQuotasForVariousUsers() throws ExecutionException, InterruptedException, TimeoutException  {
-        Admin mockAdminClient = mock(AdminClient.class);
+        Admin mockAdminClient = mock(Admin.class);
 
         // Mock result
         @SuppressWarnings("unchecked")

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialOperatorTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.user.operator;
 import io.strimzi.operator.user.ResourceUtils;
 import io.strimzi.operator.user.UserOperatorConfig;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeUserScramCredentialsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.junit.jupiter.api.Test;
@@ -60,7 +59,7 @@ public class ScramCredentialOperatorTest {
     }
 
     private static Admin mockCredentialsForVariousUsers() throws ExecutionException, InterruptedException, TimeoutException  {
-        Admin mockAdminClient = mock(AdminClient.class);
+        Admin mockAdminClient = mock(Admin.class);
 
         // Mock result
         @SuppressWarnings("unchecked")

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -15,7 +15,6 @@ import io.strimzi.operator.user.model.acl.SimpleAclRule;
 import io.strimzi.operator.user.model.acl.SimpleAclRuleResource;
 import io.strimzi.operator.user.model.acl.SimpleAclRuleResourceType;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateAclsResult;
 import org.apache.kafka.clients.admin.DeleteAclsResult;
 import org.apache.kafka.clients.admin.DescribeAclsResult;
@@ -109,7 +108,7 @@ public class SimpleAclOperatorTest {
 
     @Test
     public void testReconcileInternalCreateAddsAclsToAuthorizer() throws ExecutionException, InterruptedException {
-        Admin mockAdminClient = mock(AdminClient.class);
+        Admin mockAdminClient = mock(Admin.class);
 
         ResourcePattern resource1 = new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL);
         ResourcePattern resource2 = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
@@ -159,7 +158,7 @@ public class SimpleAclOperatorTest {
 
     @Test
     public void testReconcileInternalUpdateCreatesNewAclsAndDeletesOldAcls() throws ExecutionException, InterruptedException {
-        Admin mockAdminClient = mock(AdminClient.class);
+        Admin mockAdminClient = mock(Admin.class);
 
         ResourcePattern resource1 = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
         ResourcePattern resource2 = new ResourcePattern(ResourceType.TOPIC, "my-topic2", PatternType.LITERAL);
@@ -214,7 +213,7 @@ public class SimpleAclOperatorTest {
 
     @Test
     public void testReconcileInternalDelete() throws ExecutionException, InterruptedException {
-        Admin mockAdminClient = mock(AdminClient.class);
+        Admin mockAdminClient = mock(Admin.class);
 
         ResourcePattern resource = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
 
@@ -278,7 +277,7 @@ public class SimpleAclOperatorTest {
     }
 
     private static Admin mockAclsForVariousUsers() throws ExecutionException, InterruptedException, TimeoutException  {
-        Admin mockAdminClient = mock(AdminClient.class);
+        Admin mockAdminClient = mock(Admin.class);
 
         ResourcePattern res1 = new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL);
         ResourcePattern res2 = new ResourcePattern(ResourceType.GROUP, "my-group", PatternType.LITERAL);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

As per the [AdminClient](https://kafka.apache.org/42/javadoc/org/apache/kafka/clients/admin/AdminClient.html) javadoc:

> Client code should use the newer Admin interface in preference to this class.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

