### PR TITLE
Allow upgrades from unknown Kafka versions

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -145,10 +145,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             }
 
             if (result == null) {
-                throw new KafkaUpgradeException(String.format(
-                        "Unsupported Kafka.spec.kafka.version: %s. " +
-                                "Supported versions are: %s",
-                        version, map.keySet()));
+                throw new KafkaUpgradeException(String.format("Unknown Kafka.spec.kafka.version: %s. Known versions are: %s", version, map.keySet()));
             }
 
             return result;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
@@ -154,7 +154,14 @@ public class KRaftVersionChangeCreator {
             versionTo = versionFromCr;
         } else {
             // Highest Kafka version used by the brokers is equal or lower than desired => suspected upgrade
-            versionFrom = versions.version(lowestKafkaVersion);
+            try {
+                versionFrom = versions.version(lowestKafkaVersion);
+            } catch (KafkaUpgradeException exception) {
+                // From version is unknown but we try to handle it
+                LOGGER.warnCr(reconciliation, "Upgrading from unknown Kafka version {}", lowestKafkaVersion);
+                versionFrom = new KafkaVersion(lowestKafkaVersion, currentMetadataVersion, false, false, null);
+            }
+
             versionTo = versionFromCr;
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -44,7 +44,8 @@ public class KafkaVersionTestUtils {
     public static final String DEFAULT_KAFKA_IMAGE = LATEST_KAFKA_IMAGE;
     public static final String DEFAULT_KAFKA_CONNECT_IMAGE = LATEST_KAFKA_CONNECT_IMAGE;
     
-    public static final String UNKNOWN_KAFKA_VERSION = "99.0.0";
+    public static final String HIGH_UNKNOWN_KAFKA_VERSION = "99.0.0";
+    public static final String LOW_UNKNOWN_KAFKA_VERSION = "3.99.0";
 
     public static final KafkaVersionChange DEFAULT_KRAFT_VERSION_CHANGE = new KafkaVersionChange(getKafkaVersionLookup().defaultVersion(), getKafkaVersionLookup().defaultVersion(), null, null, getKafkaVersionLookup().defaultVersion().metadataVersion());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -444,7 +445,7 @@ public class KRaftVersionChangeCreatorTest {
     
     @Test
     public void testDowngradeFromUnknownVersion(VertxTestContext context) {
-        String unknownVersion = KafkaVersionTestUtils.UNKNOWN_KAFKA_VERSION;
+        String unknownVersion = KafkaVersionTestUtils.HIGH_UNKNOWN_KAFKA_VERSION;
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(unknownVersion))
@@ -458,6 +459,29 @@ public class KRaftVersionChangeCreatorTest {
 
             async.flag();
         })));
+    }
+
+    @Test
+    public void testUpgradeFromUnknownVersion(VertxTestContext context) {
+        KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
+                mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), "3.9-IV99"),
+                mockRos(mockUniformPods(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION))
+        );
+
+        Checkpoint async = context.checkpoint();
+        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
+            assertThat(c.from().version(), is(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION));
+            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)));
+            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()));
+
+            async.flag();
+        })));
+    }
+
+    @Test
+    public void testStickToUnknownVersion() {
+        KafkaVersion.UnsupportedKafkaVersionException kue = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> mockVersionChangeCreator(mockKafka(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION, "3.9-IV99", "3.9-IV99"), mockRos(mockUniformPods(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION))));
+        assertThat(kue.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 3.99.0."));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
@@ -594,7 +594,7 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
                 })))
                 .compose(i -> {
                     // Update annotations to higher that latest known version
-                    updateVersionsInStrimziPodSet(KafkaVersionTestUtils.UNKNOWN_KAFKA_VERSION);
+                    updateVersionsInStrimziPodSet(KafkaVersionTestUtils.HIGH_UNKNOWN_KAFKA_VERSION);
                     
                     // Downgrade Kafka
                     Kafka updatedKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
@@ -607,6 +607,41 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
                 .onComplete(context.succeeding(i -> context.verify(() -> {
                     assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_IMAGE);
+                    assertMetadataVersion(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+
+                    reconciliation.flag();
+                })));
+    }
+
+    // Tests that upgrade succeeds from a Kafka version that is higher than the latest known version
+    @Test
+    public void testUpgradeFromUnknownKafkaVersion(VertxTestContext context)  {
+        // Can't deploy higher version than latest, so first deploy latest and then update annotations to make it look like a higher version
+        Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+        Crds.kafkaOperation(client).inNamespace(namespace).resource(initialKafka).create();
+
+        Checkpoint reconciliation = context.checkpoint();
+        initialize(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+                    assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_IMAGE);
+                    assertMetadataVersion(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+                })))
+                .compose(i -> {
+                    // Update annotations to an old unknown version
+                    updateVersionsInStrimziPodSet(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION);
+
+                    // Upgrade Kafka
+                    Kafka updatedKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
+                            KafkaVersionTestUtils.LATEST_METADATA_VERSION
+                    );
+                    Crds.kafkaOperation(client).inNamespace(namespace).resource(updatedKafka).update();
+                    return Future.succeededFuture();
+                })
+                .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
+                .onComplete(context.succeeding(i -> context.verify(() -> {
+                    assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+                    assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
                     assertMetadataVersion(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
 
                     reconciliation.flag();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In #10929, we introduced the option to downgrade from unknown versions. This PR adds similar support to upgrade from unknown versions as well. This was the problem in the recent 0.45.2 release that added support for Kafka 3.9.2, which is not known to Strimzi 0.46-0.51. While fixing it now will not really help deal with 0.45.2, because upgrade to Strimzi 1.0.0 would not be possible due to the move to `v1` API, we will be at least ready and prepared should it happen again in the future.

It also fixes the exception that mixes up unsuported and unknown Kafka versions (although not it should be mostly used only internally within Strimzi and not really exposed to the users as much as it was before this fix).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md