### PR TITLE
Move remaining modules to Java 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Major changes, deprecations, and removals
 
+* The `api`, `test`, `crd-annotations`, and `crd-generator` modules now use Java 21 as their Java language level.
+  If you use one of these modules as a dependency in your Java project, you will need to upgrade to Java 21 as well.
 * Open Policy Agent (OPA) authorizer plugin is not bundled as part of the Strimzi Container images anymore.
   If you want to continue use the OPA Authorizer, you have to add it as a custom plugin by building a custom Kafka container image or using additional volumes.
   Once added, you can continue to use OPA using the `type: custom` authorization.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,8 +18,6 @@
     </licenses>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
     </properties>

--- a/crd-annotations/pom.xml
+++ b/crd-annotations/pom.xml
@@ -12,8 +12,6 @@
     <artifactId>crd-annotations</artifactId>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
     </properties>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -19,8 +19,6 @@
     </licenses>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
     </properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -12,8 +12,6 @@
     <artifactId>test</artifactId>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
     </properties>


### PR DESCRIPTION
### Type of change

- Task

### Description

As approved in [SP-126](https://github.com/strimzi/proposals/blob/main/126-move-strimzi-operators-to-java-21.md), the remaining Java modules should now move to use Java 21 as well. This includes the `api`, `test`, `crd-annotations`, and `crd-generator`.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md