### PR TITLE
Do not use @main for GitHub actions instead use local/freezed version

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Determine checkout ref
         id: determine_ref
         uses: strimzi/github-actions/.github/actions/utils/determine-ref@v1
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.determine_ref.outputs.ref }}
+
       - name: Parse Comment
         id: parse
         uses: ./.github/actions/systemtests/parse-comment


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR basically unblock STs pipelines once https://github.com/strimzi/strimzi-kafka-operator/pull/12464 will be merged. As it removes couple of actions from main branch, STs workflows won't be able to find them. Instead of using `@main` wenow uses `@v1` for those that are available in our shared repo and `local` for `parse-param`.  

This problem and fix affects only release branches and because we will probably not do new releases for `0.49` and `0.50`, we should be fine to have it only in `0.51.x`

### Checklist

- [x] Make sure all tests pass

