### PR TITLE
feat(examples,metrics,kube-state-metrics): extend configuration for W…

### DIFF
--- a/packaging/examples/metrics/kube-state-metrics/configmap.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/configmap.yaml
@@ -23,6 +23,7 @@ data:
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
                 deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 partitions: [ spec, partitions ]
                 replicas: [ spec, replicas ]
@@ -45,6 +46,7 @@ data:
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
                 deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 secret: [ status, secret ]
                 generation: [ status, observedGeneration ]
@@ -65,6 +67,7 @@ data:
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
                 deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 kafka_version: [ status, kafkaVersion ]
                 kafka_metadata_version: [ status, kafkaMetadataVersion ]
@@ -88,6 +91,7 @@ data:
                 exported_namespace: [ metadata, namespace ]
                 # KafkaNodePool is not having a ready status as this is implemented via Kafka resource
                 # ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
                 deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 node_ids: [ status, nodeIds ]
                 roles: [ status, roles ]
@@ -130,9 +134,10 @@ data:
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 proposal_ready: [ status, conditions, "[type=ProposalReady]", status ]
                 rebalancing: [ status, conditions, "[type=Rebalancing]", status ]
-                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 template: [ metadata, annotations, "strimzi.io/rebalance-template" ]
         - groupVersionKind:
             group: kafka.strimzi.io
@@ -149,8 +154,9 @@ data:
                     name: [ metadata, name ]
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
-                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 generation: [ status, observedGeneration ]
                 connectorPluginsClass: [ status, connectorPlugins, class ]
                 connectorPluginsType: [ status, connectorPlugins, type ]
@@ -172,8 +178,9 @@ data:
                     name: [ metadata, name ]
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
-                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 generation: [ status, observedGeneration ]
                 autoRestartCount: [ status, autoRestart, count ]
                 autoRestartConnectorName: [ status, autoRestart, connectorName ]
@@ -194,8 +201,9 @@ data:
                     name: [ metadata, name ]
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
-                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 generation: [ status, observedGeneration ]
                 autoRestartCount: [ status, autoRestartStatuses, count ]
                 autoRestartConnectorName: [ status, autoRestartStatuses, connectorName ]
@@ -220,5 +228,6 @@ data:
               labelsFromPath:
                 exported_namespace: [ metadata, namespace ]
                 ready: [ status, conditions, "[type=Ready]", status ]
+                warnings: [ status, conditions, "[type=Warning]", status ]
                 deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
                 generation: [ status, observedGeneration ]

--- a/packaging/examples/metrics/kube-state-metrics/prometheus-rules.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/prometheus-rules.yaml
@@ -14,6 +14,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaTopic {{ $labels.topicName }} is not ready"
+        - alert: KafkaTopicWarnings
+          expr: strimzi_kafka_topic_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaTopic {{ $labels.topicName }} has warnings for the current configuration"
         - alert: KafkaTopicDeprecated
           expr: strimzi_kafka_topic_resource_info{deprecated="Warning"}
           for: 15m
@@ -28,6 +35,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaUser {{ $labels.username }} is not ready"
+        - alert: KafkaUserWarnings
+          expr: strimzi_kafka_user_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaUser {{ $labels.username }} has warnings for the current configuration"
         - alert: KafkaUserDeprecated
           expr: strimzi_kafka_user_resource_info{deprecated="Warning"}
           for: 15m
@@ -42,6 +56,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi Kafka {{ $labels.name }} using {{ $labels.kafka_version }} is not ready"
+        - alert: KafkaWarnings
+          expr: strimzi_kafka_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi Kafka {{ $labels.name }} has warnings for the current configuration"
         - alert: KafkaDeprecated
           expr: strimzi_kafka_resource_info{deprecated="Warning"}
           for: 15m
@@ -50,6 +71,13 @@ spec:
           annotations:
             message: "Strimzi Kafka {{ $labels.name }} contains a deprecated configuration"
         # KafkaNodePool is not having a ready status as this is implemented via Kafka resource
+        - alert: KafkaNodePoolWarnings
+          expr: strimzi_kafka_node_pool_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaNodePool {{ $labels.name }} has warnings for the current configuration"
         - alert: KafkaNodePoolDeprecated
           expr: strimzi_kafka_node_pool_resource_info{deprecated="Warning"}
           for: 15m
@@ -65,6 +93,20 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaRebalance {{ $labels.name }} is not ready"
+        - alert: KafkaRebalanceWarnings
+          expr: strimzi_kafka_rebalance_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaRebalance {{ $labels.name }} has warnings for the current configuration"
+        - alert: KafkaRebalanceDeprecated
+          expr: strimzi_kafka_rebalance_resource_info{deprecated="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaRebalance {{ $labels.name }} contains a deprecated configuration"
         - alert: KafkaRebalanceProposalPending
           expr: strimzi_kafka_rebalance_resource_info{ready="True",template!="true",proposal_ready="True"}
           for: 1h
@@ -79,13 +121,6 @@ spec:
             severity: info
           annotations:
             message: "Strimzi KafkaRebalance {{ $labels.name }} is taking longer than 1h."
-        - alert: KafkaRebalanceDeprecated
-          expr: strimzi_kafka_rebalance_resource_info{deprecated="Warning"}
-          for: 15m
-          labels:
-            severity: warning
-          annotations:
-            message: "Strimzi KafkaRebalance {{ $labels.name }} contains a deprecated configuration"
         - alert: KafkaConnectNotReady
           expr: strimzi_kafka_connect_resource_info{ready!="True"}
           for: 15m
@@ -93,6 +128,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaConnect {{ $labels.name }} is not ready"
+        - alert: KafkaConnectWarnings
+          expr: strimzi_kafka_connect_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaConnect {{ $labels.name }} has warnings for the current configuration"
         - alert: KafkaConnectDeprecated
           expr: strimzi_kafka_connect_resource_info{deprecated="Warning"}
           for: 15m
@@ -107,6 +149,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaConnector {{ $labels.name }} is not ready"
+        - alert: KafkaConnectorWarnings
+          expr: strimzi_kafka_connector_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaConnector {{ $labels.name }} has warnings for the current configuration"
         - alert: KafkaConnectorDeprecated
           expr: strimzi_kafka_connector_resource_info{deprecated="Warning"}
           for: 15m
@@ -121,6 +170,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaMirrorMaker2 {{ $labels.name }} is not ready"
+        - alert: KafkaMirrorMaker2Warnings
+          expr: strimzi_kafka_mm2_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaMirrorMaker2 {{ $labels.name }} has warnings for the current configuration"
         - alert: KafkaMirrorMaker2Deprecated
           expr: strimzi_kafka_mm2_resource_info{deprecated="Warning"}
           for: 15m
@@ -135,6 +191,13 @@ spec:
             severity: warning
           annotations:
             message: "Strimzi KafkaAccess {{ $labels.name }} is not ready"
+        - alert: KafkaAccessWarnings
+          expr: strimzi_kafka_access_resource_info{warnings="Warning"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Strimzi KafkaAccess {{ $labels.name }} has warnings for the current configuration"
         - alert: KafkaAccessDeprecated
           expr: strimzi_kafka_access_resource_info{deprecated="Warning"}
           for: 15m


### PR DESCRIPTION
…arnings

Closes https://github.com/strimzi/strimzi-kafka-operator/issues/12543

### Type of change

_Select the type of your PR_

- Enhancement

### Description

This PR extends the current kube-state-metrics examples for a `warning` property. Additionally, the types `ready`, `warnings` and `deprecated` are now sorted in this order. Same for the corresponding `PrometheusRule` resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

