### PR TITLE
[ST] Fix FIPS check in case that ConfigMap is missing

### DIFF
--- a/systemtest/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/systemtest/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -105,6 +105,9 @@ public class KubeClusterResource {
 
             if (configMap != null) {
                 return configMap.getData().get("install-config").contains("fips: true");
+            } else {
+                LOGGER.warn("No 'cluster-config-v1' ConfigMap found in 'kube-system' Namespace, going to assume it's not FIPS enabled cluster");
+                return false;
             }
         }
         return false;


### PR DESCRIPTION
### Type of change

- Test fix

### Description

This small PR fixes the check if the cluster where we are running our STs is FIPS - in case that the ConfigMap is missing, the check will throw NPE.
The fix should ensure that the `false` is returned in case that the ConfigMap is missing, otherwise the data are taking from CM.

### Checklist

- [x] Make sure all tests pass
