### PR TITLE
Fix version of Syft that we are adding to GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Install Syft
         uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
         with:
-          version: "v1.20.0"
+          version: "1.20.0"
 
       - name: Push containers using push-containers action
         uses: strimzi/github-actions/.github/actions/build/push-containers@main

--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Syft
         uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
         with:
-          version: "v1.20.0"
+          version: "1.20.0"
 
       - name: Push containers using push-containers action
         uses: strimzi/github-actions/.github/actions/build/push-containers@main
@@ -164,7 +164,7 @@ jobs:
       - name: Install Syft
         uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
         with:
-          version: "v1.20.0"
+          version: "1.20.0"
 
       - name: Push containers using push-containers action
         uses: strimzi/github-actions/.github/actions/build/push-containers@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Install Syft
         uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
         with:
-          version: "v1.20.0"
+          version: "1.20.0"
 
       - name: Push containers using push-containers action
         uses: strimzi/github-actions/.github/actions/build/push-containers@main
@@ -181,7 +181,7 @@ jobs:
       - name: Install Syft
         uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
         with:
-          version: "v1.20.0"
+          version: "1.20.0"
 
       - name: Push containers using push-containers action
         uses: strimzi/github-actions/.github/actions/build/push-containers@main


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes our push containers action, which is failing on installation of Syft - because of double `v` in the URL.
That's because we should just add the version without the `v` in the parameter.

### Checklist

- [x] Make sure all tests pass
