### PR TITLE
Increase timeout compare-merge-commit to 2 hours

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -126,7 +126,7 @@ jobs:
         uses: ./.github/actions/utils/compare-merge-commit
         with:
           waitForBuild: "true"
-          maxWaitMinutes: "120"
+          maxWaitMinutes: "80"
           mergeCommitSha: ${{ steps.get-merge-sha.outputs.sha }}
           commitSha: ${{ needs.parse-params.outputs.sha }}
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Documentation

### Description

This PR increases a timeout of our `compare-merge-commit` action which ensures that (TRIGGER) of system tests is run based on the results from the build (if passes then ST workflow is executed) otherwise it is not.

But when our build takes more than 1h in some cases it might happen that if you COMMIT and then trigger system tests it would also create this `check-build` (currently 1h timeout) so if build time is more than 1h (which now would happen 100% times as we have 4 Kafka versions) then it would always timeout and no STs would be executed even build will pass.

The issue observed here [1] where build took 1h 36m. 

[1] - https://github.com/strimzi/strimzi-kafka-operator/actions/runs/23428233427

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation