### PR TITLE
[ST] Fix root logger in Bridge configuration

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaBridgeTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaBridgeTemplates.java
@@ -90,7 +90,7 @@ public class KafkaBridgeTemplates {
                 .withBootstrapServers(bootstrap)
                 .withReplicas(kafkaBridgeReplicas)
                 .withNewInlineLogging()
-                    .addToLoggers("bridge.root.logger", "DEBUG")
+                    .addToLoggers("rootLogger.level", "DEBUG")
                 .endInlineLogging()
                 .withNewHttp()
                     .withPort(DEFAULT_HTTP_PORT)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This small PR fixes completely wrong logger which we have there for Bridge since 2020 - which I think was completely wrong even in that time. Until now we didn't have any issue - in logging related tests we are configuring the right logger, however regularly there is just INFO being printed out. 

### Checklist

- [x] Make sure all tests pass