### PR TITLE
helm: add app.kubernetes.io/* recommended labels to all resources

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
@@ -10,4 +10,5 @@ metadata:
     component: service-account
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 {{- end -}}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -9,6 +9,7 @@ metadata:
     component: role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 # Resources in this role are used by the operator based on an operand being deployed in some namespace. When needed, you
 # can deploy the operator as a cluster-wide operator. But grant the rights listed in this role only on the namespaces

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -23,6 +23,7 @@ metadata:
     component: role-binding
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
+    {{- include "strimzi.labels" $ | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ $.Values.serviceAccount }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -9,6 +9,7 @@ metadata:
     component: role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - "rbac.authorization.k8s.io"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
@@ -9,6 +9,7 @@ metadata:
     component: role-binding
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -9,6 +9,7 @@ metadata:
     component: role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-RoleBinding-strimzi-cluster-operator.yaml
@@ -10,6 +10,7 @@ metadata:
     component: role-binding
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -9,6 +9,7 @@ metadata:
     component: role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 # Resources in this role are being watched by the operator. When operator is deployed as cluster-wide, these permissions
 # need to be granted to the operator on a cluster wide level as well, even if the operands will be deployed only in

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
@@ -23,6 +23,7 @@ metadata:
     component: role-binding
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
+    {{- include "strimzi.labels" $ | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ $.Values.serviceAccount }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -9,6 +9,7 @@ metadata:
     component: broker-role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
@@ -9,6 +9,7 @@ metadata:
     component: broker-role-binding
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 # The Kafka broker cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Kafka brokers.
 # This must be done to avoid escalating privileges which would be blocked by Kubernetes.
 subjects:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -9,6 +9,7 @@ metadata:
     component: entity-operator-role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - "kafka.strimzi.io"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -19,6 +19,7 @@ metadata:
     component: entity-operator-role-binding
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
+    {{- include "strimzi.labels" $ | nindent 4 }}
 # The Entity Operator cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Entity Operator.
 # This must be done to avoid escalating privileges which would be blocked by Kubernetes.
 subjects:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRole-strimzi-kafka-client.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRole-strimzi-kafka-client.yaml
@@ -9,6 +9,7 @@ metadata:
     component: client-role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
@@ -9,6 +9,7 @@ metadata:
     component: client-role-binding
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 # The Kafka clients cluster role must be bound to the cluster operator service account so that it can delegate the
 # cluster role to the Kafka clients using it for consuming from closest replica.
 # This must be done to avoid escalating privileges which would be blocked by Kubernetes.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -9,6 +9,7 @@ metadata:
     component: logging-config-map
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
 data:
   log4j2.properties: |
     {{- if .Values.logConfiguration }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -10,6 +10,7 @@ metadata:
     component: deployment
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
     {{- with .Values.deploymentLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/070-ClusterRole-strimzi-admin.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/070-ClusterRole-strimzi-admin.yaml
@@ -9,6 +9,7 @@ metadata:
     component: entity-operator-role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
     # Add these permissions to the "admin" and "edit" default roles.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/080-ClusterRole-strimzi-view.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/080-ClusterRole-strimzi-view.yaml
@@ -9,6 +9,7 @@ metadata:
     component: entity-operator-role
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "strimzi.labels" . | nindent 4 }}
     # Add these permissions to the "view" default role.
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/090-ConfigMap-strimzi-grafana-dashboards.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/090-ConfigMap-strimzi-grafana-dashboards.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ $.Values.dashboards.namespace | default $.Release.Namespace }}
   labels:
     component: grafana-dashboards
+    {{- include "strimzi.labels" $ | nindent 4 }}
     {{- if $.Values.dashboards.label }}
     {{ $.Values.dashboards.label }}: {{ ternary $.Values.dashboards.labelValue "1" (not (empty $.Values.dashboards.labelValue)) | quote }}
     {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_helpers.tpl
@@ -63,6 +63,18 @@ To use, add the following key/value pairs to the scope:
 {{- end -}}
 
 {{/*
+Standard Kubernetes recommended labels.
+These are added alongside existing labels and never replace them.
+Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+*/}}
+{{- define "strimzi.labels" -}}
+app.kubernetes.io/name: {{ template "strimzi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
  Create a list of comma-separated namespaces the operators should watch.
 */}}
 {{- define "strimzi.watchNamespacesList" -}}


### PR DESCRIPTION
## Problem

The chart uses custom labels (`app`, `chart`, `component`, `release`, `heritage`) but does not emit the Kubernetes [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/). This makes the operator invisible to tooling that filters by `app.kubernetes.io/*` labels — including many Grafana dashboards, GitOps reconciliation summaries, and label-based RBAC policies.

## Changes

Add a `strimzi.labels` helper to `_helpers.tpl` that emits:

```
app.kubernetes.io/name: <chart name>
app.kubernetes.io/instance: <release name>
app.kubernetes.io/version: <app version>
app.kubernetes.io/managed-by: <release service>
```

Include it in all 21 resource templates alongside the existing labels.

## Backwards compatibility

- Existing labels (`app`, `chart`, `component`, `release`, `heritage`) are **preserved unchanged**
- No `matchLabels` selectors are modified — the Deployment selector still uses `name: strimzi-cluster-operator` / `strimzi.io/kind: cluster-operator`
- This is a purely additive change with no impact on existing installations