### PR TITLE
helm: add optional VerticalPodAutoscaler for the operator Deployment

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/057-VerticalPodAutoscaler-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/057-VerticalPodAutoscaler-strimzi-cluster-operator.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: strimzi-cluster-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: vertical-pod-autoscaler
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: strimzi-cluster-operator
+  updatePolicy:
+    updateMode: {{ .Values.verticalPodAutoscaler.updateMode | quote }}
+  resourcePolicy:
+    containerPolicies:
+      - containerName: strimzi-cluster-operator
+        controlledResources:
+          - cpu
+          - memory
+{{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -79,6 +79,14 @@ podDisruptionBudget:
   maxUnavailable:
   unhealthyPodEvictionPolicy: IfHealthyBudget
 
+verticalPodAutoscaler:
+  # If enabled, a VerticalPodAutoscaler resource will be created for the operator Deployment.
+  # Requires the VPA CRDs to be installed on the cluster.
+  enabled: false
+  # VPA update mode: Auto or Recreate restart pods to apply recommendations;
+  # Initial applies recommendations only at pod creation; Off disables updates.
+  updateMode: "Auto"
+
 operatorNetworkPolicy:
   # If enabled, this will generate a networkPolicy for the strimzi-operator.
   # This flag DOES NOT control operator generated networkPolicies!


### PR DESCRIPTION
## Problem

The cluster operator has fixed `resources.requests/limits` in `values.yaml`, but the optimal values vary significantly with the number of Kafka clusters, topics, and users being managed. Without VPA, operators must tune resources manually based on observation, and OOMKill events are common in larger deployments.

## Changes

Add an opt-in `VerticalPodAutoscaler` resource targeting the `strimzi-cluster-operator` Deployment.

- **Disabled by default** (`verticalPodAutoscaler.enabled: false`) — no VPA CRDs are required in environments that don't use VPA
- Configurable `updateMode` (`Auto` | `Recreate` | `Initial` | `Off`)
- Controls both CPU and memory via `controlledResources`

```yaml
verticalPodAutoscaler:
  enabled: true
  updateMode: "Auto"
```

## Backwards compatibility

Disabled by default — no impact on existing installations.