### PR TITLE
Enable dynamic configuration of Metrics Reporter's allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Remove PreferredLeaderElectionGoal from Cruise Control's default.goals list
 * Add `topologySpreadConstraints` support to the Strimzi Helm chart operator Deployment
 * Update HTTP bridge to 1.0.0.
+* Enable configuring `allowList` of Strimzi Metrics Reporter dynamically
 
 ### Major changes, deprecations, and removals
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaConfigurationDiffTest.java
@@ -397,6 +397,15 @@ public class KafkaConfigurationDiffTest {
     }
 
     @Test
+    public void testPrometheusMetricsReporterAllowList() {
+        List<ConfigEntry> ces = singletonList(new ConfigEntry("prometheus.metrics.reporter.allowlist", "kafka_controller.*"));
+        KafkaConfigurationDiff kcd = new KafkaConfigurationDiff(Reconciliation.DUMMY_RECONCILIATION, getCurrentConfiguration(ces),
+            getDesiredConfiguration(ces), kafkaVersion, brokerNodeRef, false, true);
+        assertThat(kcd.getDiffSize(), is(0));
+        assertThat(kcd.canBeUpdatedDynamically(), is(true));
+    }
+
+    @Test
     public void testAreDoublesEqual() {
         assertThat(KafkaConfigurationDiff.areDoublesEqual("test.option", Map.of(), Map.of("test.option", "0.8")), is(false));
         assertThat(KafkaConfigurationDiff.areDoublesEqual("test.option", Map.of("test.option", "0.8"), Map.of()), is(false));

--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -59,6 +59,8 @@ public class KafkaConfigModelGenerator {
     public static void main(String[] args) throws Exception {
         String version = kafkaVersion();
         Map<String, ConfigModel> configs = configs(version);
+        addPrometheusMetricsReporterAllowListConfig(configs);
+
         ObjectMapper mapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
         ConfigModels root = new ConfigModels();
         root.setVersion(version);
@@ -131,6 +133,21 @@ public class KafkaConfigModelGenerator {
             result.put(configName, descriptor);
         }
         return result;
+    }
+
+    /**
+     * Adds `prometheus.metrics.reporter.allowlist` with its configuration to the ConfigModel,
+     * so we are able to update it dynamically in Kafka brokers/controllers.
+     *
+     * @param configs   config models of the Kafka version that should be updated with another config model
+     */
+    private static void addPrometheusMetricsReporterAllowListConfig(Map<String, ConfigModel> configs) {
+        String prometheusMetricAllowListName = "prometheus.metrics.reporter.allowlist";
+        ConfigModel prometheusMetricConfigModel = new ConfigModel();
+        prometheusMetricConfigModel.setScope(Scope.CLUSTER_WIDE);
+        prometheusMetricConfigModel.setType(Type.LIST);
+
+        configs.put(prometheusMetricAllowListName, prometheusMetricConfigModel);
     }
 
     private static Type parseType(String typeStr) {

--- a/development-docs/systemtests/io.strimzi.systemtest.metrics.StrimziMetricsReporterST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.metrics.StrimziMetricsReporterST.md
@@ -25,6 +25,30 @@
 
 <hr style="border:1px solid">
 
+## testDynamicReconfigurationAllowList
+
+**Description:** Test checking that `prometheus.metrics.reporter.allowlist` configuration is dynamically updatable using the .spec.kafka.metricsConfig.allowList.
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Check that `kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not - in already deployed Kafka cluster | `kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not. |
+| 2. | In already deployed Kafka cluster, change the configuration of the allowList to have just `kafka_log.*` metrics allowed. | The configuration of allowList is changed. |
+| 3. | Wait some time to verify that there will be no rolling update because of the change - verification of dynamic reconfiguration. | No Pods were rolled. |
+| 4. | Collect metrics and check that there is no metric like `kafka_server_replicamanager_leadercount` (because of removal of `kafka_server.*` metrics from allowList). | No metric has been found. |
+| 5. | Check that collected metrics contain `kafka_log_log_logstartoffset` metric for the `__cluster_metadata` topic. | Metric is present. |
+| 6. | Change the allowList back to previous state - allowing just `kafka_server.*` | The configuration of allowList is changed. |
+| 7. | Wait some time to verify that there will be no rolling update because of the change - verification of dynamic reconfiguration. | No Pods were rolled. |
+| 8. | Check that `kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not - configuration change was successful | `kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not. |
+
+**Labels:**
+
+* [kafka](labels/kafka.md)
+* [metrics](labels/metrics.md)
+* `dynamic-configuration` (description file doesn't exist)
+
+
 ## testKafkaBridgeMetrics
 
 **Description:** This test case checks several metrics exposed by KafkaBridge.

--- a/development-docs/systemtests/labels/kafka.md
+++ b/development-docs/systemtests/labels/kafka.md
@@ -32,6 +32,7 @@ These tests are crucial to ensure that Kafka clusters can handle production work
 - [testCustomSoloCertificatesForRoute](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testDeployUnsupportedKafka](../io.strimzi.systemtest.kafka.KafkaST.md)
 - [testDynamicConfiguration](../io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfSharedST.md)
+- [testDynamicReconfigurationAllowList](../io.strimzi.systemtest.metrics.StrimziMetricsReporterST.md)
 - [testDynamicallyAndNonDynamicSetConnectLoggingLevels](../io.strimzi.systemtest.log.LoggingChangeST.md)
 - [testDynamicallySetBridgeLoggingLevels](../io.strimzi.systemtest.log.LoggingChangeST.md)
 - [testDynamicallySetClusterOperatorLoggingLevels](../io.strimzi.systemtest.log.LoggingChangeST.md)

--- a/development-docs/systemtests/labels/metrics.md
+++ b/development-docs/systemtests/labels/metrics.md
@@ -11,6 +11,7 @@ Proper verification of metrics is crucial for observability, debugging, and perf
 **Tests:**
 - [testClusterOperatorMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)
 - [testCruiseControlMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)
+- [testDynamicReconfigurationAllowList](../io.strimzi.systemtest.metrics.StrimziMetricsReporterST.md)
 - [testKafkaAndKafkaConnectWithJMX](../io.strimzi.systemtest.metrics.JmxST.md)
 - [testKafkaBridgeMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)
 - [testKafkaConnectAndConnectorMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -557,6 +557,7 @@ The Strimzi Metrics Reporter offers a lightweight solution for exposing Kafka me
 
 To enable Strimzi Metrics Reporter, set the type to `strimziMetricsReporter`.
 The `allowList` configuration is a comma-separated list of regex patterns to filter the metrics that are collected. This defaults to `.*`,  which allows all metrics.
+Changes to this field will not trigger rolling update, the configuration is dynamically updated for Kafka brokers and controllers.
 
 NOTE: Using `strimziMetricsReporter` is only supported in the Kafka brokers and controllers at the moment.
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
@@ -187,7 +187,7 @@ public class RollingUpdateUtils {
         // not need to be final because reference to the array does not get another array assigned
         int[] i = {0};
 
-        LOGGER.debug("Waiting for Pods {}/{} to remain stable for {} second(s)", namespaceName, pods.toString(),
+        LOGGER.info("Waiting for Pods {}/{} to remain stable for {} second(s)", namespaceName, pods.toString(),
             TestConstants.GLOBAL_STABILIZATION_TIME);
 
         TestUtils.waitFor("Pods to remain stable and rolling update not to be triggered", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT,

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -183,12 +183,12 @@ public class MetricsUtils {
         assertThat(String.format("metric '%s' is not present in the list of metrics", metricName), containsMetric, is(true));
     }
 
-    private static List<Double> createPatternAndCollect(BaseMetricsCollector collector, String metric) {
+    public static List<Double> createPatternAndCollect(BaseMetricsCollector collector, String metric) {
         Pattern pattern = Pattern.compile(metric + " ([\\d.^\\n]+)", Pattern.CASE_INSENSITIVE);
         return collector.waitForSpecificMetricAndCollect(pattern);
     }
 
-    private static List<Double> createPatternAndCollectWithoutWait(BaseMetricsCollector collector, String metric) {
+    public static List<Double> createPatternAndCollectWithoutWait(BaseMetricsCollector collector, String metric) {
         Pattern pattern = Pattern.compile(metric + " ([\\d.^\\n]+)", Pattern.CASE_INSENSITIVE);
         return collector.collectSpecificMetric(pattern);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/StrimziMetricsReporterST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/StrimziMetricsReporterST.java
@@ -11,15 +11,18 @@ import io.skodjob.annotations.SuiteDoc;
 import io.skodjob.annotations.TestDoc;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeResources;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
+import io.strimzi.systemtest.labels.LabelSelectors;
 import io.strimzi.systemtest.performance.gather.collectors.BaseMetricsCollector;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -31,12 +34,18 @@ import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NetworkPolicyUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.systemtest.utils.specific.MetricsUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
@@ -51,6 +60,8 @@ import static io.strimzi.systemtest.TestTags.SANITY;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValue;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueHigherThanOrEqualTo;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueNotNull;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(SANITY)
@@ -269,6 +280,70 @@ public class StrimziMetricsReporterST extends AbstractST {
 
         assertMetricValueNotNull(bridgeCollector, "kafka_producer_kafka_metrics_count_count\\{.*}");
         assertMetricValueNotNull(bridgeCollector, "kafka_consumer_consumer_metrics_connection_count\\{.*}");
+    }
+
+    @IsolatedTest
+    @TestDoc(
+        description = @Desc("Test checking that `prometheus.metrics.reporter.allowlist` configuration is dynamically updatable using the .spec.kafka.metricsConfig.allowList."),
+        steps = {
+            @Step(value = "Check that `kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not - in already deployed Kafka cluster", expected = "`kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not."),
+            @Step(value = "In already deployed Kafka cluster, change the configuration of the allowList to have just `kafka_log.*` metrics allowed.", expected = "The configuration of allowList is changed."),
+            @Step(value = "Wait some time to verify that there will be no rolling update because of the change - verification of dynamic reconfiguration.", expected = "No Pods were rolled."),
+            @Step(value = "Collect metrics and check that there is no metric like `kafka_server_replicamanager_leadercount` (because of removal of `kafka_server.*` metrics from allowList).", expected = "No metric has been found."),
+            @Step(value = "Check that collected metrics contain `kafka_log_log_logstartoffset` metric for the `__cluster_metadata` topic.", expected = "Metric is present."),
+            @Step(value = "Change the allowList back to previous state - allowing just `kafka_server.*`", expected = "The configuration of allowList is changed."),
+            @Step(value = "Wait some time to verify that there will be no rolling update because of the change - verification of dynamic reconfiguration.", expected = "No Pods were rolled."),
+            @Step(value = "Check that `kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not - configuration change was successful", expected = "`kafka_server_replicamanager_leadercount` is present and `kafka_log_log_logendoffset` not."),
+        },
+        labels = {
+            @Label(value = TestDocsLabels.KAFKA),
+            @Label(value = TestDocsLabels.METRICS),
+            @Label(value = TestDocsLabels.DYNAMIC_CONFIGURATION)
+        }
+    )
+    void testDynamicReconfigurationAllowList() {
+        LOGGER.info("Checking that `kafka_server_replicamanager_leadercount` metrics contains some value and `kafka_log_log_logendoffset` doesn't exist");
+        // Firstly check that before the change, there is `kafka_server_replicamanager_leadercount` metric present
+        assertMetricValueHigherThanOrEqualTo(kafkaCollector, "kafka_server_replicamanager_leadercount", 1.0);
+        // And check that `kafka_log_log_logendoffset` is not present
+        assertThat(MetricsUtils.createPatternAndCollectWithoutWait(kafkaCollector, "kafka_log_log_logendoffset").isEmpty(), is(true));
+
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), LabelSelectors.allKafkaPodsLabelSelector(testStorage.getClusterName()));
+
+        // change configuration to disable kafka_server.* metrics and add kafka_controller.* metrics
+        LOGGER.info("Change the allowList to allow `kafka_log.*`.");
+        KafkaUtils.replace(testStorage.getNamespaceName(), testStorage.getClusterName(), kafka -> {
+                StrimziMetricsReporter config = (StrimziMetricsReporter) kafka.getSpec().getKafka().getMetricsConfig();
+                config.getValues().setAllowList(List.of("kafka_log.*"));
+
+                kafka.getSpec().getKafka().setMetricsConfig(config);
+            }
+        );
+
+        RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), LabelSelectors.allKafkaPodsLabelSelector(testStorage.getClusterName()), kafkaPods);
+
+        LOGGER.info("Check if Kafka Pods are missing the 'kafka_server_' metrics");
+        kafkaCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
+        assertThat(MetricsUtils.createPatternAndCollectWithoutWait(kafkaCollector, "kafka_server_replicamanager_leadercount").isEmpty(), is(true));
+
+        LOGGER.info("Now check if Kafka Pods contain 'kafka_log.*' metrics");
+        assertMetricValueNotNull(kafkaCollector, "kafka_log_log_logstartoffset\\{partition=\"0\",topic=\"__cluster_metadata\"\\}");
+
+        LOGGER.info("Changing back to previous state - allowing `kafka_server.*` metrics");
+        KafkaUtils.replace(testStorage.getNamespaceName(), testStorage.getClusterName(), kafka -> {
+                StrimziMetricsReporter config = (StrimziMetricsReporter) kafka.getSpec().getKafka().getMetricsConfig();
+                config.getValues().setAllowList(List.of("kafka_server.*"));
+
+                kafka.getSpec().getKafka().setMetricsConfig(config);
+            }
+        );
+
+        RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), LabelSelectors.allKafkaPodsLabelSelector(testStorage.getClusterName()), kafkaPods);
+
+        LOGGER.info("Check if Kafka Pods are not missing the 'kafka_server_' metrics");
+        kafkaCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
+
+        assertMetricValueHigherThanOrEqualTo(kafkaCollector, "kafka_server_replicamanager_leadercount", 1.0);
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds `prometheus.metrics.reporter.allowlist` to the config-models, so we are able to change this configuration dynamically by configuring the `allowList` field inside the Kafka CR.
This configuration is forbidden in case that it is configured inside the `spec.kafka.config`, however we are able to do the dynamic update using the `allowList` - as the code goes through the configuration, checks if the particular config is inside config-model and if yes and it's not `READ_ONLY`, it performs the dynamic update.

So the only thing needed was to add this configuration to the config-models.
I tried also adding "custom-config-model" with special handling (commit https://github.com/strimzi/strimzi-kafka-operator/commit/d2c72f5c1fcdcbd27a7ade12797f841fc046ed35), but FMPOV it was a lot of changes given the same result as updating the config-model-generator

Fixes #12400

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

