### PR TITLE
Add missing container relabeling to kafka resources pod monitor

### DIFF
--- a/packaging/examples/metrics/prometheus-install/pod-monitors/kafka-resources-metrics.yaml
+++ b/packaging/examples/metrics/prometheus-install/pod-monitors/kafka-resources-metrics.yaml
@@ -46,3 +46,9 @@ spec:
       targetLabel: node_ip
       replacement: $1
       action: replace
+    - sourceLabels: [__meta_kubernetes_pod_container_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: container
+      replacement: $1
+      action: replace


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Adds a missing container relabeling to the kafka resources pod monitor, since it's used by the grafana dashboard on the `process_open_fds` query: https://github.com/strimzi/strimzi-kafka-operator/blob/1a0c0e1cba06128b2b3a0f1f6f48eab249b399fe/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json#L1055

### Checklist

- [ ] Update CHANGELOG.md

