### PR TITLE
Fix naming of artifacts for CVE/Release workflows

### DIFF
--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Pull Java artifacts from GHCR
         run: |
-          oras pull ghcr.io/${{ env.REPOSITORY }}/strimzi-binaries:${{ env.TAG }}
+          oras pull ghcr.io/${{ env.REPOSITORY }}/binaries-operators:${{ env.TAG }}
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
           REPOSITORY: "strimzi"
@@ -47,8 +47,8 @@ jobs:
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v5
         with:
-          name: strimzi-binaries.tar
-          path: strimzi-binaries.tar
+          name: binaries-operators.tar
+          path: binaries-operators.tar
 
   # Rebuild containers using artifacts from a previous build
   build-containers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Download strimzi binaries from source build
         uses: actions/download-artifact@v7
         with:
-          name: strimzi-binaries.tar
+          name: binaries-operators.tar
           run-id: ${{ inputs.sourceBuildRunId }}
           github-token: ${{ github.token }}
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Push Java artifacts to GHCR
         run: |
-          oras push ghcr.io/${{ env.REPOSITORY }}/strimzi-binaries:${{ env.TAG }} strimzi-binaries.tar:application/x-tar
+          oras push ghcr.io/${{ env.REPOSITORY }}/binaries-operators:${{ env.TAG }} binaries-operators.tar:application/x-tar
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
           REPOSITORY: "strimzi"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During 1st release of Bridge we found out that we had wrong names for artifacts within CVE and release workflows. This PR fixes it in operators repo.

### Checklist

- [ ] Make sure all tests pass

