### PR TITLE
Fixed Vert.x log verbosity within the default bridge logging configuration

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/KafkaBridgeCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaBridgeCluster.properties
@@ -22,3 +22,7 @@ logger.healthy.name = http.openapi.operation.healthy
 logger.healthy.level = WARN
 logger.ready.name = http.openapi.operation.ready
 logger.ready.level = WARN
+
+# Reduce verbosity of RouterBuilderImpl warnings for unimplemented OpenAPI endpoints because bridge servers share the same OpenAPI contract with different endpoints implemented.
+logger.vertx.name = io.vertx.ext.web.openapi.router.impl.RouterBuilderImpl
+logger.vertx.level = ERROR


### PR DESCRIPTION
With the new HTTP bridge 1.0.0, the internal implementation uses two distinct Vert.x `RouterBuilder` for exposing the two distinct HTTP servers: one for usual Kafka-related operations and the other one for the management.
Because of how the `RouterBuilder` works, it logs warnings about missing handlers because the same OpenAPI specification is used while each router implements just part of it.

```shell
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation healthy - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation metrics - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation ready - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation info - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation createTopic - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation openapi - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation openapiv3 - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation listTopics - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation createConsumer - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation deleteConsumer - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation assign - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation commit - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation seek - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation seekToBeginning - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation seekToEnd - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation poll - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation subscribe - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation listSubscriptions - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation unsubscribe - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation send - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation getTopic - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation listPartitions - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation sendToPartition - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation getPartition - skipping route creation
2026-04-07 08:56:29 WARN  [vert.x-eventloop-thread-0] RouterBuilderImpl:74 - No handlers found for operation getOffsets - skipping route creation
```

It's already addressed in the HTTP bridge repository, within the default log4j2.properties file, by having: 

```shell
# Reduce verbosity of RouterBuilderImpl warnings for unimplemented OpenAPI endpoints because bridge servers share the same OpenAPI contract with different endpoints implemented.
logger.vertx.name = io.vertx.ext.web.openapi.router.impl.RouterBuilderImpl
logger.vertx.level = ERROR
```

This PR fixes the issue within the default logging configuration for the bridge within the cluster operator because otherwise it would print the above bunch of warnings on start up.

