### PR TITLE
Fix missing space in Listener API description

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -97,7 +97,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
             "* `Hostname`\n" +
             "\n" +
             "This property is used to select the preferred address type, which is checked first. " +
-            "If no address is found for this address type, the other types are checked in the default order." +
+            "If no address is found for this address type, the other types are checked in the default order. " +
             "For `nodeport` listeners only.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public NodeAddressType getPreferredNodePortAddressType() {

--- a/api/src/test/resources/crds/v1/040-Crd-kafka.yaml
+++ b/api/src/test/resources/crds/v1/040-Crd-kafka.yaml
@@ -298,7 +298,7 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order.For `nodeport` listeners only.
+                                This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. For `nodeport` listeners only.
                             publishNotReadyAddresses:
                               type: boolean
                               description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -313,7 +313,7 @@ The default is `.cluster.local`, but this is customizable using the environment 
 * `InternalIP`
 * `Hostname`
 
-This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order.For `nodeport` listeners only.
+This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. For `nodeport` listeners only.
 |publishNotReadyAddresses
 |boolean
 |Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -299,7 +299,7 @@ spec:
                                   * `InternalIP`
                                   * `Hostname`
 
-                                  This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order.For `nodeport` listeners only.
+                                  This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. For `nodeport` listeners only.
                               publishNotReadyAddresses:
                                 type: boolean
                                 description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -298,7 +298,7 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order.For `nodeport` listeners only.
+                                This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. For `nodeport` listeners only.
                             publishNotReadyAddresses:
                               type: boolean
                               description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes a missing space in the API description in the listener configuration section.

### Checklist

- [x] Update documentation