### PR TITLE
Support force-renewal of KafkaUser certificates with annotation

### DIFF
--- a/.checkstyle/import-control.xml
+++ b/.checkstyle/import-control.xml
@@ -98,7 +98,6 @@ We also control imports only in production classes and not in tests. This is con
         <allow pkg="io.strimzi.certs" />
         <allow pkg="io.strimzi.operator.common.model" />
         <allow pkg="io.strimzi.operator.user.model" />
-        <allow class="io.strimzi.api.ResourceAnnotations" />
         <allow class="io.strimzi.operator.common.Annotations" />
         <allow class="io.strimzi.operator.common.Reconciliation" />
         <allow class="io.strimzi.operator.common.ReconciliationLogger" />

--- a/.checkstyle/import-control.xml
+++ b/.checkstyle/import-control.xml
@@ -98,6 +98,8 @@ We also control imports only in production classes and not in tests. This is con
         <allow pkg="io.strimzi.certs" />
         <allow pkg="io.strimzi.operator.common.model" />
         <allow pkg="io.strimzi.operator.user.model" />
+        <allow class="io.strimzi.api.ResourceAnnotations" />
+        <allow class="io.strimzi.operator.common.Annotations" />
         <allow class="io.strimzi.operator.common.Reconciliation" />
         <allow class="io.strimzi.operator.common.ReconciliationLogger" />
         <allow class="io.strimzi.operator.common.Util" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Update HTTP bridge to 1.0.0.
   * `/metrics` endpoint is no longer available on the regular HTTP interface (port 8080 by default). It is now available on the HTTP management interface, 8081.
     Users upgrading to Strimzi 1.0.0+ should check all monitoring configurations that scrape Kafka Bridge metrics and update them to use port 8081 instead of 8080 or any other non-default port before or immediately after the upgrade to avoid metrics collection failures.
+* Support force-renewal of KafkaUser certificates via `strimzi.io/force-renew` annotation
 
 ## 0.51.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Enable configuring `allowList` of Strimzi Metrics Reporter dynamically
 * Add support for TLS/SSL on the HTTP Bridge
   Set `spec.http.tls.certificateAndKey` configuration to enable it and provide the certificate and key via Secret.
+* Add support force-renewal of KafkaUser certificates via `strimzi.io/force-renew` annotation
 
 ### Major changes, deprecations, and removals
 
@@ -30,7 +31,6 @@
 * Update HTTP bridge to 1.0.0.
   * `/metrics` endpoint is no longer available on the regular HTTP interface (port 8080 by default). It is now available on the HTTP management interface, 8081.
     Users upgrading to Strimzi 1.0.0+ should check all monitoring configurations that scrape Kafka Bridge metrics and update them to use port 8081 instead of 8080 or any other non-default port before or immediately after the upgrade to avoid metrics collection failures.
-* Support force-renewal of KafkaUser certificates via `strimzi.io/force-renew` annotation
 
 ## 0.51.0
 

--- a/documentation/modules/security/con-securing-client-authentication.adoc
+++ b/documentation/modules/security/con-securing-client-authentication.adoc
@@ -103,6 +103,22 @@ ssl.keystore.password=<keystore_password> # <6>
 <5> The keystore location contains the public key certificate (`user.p12`) for the Kafka user.
 <6> The password (`user.password`) for accessing the keystore.
 
+=== Manually renewing KafkaUser certificates
+
+You can force the User Operator to renew a user certificate on demand by adding the `strimzi.io/force-renew: "true"` annotation to the user secret.
+
+.Annotating the user secret to force certificate renewal
+[source,shell]
+----
+kubectl annotate secret my-user -n my-project strimzi.io/force-renew="true"
+----
+
+At the next reconciliation, the User Operator generates a new certificate and updates the secret. The annotation is then automatically removed.
+
+IMPORTANT: Renewing the certificate does not invalidate the previous certificate.
+The old certificate remains valid until it expires naturally.
+Clients using the old certificate will continue to connect successfully until they are updated to use the new one.
+
 == mTLS authentication using a certificate issued outside the User Operator
 
 To use mTLS authentication using a certificate issued outside the User Operator, you set the `type` field in the `KafkaUser` resource to `tls-external`.

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserAuthentication;
 import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimple;
@@ -20,6 +21,7 @@ import io.strimzi.api.kafka.model.user.acl.AclRule;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
@@ -244,7 +246,11 @@ public class KafkaUserModel {
             String userCrt = userSecret.getData().get("user.crt");
             String userKey = userSecret.getData().get("user.key");
 
-            if (originalCaCrt != null
+            if (userSecret.getMetadata() != null
+                    && Annotations.booleanAnnotation(userSecret, ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, false)) {
+                // The user secret has the annotation which forces replacement => we have to generate a new user certificate
+                this.userCertAndKey = generateNewCertificate(reconciliation, clientsCa);
+            } else if (originalCaCrt != null
                     && originalCaCrt.equals(caCrt)
                     && userCrt != null
                     && !userCrt.isEmpty()

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserAuthentication;
 import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimple;
@@ -247,8 +246,9 @@ public class KafkaUserModel {
             String userKey = userSecret.getData().get("user.key");
 
             if (userSecret.getMetadata() != null
-                    && Annotations.booleanAnnotation(userSecret, ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, false)) {
+                    && Annotations.booleanAnnotation(userSecret, Annotations.ANNO_STRIMZI_IO_FORCE_RENEW, false)) {
                 // The user secret has the annotation which forces replacement => we have to generate a new user certificate
+                LOGGER.infoCr(reconciliation, "Certificate for user {} in namespace {} will be renewed due to force-renew annotation", name, namespace);
                 this.userCertAndKey = generateNewCertificate(reconciliation, clientsCa);
             } else if (originalCaCrt != null
                     && originalCaCrt.equals(caCrt)

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
@@ -6,9 +6,9 @@ package io.strimzi.operator.user.model;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.Labels;
@@ -75,7 +75,7 @@ public class KafkaUserModelCertificateHandlingTest {
                 .withNewMetadata()
                     .withName(ResourceUtils.NAME)
                     .withNamespace(ResourceUtils.NAMESPACE)
-                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
                 .endMetadata()
                 .build();
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.user.model;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.common.Reconciliation;
@@ -63,6 +64,23 @@ public class KafkaUserModelCertificateHandlingTest {
     public void testNewUser() {
         MockKafkaUserModel model = new MockKafkaUserModel();
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, Clock.systemUTC());
+
+        assertThat(model.generateNewCertificateCalled, is(1));
+        assertThat(model.reuseCertificateCalled, is(0));
+    }
+
+    @Test
+    public void testExistingUserWithForceRenewAnnotation() {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                    .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, "true")
+                .endMetadata()
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 365, 30, null, Clock.systemUTC());
 
         assertThat(model.generateNewCertificateCalled, is(1));
         assertThat(model.reuseCertificateCalled, is(0));


### PR DESCRIPTION
### Type of change
- Enhancement

### Description
This PR implements [proposal #137](https://github.com/strimzi/proposals/blob/main/137-re-issue-kafka-user-certificate-on-demand.md) and issue #12337 by supporting the existing `strimzi.io/force-renew` annotation on the user secret. When the annotation is set to true, the User Operator generates a new certificate at the next reconciliation and automatically removes the annotation. The previous certificate remains valid until it expires naturally, ensuring no service interruption.

Changes:
- `KafkaUserModel` — checks for `strimzi.io/force-renew` annotation on the user secret and triggers certificate regeneration
- `KafkaUserModelCertificateHandlingTest` — adds test coverage for the force-renew path
- `Documentation` — adds "Manually renewing KafkaUser certificates" section in con-securing-client-authentication.adoc

### Checklist
- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md