### PR TITLE
Support custom Kafka username via spec.userName in KafkaUser

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
@@ -18,14 +18,27 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "authentication", "authorization", "quotas", "template" })
+@JsonPropertyOrder({ "authentication", "authorization", "quotas", "template", "userName" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserSpec extends Spec {
+    private String userName;
     private KafkaUserAuthentication authentication;
     private KafkaUserAuthorization authorization;
     private KafkaUserQuotas quotas;
     private KafkaUserTemplate template;
+
+    @Description("The name of the user. " +
+            "When absent this will default to the metadata.name of the user. " +
+            "It is recommended to not set this unless the user name is not a " +
+            "valid Kubernetes resource name.")
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
 
     @Description("Authentication mechanism enabled for this Kafka user. " +
             "The supported authentication mechanisms are `scram-sha-512`, `tls`, and `tls-external`. \n\n" +

--- a/api/src/test/resources/crds/v1/044-Crd-kafkauser.yaml
+++ b/api/src/test/resources/crds/v1/044-Crd-kafkauser.yaml
@@ -57,6 +57,9 @@ spec:
           spec:
             type: object
             properties:
+              userName:
+                type: string
+                description: The name of the user. When absent this will default to the metadata.name of the user. It is recommended to not set this unless the user name is not a valid Kubernetes resource name.
               authentication:
                 type: object
                 properties:

--- a/api/src/test/resources/crds/v1beta2/044-Crd-kafkauser.yaml
+++ b/api/src/test/resources/crds/v1beta2/044-Crd-kafkauser.yaml
@@ -57,6 +57,9 @@ spec:
           spec:
             type: object
             properties:
+              userName:
+                type: string
+                description: The name of the user. When absent this will default to the metadata.name of the user. It is recommended to not set this unless the user name is not a valid Kubernetes resource name.
               authentication:
                 type: object
                 properties:
@@ -278,6 +281,8 @@ spec:
           spec:
             type: object
             properties:
+              userName:
+                type: string
               authentication:
                 type: object
                 properties:
@@ -474,6 +479,8 @@ spec:
           spec:
             type: object
             properties:
+              userName:
+                type: string
               authentication:
                 type: object
                 properties:
@@ -670,6 +677,8 @@ spec:
           spec:
             type: object
             properties:
+              userName:
+                type: string
               authentication:
                 type: object
                 properties:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2609,6 +2609,9 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|userName
+|string
+|The name of the user. When absent this will default to the metadata.name of the user. It is recommended to not set this unless the user name is not a valid Kubernetes resource name.
 |authentication
 |xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`], xref:type-KafkaUserTlsExternalClientAuthentication-{context}[`KafkaUserTlsExternalClientAuthentication`], xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`]
 |Authentication mechanism enabled for this Kafka user. The supported authentication mechanisms are `scram-sha-512`, `tls`, and `tls-external`. 

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -57,6 +57,9 @@ spec:
           spec:
             type: object
             properties:
+              userName:
+                type: string
+                description: The name of the user. When absent this will default to the metadata.name of the user. It is recommended to not set this unless the user name is not a valid Kubernetes resource name.
               authentication:
                 type: object
                 properties:

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -61,7 +61,19 @@ public class KafkaUserModel {
     public static final String KEY_SASL_JAAS_CONFIG = "sasl.jaas.config";
 
     protected final String namespace;
+
+    /**
+     * The Kafka username. This is either spec.userName (if set) or metadata.name.
+     * Used for authentication (CN=..., SCRAM username, ACLs, certificates).
+     */
     protected final String name;
+
+    /**
+     * The Kubernetes resource name, always equal to metadata.name.
+     * Used for the Secret name, owner references, and Kubernetes labels.
+     */
+    protected final String resourceName;
+
     protected final Labels labels;
 
     protected KafkaUserAuthentication authentication;
@@ -71,7 +83,7 @@ public class KafkaUserModel {
     protected Set<SimpleAclRule> simpleAclRules = null;
 
     /**
-     * Name of the USer Operator used for the Kubernetes labels
+     * Name of the User Operator used for the Kubernetes labels
      */
     public static final String KAFKA_USER_OPERATOR_NAME = "strimzi-user-operator";
 
@@ -90,16 +102,19 @@ public class KafkaUserModel {
      * Constructor
      *
      * @param namespace Kubernetes namespace where Kafka Connect cluster resources are going to be created
-     * @param name   User name
+     * @param name         Kafka username (spec.userName if set, otherwise metadata.name)
+     * @param resourceName Kubernetes resource name (always metadata.name); used for Secret name, labels, owner references
      * @param labels   Labels
+     * @param secretPrefix Secret name prefix
      */
-    protected KafkaUserModel(String namespace, String name, Labels labels, String secretPrefix) {
+    protected KafkaUserModel(String namespace, String name, String resourceName, Labels labels, String secretPrefix) {
         this.namespace = namespace;
         this.name = name;
+        this.resourceName = resourceName;
         this.labels = labels.withKubernetesName(KAFKA_USER_OPERATOR_NAME)
-            .withKubernetesInstance(name)
-            .withKubernetesPartOf(name)
-            .withKubernetesManagedBy(KAFKA_USER_OPERATOR_NAME);
+                .withKubernetesInstance(resourceName)
+                .withKubernetesPartOf(resourceName)
+                .withKubernetesManagedBy(KAFKA_USER_OPERATOR_NAME);
         this.secretPrefix = secretPrefix;
     }
 
@@ -115,8 +130,13 @@ public class KafkaUserModel {
     public static KafkaUserModel fromCrd(KafkaUser kafkaUser,
                                          String secretPrefix,
                                          boolean aclsAdminApiSupported) {
-        KafkaUserModel result = new KafkaUserModel(kafkaUser.getMetadata().getNamespace(),
-                kafkaUser.getMetadata().getName(),
+        String kafkaUsername = KafkaUserUtils.userName(kafkaUser);
+        String k8sResourceName = kafkaUser.getMetadata().getName();
+
+        KafkaUserModel result = new KafkaUserModel(
+                kafkaUser.getMetadata().getNamespace(),
+                kafkaUsername,
+                k8sResourceName,
                 Labels.fromResource(kafkaUser).withStrimziKind(kafkaUser.getKind()),
                 secretPrefix);
 
@@ -150,12 +170,13 @@ public class KafkaUserModel {
     /**
      * Validates if a user with TLS authentication doesn't have too long name. This has to be done because OpenSSL has
      * a limit how long the CN of a certificate can be.
+     * The effective Kafka username (spec.userName if set, otherwise metadata.name) is validated.
      *
      * @param user  The KafkaUser which should be validated
      */
-    private static void validateTlsUsername(KafkaUser user)  {
+    private static void validateTlsUsername(KafkaUser user) {
         if (user.getSpec().getAuthentication() instanceof KafkaUserTlsClientAuthentication) {
-            if (user.getMetadata().getName().length() > OpenSslCertManager.MAXIMUM_CN_LENGTH)    {
+            if (KafkaUserUtils.userName(user).length() > OpenSslCertManager.MAXIMUM_CN_LENGTH) {
                 throw new InvalidResourceException("Users with TLS client authentication can have a username (name of the KafkaUser custom resource) only up to 64 characters long.");
             }
         }
@@ -401,6 +422,7 @@ public class KafkaUserModel {
 
     /**
      * Generate the OwnerReference object to link newly created objects to their parent (the custom resource)
+     * Always uses the Kubernetes resource name (metadata.name), not the Kafka username.
      *
      * @return The owner reference.
      */
@@ -408,7 +430,7 @@ public class KafkaUserModel {
         return new OwnerReferenceBuilder()
                 .withApiVersion(ownerApiVersion)
                 .withKind(ownerKind)
-                .withName(name)
+                .withName(resourceName)
                 .withUid(ownerUid)
                 .withBlockOwnerDeletion(true)
                 .withController(false)
@@ -482,7 +504,7 @@ public class KafkaUserModel {
     }
 
     /**
-     * Gets the name of the user.
+     * Gets the Kafka username (spec.userName if set, otherwise metadata.name).
      *
      * @return The name of the user.
      */
@@ -491,14 +513,24 @@ public class KafkaUserModel {
     }
 
     /**
-     * Generates the name of the User secret based on the username.
+     * Gets the Kubernetes resource name (always metadata.name).
+     * Used for Secret name, owner references, and Kubernetes labels.
+     *
+     * @return The Kubernetes resource name.
+     */
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    /**
+     * Generates the name of the User Secret based on the K8s resource name and prefix.
      *
      * @param secretPrefix The secret prefix
-     * @param username The username.
-     * @return The name of the user.
+     * @param resourceName The Kubernetes resource name (metadata.name).
+     * @return The Secret name.
      */
-    public static String getSecretName(String secretPrefix, String username)    {
-        return secretPrefix + username;
+    public static String getSecretName(String secretPrefix, String resourceName) {
+        return secretPrefix + resourceName;
     }
 
     /**
@@ -513,7 +545,8 @@ public class KafkaUserModel {
     }
 
     /**
-     * Gets the name of the User secret.
+     * Gets the name of the User Secret.
+     * Always based on the Kubernetes resource name (metadata.name), not the Kafka username.
      *
      * @return The name of the user secret.
      */

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserUtils.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.model;
+
+import io.strimzi.api.kafka.model.user.KafkaUser;
+
+/**
+ * Various utility methods used by the KafkaUserModel to make leaner and easier to read
+ */
+public class KafkaUserUtils {
+    private KafkaUserUtils() { }
+
+    /**
+     * Get the user name from a {@link KafkaUser} resource.
+     *
+     * @param kafkaUser User resource.
+     * @return User name.
+     */
+    public static String userName(KafkaUser kafkaUser) {
+        String userName = null;
+        if (kafkaUser.getSpec() != null) {
+            userName = kafkaUser.getSpec().getUserName();
+        }
+        if (userName == null) {
+            userName = kafkaUser.getMetadata().getName();
+        }
+        return userName;
+    }
+}

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.common.operator.resource.concurrent.CrdOperator;
 import io.strimzi.operator.common.operator.resource.concurrent.SecretOperator;
 import io.strimzi.operator.user.UserOperatorConfig;
 import io.strimzi.operator.user.model.KafkaUserModel;
+import io.strimzi.operator.user.model.KafkaUserUtils;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
 
 import java.time.Clock;
@@ -156,7 +157,7 @@ public class KafkaUserOperator {
     private CompletionStage<Set<String>> getAllKafkaUserUsernames(String namespace)  {
         return kafkaUserCrdOperator.listAsync(namespace, Labels.fromMap(selector.getMatchLabels()))
             .thenApply(users -> users.stream()
-                    .map(resource -> resource.getMetadata().getName())
+                    .map(KafkaUserUtils::userName)
                     .collect(Collectors.toSet()));
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -34,6 +34,7 @@ public class ResourceUtils {
     public static final Map<String, String> LABELS = Collections.singletonMap("foo", "bar");
     public static final String NAMESPACE = "namespace";
     public static final String NAME = "user";
+    public static final String CUSTOM_NAME = "custom-user";
     public static final String CA_CERT_NAME = "ca-cert";
     public static final String CA_KEY_NAME = "ca-key";
     public static final String PASSWORD = "my-password";

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
@@ -185,7 +185,7 @@ public class KafkaUserModelCertificateHandlingTest {
         public int generateNewCertificateCalled = 0;
 
         protected MockKafkaUserModel() {
-            super(ResourceUtils.NAMESPACE, ResourceUtils.NAME, Labels.EMPTY, null);
+            super(ResourceUtils.NAMESPACE, ResourceUtils.NAME, ResourceUtils.CUSTOM_NAME, Labels.EMPTY, null);
         }
 
         @Override

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -61,6 +61,83 @@ public class KafkaUserModelTest {
     }
 
     @Test
+    public void testFromCrdTlsUserWithCustomUserName() {
+        KafkaUser userWithCustomName = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                .withUserName("my-custom-username")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomName, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+
+        // model.name should be the custom username, not metadata.name
+        assertThat(model.name, is("my-custom-username"));
+        assertThat(model.getUserName(), is("CN=my-custom-username"));
+    }
+
+    @Test
+    public void testFromCrdScramShaUserWithCustomUserName() {
+        KafkaUser userWithCustomName = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                .withUserName("my-custom-scram-username")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomName, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+
+        assertThat(model.name, is("my-custom-scram-username"));
+        assertThat(model.getUserName(), is("my-custom-scram-username"));
+    }
+
+    @Test
+    public void testFromCrdUserWithNullUserNameFallsBackToMetadataName() {
+        KafkaUser userWithNullCustomName = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                .withUserName(null)
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithNullCustomName, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+
+        // Should fall back to metadata.name
+        assertThat(model.name, is(ResourceUtils.NAME));
+        assertThat(model.getUserName(), is("CN=" + ResourceUtils.NAME));
+    }
+
+    @Test
+    public void testFromCrdUserWithCustomUserNameSecretNameUsesMetadataName() {
+        // The secret name should always be based on metadata.name (+ prefix), not the custom userName
+        KafkaUser userWithCustomName = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                .withUserName("my-custom-username")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomName, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+
+        // Secret name is based on metadata.name, not the custom userName
+        assertThat(model.getSecretName(), is(ResourceUtils.NAME));
+    }
+
+    @Test
+    public void testFromCrdTlsUserWithCustomUserNameGeneratesCorrectSecret() {
+        KafkaUser userWithCustomName = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                .withUserName("my-custom-username")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomName, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, Clock.systemUTC());
+        Secret generatedSecret = model.generateSecret();
+
+        // Secret name still based on metadata.name
+        assertThat(generatedSecret.getMetadata().getName(), is(ResourceUtils.NAME));
+        assertThat(generatedSecret.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));
+        assertThat(generatedSecret.getData().keySet(), is(Set.of("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
+    }
+
+    @Test
     public void testFromCrdTlsUser() {
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

#### Motivation
Currently, the Kafka username is always derived from metadata.name of the KafkaUser custom resource. Kubernetes resource names are subject to DNS subdomain naming constraints (lowercase, max 253 chars, no special characters), which makes it impossible to create Kafka users whose names don't conform to these rules — for example usernames with dots, or other characters that are valid in Kafka but not in Kubernetes.
Changes
This PR introduces an optional spec.userName field to KafkaUserSpec. When set, this value is used as the effective Kafka username instead of metadata.name. This allows users to define Kafka usernames that are not valid Kubernetes resource names.

`KafkaUserSpec:`

Added optional userName field with getter/setter.

`KafkaUserModel:`

Introduced a separate resourceName field (always metadata.name) alongside the existing name field.
Secret name, owner references, and Kubernetes labels always use resourceName (metadata.name) to remain valid Kubernetes identifiers.
The Kafka username (name) is used for certificate CNs, SCRAM credentials, ACLs, and JAAS config.
Fixed validateTlsUsername() to validate the effective Kafka username (which may come from spec.userName) against the OpenSSL CN length limit.

`KafkaUserUtils:`

userName() resolves the effective Kafka username: returns spec.userName if set, falls back to metadata.name.

#### Backwards Compatibility
The spec.userName field is optional. Existing KafkaUser resources without this field continue to behave exactly as before, metadata.name is used as the Kafka username.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

