### PR TITLE
Remove afterEachMayOverride() workaround in UserOperatorScalabilityPerformance

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorScalabilityPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorScalabilityPerformance.java
@@ -278,19 +278,6 @@ public class UserOperatorScalabilityPerformance extends AbstractST {
         });
     }
 
-    @Override
-    protected void afterEachMayOverride() {
-        // Override to use sequential (non-async) resource cleanup.
-        // The default `deleteResources(true)` spawns a CompletableFuture per tracked resource.
-        // With 2000 KafkaUsers on the stack, this creates 2000 concurrent deletion threads that
-        // overwhelm the K8s API server on slow GHA runners and eventually run into deadlock/starvation
-        //
-        // note: remove this when https://github.com/skodjob/kubetest4j 1.1.0 is released.
-        if (!Environment.SKIP_TEARDOWN) {
-            KubeResourceManager.get().deleteResources(false);
-        }
-    }
-
     @BeforeAll
     void setUp() {
         SetupClusterOperator


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

With the merge of #12608 (kubetest4j 1.1.0), the `afterEachMayOverride()` method in `UserOperatorScalabilityPerformance` is no longer needed. This method was a temporary workaround to force sequential (non-async) resource cleanup to avoid overwhelming the K8s API server when deleting large numbers of KafkaUsers.
The framework now handles this properly by default, so the override has been removed.
Closes #12630

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

