### PR TITLE
Clean unused parts of our startup scripts

### DIFF
--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -2,8 +2,11 @@
 set -e
 set +x
 
+# Clean-up /tmp directory from files which might have remained from previous container restart
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/cruise-control/* || true
+
 export CLASSPATH="$CLASSPATH:/opt/cruise-control/libs/*"
-export SCALA_VERSION="2.11.11"
 
 # Generate temporary keystore password
 CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
@@ -13,12 +16,6 @@ mkdir -p /tmp/cruise-control
 
 # Import certificates into keystore and truststore
 "$CRUISE_CONTROL_HOME"/cruise_control_tls_prepare_certificates.sh
-
-export STRIMZI_TRUSTSTORE_LOCATION=/tmp/cruise-control/replication.truststore.p12
-export STRIMZI_TRUSTSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
-
-export STRIMZI_KEYSTORE_LOCATION=/tmp/cruise-control/cruise-control.keystore.p12
-export STRIMZI_KEYSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=file:$CRUISE_CONTROL_HOME/custom-config/log4j2.properties"

--- a/docker-images/kafka-based/kafka/scripts/tls_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/tls_utils.sh
@@ -43,20 +43,6 @@ function create_keystore_without_ca_file {
     PASSWORD=$2 RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -name "$5" -password env:PASSWORD -out "$1" -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
 }
 
-# Searches the directory with the CAs and finds the CA matching our key.
-# This is useful during certificate renewals
-#
-# Parameters:
-# $1: The directory with the CA certificates
-# $2: Public key to be imported
-function find_ca {
-    for ca in "$1"/*; do
-        if openssl verify -CAfile "$ca" "$2" &> /dev/null; then
-            echo "$ca"
-        fi
-    done
-}
-
 # Parameters:
 # $1: Path to the new truststore
 # $2: Truststore password


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes some unused parts of our startup scripts:
* The `find_ca` method from TLS ustils
* Some unused variables from Cruise Control run script

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally