### PR TITLE
Use rack-aware affinity only for nodes with broker-role

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1195,7 +1195,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                             DEFAULT_POD_LABELS,
                             podAnnotationsProvider.apply(node),
                             KafkaResources.brokersServiceName(cluster),
-                            ModelUtils.affinityWithRackLabelSelector(pool.templatePod, rack),
+                            ModelUtils.affinityWithRackLabelSelector(pool.templatePod, node.broker() ? rack : null), // Only nodes with broker role have rack awareness
                             ContainerUtils.listOrNull(createInitContainer(imagePullPolicy, pool)),
                             List.of(createContainer(imagePullPolicy, pool)),
                             getPodSetVolumes(node, pool.storage, pool.templatePod),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2438,7 +2438,11 @@ public class KafkaClusterTest {
             List<Pod> pods = PodSetUtils.podSetToPods(podSet);
 
             for (Pod pod : pods) {
-                assertThat(pod.getSpec().getAffinity(), is(rackAffinity));
+                if (pod.getMetadata().getName().contains("-controllers-"))  {
+                    assertThat(pod.getSpec().getAffinity(), is(nullValue()));
+                } else {
+                    assertThat(pod.getSpec().getAffinity(), is(rackAffinity));
+                }
             }
         }
     }
@@ -2727,7 +2731,11 @@ public class KafkaClusterTest {
             List<Pod> pods = PodSetUtils.podSetToPods(podSet);
 
             for (Pod pod : pods) {
-                assertThat(pod.getSpec().getAffinity(), is(mergedRackAffinity));
+                if (pod.getMetadata().getName().contains("-controllers-"))  {
+                    assertThat(pod.getSpec().getAffinity(), is(affinity));
+                } else {
+                    assertThat(pod.getSpec().getAffinity(), is(mergedRackAffinity));
+                }
             }
         }
     }
@@ -2891,6 +2899,8 @@ public class KafkaClusterTest {
             for (Pod pod : pods) {
                 if (pod.getMetadata().getName().contains("brokers"))    {
                     assertThat(pod.getSpec().getAffinity(), is(poolMergedRackAffinity));
+                } else if (pod.getMetadata().getName().contains("-controllers-"))  {
+                    assertThat(pod.getSpec().getAffinity(), is(affinity));
                 } else {
                     assertThat(pod.getSpec().getAffinity(), is(mergedRackAffinity));
                 }
@@ -2993,7 +3003,17 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
 
-        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_CONTROLLERS, POOL_MIXED, brokers), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaNodePool controllers = new KafkaNodePoolBuilder(POOL_CONTROLLERS)
+                .editSpec()
+                    .withNewTemplate()
+                        .withNewPod()
+                            .withAffinity(poolAffinity)
+                        .endPod()
+                    .endTemplate()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(controllers, POOL_MIXED, brokers), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
 
         List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
@@ -3004,8 +3024,10 @@ public class KafkaClusterTest {
             List<Pod> pods = PodSetUtils.podSetToPods(podSet);
 
             for (Pod pod : pods) {
-                if (pod.getMetadata().getName().contains("brokers"))    {
+                if (pod.getMetadata().getName().contains("brokers")) {
                     assertThat(pod.getSpec().getAffinity(), is(mergedRackAffinity));
+                } else if (pod.getMetadata().getName().contains("-controllers-"))  {
+                    assertThat(pod.getSpec().getAffinity(), is(poolAffinity));
                 } else {
                     assertThat(pod.getSpec().getAffinity(), is(rackAffinity));
                 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When Rack awareness is configured, it is applied only to Kafka nodes with the broker role. But the rack-aware affinity rules are currently applied even on controller-only nodes. This PR fixes it and applies the rack-based affinity (essentially a selector to schedule the Pods only on nodes with the topology label) only on nodes with the broker role and not on controller-only nodes.

This should resolve #12596.

### Checklist

- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging