### PR TITLE
Simplify SystemTestCertBundle construction with factory methods for Cluster and Clients CA

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertBundle.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertBundle.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.skodjob.kubetest4j.security.CertAndKey;
 import io.skodjob.kubetest4j.security.CertAndKeyFiles;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -118,6 +119,32 @@ public class SystemTestCertBundle {
         }
         KubeResourceManager.get().kubeClient().getClient()
             .secrets().inNamespace(testStorage.getNamespaceName()).withName(secret.getMetadata().getName()).patch(PatchContext.of(PatchType.JSON), secret);
+    }
+
+    /**
+     * Creates a SystemTestCertBundle for the ClusterCA.
+     *
+     * @param testStorage storage with information about test, which is used to create custom key-pair and related Secrets
+     * @return SystemTestCertBundle with prepared custom key-pair and related Secrets
+     */
+    public static SystemTestCertBundle forClusterCa(final TestStorage testStorage) {
+        return new SystemTestCertBundle(
+            "CN=" + testStorage.getTestName() + "ClusterCA",
+            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
+            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+    }
+
+    /**
+     * Creates a SystemTestCertBundle for the ClientsCA.
+     *
+     * @param testStorage storage with information about test, which is used to create custom key-pair and related Secrets
+     * @return SystemTestCertBundle with prepared custom key-pair and related Secrets
+     */
+    public static SystemTestCertBundle forClientsCa(final TestStorage testStorage) {
+        return new SystemTestCertBundle(
+            "CN=" + testStorage.getTestName() + "ClientsCA",
+            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
+            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
     }
 
     public CertAndKey getStrimziRootCa() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaChainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaChainST.java
@@ -80,15 +80,9 @@ public class CustomCaChainST extends AbstractST {
     void testMultistageCustomCaUserCertificateAuthentication() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
 
         clusterCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
         clientsCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
@@ -188,15 +182,9 @@ public class CustomCaChainST extends AbstractST {
     void testMultistageCustomCaTrustChainEstablishment() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
 
         clusterCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
         clientsCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
@@ -313,15 +301,9 @@ public class CustomCaChainST extends AbstractST {
     void testCustomCaTrustChainOnInternalPort() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
 
         clusterCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
         clientsCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
@@ -440,15 +422,9 @@ public class CustomCaChainST extends AbstractST {
     void testKafkaConnectTrustWithCustomCaChain() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
 
         // Generate a Subleaf CA signed by the Leaf CA (one level deeper)
         final CertAndKey subleafCa = generateStrimziCaCertAndKey(clusterCa.getSystemTestCa(), "C=CZ, L=Prague, O=StrimziTest, CN=SubleafCA");

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -89,10 +89,7 @@ public class CustomCaST extends AbstractST {
     void testReplacingCustomClusterKeyPairToInvokeRenewalProcess() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         // Generate root and intermediate certificate authority with cluster CA
-        SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
         prepareTestCaWithBundleAndKafkaCluster(clusterCa, testStorage, 5, 20);
 
@@ -172,11 +169,7 @@ public class CustomCaST extends AbstractST {
     void testReplacingCustomClientsKeyPairToInvokeRenewalProcess() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         // Generate root and intermediate certificate authority with clients CA
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
-
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
         prepareTestCaWithBundleAndKafkaCluster(clientsCa, testStorage, 5, 20);
 
         // Take snapshots for later comparison
@@ -227,14 +220,8 @@ public class CustomCaST extends AbstractST {
     void testCustomClusterCaAndClientsCaCertificates() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
-        final SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
+        final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
         // prepare custom Ca and copy that to the related Secrets
         clientsCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
@@ -306,10 +293,7 @@ public class CustomCaST extends AbstractST {
         final int validityDays = 20;
         final int newValidityDays = 200;
 
-        SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClusterCA",
-            KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+        SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
         prepareTestCaWithBundleAndKafkaCluster(clusterCa, testStorage, renewalDays, validityDays);
 
@@ -403,10 +387,7 @@ public class CustomCaST extends AbstractST {
         final int validityDays = 20;
         final int newValidityDays = 200;
 
-        final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-            "CN=" + testStorage.getTestName() + "ClientsCA",
-            KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-            KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
+        final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
 
         prepareTestCaWithBundleAndKafkaCluster(clientsCa, testStorage, renewalDays, validityDays);
 
@@ -562,17 +543,11 @@ public class CustomCaST extends AbstractST {
         //     (f.e., Clients CA should not be generated, but the secrets were not found.)
         if (certificateAuthority.getCaCertSecretName().equals(KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName())) &&
             certificateAuthority.getCaKeySecretName().equals(KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()))) {
-            final SystemTestCertBundle clientsCa = new SystemTestCertBundle(
-                "CN=" + testStorage.getTestName() + "ClientsCA",
-                KafkaResources.clientsCaCertificateSecretName(testStorage.getClusterName()),
-                KafkaResources.clientsCaKeySecretName(testStorage.getClusterName()));
+            final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
             clientsCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
         } else {
             // otherwise we generate Cluster CA
-            final SystemTestCertBundle clusterCa = new SystemTestCertBundle(
-                "CN=" + testStorage.getTestName() + "ClusterCA",
-                KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()),
-                KafkaResources.clusterCaKeySecretName(testStorage.getClusterName()));
+            final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
             clusterCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
         }
 


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
`SystemTestCertBundle` was instantiated repeatedly across `CustomCaST` and `CustomCaChainST` with the same boilerplate pattern. Add two factory methods `forClusterCa(TestStorage)` and `forClientsCa(TestStorage)` so all required parameters can be derived from `TestStorage` automatically, and update all call sites to use them.
Close #12617

### Checklist
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging

