### PR TITLE
Limit Kafka cache saves in GitHub Actions only for default branch

### DIFF
--- a/.github/actions/build/test-strimzi/action.yml
+++ b/.github/actions/build/test-strimzi/action.yml
@@ -63,7 +63,7 @@ runs:
         fail-on-error: false
         
     - name: Upload test coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./target/site/jacoco/jacoco.xml
         flags: unittests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
           MVN_ARGS: "-B -DskipTests -Dmaven.javadoc.skip=true"
 
       - name: Save Kafka binaries cache
+        # Save maven cache only after pushes into default branch
+        if: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
         uses: actions/cache/save@v5
         with:
           path: docker-images/artifacts/binaries/kafka/archives


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When I enabled back Kafka cache I didn't realize that cache is saved for every branch. This can pollute cache space quite quickly and it is not desired. This PR restrict saving of Kafka cache only on default branch.

Similar to https://github.com/strimzi/github-actions/pull/33

### Checklist

- [ ] Make sure all tests pass

