### PR TITLE
Replace ResourceAnnotations with Annotations in CaReconciler

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.common.CertificateAuthority;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -577,8 +576,8 @@ public class CaReconciler {
 
     private boolean isForceReplace(Secret caSecret) {
         if (caSecret != null && caSecret.getMetadata() != null &&
-                Annotations.hasAnnotation(caSecret, ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE)) {
-            return Annotations.booleanAnnotation(caSecret, ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE, false);
+                Annotations.hasAnnotation(caSecret, Annotations.ANNO_STRIMZI_IO_FORCE_REPLACE)) {
+            return Annotations.booleanAnnotation(caSecret, Annotations.ANNO_STRIMZI_IO_FORCE_REPLACE, false);
         } else {
             return false;
         }
@@ -586,8 +585,8 @@ public class CaReconciler {
 
     private boolean isForceRenew(Secret caSecret) {
         if (caSecret != null && caSecret.getMetadata() != null &&
-                Annotations.hasAnnotation(caSecret, ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW)) {
-            return Annotations.booleanAnnotation(caSecret, ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_RENEW, false);
+                Annotations.hasAnnotation(caSecret, Annotations.ANNO_STRIMZI_IO_FORCE_RENEW)) {
+            return Annotations.booleanAnnotation(caSecret, Annotations.ANNO_STRIMZI_IO_FORCE_RENEW, false);
         } else {
             return false;
         }


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
Since `Annotations` extends `ResourceAnnotations` and inherits those constants, the `ResourceAnnotations` import is redundant. Replacing it with `Annotations` improves consistency within the file and removes the unnecessary import.
Close #12646.

### Checklist
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging

