### PR TITLE
Use multistage Docker builds to pull various binaries

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,3 +1,42 @@
+#####
+# Build the helper container image for downloading prerequisites
+#####
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS downloader
+
+ARG TARGETOS
+ARG TARGETARCH
+
+#####
+# Get Tini
+#####
+ENV TINI_VERSION=v0.19.0
+ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+
+RUN set -ex; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
+        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
+        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
+        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
+        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    fi
+
+#####
+# Build the main container image
+#####
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
@@ -30,29 +69,6 @@ RUN microdnf update -y \
 ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
 
 #####
-# Add Tini
+# Copy Tini from the downloader stage
 #####
-ENV TINI_VERSION=v0.19.0
-ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
-ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
-ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
-ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
-
-RUN set -ex; \
-    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
-        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
-        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
-        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
-        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    fi
+COPY --from=downloader /usr/bin/tini /usr/bin/tini

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -7,8 +7,6 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
-            # find and xargs are also used in our Kafka Connect Build Dockerfiles \
-            findutils \
             # Tar is used to unpack the downloaded binaries here in the Dockerfile \
             tar \
             # gzip is used to unpack the downloaded binaries here in the Dockerfile \
@@ -96,6 +94,7 @@ RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
             # hostname is used by Strimzi scripts to determine the Kafka node ID \
             hostname  \
             # xargs is used by Kafka's own shell scripts \
+            # find and xargs are also used in our Kafka Connect Build Dockerfiles \
             findutils \
             # Tar is also used in our Kafka Connect Build Dockerfiles \
             tar \

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -1,55 +1,21 @@
-FROM strimzi/base:latest
+#####
+# Build the helper container image for downloading prerequisites
+#####
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS downloader
 
-LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
-
-ARG KAFKA_DIST_DIR
-ARG KAFKA_VERSION
-ARG THIRD_PARTY_LIBS
-ARG strimzi_version
 ARG TARGETOS
 ARG TARGETARCH
 
-LABEL name='kafka' \
-    version="${strimzi_version}-${KAFKA_VERSION}" \
-    release="${strimzi_version}" \
-    summary="Kafka ${KAFKA_VERSION} image of the Strimzi Kafka Operator project." \
-    description="Kafka image used by the Strimzi Kafka Operator to run Kafka ${KAFKA_VERSION} clusters."
-
 RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
-            # net-tools are needed for the health check probes (netstat) \
-            net-tools \
-            # hostname is used by Strimzi scripts to determine the Kafka node ID \
-            hostname  \
-            # xargs is used by Kafka's own shell scripts \
             # find and xargs are also used in our Kafka Connect Build Dockerfiles \
             findutils \
             # Tar is used to unpack the downloaded binaries here in the Dockerfile \
-            # Tar is also used in our Kafka Connect Build Dockerfiles \
             tar \
             # gzip is used to unpack the downloaded binaries here in the Dockerfile \
-            # gzip is also used in our Kafka Connect Build Dockerfiles \
-            gzip \
-            # unzip is used in our Kafka Connect Build Dockerfiles \
-            unzip \
-    && microdnf clean all -y
-
-# Add kafka user with UID 1001
-# The user is in the group 0 to have access to the mounted volumes and storage
-RUN useradd -r -m -u 1001 -g 0 kafka
+            gzip
 
 #####
-# Add Kafka
-#####
-ENV KAFKA_HOME=/opt/kafka
-ENV KAFKA_VERSION=${KAFKA_VERSION}
-ENV STRIMZI_VERSION=${strimzi_version}
-
-COPY $KAFKA_DIST_DIR $KAFKA_HOME
-COPY ./scripts/ $KAFKA_HOME
-RUN mkdir $KAFKA_HOME/plugins
-
-#####
-# Add Kafka Exporter
+# Get Kafka Exporter
 #####
 ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
 ENV KAFKA_EXPORTER_VERSION=1.9.0
@@ -89,10 +55,8 @@ RUN set -ex; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz*; \
     fi
 
-COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
-
 #####
-# Add Prometheus JMX Exporter
+# Get Prometheus JMX Exporter
 #####
 ENV JMX_EXPORTER_HOME=/opt/prometheus-jmx-exporter
 ENV JMX_EXPORTER_VERSION=1.5.0
@@ -105,6 +69,69 @@ RUN set -ex; \
     mkdir $JMX_EXPORTER_HOME; \
     mv jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar $JMX_EXPORTER_HOME/; \
     rm -f jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha512;
+
+#####
+# Build the main container image
+#####
+FROM strimzi/base:latest
+
+LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
+
+ARG KAFKA_DIST_DIR
+ARG KAFKA_VERSION
+ARG THIRD_PARTY_LIBS
+ARG strimzi_version
+ARG TARGETOS
+ARG TARGETARCH
+
+LABEL name='kafka' \
+    version="${strimzi_version}-${KAFKA_VERSION}" \
+    release="${strimzi_version}" \
+    summary="Kafka ${KAFKA_VERSION} image of the Strimzi Kafka Operator project." \
+    description="Kafka image used by the Strimzi Kafka Operator to run Kafka ${KAFKA_VERSION} clusters."
+
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+            # net-tools are needed for the health check probes (netstat) \
+            net-tools \
+            # hostname is used by Strimzi scripts to determine the Kafka node ID \
+            hostname  \
+            # xargs is used by Kafka's own shell scripts \
+            findutils \
+            # Tar is also used in our Kafka Connect Build Dockerfiles \
+            tar \
+            # gzip is also used in our Kafka Connect Build Dockerfiles \
+            gzip \
+            # unzip is used in our Kafka Connect Build Dockerfiles \
+            unzip \
+    && microdnf clean all -y
+
+# Add kafka user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 kafka
+
+#####
+# Add Kafka
+#####
+ENV KAFKA_HOME=/opt/kafka
+ENV KAFKA_VERSION=${KAFKA_VERSION}
+ENV STRIMZI_VERSION=${strimzi_version}
+
+COPY $KAFKA_DIST_DIR $KAFKA_HOME
+COPY ./scripts/ $KAFKA_HOME
+RUN mkdir $KAFKA_HOME/plugins
+
+#####
+# Copy Kafka Experter from the downloader stage and the helper scripts from local filesystem
+#####
+ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
+COPY --from=downloader $KAFKA_EXPORTER_HOME/kafka_exporter $KAFKA_EXPORTER_HOME/kafka_exporter
+COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
+
+#####
+# Copy Prometheus JMX Exporter from the donwnloader stage
+#####
+ENV JMX_EXPORTER_HOME=/opt/prometheus-jmx-exporter
+COPY --from=downloader $JMX_EXPORTER_HOME/jmx_prometheus_javaagent*.jar $JMX_EXPORTER_HOME/
 
 #####
 # Add Strimzi agents


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR uses multi-stage build to pull the `tini`, `kafka-exporter`, and Prometheus JMX Exporter binaries in our container images instead of doing so in the main containers.

This should resolve #12603.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging