### PR TITLE
Remove unused Vert.x parameter from `CaReconciler` class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -51,7 +51,6 @@ import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -113,7 +112,6 @@ public class CaReconciler {
      * @param kafkaCr           The Kafka custom resource
      * @param config            Cluster Operator Configuration
      * @param supplier          Supplier with Kubernetes Resource Operators
-     * @param vertx             Vert.x instance
      * @param certManager       Certificate Manager for managing certificates
      * @param passwordGenerator Password generator for generating passwords
      */
@@ -122,7 +120,6 @@ public class CaReconciler {
             Kafka kafkaCr,
             ClusterOperatorConfig config,
             ResourceOperatorSupplier supplier,
-            Vertx vertx,
             CertManager certManager,
             PasswordGenerator passwordGenerator
     ) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -401,7 +401,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * @return  CaReconciler instance
          */
         CaReconciler caReconciler()   {
-            return new CaReconciler(reconciliation, kafkaAssembly, config, supplier, vertx, certManager, passwordGenerator);
+            return new CaReconciler(reconciliation, kafkaAssembly, config, supplier, certManager, passwordGenerator);
         }
 
         /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
@@ -140,7 +140,7 @@ public class CaReconcilerReconcileCasTest {
         sharedWorkerExecutor.close();
     }
 
-    private Future<Void> reconcileCas(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
+    private Future<Void> reconcileCas(CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .withClusterCa(clusterCa)
@@ -148,10 +148,10 @@ public class CaReconcilerReconcileCasTest {
                 .endSpec()
                 .build();
 
-        return reconcileCas(vertx, kafka, Clock.systemUTC());
+        return reconcileCas(kafka, Clock.systemUTC());
     }
 
-    private Future<Void> reconcileCas(Vertx vertx, Kafka kafka, Clock clock) {
+    private Future<Void> reconcileCas(Kafka kafka, Clock clock) {
         SecretOperator secretOps = supplier.secretOperations;
 
         when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenAnswer(invocation -> {
@@ -173,7 +173,7 @@ public class CaReconcilerReconcileCasTest {
         Promise<Void> reconcileCasComplete = Promise.promise();
 
         new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR)
+                supplier, CERT_MANAGER, PASSWORD_GENERATOR)
                 .reconcileCas(clock)
                 .onComplete(ar -> {
                     if (ar.succeeded()) {
@@ -305,7 +305,7 @@ public class CaReconcilerReconcileCasTest {
     //////////
 
     @Test
-    public void testReconcileCasGeneratesCertsInitially(Vertx vertx, VertxTestContext context) {
+    public void testReconcileCasGeneratesCertsInitially(VertxTestContext context) {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
                 .withRenewalDays(10)
@@ -313,7 +313,7 @@ public class CaReconcilerReconcileCasTest {
                 .build();
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -333,7 +333,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testReconcileCasNoCertsGetGeneratedOutsideRenewalPeriod(Vertx vertx, VertxTestContext context)
+    public void testReconcileCasNoCertsGetGeneratedOutsideRenewalPeriod(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
@@ -356,7 +356,7 @@ public class CaReconcilerReconcileCasTest {
 
         Checkpoint async = context.checkpoint();
 
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -379,7 +379,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testGenerateTruststoreFromOldSecrets(Vertx vertx, VertxTestContext context)
+    public void testGenerateTruststoreFromOldSecrets(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
@@ -407,7 +407,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -436,7 +436,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testNewCertsGetGeneratedWhenInRenewalPeriodAuto(Vertx vertx, VertxTestContext context)
+    public void testNewCertsGetGeneratedWhenInRenewalPeriodAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(2)
@@ -457,7 +457,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -488,7 +488,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoOutsideOfMaintenanceWindow(Vertx vertx, VertxTestContext context)
+    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoOutsideOfMaintenanceWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(2)
@@ -518,7 +518,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -554,7 +554,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoWithinMaintenanceWindow(Vertx vertx, VertxTestContext context)
+    public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoWithinMaintenanceWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(2)
@@ -584,7 +584,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T10:12:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(kafka, Clock.fixed(Instant.parse("2018-11-26T10:12:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -622,7 +622,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testNewKeyGetGeneratedWhenInRenewalPeriodAuto(Vertx vertx, VertxTestContext context)
+    public void testNewKeyGetGeneratedWhenInRenewalPeriodAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(2)
@@ -645,7 +645,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -703,7 +703,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testNewKeyGeneratedWhenInRenewalPeriodAutoOutsideOfTimeWindow(Vertx vertx, VertxTestContext context)
+    public void testNewKeyGeneratedWhenInRenewalPeriodAutoOutsideOfTimeWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(2)
@@ -734,7 +734,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(kafka, Clock.fixed(Instant.parse("2018-11-26T09:00:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -774,7 +774,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testNewKeyGeneratedWhenInRenewalPeriodAutoWithinTimeWindow(Vertx vertx, VertxTestContext context)
+    public void testNewKeyGeneratedWhenInRenewalPeriodAutoWithinTimeWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(2)
@@ -805,7 +805,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, kafka, Clock.fixed(Instant.parse("2018-11-26T09:12:00Z"), Clock.systemUTC().getZone()))
+        reconcileCas(kafka, Clock.fixed(Instant.parse("2018-11-26T09:12:00Z"), Clock.systemUTC().getZone()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -870,7 +870,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testExpiredCertsGetRemovedAuto(Vertx vertx, VertxTestContext context)
+    public void testExpiredCertsGetRemovedAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
@@ -926,7 +926,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                 assertCaptorSecretsNotNull(captorSecrets);
@@ -951,7 +951,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testCustomLabelsAndAnnotations(Vertx vertx, VertxTestContext context) {
+    public void testCustomLabelsAndAnnotations(VertxTestContext context) {
         Map<String, String> labels = new HashMap<>(2);
         labels.put("label1", "value1");
         labels.put("label2", "value2");
@@ -976,7 +976,7 @@ public class CaReconcilerReconcileCasTest {
                 .build();
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, kafka, Clock.systemUTC())
+        reconcileCas(kafka, Clock.systemUTC())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                     assertCaptorSecretsNotNull(captorSecrets);
@@ -1005,7 +1005,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testClusterCASecretsWithoutOwnerReference(Vertx vertx, VertxTestContext context) {
+    public void testClusterCASecretsWithoutOwnerReference(VertxTestContext context) {
         CertificateAuthority caConfig = new CertificateAuthority();
         caConfig.setGenerateSecretOwnerReference(false);
 
@@ -1017,7 +1017,7 @@ public class CaReconcilerReconcileCasTest {
 
         Checkpoint async = context.checkpoint();
 
-        reconcileCas(vertx, kafka, Clock.systemUTC())
+        reconcileCas(kafka, Clock.systemUTC())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
                     assertCaptorSecretsNotNull(captorSecrets);
@@ -1040,7 +1040,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testClientsCASecretsWithoutOwnerReference(Vertx vertx, VertxTestContext context) {
+    public void testClientsCASecretsWithoutOwnerReference(VertxTestContext context) {
         CertificateAuthority caConfig = new CertificateAuthority();
         caConfig.setGenerateSecretOwnerReference(false);
 
@@ -1052,7 +1052,7 @@ public class CaReconcilerReconcileCasTest {
 
         Checkpoint async = context.checkpoint();
 
-        reconcileCas(vertx, kafka, Clock.systemUTC())
+        reconcileCas(kafka, Clock.systemUTC())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     CaptorSecrets captorSecrets = verifyCaSecretReconcileCalls(supplier.secretOperations);
 
@@ -1073,7 +1073,7 @@ public class CaReconcilerReconcileCasTest {
     //////////
 
     @Test
-    public void testReconcileCasWhenUserManagedCertsAreMissingThrows(Vertx vertx, VertxTestContext context) {
+    public void testReconcileCasWhenUserManagedCertsAreMissingThrows(VertxTestContext context) {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
                 .withRenewalDays(10)
@@ -1081,7 +1081,7 @@ public class CaReconcilerReconcileCasTest {
                 .build();
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
                 .onComplete(context.failing(e -> context.verify(() -> {
                     assertThat(e, instanceOf(InvalidResourceException.class));
                     assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
@@ -1090,7 +1090,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testUserManagedCertsNotReconciled(Vertx vertx, VertxTestContext context) throws IOException {
+    public void testUserManagedCertsNotReconciled(VertxTestContext context) throws IOException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
                 .withRenewalDays(10)
@@ -1151,7 +1151,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), any(Secret.class));
                     verify(supplier.secretOperations, times(0)).reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), any(Secret.class));
@@ -1162,7 +1162,7 @@ public class CaReconcilerReconcileCasTest {
     }
 
     @Test
-    public void testUserManagedCasWithInvalidCa(Vertx vertx, VertxTestContext context) throws IOException {
+    public void testUserManagedCasWithInvalidCa(VertxTestContext context) throws IOException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
                 .withRenewalDays(10)
@@ -1223,7 +1223,7 @@ public class CaReconcilerReconcileCasTest {
         secrets.add(initialClientsCaKeySecret);
 
         Checkpoint async = context.checkpoint();
-        reconcileCas(vertx, certificateAuthority, certificateAuthority)
+        reconcileCas(certificateAuthority, certificateAuthority)
                 .onComplete(context.failing(e -> context.verify(() -> {
                     assertThat(e, instanceOf(RuntimeException.class));
                     assertThat(e.getMessage(), is("User supplied Cluster CA cert chain ca.crt is not valid. Certificates must be provided in the correct order."));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -199,9 +199,8 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testOldClusterCaCertsGetsRemovedAuto(Vertx vertx, VertxTestContext context)
+    public void testOldClusterCaCertsGetsRemovedAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -271,7 +270,7 @@ public class CaReconcilerTest {
                 List.of(brokerPod));
 
         Checkpoint async = context.checkpoint();
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -317,7 +316,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testStrimziManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testStrimziManagedClusterCaKeyReplaced(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -372,7 +371,7 @@ public class CaReconcilerTest {
             return Future.succeededFuture();
         });
 
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -390,7 +389,7 @@ public class CaReconcilerTest {
 
     // Strimzi Cluster CA key replaced in previous reconcile and some pods already rolled
     @Test
-    public void testStrimziManagedClusterCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testStrimziManagedClusterCaKeyReplacedPreviously(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -455,7 +454,7 @@ public class CaReconcilerTest {
             return Future.succeededFuture();
         });
 
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -476,7 +475,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testStrimziManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testStrimziManagedClusterCaCertRenewed(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -512,7 +511,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -523,7 +522,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testUserManagedClusterCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testUserManagedClusterCaKeyReplaced(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -591,7 +590,7 @@ public class CaReconcilerTest {
                     .endClusterCa()
                 .endSpec()
                 .build();
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -608,7 +607,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testUserManagedClusterCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testUserManagedClusterCaCertRenewed(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -652,7 +651,7 @@ public class CaReconcilerTest {
                     .endClusterCa()
                 .endSpec()
                 .build();
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -663,7 +662,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testStrimziManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testStrimziManagedClientsCaKeyReplaced(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -699,7 +698,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -712,7 +711,7 @@ public class CaReconcilerTest {
 
     // Strimzi Clients CA key replaced in previous reconcile and some pods already rolled
     @Test
-    public void testStrimziManagedClientsCaKeyReplacedPreviously(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testStrimziManagedClientsCaKeyReplacedPreviously(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -753,7 +752,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -765,7 +764,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testStrimziManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testStrimziManagedClientsCaCertRenewed(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -801,7 +800,7 @@ public class CaReconcilerTest {
 
         Checkpoint async = context.checkpoint();
 
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -812,7 +811,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testUserManagedClientsCaKeyReplaced(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testUserManagedClientsCaKeyReplaced(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -861,7 +860,7 @@ public class CaReconcilerTest {
                     .endClientsCa()
                 .endSpec()
                 .build();
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -873,7 +872,7 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testUserManagedClientsCaCertRenewed(Vertx vertx, VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+    public void testUserManagedClientsCaCertRenewed(VertxTestContext context) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = getCertificateAuthority();
 
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
@@ -917,7 +916,7 @@ public class CaReconcilerTest {
                     .endClientsCa()
                 .endSpec()
                 .build();
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier, vertx);
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(kafka, supplier);
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
@@ -975,12 +974,11 @@ public class CaReconcilerTest {
         Map<String, RestartReasons> kafkaRestartReasons = new HashMap<>();
         Map<String, String> deploymentRestartReasons = new HashMap<>();
 
-        public MockCaReconciler(Kafka kafkaCr, ResourceOperatorSupplier supplier, Vertx vertx) {
+        public MockCaReconciler(Kafka kafkaCr, ResourceOperatorSupplier supplier) {
             super(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME),
                     kafkaCr,
                     new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
                     supplier,
-                    vertx,
                     CERT_MANAGER,
                     PASSWORD_GENERATOR
             );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -379,11 +379,11 @@ public class KubernetesRestartEventsMockTest {
     }
 
     @Test
-    void testEventEmittedWhenClusterCaCertKeyReplaced(Vertx vertx, VertxTestContext context) {
+    void testEventEmittedWhenClusterCaCertKeyReplaced(VertxTestContext context) {
         // Force replace ca key
         patchClusterCaKeySecretWithAnnotation(ResourceAnnotations.ANNO_STRIMZI_IO_FORCE_REPLACE, "true");
 
-        CaReconciler reconciler = new CaReconciler(reconciliation, kafka, clusterOperatorConfig, supplier, vertx, mockCertManager, passwordGenerator);
+        CaReconciler reconciler = new CaReconciler(reconciliation, kafka, clusterOperatorConfig, supplier, mockCertManager, passwordGenerator);
         reconciler.reconcile(Clock.systemUTC()).onComplete(verifyEventPublished(CLUSTER_CA_CERT_KEY_REPLACED, context));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `CaReconciler` class has an unused Vert.x parameter. This PR removes it from it and from all the places it is called from.

### Checklist

- [ ] Make sure all tests pass