### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -1,10 +1,6 @@
 name: Run System Tests
 
-# Permissions has to have at least the following permissions for the job to work properly
-permissions:
-  contents: read
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 on:
   workflow_call:
@@ -52,6 +48,11 @@ on:
 
 jobs:
   run-tests:
+    # Permissions has to have at least the following permissions for the job to work properly
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     strategy:
       matrix:
         config: ${{ fromJson(inputs.matrix) }}

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -1,6 +1,7 @@
 name: Run System Tests
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   workflow_call:
@@ -48,7 +49,6 @@ on:
 
 jobs:
   run-tests:
-    # Permissions has to have at least the following permissions for the job to work properly
     permissions:
       contents: read
       pull-requests: write
@@ -213,11 +213,11 @@ jobs:
           CONNECT_IMAGE="${CONNECT_BUILD_REGISTRY}/${DOCKER_ORG}/connect-file-sink:latest"
           KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
           BASE_IMAGE="${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka:${DOCKER_TAG}-kafka-${KAFKA_VERSION}"
-          
+
           echo "Base image: $BASE_IMAGE"
           eval "$(./systemtest/src/test/resources/connect-build/build-connect-image.sh "$KAFKA_VERSION" "$BASE_IMAGE" "$CONNECT_IMAGE")"
           echo "connect build image: $CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN"
-          
+
           # Push the images
           docker push ${CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN}
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Currently the score for the Token Permissions is 9 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will improve to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #12655

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] ~Write tests~
- [ ] ~Make sure all tests pass~
- [ ] ~Update documentation~
- [ ] ~Check RBAC rights for Kubernetes / OpenShift roles~
- [ ] ~Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally~
- [x] Reference relevant issue(s) and close them after merging
- [ ] ~Update CHANGELOG.md~
- [ ] ~Supply screenshots for visual changes, such as Grafana dashboards~
