### PR TITLE
Use defaut keystore type in TO Cruise Control client

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
@@ -239,14 +239,14 @@ public class CruiseControlClientImpl implements CruiseControlClient {
                 try (var caInput = new ByteArrayInputStream(sslCertificate)) {
                     ca = cf.generateCertificate(caInput);
                 }
-                
-                // create a P12 keystore containing our trusted chain
+
+                // create an in-memory KeyStore using the JVM's default keystore type containing our trusted chain
                 KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
                 keyStore.load(null, null);
                 keyStore.setCertificateEntry("ca", ca);
 
                 // create a trust manager that trusts the chain in our keystore
-                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX");
                 tmf.init(keyStore);
 
                 // create an SSL context that uses our trust manager

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
@@ -241,14 +241,14 @@ public class CruiseControlClientImpl implements CruiseControlClient {
                 }
                 
                 // create a P12 keystore containing our trusted chain
-                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
                 keyStore.load(null, null);
                 keyStore.setCertificateEntry("ca", ca);
-                
+
                 // create a trust manager that trusts the chain in our keystore
-                TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX");
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
                 tmf.init(keyStore);
-                
+
                 // create an SSL context that uses our trust manager
                 SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(null, tmf.getTrustManagers(), null);


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR follows on #12506 and #12627, with the intent of making Strimzi more portable between variously configured Java installations and make it work with BouncyCastle-based FIPS compliant Java installations (such as Chainguard Java FIPS images), it updates the way the Cruise Control client is configured in the Topic Operator and makes it use the default keystore and trust manager implementations rather then using specific hard-coded ones.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally