### PR TITLE
Change retrieveKafkaBrokerSANs signature to use explicit parameters

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertBundle.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertBundle.java
@@ -62,12 +62,12 @@ public class SystemTestCertBundle {
         this.caKeySecretName = caKeySecretName;
     }
 
-    private SystemTestCertBundle(final TestStorage testStorage) {
+    private SystemTestCertBundle(final String namespaceName, final String clusterName) {
         this.strimziRootCa = SystemTestCertGenerator.generateRootCaCertAndKey();
         this.intermediateCa = SystemTestCertGenerator.generateIntermediateCaCertAndKey(this.strimziRootCa);
         this.subjectDn = SystemTestCertGenerator.STRIMZI_END_SUBJECT;
         this.systemTestCa = SystemTestCertGenerator.generateEndEntityCertAndKey(
-            this.intermediateCa, SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage));
+            this.intermediateCa, SystemTestCertGenerator.retrieveKafkaBrokerSANs(namespaceName, clusterName));
         this.bundle = SystemTestCertGenerator.exportToPemFiles(
             this.systemTestCa, this.intermediateCa, this.strimziRootCa);
         this.caCertSecretName = null;
@@ -80,11 +80,12 @@ public class SystemTestCertBundle {
      * (i.e., it has no CA basic constraint), so it cannot be used to sign further certificates.
      * Useful for custom broker cert chain tests.
      *
-     * @param testStorage the test storage providing broker SAN information
+     * @param namespaceName the Kubernetes namespace in which the Kafka cluster is deployed
+     * @param clusterName   the name of the Kafka cluster
      * @return a new SystemTestCertBundle with root → intermediate → end-entity (non-CA) hierarchy
      */
-    public static SystemTestCertBundle forBrokerEndEntityCertificate(final TestStorage testStorage) {
-        return new SystemTestCertBundle(testStorage);
+    public static SystemTestCertBundle forBrokerEndEntityCertificate(final String namespaceName, final String clusterName) {
+        return new SystemTestCertBundle(namespaceName, clusterName);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertGenerator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertGenerator.java
@@ -7,7 +7,6 @@ package io.strimzi.systemtest.security;
 import io.skodjob.kubetest4j.security.CertAndKey;
 import io.skodjob.kubetest4j.security.CertAndKeyBuilder;
 import io.skodjob.kubetest4j.security.CertAndKeyFiles;
-import io.strimzi.systemtest.storage.TestStorage;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
@@ -91,16 +90,17 @@ public class SystemTestCertGenerator {
 
     /**
      * Generates a broker certificate chain (root CA, intermediate CA, and broker end-entity cert)
-     * using SANs derived from the provided {@link TestStorage} context. The resulting certificates
+     * using SANs derived from the provided namespace and cluster name. The resulting certificates
      * are exported to PEM files and returned in a {@link CertAndKeyFiles} bundle.
      *
-     * @param testStorage Holds the test context (e.g. cluster name, namespace) used for building SANs.
+     * @param namespaceName the Kubernetes namespace in which the Kafka cluster is deployed
+     * @param clusterName   the name of the Kafka cluster
      * @return A {@link CertAndKeyFiles} object with the broker certificate and key in PEM format.
      */
-    public static CertAndKeyFiles createBrokerCertChain(final TestStorage testStorage) {
+    public static CertAndKeyFiles createBrokerCertChain(final String namespaceName, final String clusterName) {
         final CertAndKey root = generateRootCaCertAndKey();
         final CertAndKey intermediate = generateIntermediateCaCertAndKey(root);
-        final CertAndKey brokerCertAndKey = generateEndEntityCertAndKey(intermediate, retrieveKafkaBrokerSANs(testStorage));
+        final CertAndKey brokerCertAndKey = generateEndEntityCertAndKey(intermediate, retrieveKafkaBrokerSANs(namespaceName, clusterName));
 
         return exportToPemFiles(brokerCertAndKey);
     }
@@ -153,16 +153,17 @@ public class SystemTestCertGenerator {
      * Constructs a list of Subject Alternative Name (SAN) DNS entries commonly used
      * for Kafka broker certificates in tests.
      *
-     * @param testStorage   Holds test-related identifiers such as the cluster name and namespace.
+     * @param namespaceName the Kubernetes namespace in which the Kafka cluster is deployed
+     * @param clusterName   the name of the Kafka cluster
      * @return An array of ASN1Encodable objects representing DNS Subject Alternative Names for Kafka brokers.
      */
-    public static ASN1Encodable[] retrieveKafkaBrokerSANs(final TestStorage testStorage) {
+    public static ASN1Encodable[] retrieveKafkaBrokerSANs(final String namespaceName, final String clusterName) {
         return new ASN1Encodable[] {
             new GeneralName(GeneralName.dNSName, "*.127.0.0.1.nip.io"),
-            new GeneralName(GeneralName.dNSName, "*." + testStorage.getClusterName() + "-kafka-brokers"),
-            new GeneralName(GeneralName.dNSName, "*." + testStorage.getClusterName() + "-kafka-brokers." + testStorage.getNamespaceName() + ".svc"),
-            new GeneralName(GeneralName.dNSName, testStorage.getClusterName() + "-kafka-bootstrap"),
-            new GeneralName(GeneralName.dNSName, testStorage.getClusterName() + "-kafka-bootstrap." + testStorage.getNamespaceName() + ".svc")
+            new GeneralName(GeneralName.dNSName, "*." + clusterName + "-kafka-brokers"),
+            new GeneralName(GeneralName.dNSName, "*." + clusterName + "-kafka-brokers." + namespaceName + ".svc"),
+            new GeneralName(GeneralName.dNSName, clusterName + "-kafka-bootstrap"),
+            new GeneralName(GeneralName.dNSName, clusterName + "-kafka-bootstrap." + namespaceName + ".svc")
         };
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -462,10 +462,10 @@ public class ListenersST extends AbstractST {
         final CertAndKey rootCa1 = generateRootCaCertAndKey();
         final CertAndKey rootCa2 = generateRootCaCertAndKey();
         final CertAndKey user1 = generateEndEntityCertAndKey(rootCa1,
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + testStorage.getUsername());
         final CertAndKey user2 = generateEndEntityCertAndKey(rootCa2,
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + superuserName);
 
         final CertAndKeyFiles rootCertAndKey = exportToPemFiles(rootCa1, rootCa2);
@@ -1109,7 +1109,7 @@ public class ListenersST extends AbstractST {
     )
     void testCustomSoloCertificatesForNodePort() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage))
+        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName()))
             .withLeafOnly(TrustChainSecrets.TRUST_LEAF_ONLY)
             .build(testStorage.getNamespaceName(), testStorage.getClusterName());
 
@@ -1206,7 +1206,7 @@ public class ListenersST extends AbstractST {
     )
     void testCustomChainCertificatesForNodePort() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        final SystemTestCertBundle brokerBundle = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
+        final SystemTestCertBundle brokerBundle = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         TrustChainSecrets.fromBundle(brokerBundle)
             .withFullChain(TrustChainSecrets.TRUST_FULL_CHAIN)
@@ -1305,7 +1305,7 @@ public class ListenersST extends AbstractST {
     )
     void testCustomSoloCertificatesForLoadBalancer() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage))
+        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName()))
             .withLeafOnly(TrustChainSecrets.TRUST_LEAF_ONLY)
             .build(testStorage.getNamespaceName(), testStorage.getClusterName());
 
@@ -1404,7 +1404,7 @@ public class ListenersST extends AbstractST {
     void testCustomChainCertificatesForLoadBalancer() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle brokerBundle = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
+        final SystemTestCertBundle brokerBundle = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         TrustChainSecrets.fromBundle(brokerBundle)
             .withFullChain(TrustChainSecrets.TRUST_FULL_CHAIN)
@@ -1512,7 +1512,7 @@ public class ListenersST extends AbstractST {
     )
     void testCustomSoloCertificatesForRoute() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage))
+        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName()))
             .withLeafOnly(TrustChainSecrets.TRUST_LEAF_ONLY)
             .build(testStorage.getNamespaceName(), testStorage.getClusterName());
 
@@ -1610,7 +1610,7 @@ public class ListenersST extends AbstractST {
     void testCustomChainCertificatesForRoute() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
-        final SystemTestCertBundle brokerBundle = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
+        final SystemTestCertBundle brokerBundle = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         TrustChainSecrets.fromBundle(brokerBundle)
             .withFullChain(TrustChainSecrets.TRUST_FULL_CHAIN)
@@ -1711,8 +1711,8 @@ public class ListenersST extends AbstractST {
     )
     void testCustomCertLoadBalancerAndTlsRollingUpdate() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        final SystemTestCertBundle brokerBundle1 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
-        final SystemTestCertBundle brokerBundle2 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
+        final SystemTestCertBundle brokerBundle1 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
+        final SystemTestCertBundle brokerBundle2 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         TrustChainSecrets.withoutBundle()
             .withCustom(customCertServer1, brokerBundle1.getSystemTestCa())
@@ -1970,8 +1970,8 @@ public class ListenersST extends AbstractST {
     )
     void testCustomCertNodePortAndTlsRollingUpdate() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        final SystemTestCertBundle brokerBundle1 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
-        final SystemTestCertBundle brokerBundle2 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
+        final SystemTestCertBundle brokerBundle1 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
+        final SystemTestCertBundle brokerBundle2 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         TrustChainSecrets.withoutBundle()
             .withCustom(customCertServer1, brokerBundle1.getSystemTestCa())
@@ -2227,8 +2227,8 @@ public class ListenersST extends AbstractST {
     )
     void testCustomCertRouteAndTlsRollingUpdate() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        final SystemTestCertBundle brokerBundle1 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
-        final SystemTestCertBundle brokerBundle2 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage);
+        final SystemTestCertBundle brokerBundle1 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
+        final SystemTestCertBundle brokerBundle2 = SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         TrustChainSecrets.withoutBundle()
             .withCustom(customCertServer1, brokerBundle1.getSystemTestCa())
@@ -2542,7 +2542,7 @@ public class ListenersST extends AbstractST {
     void testCertificateWithNonExistingDataCrt() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         final String nonExistingCertName = "non-existing-crt";
-        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage))
+        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName()))
             .withLeafOnly(TrustChainSecrets.TRUST_LEAF_ONLY)
             .build(testStorage.getNamespaceName(), testStorage.getClusterName());
 
@@ -2592,7 +2592,7 @@ public class ListenersST extends AbstractST {
     void testCertificateWithNonExistingDataKey() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         final String nonExistingCertKey = "non-existing-key";
-        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage))
+        TrustChainSecrets.fromBundle(SystemTestCertBundle.forBrokerEndEntityCertificate(testStorage.getNamespaceName(), testStorage.getClusterName()))
             .withLeafOnly(TrustChainSecrets.TRUST_LEAF_ONLY)
             .build(testStorage.getNamespaceName(), testStorage.getClusterName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaChainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaChainST.java
@@ -109,7 +109,7 @@ public class CustomCaChainST extends AbstractST {
         LOGGER.info("Testing that client with Clients-CA-Leaf-signed certificate can connect");
         final String leafSignedClientName = "leaf-ca-signed-client";
         final CertAndKey leafSignedClient = generateEndEntityCertAndKey(clientsCa.getSystemTestCa(),
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + leafSignedClientName);
         final CertAndKeyFiles leafSignedClientFiles = exportToPemFiles(leafSignedClient);
         SecretUtils.createCustomCertSecret(testStorage.getNamespaceName(), testStorage.getClusterName(),
@@ -128,7 +128,7 @@ public class CustomCaChainST extends AbstractST {
         LOGGER.info("Testing that client with Root-CA-signed certificate is rejected");
         final String rootSignedClientName = "root-ca-signed-client";
         final CertAndKey rootSignedClient = generateEndEntityCertAndKey(clientsCa.getStrimziRootCa(),
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + rootSignedClientName);
         final CertAndKeyFiles rootSignedClientFiles = exportToPemFiles(rootSignedClient);
         SecretUtils.createCustomCertSecret(testStorage.getNamespaceName(), testStorage.getClusterName(),
@@ -147,7 +147,7 @@ public class CustomCaChainST extends AbstractST {
         LOGGER.info("Testing that client with Intermediate-CA-signed certificate is rejected");
         final String intermediateSignedClientName = "intermediate-ca-signed-client";
         final CertAndKey intermediateSignedClient = generateEndEntityCertAndKey(clientsCa.getIntermediateCa(),
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + intermediateSignedClientName);
         final CertAndKeyFiles intermediateSignedClientFiles = exportToPemFiles(intermediateSignedClient);
         SecretUtils.createCustomCertSecret(testStorage.getNamespaceName(), testStorage.getClusterName(),
@@ -332,7 +332,7 @@ public class CustomCaChainST extends AbstractST {
         LOGGER.info("Testing that client with Leaf-CA-signed certificate can connect on port 9091");
         final String leafSignedClientName = "leaf-ca-signed-client";
         final CertAndKey leafSignedClient = generateEndEntityCertAndKey(clusterCa.getSystemTestCa(),
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + leafSignedClientName);
         final CertAndKeyFiles leafSignedClientFiles = exportToPemFiles(leafSignedClient);
         SecretUtils.createCustomCertSecret(testStorage.getNamespaceName(), testStorage.getClusterName(),
@@ -352,7 +352,7 @@ public class CustomCaChainST extends AbstractST {
         LOGGER.info("Testing that client with Root-CA-signed certificate is rejected on port 9091");
         final String rootSignedClientName = "root-ca-signed-client";
         final CertAndKey rootSignedClient = generateEndEntityCertAndKey(clusterCa.getStrimziRootCa(),
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + rootSignedClientName);
         final CertAndKeyFiles rootSignedClientFiles = exportToPemFiles(rootSignedClient);
         SecretUtils.createCustomCertSecret(testStorage.getNamespaceName(), testStorage.getClusterName(),
@@ -372,7 +372,7 @@ public class CustomCaChainST extends AbstractST {
         LOGGER.info("Testing that client with Intermediate-CA-signed certificate is rejected on port 9091");
         final String intermediateSignedClientName = "intermediate-ca-signed-client";
         final CertAndKey intermediateSignedClient = generateEndEntityCertAndKey(clusterCa.getIntermediateCa(),
-            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage),
+            SystemTestCertGenerator.retrieveKafkaBrokerSANs(testStorage.getNamespaceName(), testStorage.getClusterName()),
             "C=CZ, L=Prague, O=Strimzi, CN=" + intermediateSignedClientName);
         final CertAndKeyFiles intermediateSignedClientFiles = exportToPemFiles(intermediateSignedClient);
         SecretUtils.createCustomCertSecret(testStorage.getNamespaceName(), testStorage.getClusterName(),


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Resolves #12651.

Changes the signature of `retrieveKafkaBrokerSANs` from `retrieveKafkaBrokerSANs(final TestStorage testStorage)` to `retrieveKafkaBrokerSANs(final String namespaceName, final String clusterName)` to improve readability at call sites by making the required parameters explicit instead of hiding them inside a `TestStorage` object.
The same change is applied consistently to related methods that only accepted `TestStorage` to forward it to `retrieveKafkaBrokerSANs`:
- `createBrokerCertChain` in `SystemTestCertGenerator`
- Private constructor and `forBrokerEndEntityCertificate` factory method in `SystemTestCertBundle`
All call sites across `CustomCaChainST`, `ListenersST`, and `SystemTestCertBundle` have been updated accordingly.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

