### PR TITLE
Bump strimzi/github-actions version to v1 and pass build-id for containers push properly

### DIFF
--- a/.github/actions/build/test-strimzi/action.yml
+++ b/.github/actions/build/test-strimzi/action.yml
@@ -5,20 +5,20 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@main
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
       with:
         javaVersion: "21"
 
     - name: Install Docker
-      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
       with:
         version: "v4.6.3"
 
     - name: Install Helm
-      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@main
+      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v1
       with:
         helmVersion: "v3.16.0"
 
@@ -31,7 +31,7 @@ runs:
           maven-
 
     - name: Setup Kind cluster
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@main
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@v1
       with:
         controlNodes: 1
         workerNodes: 3

--- a/.github/workflows/actions-tests.yml
+++ b/.github/workflows/actions-tests.yml
@@ -35,7 +35,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
           
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
@@ -121,7 +121,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
@@ -208,7 +208,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
@@ -305,7 +305,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,22 +44,22 @@ jobs:
           rm -rf commit-sha.txt
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@main
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v1
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v1
         with:
           helmVersion: "v3.16.0"
 
@@ -72,7 +72,7 @@ jobs:
             kafka-binaries-
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@main
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@v1
         with:
           mainJavaBuild: "true"
           artifactSuffix: "operators"
@@ -111,12 +111,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install AsciiDoctor
-        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@v1
         with:
           rubyVersion: "3.2"
 
@@ -142,19 +142,19 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v1
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@main
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@v1
         with:
           architecture: ${{ matrix.architecture }}
           imagesDir: "./docker-images/container-archives"
@@ -179,20 +179,20 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@main
+        uses: strimzi/github-actions/.github/actions/build/push-containers@v1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -235,17 +235,17 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@main
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Deploy to Maven Central
-        uses: strimzi/github-actions/.github/actions/build/deploy-java@main
+        uses: strimzi/github-actions/.github/actions/build/deploy-java@v1
         with:
           modules: "./,crd-annotations,crd-generator,test,api,v1-api-conversion"
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,12 +45,12 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@main
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
       with:
         javaVersion: "21"
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
       with:
         version: "v4.6.3"
 

--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -69,19 +69,19 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v1
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@main
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@v1
         with:
           architecture: ${{ matrix.architecture }}
           imagesDir: "./docker-images/container-archives"
@@ -101,20 +101,20 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@main
+        uses: strimzi/github-actions/.github/actions/build/push-containers@v1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -154,20 +154,20 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@main
+        uses: strimzi/github-actions/.github/actions/build/push-containers@v1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,33 +37,33 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@main
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v1
         with:
           helmVersion: "v3.16.0"
 
       - name: Install AsciiDoctor
-        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@v1
         with:
           rubyVersion: "3.2"
 
       - name: Prepare release artifacts
-        uses: strimzi/github-actions/.github/actions/build/release-artifacts@main
+        uses: strimzi/github-actions/.github/actions/build/release-artifacts@v1
         with:
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "operators"
 
       - name: Deploy to Maven Central
-        uses: strimzi/github-actions/.github/actions/build/deploy-java@main
+        uses: strimzi/github-actions/.github/actions/build/deploy-java@v1
         with:
           modules: "./,crd-annotations,crd-generator,test,api,v1-api-conversion"
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -123,20 +123,20 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@main
+        uses: strimzi/github-actions/.github/actions/build/push-containers@v1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -171,20 +171,20 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@main
+        uses: strimzi/github-actions/.github/actions/build/push-containers@v1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -193,6 +193,7 @@ jobs:
           containerTag: "${{ inputs.releaseVersion }}"
           architectures: "amd64,arm64,ppc64le,s390x"
           artifactSuffix: "operators"
+          buildRunId: ${{ inputs.sourceBuildRunId }}
 
   # Publish Helm Chart as OCI artifact
   publish-helm-chart:
@@ -211,12 +212,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v1
         with:
           helmVersion: "v3.16.0"
 
       - name: Publish Helm charts using publish-helm action
-        uses: strimzi/github-actions/.github/actions/build/publish-helm-chart@main
+        uses: strimzi/github-actions/.github/actions/build/publish-helm-chart@v1
         with:
           registryUser: ${{ secrets.QUAY_HELM_USER }}
           registryPassword: ${{ secrets.QUAY_HELM_PASS }}

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -93,28 +93,28 @@ jobs:
           checkDescription: "Test run for ${{ matrix.config.jobName }}"
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@main
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
           architecture: ${{ matrix.config.arch }}
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v1
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v1
         with:
           helmVersion: "v3.16.0"
 
       - name: Setup Kind cluster
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@main
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@v1
         with:
           architecture: ${{ matrix.config.arch }}
           controlNodes: 1

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -226,22 +226,22 @@ jobs:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v1
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v1
         with:
           helmVersion: "v3.16.0"
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@main
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@v1
         with:
           mainJavaBuild: "true"
           artifactSuffix: "operators"
@@ -278,19 +278,19 @@ jobs:
           ref: ${{ needs.parse-params.outputs.ref }}
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@main
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v1
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@main
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@v1
         with:
           architecture: ${{ matrix.architecture }}
           imagesDir: "./docker-images/container-archives"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR uses `v1` of strimzi/github-actions to freeze used tooling. It also properly pass `buildRunId` parameter to push container job in release workflow. Without it the job looks for the artifacts in current workflow which is not desired. 

This PR should be cherry-picked to `release-1.0.x`

### Checklist

- [ ] Make sure all tests pass
