### PR TITLE
Added missing labels in the KSM deployment file

### DIFF
--- a/packaging/examples/metrics/kube-state-metrics/ksm.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/ksm.yaml
@@ -54,6 +54,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: strimzi-kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: strimzi-kube-state-metrics
 spec:
   type: "ClusterIP"
   ports:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This commit adds the missing app.kubernetes.io/name and app.kubernetes.io/instance labels to the strimzi-kube-state-metrics Service resource in the KSM.yaml of metrics example configuration. The ServiceMonitor seems to look for the label and since it is not able find them in the Service, the metrics are not scraped properly and therefore they don't appear in the prometheus metrics. This PR fixes the issue


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

