### PR TITLE
Bumped Vert.x 5.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <fasterxml.jackson-annotations.version>2.21</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.21.2</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.21.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>5.0.10</vertx.version>
-        <vertx-junit5.version>5.0.10</vertx-junit5.version>
+        <vertx.version>5.0.11</vertx.version>
+        <vertx-junit5.version>5.0.11</vertx-junit5.version>
         <kafka.version>4.2.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>


### PR DESCRIPTION
Trivial PR to bump Vert.x. The Netty version stays the same within Vert.x.