### PR TITLE
chore: Use resrouce group constants

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/StructuralCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/StructuralCrdIT.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.api.annotations.ApiVersion;
 import io.strimzi.api.annotations.VersionRange;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -29,16 +30,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class StructuralCrdIT extends AbstractCrdIT {
     private final static Map<String, String> CRD_FILES = Map.of(
-            "kafkas.kafka.strimzi.io", "040-Crd-kafka.yaml",
-            "kafkaconnects.kafka.strimzi.io", "041-Crd-kafkaconnect.yaml",
-            "kafkatopics.kafka.strimzi.io", "043-Crd-kafkatopic.yaml",
-            "kafkausers.kafka.strimzi.io", "044-Crd-kafkauser.yaml",
-            "kafkabridges.kafka.strimzi.io", "046-Crd-kafkabridge.yaml",
-            "kafkaconnectors.kafka.strimzi.io", "047-Crd-kafkaconnector.yaml",
-            "kafkamirrormaker2s.kafka.strimzi.io", "048-Crd-kafkamirrormaker2.yaml",
-            "kafkarebalances.kafka.strimzi.io", "049-Crd-kafkarebalance.yaml",
-            "kafkanodepools.kafka.strimzi.io", "045-Crd-kafkanodepool.yaml"
-    );
+            "kafkas." + Constants.RESOURCE_GROUP_NAME, "040-Crd-kafka.yaml",
+            "kafkaconnects." + Constants.RESOURCE_GROUP_NAME, "041-Crd-kafkaconnect.yaml",
+            "kafkatopics." + Constants.RESOURCE_GROUP_NAME, "043-Crd-kafkatopic.yaml",
+            "kafkausers." + Constants.RESOURCE_GROUP_NAME, "044-Crd-kafkauser.yaml",
+            "kafkabridges." + Constants.RESOURCE_GROUP_NAME, "046-Crd-kafkabridge.yaml",
+            "kafkaconnectors." + Constants.RESOURCE_GROUP_NAME, "047-Crd-kafkaconnector.yaml",
+            "kafkamirrormaker2s." + Constants.RESOURCE_GROUP_NAME, "048-Crd-kafkamirrormaker2.yaml",
+            "kafkarebalances." + Constants.RESOURCE_GROUP_NAME, "049-Crd-kafkarebalance.yaml",
+            "kafkanodepools." + Constants.RESOURCE_GROUP_NAME, "045-Crd-kafkanodepool.yaml");
 
     @BeforeEach
     public void beforeEach() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RbacUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RbacUtilsTest.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
@@ -45,7 +46,7 @@ public class RbacUtilsTest {
     @Test
     public void testRole()  {
         PolicyRule rule = new PolicyRuleBuilder()
-                .withApiGroups("kafka.strimzi.io")
+                .withApiGroups(Constants.RESOURCE_GROUP_NAME)
                 .withResources("kafkausers", "kafkausers/status")
                 .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
                 .build();
@@ -64,7 +65,7 @@ public class RbacUtilsTest {
     @Test
     public void testRoleWithTemplate()  {
         PolicyRule rule = new PolicyRuleBuilder()
-                .withApiGroups("kafka.strimzi.io")
+                .withApiGroups(Constants.RESOURCE_GROUP_NAME)
                 .withResources("kafkausers", "kafkausers/status")
                 .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.ConditionBuilder;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
@@ -1514,7 +1515,7 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
         // Set up the rebalance endpoint with the number of pending calls before a response is received.
         cruiseControlServer.setupCCRebalanceResponse(0, CruiseControlEndpoints.REBALANCE, "true");
 
-        String rebalanceString = "apiVersion: kafka.strimzi.io/v1beta2\n" +
+        String rebalanceString = "apiVersion: " + Constants.RESOURCE_GROUP_NAME + "/v1beta2\n" +
                 "kind: KafkaRebalance\n" +
                 "metadata:\n" +
                 "  name: " + RESOURCE_NAME + "\n" +

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.common.model;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.operator.common.Reconciliation;
@@ -45,8 +46,8 @@ public class ValidationVisitorTest {
         List<String> warningMessages = warningConditions.stream().map(Condition::getMessage).collect(Collectors.toList());
 
         assertThat(warningMessages, hasItem("Resource Kafka(testnamespace/testname) contains object at path spec.kafka with an unknown property: foo"));
-        assertThat(warningMessages, hasItem("In resource Kafka(testnamespace/testname) in API version kafka.strimzi.io/v1 the enableECDSA property at path spec.kafka.listeners.auth.enableECDSA has been deprecated."));
-        assertThat(warningMessages, hasItem("In resource Kafka(testnamespace/testname) in API version kafka.strimzi.io/v1 the service property at path spec.kafkaExporter.template.service has been deprecated. " +
+        assertThat(warningMessages, hasItem("In resource Kafka(testnamespace/testname) in API version " + Constants.RESOURCE_GROUP_NAME + "/v1 the enableECDSA property at path spec.kafka.listeners.auth.enableECDSA has been deprecated."));
+        assertThat(warningMessages, hasItem("In resource Kafka(testnamespace/testname) in API version " + Constants.RESOURCE_GROUP_NAME + "/v1 the service property at path spec.kafkaExporter.template.service has been deprecated. " +
                 "The Kafka Exporter service has been removed."));
 
         logger.assertLoggedAtLeastOnce(lm -> lm.level() == Level.WARN
@@ -54,10 +55,10 @@ public class ValidationVisitorTest {
                 "Resource Kafka\\(testnamespace/testname\\) contains object at path spec.kafka with an unknown property: foo"));
         logger.assertLoggedAtLeastOnce(lm -> lm.level() == Level.WARN
                 && lm.formattedMessage().matches("Reconciliation #[0-9]*\\(test\\) kind\\(namespace/name\\): " +
-                "In resource Kafka\\(testnamespace/testname\\) in API version kafka.strimzi.io/v1 the enableECDSA property at path spec.kafka.listeners.auth.enableECDSA has been deprecated."));
+                "In resource Kafka\\(testnamespace/testname\\) in API version " + Constants.RESOURCE_GROUP_NAME + "/v1 the enableECDSA property at path spec.kafka.listeners.auth.enableECDSA has been deprecated."));
         logger.assertLoggedAtLeastOnce(lm -> lm.level() == Level.WARN
                 && lm.formattedMessage().matches("Reconciliation #[0-9]*\\(test\\) kind\\(namespace/name\\): " +
-                "In resource Kafka\\(testnamespace/testname\\) in API version kafka.strimzi.io/v1 the service property at path spec.kafkaExporter.template.service has been deprecated. " +
+                "In resource Kafka\\(testnamespace/testname\\) in API version " + Constants.RESOURCE_GROUP_NAME + "/v1 the service property at path spec.kafkaExporter.template.service has been deprecated. " +
                 "The Kafka Exporter service has been removed."));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest;
 
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.test.TestUtils;
 
 import java.time.Duration;
@@ -356,5 +357,5 @@ public interface TestConstants {
     /**
      * API version
      */
-    String V1_BETA_2_API_VERSION = "kafka.strimzi.io/v1beta2";
+    String V1_BETA_2_API_VERSION = Constants.RESOURCE_GROUP_NAME + "/v1beta2";
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -30,6 +30,7 @@ import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.ConnectorState;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.PasswordSecretSourceBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
@@ -1308,7 +1309,7 @@ class ConnectST extends AbstractST {
         LOGGER.info("-------> Scaling KafkaConnect subresource <-------");
         LOGGER.info("Scaling subresource replicas to {}", scaleTo);
 
-        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaConnect.RESOURCE_KIND + ".kafka.strimzi.io", testStorage.getClusterName(), scaleTo);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaConnect.RESOURCE_KIND + "." + Constants.RESOURCE_GROUP_NAME, testStorage.getClusterName(), scaleTo);
 
         PodUtils.waitForPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaConnectSelector(), scaleTo, true);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -17,6 +17,7 @@ import io.skodjob.annotations.TestDoc;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.ConnectorState;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
@@ -544,7 +545,7 @@ class MirrorMaker2ST extends AbstractST {
 
         LOGGER.info("Scaling subresource replicas to {}", scaleTo);
 
-        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaMirrorMaker2.RESOURCE_KIND + ".kafka.strimzi.io", testStorage.getClusterName(), scaleTo);
+        KubeResourceManager.get().kubeCmdClient().inNamespace(testStorage.getNamespaceName()).scaleByName(KafkaMirrorMaker2.RESOURCE_KIND + "." + Constants.RESOURCE_GROUP_NAME, testStorage.getClusterName(), scaleTo);
         RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getMM2Selector(), scaleTo);
 
         LOGGER.info("Check if replicas is set to {}, naming prefix should be same and observed generation higher", scaleTo);

--- a/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/AbstractCommand.java
+++ b/v1-api-conversion/src/main/java/io/strimzi/kafka/api/conversion/v1/cli/AbstractCommand.java
@@ -5,6 +5,7 @@
 package io.strimzi.kafka.api.conversion.v1.cli;
 
 import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.model.common.Constants;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,31 +36,31 @@ public abstract class AbstractCommand implements Runnable {
     );
 
     protected static final Map<String, String> STRIMZI_GROUPS = Map.of(
-            "Kafka", "kafka.strimzi.io",
-            "KafkaConnect", "kafka.strimzi.io",
-            "KafkaBridge", "kafka.strimzi.io",
-            "KafkaMirrorMaker2", "kafka.strimzi.io",
-            "KafkaTopic", "kafka.strimzi.io",
-            "KafkaUser", "kafka.strimzi.io",
-            "KafkaConnector", "kafka.strimzi.io",
-            "KafkaRebalance", "kafka.strimzi.io",
-            "KafkaNodePool", "kafka.strimzi.io",
-            "StrimziPodSet", "core.strimzi.io"
+            "Kafka", Constants.RESOURCE_GROUP_NAME,
+            "KafkaConnect", Constants.RESOURCE_GROUP_NAME,
+            "KafkaBridge", Constants.RESOURCE_GROUP_NAME,
+            "KafkaMirrorMaker2", Constants.RESOURCE_GROUP_NAME,
+            "KafkaTopic", Constants.RESOURCE_GROUP_NAME,
+            "KafkaUser", Constants.RESOURCE_GROUP_NAME,
+            "KafkaConnector", Constants.RESOURCE_GROUP_NAME,
+            "KafkaRebalance", Constants.RESOURCE_GROUP_NAME,
+            "KafkaNodePool", Constants.RESOURCE_GROUP_NAME,
+            "StrimziPodSet", Constants.RESOURCE_CORE_GROUP_NAME
     );
 
     // Mapping between kinds and the CRD names used to get the right CRD from the Kubernetes API
     @SuppressWarnings("SpellCheckingInspection")
     protected static final Map<String, String> CRD_NAMES = Map.of(
-            "Kafka", "kafkas.kafka.strimzi.io",
-            "KafkaConnect", "kafkaconnects.kafka.strimzi.io",
-            "KafkaBridge", "kafkabridges.kafka.strimzi.io",
-            "KafkaMirrorMaker2", "kafkamirrormaker2s.kafka.strimzi.io",
-            "KafkaTopic", "kafkatopics.kafka.strimzi.io",
-            "KafkaUser", "kafkausers.kafka.strimzi.io",
-            "KafkaConnector", "kafkaconnectors.kafka.strimzi.io",
-            "KafkaRebalance", "kafkarebalances.kafka.strimzi.io",
-            "KafkaNodePool", "kafkanodepools.kafka.strimzi.io",
-            "StrimziPodSet", "strimzipodsets.core.strimzi.io"
+            "Kafka", "kafkas." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaConnect", "kafkaconnects." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaBridge", "kafkabridges." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaMirrorMaker2", "kafkamirrormaker2s." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaTopic", "kafkatopics." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaUser", "kafkausers." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaConnector", "kafkaconnectors." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaRebalance", "kafkarebalances." + Constants.RESOURCE_GROUP_NAME,
+            "KafkaNodePool", "kafkanodepools." + Constants.RESOURCE_GROUP_NAME,
+            "StrimziPodSet", "strimzipodsets." + Constants.RESOURCE_CORE_GROUP_NAME
     );
 
     @CommandLine.Spec

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConversionTestUtils.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConversionTestUtils.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.Updatable;
 import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.test.CrdUtils;
 
 import java.util.List;
@@ -131,23 +132,23 @@ public class ConversionTestUtils {
     }
 
     public static MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> kafkaOperation(KubernetesClient client) {
-        return operation(client, "Kafka", "kafka.strimzi.io", ApiVersion.V1BETA2);
+        return operation(client, "Kafka", Constants.RESOURCE_GROUP_NAME, ApiVersion.V1BETA2);
     }
 
     public static MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> kafkaV1Operation(KubernetesClient client) {
-        return operation(client, "Kafka", "kafka.strimzi.io", ApiVersion.V1);
+        return operation(client, "Kafka", Constants.RESOURCE_GROUP_NAME, ApiVersion.V1);
     }
 
     public static MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> connectOperation(KubernetesClient client) {
-        return operation(client, "KafkaConnect", "kafka.strimzi.io", ApiVersion.V1BETA2);
+        return operation(client, "KafkaConnect", Constants.RESOURCE_GROUP_NAME, ApiVersion.V1BETA2);
     }
 
     public static MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> connectV1Operation(KubernetesClient client) {
-        return operation(client, "KafkaConnect", "kafka.strimzi.io", ApiVersion.V1);
+        return operation(client, "KafkaConnect", Constants.RESOURCE_GROUP_NAME, ApiVersion.V1);
     }
 
     public static MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> bridgeOperation(KubernetesClient client) {
-        return operation(client, "KafkaBridge", "kafka.strimzi.io", ApiVersion.V1BETA2);
+        return operation(client, "KafkaBridge", Constants.RESOURCE_GROUP_NAME, ApiVersion.V1BETA2);
     }
 
     public static <T> T genericToTyped(GenericKubernetesResource genericResource, Class<T> type)    {

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertResourceCommandIT.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/ConvertResourceCommandIT.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.model.bridge.KafkaBridge;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorage;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -105,8 +106,8 @@ public class ConvertResourceCommandIT {
 
             Kafka kafka2 = new KafkaBuilder(kafka1).editMetadata().withName("kafka2").endMetadata().build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -151,7 +152,7 @@ public class ConvertResourceCommandIT {
                     .endSpec()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(bridge, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(bridge, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -225,8 +226,8 @@ public class ConvertResourceCommandIT {
                     .endMetadata()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -307,8 +308,8 @@ public class ConvertResourceCommandIT {
                     .endSpec()
                     .build();
 
-            kafkaOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            bridgeOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(bridge, "kafka.strimzi.io/v1beta2")).create();
+            kafkaOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            bridgeOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(bridge, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -390,8 +391,8 @@ public class ConvertResourceCommandIT {
                     .endSpec()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -474,8 +475,8 @@ public class ConvertResourceCommandIT {
                     .endSpec()
                     .build();
 
-            kafkaOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            bridgeOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(bridge, "kafka.strimzi.io/v1beta2")).create();
+            kafkaOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            bridgeOp.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(bridge, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -557,8 +558,8 @@ public class ConvertResourceCommandIT {
                     .endMetadata()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            op.inNamespace(namespace2).resource(ConversionTestUtils.typedToGeneric(kafka2, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            op.inNamespace(namespace2).resource(ConversionTestUtils.typedToGeneric(kafka2, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -637,8 +638,8 @@ public class ConvertResourceCommandIT {
                     .endMetadata()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka2, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/CrdUpgradeCommandIT.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/CrdUpgradeCommandIT.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -88,7 +89,7 @@ public class CrdUpgradeCommandIT {
                     .endSpec()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -152,7 +153,7 @@ public class CrdUpgradeCommandIT {
                     .endSpec()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(connect1, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(connect1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/FullUpgradeLifecycleIT.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/cli/FullUpgradeLifecycleIT.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -104,7 +105,7 @@ public class FullUpgradeLifecycleIT {
                     .endSpec()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(kafka1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             CommandLine cmd = new CommandLine(new EntryCommand());
             StringWriter sw = new StringWriter();
@@ -169,7 +170,7 @@ public class FullUpgradeLifecycleIT {
                     .endSpec()
                     .build();
 
-            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(connect1, "kafka.strimzi.io/v1beta2")).create();
+            op.inNamespace(NAMESPACE).resource(ConversionTestUtils.typedToGeneric(connect1, Constants.RESOURCE_GROUP_NAME + "/v1beta2")).create();
 
             // First try with unconverted resources => should fail
             CommandLine cmd = new CommandLine(new EntryCommand());

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/converter/conversions/BridgeMetricsConversionTest.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/converter/conversions/BridgeMetricsConversionTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.strimzi.api.annotations.ApiVersion;
 import io.strimzi.api.kafka.model.bridge.KafkaBridge;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.kafka.api.conversion.v1.converter.AbstractConverter;
@@ -41,7 +42,7 @@ class BridgeMetricsConversionTest {
     @Test
     public void testBridgeMetricsConversion() throws Exception {
         KafkaBridge kb = new KafkaBridgeBuilder()
-                .withApiVersion("kafka.strimzi.io/v1beta2")
+                .withApiVersion(Constants.RESOURCE_GROUP_NAME + "/v1beta2")
                 .withNewMetadata()
                     .withName("test")
                 .endMetadata()
@@ -54,7 +55,7 @@ class BridgeMetricsConversionTest {
                     .withEnableMetrics(true)
                 .endSpec()
                 .build();
-        kb.setApiVersion("kafka.strimzi.io/v1beta2");
+        kb.setApiVersion(Constants.RESOURCE_GROUP_NAME + "/v1beta2");
 
         verify(crConversion(new KafkaBridgeConverter(), kb, ApiVersion.V1));
         verify(jsonConversion(new KafkaBridgeConverter(), kb, ApiVersion.V1));

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/converter/conversions/VersionConversionTest.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/converter/conversions/VersionConversionTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
 import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
@@ -23,10 +24,10 @@ class VersionConversionTest {
 
     @Test
     public void testVersionConversion() throws Exception {
-        KafkaConnector kc = new KafkaConnectorBuilder().withApiVersion("kafka.strimzi.io/v1beta2").withNewSpec().endSpec().build();
+        KafkaConnector kc = new KafkaConnectorBuilder().withApiVersion(Constants.RESOURCE_GROUP_NAME + "/v1beta2").withNewSpec().endSpec().build();
         versionConversion(new KafkaConnectorConverter(), kc, ApiVersion.V1);
 
-        KafkaRebalance kr = new KafkaRebalanceBuilder().withApiVersion("kafka.strimzi.io/v1beta2").withNewSpec().endSpec().build();
+        KafkaRebalance kr = new KafkaRebalanceBuilder().withApiVersion(Constants.RESOURCE_GROUP_NAME + "/v1beta2").withNewSpec().endSpec().build();
         versionConversion(new KafkaRebalanceConverter(), kr, ApiVersion.V1);
     }
 
@@ -41,10 +42,10 @@ class VersionConversionTest {
         converter.convertTo(node, toApiVersion);
         T converted = JSON_MAPPER.readerFor(converter.crClass()).readValue(node);
         String apiVersion = converted.getApiVersion();
-        Assertions.assertEquals("kafka.strimzi.io/v1", apiVersion);
+        Assertions.assertEquals(Constants.RESOURCE_GROUP_NAME + "/v1", apiVersion);
 
         converter.convertTo(cr, toApiVersion);
         apiVersion = converted.getApiVersion();
-        Assertions.assertEquals("kafka.strimzi.io/v1", apiVersion);
+        Assertions.assertEquals(Constants.RESOURCE_GROUP_NAME + "/v1", apiVersion);
     }
 }

--- a/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/utils/UtilsIT.java
+++ b/v1-api-conversion/src/test/java/io/strimzi/kafka/api/conversion/v1/utils/UtilsIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.kafka.api.conversion.v1.cli.ConversionTestUtils;
 import io.strimzi.test.CrdUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -37,13 +38,13 @@ public class UtilsIT {
 
     @Test
     public void testMissingVersion() {
-        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () -> Utils.checkCrdsHaveApiVersions(client, List.of("kafkas.kafka.strimzi.io"), ApiVersion.V1BETA2, ApiVersion.V1));
-        assertThat(ex.getMessage(), containsString("CRD kafkas.kafka.strimzi.io is missing at least one of the required API versions [v1beta2, v1]"));
+        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () -> Utils.checkCrdsHaveApiVersions(client, List.of("kafkas." + Constants.RESOURCE_GROUP_NAME), ApiVersion.V1BETA2, ApiVersion.V1));
+        assertThat(ex.getMessage(), containsString("CRD kafkas." + Constants.RESOURCE_GROUP_NAME + " is missing at least one of the required API versions [v1beta2, v1]"));
     }
 
     @Test
     public void testMissingCrd() {
-        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () -> Utils.checkCrdsHaveApiVersions(client, List.of("kafkaconnects.kafka.strimzi.io"), ApiVersion.V1BETA2, ApiVersion.V1));
-        assertThat(ex.getMessage(), containsString("CRD kafkaconnects.kafka.strimzi.io is missing"));
+        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () -> Utils.checkCrdsHaveApiVersions(client, List.of("kafkaconnects." + Constants.RESOURCE_GROUP_NAME), ApiVersion.V1BETA2, ApiVersion.V1));
+        assertThat(ex.getMessage(), containsString("CRD kafkaconnects." + Constants.RESOURCE_GROUP_NAME + " is missing"));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We have constants specifying the Strimzi resource groups, but some Java files do not use the constant and instead hard code the same values. It would be nice to use the constants instead. This is just a refactor and should have no impact on capabilities, test etc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

