### PR TITLE
[ST] [perf] Improvements to capacity tests

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.performance.TopicOperatorPerformance.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.performance.TopicOperatorPerformance.md
@@ -20,7 +20,7 @@
 | 2. | Start collecting Topic Operator metrics. | Metrics collection is running. |
 | 3. | Create KafkaTopics in batches of 100, each with 12 partitions and 3 replicas. | Topics are created and reach Ready state. |
 | 4. | Continue creating topic batches until the Topic Operator fails to reconcile. | Maximum capacity is reached and failure is detected. |
-| 5. | Collect logs from Topic Operator and Kafka pods for analysis. | Logs are collected for identifying bottlenecks. |
+| 5. | Collect scoped logs (pods, deployments, configmaps, Kafka CR) using TestLogCollector with a custom resource list to avoid collecting thousands of KafkaTopic CRs and Secrets. | Logs are collected for identifying bottlenecks. |
 | 6. | Clean up all KafkaTopics and persist performance metrics. | Namespace is cleaned and performance data is saved to topic-operator report directory. |
 
 **Labels:**

--- a/development-docs/systemtests/io.strimzi.systemtest.performance.UserOperatorPerformance.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.performance.UserOperatorPerformance.md
@@ -20,7 +20,7 @@
 | 2. | Start collecting User Operator metrics. | Metrics collection is running. |
 | 3. | Create KafkaUsers with TLS authentication in batches of 100. | Users are created and reach Ready state. |
 | 4. | Continue creating user batches until the User Operator fails to reconcile. | Maximum capacity is reached and failure is detected. |
-| 5. | Collect logs from User Operator and Kafka pods for analysis. | Logs are collected for identifying bottlenecks. |
+| 5. | Collect scoped logs (pods, deployments, configmaps, Kafka CR) using TestLogCollector with a custom resource list to avoid collecting thousands of KafkaUser CRs and Secrets. | Logs are collected for identifying bottlenecks. |
 | 6. | Clean up all KafkaUsers and persist performance metrics. | Namespace is cleaned and performance data is saved to user-operator report directory. |
 
 **Labels:**

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
@@ -122,20 +122,9 @@ public class TestLogCollector {
     }
 
     /**
-     * TestLogCollector's constructor
+     * TestLogCollector's constructor with default list of namespaced resources.
      */
     public TestLogCollector() {
-        this.logCollector = defaultLogCollector();
-    }
-
-    /**
-     * Method for creating default configuration of the {@link LogCollector}.
-     * It provides default list of resources into the builder and configures the required {@link KubeClient} and
-     * {@link Kubectl}
-     *
-     * @return  {@link LogCollector} configured with default configuration for the tests
-     */
-    private LogCollector defaultLogCollector() {
         List<String> resources = new ArrayList<>(List.of(
             TestConstants.SECRET.toLowerCase(Locale.ROOT),
             TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),
@@ -163,13 +152,40 @@ public class TestLogCollector {
             ));
         }
 
+        this.logCollector = defaultLogCollectorBuilder()
+            .withNamespacedResources(resources.toArray(new String[0]))
+            .build();
+    }
+
+    private TestLogCollector(LogCollector logCollector) {
+        this.logCollector = logCollector;
+    }
+
+    /**
+     * Create an instance of {@link TestLogCollector}.
+     *
+     * @param logCollector instance of LogCollector
+     * @return      {@link TestLogCollector}
+     */
+    public static TestLogCollector of(LogCollector logCollector) {
+        return new TestLogCollector(logCollector);
+    }
+
+    /**
+     * Creates a pre-configured {@link LogCollectorBuilder} with the common settings
+     * (clients, root folder path, previous logs collection).
+     * Callers can further customize the builder (e.g., with a scoped namespaced resource list)
+     * before calling {@link LogCollectorBuilder#build()} and passing the result to
+     * {@link #TestLogCollector(LogCollector)}.
+     *
+     * @return  {@link LogCollectorBuilder} with default configuration
+     */
+    public static LogCollectorBuilder defaultLogCollectorBuilder() {
         return new LogCollectorBuilder()
             .withKubeClient(new KubeClient())
             .withKubeCmdClient(new Kubectl())
             .withRootFolderPath(Environment.TEST_LOG_DIR)
-            .withNamespacedResources(resources.toArray(new String[0]))
-            .withCollectPreviousLogs()
-            .build();
+            .withCollectPreviousLogs();
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/UserOperatorPerformanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/UserOperatorPerformanceUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.performance.utils;
 
-import io.fabric8.kubernetes.api.model.Secret;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimple;

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/UserOperatorPerformanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/UserOperatorPerformanceUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.performance.utils;
 
+import io.fabric8.kubernetes.api.model.Secret;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimple;
@@ -11,6 +12,7 @@ import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimpleBuilder;
 import io.strimzi.api.kafka.model.user.KafkaUserQuotas;
 import io.strimzi.api.kafka.model.user.KafkaUserQuotasBuilder;
 import io.strimzi.api.kafka.model.user.acl.AclOperation;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.UserAuthType;
 import io.strimzi.systemtest.resources.CrdClients;
@@ -26,6 +28,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -160,6 +163,10 @@ public class UserOperatorPerformanceUtils {
             final long deleteApiCallMs = Duration.ofNanos(System.nanoTime() - batchStartTime).toMillis();
             LOGGER.info("Batch {}/{} delete API calls took {} ms", batchNumber, totalBatches, deleteApiCallMs);
 
+            List<String> batchSecretNames = batch.stream()
+                .map(u -> u.getMetadata().getName())
+                .toList();
+
             TestUtils.waitFor(
                 "deletion of batch " + batchNumber + "/" + totalBatches,
                 TestConstants.GLOBAL_POLL_INTERVAL,
@@ -177,15 +184,69 @@ public class UserOperatorPerformanceUtils {
                     }
                 });
 
+            waitForUserSecretsCleanup(testStorage, batchSecretNames, batchNumber, totalBatches);
+
             final long batchTotalMs = Duration.ofNanos(System.nanoTime() - batchStartTime).toMillis();
             LOGGER.info("Batch {}/{} completed in {} ms (API calls: {} ms, reconciliation wait: {} ms)",
                 batchNumber, totalBatches, batchTotalMs, deleteApiCallMs, batchTotalMs - deleteApiCallMs);
         }
 
         final long totalCleanupMs = Duration.ofNanos(System.nanoTime() - cleanupStartTime).toMillis();
-        LOGGER.info("All {} KafkaUsers with prefix '{}' deleted in {} ms ({} ms/user avg)",
-            kafkaUsers.size(), testStorage.getUsername(), totalCleanupMs,
+        LOGGER.info("Full cleanup (KafkaUsers + Secrets) of {} users completed in {} ms ({} ms/user avg)",
+            kafkaUsers.size(), totalCleanupMs,
             kafkaUsers.size() > 0 ? totalCleanupMs / kafkaUsers.size() : 0);
+    }
+
+    /**
+     * Waits until all Secrets for the given batch of deleted KafkaUsers are fully removed.
+     * The User Operator deletes Secrets one-by-one through its reconciliation loop, which
+     * can be slow for large numbers of users. This method ensures each batch's Secrets are
+     * cleaned up before proceeding to the next batch.
+     *
+     * @param testStorage       storage containing namespace information
+     * @param secretNames       names of the Secrets to wait for (same as the KafkaUser names)
+     * @param batchNumber       current batch number (for logging)
+     * @param totalBatches      total number of batches (for logging)
+     */
+    private static void waitForUserSecretsCleanup(TestStorage testStorage,
+                                                  List<String> secretNames,
+                                                  int batchNumber,
+                                                  int totalBatches) {
+        final Set<String> secretNameSet = Set.copyOf(secretNames);
+
+        LOGGER.info("Waiting for {} Secrets from batch {}/{} to be cleaned up",
+            secretNameSet.size(), batchNumber, totalBatches);
+
+        final long secretWaitStart = System.nanoTime();
+
+        TestUtils.waitFor(
+            "deletion of Secrets from batch " + batchNumber + "/" + totalBatches,
+            TestConstants.GLOBAL_POLL_INTERVAL,
+            TestConstants.GLOBAL_TIMEOUT,
+            () -> {
+                List<String> remaining = KubeResourceManager.get().kubeClient().getClient()
+                    .secrets()
+                    .inNamespace(testStorage.getNamespaceName())
+                    .withLabel(Labels.STRIMZI_KIND_LABEL, KafkaUser.RESOURCE_KIND)
+                    .list()
+                    .getItems()
+                    .stream()
+                    .map(s -> s.getMetadata().getName())
+                    .filter(secretNameSet::contains)
+                    .toList();
+
+                if (remaining.isEmpty()) {
+                    return true;
+                }
+
+                LOGGER.debug("Batch {}/{}: still {} Secrets remaining",
+                    batchNumber, totalBatches, remaining.size());
+                return false;
+            });
+
+        final long secretWaitMs = Duration.ofNanos(System.nanoTime() - secretWaitStart).toMillis();
+        LOGGER.info("Batch {}/{} Secrets cleaned up in {} ms",
+            batchNumber, totalBatches, secretWaitMs);
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
@@ -11,6 +11,7 @@ import io.skodjob.annotations.SuiteDoc;
 import io.skodjob.annotations.TestDoc;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.skodjob.kubetest4j.wait.WaitException;
+import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -46,6 +47,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -120,6 +122,7 @@ public class TopicOperatorPerformance extends AbstractST {
                     .editSpec()
                         .withNewPersistentClaimStorage()
                             .withSize("50Gi")
+                            .withDeleteClaim(true)
                         .endPersistentClaimStorage()
                     .endSpec()
                     .build(),
@@ -127,6 +130,7 @@ public class TopicOperatorPerformance extends AbstractST {
                     .editSpec()
                         .withNewPersistentClaimStorage()
                             .withSize("5Gi")
+                            .withDeleteClaim(true)
                         .endPersistentClaimStorage()
                     .endSpec()
                     .build()
@@ -207,9 +211,15 @@ public class TopicOperatorPerformance extends AbstractST {
                 } catch (WaitException e) {
                     LOGGER.error("Failed to create Kafka topics from index {} to {}: {}", start, end, e.getMessage());
 
-                    // after a failure we will gather logs from all components under test (i.e., TO, Kafka pods) to observer behaviour
-                    // what might be a bottleneck of such performance
-                    this.logCollector = new TestLogCollector();
+                    this.logCollector = TestLogCollector.of(
+                        TestLogCollector.defaultLogCollectorBuilder()
+                            // Collect only resources, which are important to debug the failure (e.g., pods, deployments, Kafka CR).
+                            // Full collection would include thousands of KafkaTopic CRs, which is too slow to be practical.
+                            .withNamespacedResources(
+                                TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),
+                                TestConstants.CONFIG_MAP.toLowerCase(Locale.ROOT),
+                                Kafka.RESOURCE_SINGULAR
+                            ).build());
                     this.logCollector.collectLogs();
 
                     break; // Break out of the loop if an error occurs

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
@@ -100,7 +100,7 @@ public class TopicOperatorPerformance extends AbstractST {
             @Step(value = "Start collecting Topic Operator metrics.", expected = "Metrics collection is running."),
             @Step(value = "Create KafkaTopics in batches of 100, each with 12 partitions and 3 replicas.", expected = "Topics are created and reach Ready state."),
             @Step(value = "Continue creating topic batches until the Topic Operator fails to reconcile.", expected = "Maximum capacity is reached and failure is detected."),
-            @Step(value = "Collect logs from Topic Operator and Kafka pods for analysis.", expected = "Logs are collected for identifying bottlenecks."),
+            @Step(value = "Collect scoped logs (pods, deployments, configmaps, Kafka CR) using TestLogCollector with a custom resource list to avoid collecting thousands of KafkaTopic CRs and Secrets.", expected = "Logs are collected for identifying bottlenecks."),
             @Step(value = "Clean up all KafkaTopics and persist performance metrics.", expected = "Namespace is cleaned and performance data is saved to topic-operator report directory.")
         },
         labels = {

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
@@ -212,9 +212,10 @@ public class TopicOperatorPerformance extends AbstractST {
                     LOGGER.error("Failed to create Kafka topics from index {} to {}: {}", start, end, e.getMessage());
 
                     this.logCollector = TestLogCollector.of(
+                        // Pod logs and descriptions are always collected by LogCollector automatically.
+                        // Here we scope the additional namespaced resources to only deployments, configmaps, and Kafka CRs,
+                        // avoiding the default full set which would include thousands of KafkaTopic CRs.
                         TestLogCollector.defaultLogCollectorBuilder()
-                            // Collect only resources, which are important to debug the failure (e.g., pods, deployments, Kafka CR).
-                            // Full collection would include thousands of KafkaTopic CRs, which is too slow to be practical.
                             .withNamespacedResources(
                                 TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),
                                 TestConstants.CONFIG_MAP.toLowerCase(Locale.ROOT),

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
@@ -10,6 +10,8 @@ import io.skodjob.annotations.Step;
 import io.skodjob.annotations.SuiteDoc;
 import io.skodjob.annotations.TestDoc;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
+import io.skodjob.kubetest4j.wait.WaitException;
+import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -23,14 +25,11 @@ import io.strimzi.systemtest.performance.gather.schedulers.UserOperatorMetricsCo
 import io.strimzi.systemtest.performance.report.UserOperatorPerformanceReporter;
 import io.strimzi.systemtest.performance.report.parser.BasePerformanceMetricsParser;
 import io.strimzi.systemtest.performance.utils.UserOperatorPerformanceUtils;
-import io.strimzi.systemtest.resources.CrdClients;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
-import io.strimzi.test.WaitException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -45,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -66,7 +66,6 @@ public class UserOperatorPerformance extends AbstractST {
     private UserOperatorMetricsCollector userOperatorCollector;
     private UserOperatorMetricsCollectionScheduler userOperatorMetricsGatherer;
     private UserOperatorPerformanceReporter userOperatorPerformanceReporter = new UserOperatorPerformanceReporter();
-    private TestLogCollector logCollector;
 
     /**
      * Provides a stream of configurations for capacity testing, designed to evaluate
@@ -135,6 +134,7 @@ public class UserOperatorPerformance extends AbstractST {
                     .editSpec()
                         .withNewPersistentClaimStorage()
                             .withSize("10Gi")
+                            .withDeleteClaim(true)
                         .endPersistentClaimStorage()
                     .endSpec()
                     .build(),
@@ -218,20 +218,23 @@ public class UserOperatorPerformance extends AbstractST {
                 } catch (WaitException e) {
                     LOGGER.error("Failed to create Kafka users from index {} to {}: {}", start, end, e.getMessage());
 
-                    // after a failure we will gather logs from all components under test (i.e., UO, Kafka pods) to observer behaviour
-                    // what might be a bottleneck of such performance
-                    this.logCollector = new TestLogCollector();
-                    this.logCollector.collectLogs();
+                    final TestLogCollector logCollector = TestLogCollector.of(
+                        // Collect only resources, which are important to debug the failure (e.g., pods, deployments, Kafka CR).
+                        // Full collection would include thousands of KafkaUser CRs and Secrets, which is too slow to be practical.
+                        TestLogCollector.defaultLogCollectorBuilder()
+                            .withNamespacedResources(
+                                TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),
+                                TestConstants.CONFIG_MAP.toLowerCase(Locale.ROOT),
+                                Kafka.RESOURCE_SINGULAR
+                            ).build()
+                    );
+                    logCollector.collectLogs();
 
                     break; // Break out of the loop if an error occurs
                 }
             }
         } finally {
-            // to enchantment a process of deleting we should delete all resources at once
-            // I saw a behaviour where deleting one by one might lead to 10s delay for deleting each KafkaUser
-            List<KafkaUser> kafkaUsers = CrdClients.kafkaUserClient().inNamespace(testStorage.getNamespaceName()).list().getItems();
-            KubeResourceManager.get().deleteResourceAsyncWait(kafkaUsers.toArray(new KafkaUser[0]));
-            KafkaUserUtils.waitForUserWithPrefixDeletion(testStorage.getNamespaceName(), testStorage.getUsername());
+            UserOperatorPerformanceUtils.cleanupKafkaUsers(testStorage);
 
             if (this.userOperatorMetricsGatherer != null) {
                 this.userOperatorMetricsGatherer.stopCollecting();

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
@@ -110,7 +110,7 @@ public class UserOperatorPerformance extends AbstractST {
             @Step(value = "Start collecting User Operator metrics.", expected = "Metrics collection is running."),
             @Step(value = "Create KafkaUsers with TLS authentication in batches of 100.", expected = "Users are created and reach Ready state."),
             @Step(value = "Continue creating user batches until the User Operator fails to reconcile.", expected = "Maximum capacity is reached and failure is detected."),
-            @Step(value = "Collect logs from User Operator and Kafka pods for analysis.", expected = "Logs are collected for identifying bottlenecks."),
+            @Step(value = "Collect scoped logs (pods, deployments, configmaps, Kafka CR) using TestLogCollector with a custom resource list to avoid collecting thousands of KafkaUser CRs and Secrets.", expected = "Logs are collected for identifying bottlenecks."),
             @Step(value = "Clean up all KafkaUsers and persist performance metrics.", expected = "Namespace is cleaned and performance data is saved to user-operator report directory.")
         },
         labels = {

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
@@ -219,8 +219,9 @@ public class UserOperatorPerformance extends AbstractST {
                     LOGGER.error("Failed to create Kafka users from index {} to {}: {}", start, end, e.getMessage());
 
                     final TestLogCollector logCollector = TestLogCollector.of(
-                        // Collect only resources, which are important to debug the failure (e.g., pods, deployments, Kafka CR).
-                        // Full collection would include thousands of KafkaUser CRs and Secrets, which is too slow to be practical.
+                        // Pod logs and descriptions are always collected by LogCollector automatically.
+                        // Here we scope the additional namespaced resources to only deployments, configmaps, and Kafka CRs,
+                        // avoiding the default full set which would include thousands of KafkaUser CRs and Secrets.
                         TestLogCollector.defaultLogCollectorBuilder()
                             .withNamespacedResources(
                                 TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR adds a few improvements:
1. Reducing un-necessary KafkaUser and KafkaTopic CRs within capacity tests => no need because logs from pods are enough + Kafka CR etc. (i.e., we don't need to gather 30k KU CRs which are in ready state...)
2. Add check for KafkaUser Secret ... so we don't eventually end up with timeout on deleting PVCs or Kafka ... (because UO still processing deletion of Secrets).
3. also adding `.withDeleteClaim(true)` so PVCs are deleted automatically and no need for manual.
4. also we need to add `io.skodjob.kubetest4j.wait.WaitException` instead of our test WaitException because when we use `KubeResourceManager.get().createResourceWithoutWait` during creation and that `KubeResourceManager` would throw `io.skodjob.kubetest4j.wait.WaitException`. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation