### PR TITLE
Remove deletion of old brokers certificate Secret

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
@@ -159,18 +159,6 @@ public class KafkaResources {
     }
 
     /**
-     * Returns the name of the Kafka Secret with server certificates.
-     *
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     *
-     * @return The name of the corresponding Kafka Secret.
-     */
-    @Deprecated // Kafka server certificates are now kept in per-node Secrets
-    public static String kafkaSecretName(String clusterName) {
-        return clusterName + "-kafka-brokers";
-    }
-
-    /**
      * Returns the name of the Kafka Secret with JMX credentials.
      *
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -808,20 +808,8 @@ public class KafkaReconciler {
                 .map(secretName -> {
                     LOGGER.debugCr(reconciliation, "Deleting old Secret {}/{} that is no longer used.", reconciliation.namespace(), secretName);
                     return secretOperator.deleteAsync(reconciliation, reconciliation.namespace(), secretName, false);
-                }).collect(Collectors.toCollection(ArrayList::new)); // We need to collect to mutable list because we might need to add to the list more items later
-
-        // Remove old Secret containing all certs if it exists
-        @SuppressWarnings("deprecation")
-        String oldSecretName = KafkaResources.kafkaSecretName(reconciliation.name());
-        return secretOperator.getAsync(reconciliation.namespace(), oldSecretName)
-                .compose(oldSecret -> {
-                    if (oldSecret != null) {
-                        LOGGER.debugCr(reconciliation, "Deleting legacy Secret {}/{} that is replaced by pod specific Secret.", reconciliation.namespace(), oldSecretName);
-                        deleteFutures.add(secretOperator.deleteAsync(reconciliation, reconciliation.namespace(), oldSecretName, false));
-                    }
-
-                    return Future.join(deleteFutures).mapEmpty();
-                });
+                }).toList();
+        return Future.join(deleteFutures).mapEmpty();
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Task

### Description

In Strimzi 0.46.0 / #10967 we moved from a single shared Secret with all broker certificates to per-broker Secrets. Since then we have been deleting the old Secret as a cleanup. This PR removes the cleanup as it should not be needed anymore (upgrades from 0.45 and earlier to 1.x have to go through 0.49-0.51, which would delete it).

### Checklist

- [x] Make sure all tests pass