### PR TITLE
Bound HTTP timeouts in KafkaAgentClient to keep KafkaRoller responsive

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -23,6 +23,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
 
 /**
  * Creates HTTP client and interacts with Kafka Agent's REST endpoint
@@ -34,6 +35,11 @@ public class KafkaAgentClient {
     private static final String BROKER_STATE_REST_PATH = "/v1/broker-state/";
     private static final int KAFKA_AGENT_HTTPS_PORT = 8443;
     private static final char[] KEYSTORE_PASSWORD = "changeit".toCharArray();
+    // Bounds the connect and full HTTP request lifecycle so that a broker which accepts the TCP connection but
+    // never produces a response (e.g. alive but stuck on IO) cannot block the KafkaRoller's single-threaded
+    // executor indefinitely. The Kafka Agent only serves a small broker-state JSON, so 10 seconds is well above
+    // the expected response time on a healthy broker yet small enough to keep the roller responsive.
+    /* test */ static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private final String namespace;
     private final Reconciliation reconciliation;
     private final String cluster;
@@ -92,7 +98,7 @@ public class KafkaAgentClient {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 
-            return HttpClient.newBuilder()
+            return httpClientBuilder()
                     .sslContext(sslContext)
                     .build();
         } catch (GeneralSecurityException | IOException e) {
@@ -100,12 +106,37 @@ public class KafkaAgentClient {
         }
     }
 
+    /**
+     * Returns an {@link HttpClient.Builder} pre-configured with {@link #HTTP_REQUEST_TIMEOUT} as the connect timeout.
+     * Centralising the timeout wiring here keeps {@link #createHttpClient()} focused on TLS setup and lets tests
+     * assert that the configured connect timeout is applied without needing a TLS identity.
+     *
+     * @return an {@link HttpClient.Builder} with the connect timeout already applied
+     */
+    /* test */ static HttpClient.Builder httpClientBuilder() {
+        return HttpClient.newBuilder().connectTimeout(HTTP_REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Builds a {@code GET} {@link HttpRequest} for the given URI with {@link #HTTP_REQUEST_TIMEOUT} applied as the
+     * full request timeout. Centralising the timeout wiring here lets tests assert the request timeout without
+     * needing a live HTTP endpoint.
+     *
+     * @param uri   the target URI for the request
+     *
+     * @return a {@code GET} {@link HttpRequest} for {@code uri} with the request timeout already applied
+     */
+    /* test */ static HttpRequest buildRequest(URI uri) {
+        return HttpRequest.newBuilder()
+                .uri(uri)
+                .timeout(HTTP_REQUEST_TIMEOUT)
+                .GET()
+                .build();
+    }
+
     String doGet(URI uri) {
         try {
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .GET()
-                    .build();
+            HttpRequest req = buildRequest(uri);
 
             var response = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -39,7 +39,7 @@ public class KafkaAgentClient {
     // never produces a response (e.g. alive but stuck on IO) cannot block the KafkaRoller's single-threaded
     // executor indefinitely. The Kafka Agent only serves a small broker-state JSON, so 10 seconds is well above
     // the expected response time on a healthy broker yet small enough to keep the roller responsive.
-    /* test */ static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private final String namespace;
     private final Reconciliation reconciliation;
     private final String cluster;
@@ -98,7 +98,8 @@ public class KafkaAgentClient {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 
-            return httpClientBuilder()
+            return HttpClient.newBuilder()
+                    .connectTimeout(HTTP_REQUEST_TIMEOUT)
                     .sslContext(sslContext)
                     .build();
         } catch (GeneralSecurityException | IOException e) {
@@ -106,37 +107,13 @@ public class KafkaAgentClient {
         }
     }
 
-    /**
-     * Returns an {@link HttpClient.Builder} pre-configured with {@link #HTTP_REQUEST_TIMEOUT} as the connect timeout.
-     * Centralising the timeout wiring here keeps {@link #createHttpClient()} focused on TLS setup and lets tests
-     * assert that the configured connect timeout is applied without needing a TLS identity.
-     *
-     * @return an {@link HttpClient.Builder} with the connect timeout already applied
-     */
-    /* test */ static HttpClient.Builder httpClientBuilder() {
-        return HttpClient.newBuilder().connectTimeout(HTTP_REQUEST_TIMEOUT);
-    }
-
-    /**
-     * Builds a {@code GET} {@link HttpRequest} for the given URI with {@link #HTTP_REQUEST_TIMEOUT} applied as the
-     * full request timeout. Centralising the timeout wiring here lets tests assert the request timeout without
-     * needing a live HTTP endpoint.
-     *
-     * @param uri   the target URI for the request
-     *
-     * @return a {@code GET} {@link HttpRequest} for {@code uri} with the request timeout already applied
-     */
-    /* test */ static HttpRequest buildRequest(URI uri) {
-        return HttpRequest.newBuilder()
-                .uri(uri)
-                .timeout(HTTP_REQUEST_TIMEOUT)
-                .GET()
-                .build();
-    }
-
     String doGet(URI uri) {
         try {
-            HttpRequest req = buildRequest(uri);
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .timeout(HTTP_REQUEST_TIMEOUT)
+                    .GET()
+                    .build();
 
             var response = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientTest.java
@@ -7,6 +7,11 @@ package io.strimzi.operator.cluster.operator.resource;
 import io.strimzi.operator.common.Reconciliation;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -59,5 +64,31 @@ public class KafkaAgentClientTest {
         assertEquals(-1, actual.code());
         assertEquals(0, actual.remainingLogsToRecover());
         assertEquals(0, actual.remainingSegmentsToRecover());
+    }
+
+    /**
+     * Regression guard: a previous version of KafkaAgentClient configured no timeout on the per-request side,
+     * which let a broker stuck on IO block the KafkaRoller's single-threaded executor indefinitely. Verify that
+     * requests built via the package-private helper carry the configured timeout.
+     */
+    @Test
+    public void testBuildRequestAppliesHttpRequestTimeout() {
+        HttpRequest request = KafkaAgentClient.buildRequest(URI.create("https://example.invalid/v1/broker-state/"));
+        Duration timeout = request.timeout().orElseThrow(() -> new AssertionError("HTTP request timeout was not configured"));
+        assertEquals(KafkaAgentClient.HTTP_REQUEST_TIMEOUT, timeout, "Request timeout must equal HTTP_REQUEST_TIMEOUT");
+        assertTrue(timeout.toMillis() > 0, "HTTP request timeout must be positive but was " + timeout);
+    }
+
+    /**
+     * Regression guard: a previous version of KafkaAgentClient configured no connect timeout, which let an
+     * unresponsive broker block the KafkaRoller's single-threaded executor indefinitely. Verify that clients
+     * built via the package-private helper carry the configured connect timeout.
+     */
+    @Test
+    public void testHttpClientBuilderAppliesConnectTimeout() {
+        HttpClient client = KafkaAgentClient.httpClientBuilder().build();
+        Duration connectTimeout = client.connectTimeout().orElseThrow(() -> new AssertionError("HTTP connect timeout was not configured"));
+        assertEquals(KafkaAgentClient.HTTP_REQUEST_TIMEOUT, connectTimeout, "Connect timeout must equal HTTP_REQUEST_TIMEOUT");
+        assertTrue(connectTimeout.toMillis() > 0, "HTTP connect timeout must be positive but was " + connectTimeout);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientTest.java
@@ -7,11 +7,6 @@ package io.strimzi.operator.cluster.operator.resource;
 import io.strimzi.operator.common.Reconciliation;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,31 +59,5 @@ public class KafkaAgentClientTest {
         assertEquals(-1, actual.code());
         assertEquals(0, actual.remainingLogsToRecover());
         assertEquals(0, actual.remainingSegmentsToRecover());
-    }
-
-    /**
-     * Regression guard: a previous version of KafkaAgentClient configured no timeout on the per-request side,
-     * which let a broker stuck on IO block the KafkaRoller's single-threaded executor indefinitely. Verify that
-     * requests built via the package-private helper carry the configured timeout.
-     */
-    @Test
-    public void testBuildRequestAppliesHttpRequestTimeout() {
-        HttpRequest request = KafkaAgentClient.buildRequest(URI.create("https://example.invalid/v1/broker-state/"));
-        Duration timeout = request.timeout().orElseThrow(() -> new AssertionError("HTTP request timeout was not configured"));
-        assertEquals(KafkaAgentClient.HTTP_REQUEST_TIMEOUT, timeout, "Request timeout must equal HTTP_REQUEST_TIMEOUT");
-        assertTrue(timeout.toMillis() > 0, "HTTP request timeout must be positive but was " + timeout);
-    }
-
-    /**
-     * Regression guard: a previous version of KafkaAgentClient configured no connect timeout, which let an
-     * unresponsive broker block the KafkaRoller's single-threaded executor indefinitely. Verify that clients
-     * built via the package-private helper carry the configured connect timeout.
-     */
-    @Test
-    public void testHttpClientBuilderAppliesConnectTimeout() {
-        HttpClient client = KafkaAgentClient.httpClientBuilder().build();
-        Duration connectTimeout = client.connectTimeout().orElseThrow(() -> new AssertionError("HTTP connect timeout was not configured"));
-        assertEquals(KafkaAgentClient.HTTP_REQUEST_TIMEOUT, connectTimeout, "Connect timeout must equal HTTP_REQUEST_TIMEOUT");
-        assertTrue(connectTimeout.toMillis() > 0, "HTTP connect timeout must be positive but was " + connectTimeout);
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #12513.

`KafkaAgentClient.getBrokerState()` is invoked from the KafkaRoller's single-threaded executor whenever a broker fails the readiness `await`. The underlying `java.net.http.HttpClient` and `HttpRequest` builders had no timeouts configured, so if a broker was alive but stuck on IO (for example because the underlying block storage had degraded to zero IOPS), the kernel TCP stack would still accept the connection but the Kafka Agent handler thread — also blocked on disk IO — would never produce a response. The HTTP call could therefore block the roller's single thread for the entire duration of the storage outage, preventing any other broker from being processed and significantly inflating reconciliation time.

This change adds a bounded 10 second timeout on both `HttpClient.connectTimeout(...)` and `HttpRequest.timeout(...)`. When the timeout fires, the resulting `HttpTimeoutException` (subclass of `IOException`) is caught by the existing `IOException` handler in `doGet()` and wrapped as `RuntimeException`. `getBrokerState()` already handles that case gracefully by returning `BrokerState(-1, null)`, so the roller can move on to other brokers and retry on the next reconciliation. No behaviour change for healthy brokers.

The Kafka Agent only serves a tiny broker-state JSON, so 10 seconds is well above the expected response latency on a healthy broker yet small enough to keep the single-threaded roller responsive (worst-case extra delay per stuck broker is `operationTimeoutMs` + 10 s instead of `operationTimeoutMs` + unbounded). 


### Checklist

- [x] Write tests
- [x] Make sure all tests pass — verified locally (see above) for the impacted test classes; full project CI handles the rest.
- [x] Update documentation — no `CHANGELOG.md` entry per maintainer review (this is a bugfix); no user-facing docs affected.
- [ ] Check RBAC rights for Kubernetes / OpenShift roles — n/a, no RBAC change.
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally — n/a, change is internal to the Cluster Operator's HTTP client and exercised via unit tests.
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md — intentionally not updated (bugfix, per maintainer review).
- [ ] Supply screenshots for visual changes — n/a.

### Notes

The fix is the one suggested by the issue reporter (@dariocazas) and acknowledged by maintainers (@scholzj, @ppatierno, @katheris) as a sensible enhancement. No backport to 0.47.x is requested as part of this PR (per maintainer feedback on the issue).
