### PR TITLE
Fix null reason logged in Ca DEBUG message for NOOP renewal type

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -697,7 +697,9 @@ public abstract class Ca {
         }
 
         switch (renewalType) {
-            case REPLACE_KEY, RENEW_CERT, CREATE, NOOP ->
+            case NOOP ->
+                    LOGGER.debugCr(reconciliation, "{}: {}", this, renewalType.preDescription(caName()));
+            case REPLACE_KEY, RENEW_CERT, CREATE ->
                     LOGGER.debugCr(reconciliation, "{}: {}: {}", this, renewalType.preDescription(caName()), reason);
             case POSTPONED ->
                     LOGGER.warnCr(reconciliation, "{}: {}: {}", this, renewalType.preDescription(caName()), reason);

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
@@ -94,6 +94,18 @@ class CaTest {
     }
 
     @Test
+    @DisplayName("Should result in NOOP when CA key and certificate already exist and are valid")
+    void shouldNoopWhenCaAlreadyExists() {
+        ca.createRenewOrReplace(true, false, false);
+        assertTrue(ca.keyCreated(), "First call should create the CA");
+
+        ca.createRenewOrReplace(true, false, false);
+        assertFalse(ca.certRenewed(), "Second call should not renew the certificate");
+        assertFalse(ca.keyReplaced(), "Second call should not replace the key");
+        assertFalse(ca.keyCreated(), "Second call should not create a new key");
+    }
+
+    @Test
     @DisplayName("Should raise RuntimeException when certificate is not present")
     void shouldReturnZeroWhenCertificateNotPresent() {
         Exception exception = assertThrows(RuntimeException.class, () -> ca.getCertificateExpirationDateEpoch());


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

When the Ca class determines that no certificate renewal or key replacement is needed (NOOP), the DEBUG log message includes : null at the end:
`2026-04-27 16:06:30 DEBUG Ca:701 - Reconciliation #252(timer) Kafka(myproject/my-cluster): clients-ca: CA key and certificate (in Clients CA Secrets) already exist and do not need replacing or renewing: null
`
This happens because the reason variable is initialized to null and is only set when a renewal or replacement is actually needed. The NOOP case was grouped with REPLACE_KEY, RENEW_CERT, and CREATE in the switch statement, so it logged the null reason.

The fix separates NOOP into its own case branch that logs without the reason, since it is the only renewal type where no reason is set.

Fixes #12682
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

