### PR TITLE
Fix default operatorNetworkPolicy value to use a widlcard egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 1.1.0
 
 * Support for dependency scope configuration of Maven artifacts in Kafka Connect Build
-* Fix the default `operatorNetworkPolicy.egress` value in the Helm chart so that enabling the operator NetworkPolicy without overriding `egress` produces a wildcard egress rule (allow-all) instead of a deny-all empty rule
 
 ### Major changes, deprecations, and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 
 * Support for dependency scope configuration of Maven artifacts in Kafka Connect Build
+* Fix the default `operatorNetworkPolicy.egress` value in the Helm chart so that enabling the operator NetworkPolicy without overriding `egress` produces a wildcard egress rule (allow-all) instead of a deny-all empty rule
 
 ### Major changes, deprecations, and removals
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_network_policy_test.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_network_policy_test.yaml
@@ -1,0 +1,66 @@
+suite: strimzi operator network policy
+release:
+  name: strimzi-test
+  namespace: strimzi-test-namespace
+templates:
+  - 052-NetworkPolicy-strimzi-cluster-operator.yaml
+tests:
+  - it: should not render the NetworkPolicy by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render the NetworkPolicy when enabled
+    set:
+      operatorNetworkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: strimzi-cluster-operator-network-policy
+
+  - it: should default egress to a wildcard rule allowing all traffic
+    set:
+      operatorNetworkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.egress
+          value:
+            - {}
+
+  - it: should default ingress to allow the metrics http port
+    set:
+      operatorNetworkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.ingress
+          value:
+            - ports:
+                - protocol: TCP
+                  port: http
+
+  - it: should allow custom egress rules to override the default
+    set:
+      operatorNetworkPolicy.enabled: true
+      operatorNetworkPolicy.egress:
+        - ports:
+            - protocol: UDP
+              port: 53
+            - protocol: TCP
+              port: 53
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.egress
+          value:
+            - ports:
+                - protocol: UDP
+                  port: 53
+                - protocol: TCP
+                  port: 53

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -99,7 +99,8 @@ operatorNetworkPolicy:
   #
   # Any meaningful network restrictions must be defined per cluster,
   # with a full knowledge of the Kafka topology and port configuration.
-  egress: {}
+  egress:
+  - {}
 
 # If you are using the grafana dashboard sidecar,
 # you can import some default dashboards here


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The default value for the operator network policy egress seems incorrect.

When templating the chart with the operator network policy enabled, the default values produce a empty/null egress directive which would result in a deny all traffic for the operator egress.

```
$ helm template strimzi ./helm-charts/helm3/strimzi-kafka-operator --output-dir out --set 'operatorNetworkPolicy.enabled=true'
wrote out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
wrote out/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
... truncated output ...

$ cat out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
---
# Source: strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: strimzi-cluster-operator-network-policy
spec:
  egress:
  ingress:
    - ports:
      - port: http
        protocol: TCP
  podSelector:
    matchLabels:
      name: strimzi-cluster-operator
  policyTypes:
  - Egress
  - Ingress
```

I managed to workaround this by using a custom value, but this produces a warning.

```
$ cat custom.yaml
operatorNetworkPolicy:
  enabled: true
  egress:
    - {}
$ helm template strimzi ./helm-charts/helm3/strimzi-kafka-operator --output-dir out --values custom.yaml
level=INFO msg="warning: cannot overwrite table with non table for strimzi-kafka-operator.operatorNetworkPolicy.egress (map[])"
wrote out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
wrote out/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
... truncated output ...

$ cat out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
---
# Source: strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: strimzi-cluster-operator-network-policy
spec:
  egress:
    - {}
  ingress:
    - ports:
      - port: http
        protocol: TCP
  podSelector:
    matchLabels:
      name: strimzi-cluster-operator
  policyTypes:
  - Egress
  - Ingress
```


#### Solution

This PR fixes this by defining the wildcard egress as the default operator network policy value.

```
$ helm template strimzi ./helm-charts/helm3/strimzi-kafka-operator --output-dir out --set 'operatorNetworkPolicy.enabled=true'
wrote out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
wrote out/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
... truncated output ...

---
# Source: strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: strimzi-cluster-operator-network-policy
spec:
  egress:
    - {}
  ingress:
    - ports:
      - port: http
        protocol: TCP
  podSelector:
    matchLabels:
      name: strimzi-cluster-operator
  policyTypes:
  - Egress
  - Ingress
```

Providing custom egress values now does not produces any templating warning:

```
$ cat test.yaml
operatorNetworkPolicy:
  enabled: true
  egress:
  - ports:
      - protocol: UDP
        port: 53
      - protocol: TCP
        port: 53
$ helm template strimzi ./helm-charts/helm3/strimzi-kafka-operator --values test.yaml --output-dir out
wrote out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
wrote out/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
... truncated output ...

$ cat out/strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
---
# Source: strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: strimzi-cluster-operator-network-policy
spec:
  egress:
    - ports:
      - port: 53
        protocol: UDP
      - port: 53
        protocol: TCP
  ingress:
    - ports:
      - port: http
        protocol: TCP
  podSelector:
    matchLabels:
      name: strimzi-cluster-operator
  policyTypes:
  - Egress
  - Ingress
```

### Checklist

- [x] Write tests — added `packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_network_policy_test.yaml` covering the default disabled state, the wildcard egress default when enabled, the ingress default, and user-supplied egress overrides.
- [x] Make sure all tests pass — `helm unittest packaging/helm-charts/helm3/strimzi-kafka-operator/` reports 23/23 passing.
- [ ] Update documentation — N/A. The README only documents `operatorNetworkPolicy.enabled`; the `egress`/`ingress` values are not listed in the configuration table, so no doc change is required.
- [ ] Check RBAC rights for Kubernetes / OpenShift roles — N/A, this PR only changes a Helm chart default value, no RBAC change.
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally — verified via `helm template` rendering (see above); the change is only the default value of the existing NetworkPolicy template so behavior in-cluster matches the rendered manifest. Also verified this on a live Kubernetes cluster.
- [ ] Reference relevant issue(s) and close them after merging - No related issue found.
- [x] Update CHANGELOG.md — entry added under `1.1.0`.
- [ ] Supply screenshots for visual changes, such as Grafana dashboards — N/A, no UI changes.