### PR TITLE
[ST] Add Strimzi 1.0.0 to upgrade/downgrade tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/BundleVersionModificationData.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/BundleVersionModificationData.java
@@ -22,6 +22,7 @@ public class BundleVersionModificationData extends CommonVersionModificationData
     private Map<String, String> imagesAfterOperations;
     private Map<String, Object> client;
     private Map<String, String> environmentInfo;
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     @JsonIgnoreProperties
     private Boolean convertCrsAndCrds = false;
 
@@ -109,10 +110,12 @@ public class BundleVersionModificationData extends CommonVersionModificationData
         this.environmentInfo = environmentInfo;
     }
 
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     public Boolean getConvertCrsAndCrds() {
         return convertCrsAndCrds;
     }
 
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     public void setConvertCrsAndCrds(Boolean convertCrsAndCrds) {
         if (convertCrsAndCrds == null) {
             this.convertCrsAndCrds = false;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -168,6 +168,9 @@ public class AbstractKRaftUpgradeST extends AbstractST {
         if (upgradeDowngradeData.getConvertCrsAndCrds()) {
             // convert CRs and CRDs to v1
             convertCrsAndCrds(testStorage.getNamespaceName());
+        } else if (upgradeDowngradeData.getFromVersion().equals("0.51.0")) {
+            // convert CRDs to v1
+            convertCrds(testStorage.getNamespaceName());
         }
 
         // 5. Upgrade CO to HEAD and wait for readiness of ClusterOperator

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -120,6 +120,8 @@ public class AbstractKRaftUpgradeST extends AbstractST {
     protected final LabelSelector coSelector = new LabelSelectorBuilder().withMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "cluster-operator")).build();
     protected final LabelSelector connectLabelSelector = LabelSelectors.connectLabelSelector(CLUSTER_NAME, KafkaConnectResources.componentName(CLUSTER_NAME));
 
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
+    // Plus delete all the files on the path
     protected static final String PATH_TO_CONVERSION_RESOURCES_FILES = TestUtils.USER_PATH + "/../systemtest/src/test/resources/upgrade/conversion/";
     protected static final String CONVERSION_TOOL_JOB_NAME = "strimzi-v1-api-conversion";
 
@@ -162,6 +164,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
         // 4. Verify KafkaConnector FileSink
         verifyKafkaConnectorFileSink(testStorage);
 
+        // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
         if (upgradeDowngradeData.getConvertCrsAndCrds()) {
             // convert CRs and CRDs to v1
             convertCrsAndCrds(testStorage.getNamespaceName());
@@ -273,6 +276,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
             if (upgradeData.getFromVersion().equals("HEAD")) {
                 kafkaTopicYaml = new File(dir, PATH_TO_PACKAGING_EXAMPLES + "/topic/kafka-topic.yaml");
             } else if (upgradeData.getConvertCrsAndCrds()) {
+                // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
                 kafkaTopicYaml = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "kafka-topic.yaml");
             } else {
                 kafkaTopicYaml = new File(dir, upgradeData.getFromExamples() + "/examples/topic/kafka-topic.yaml");
@@ -369,6 +373,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
                         .endSpec()
                         .build());
             } else {
+                // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
                 if (upgradeData.getConvertCrsAndCrds()) {
                     kafkaYaml = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "kafka.yaml");
                 } else {
@@ -400,6 +405,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
             if (upgradeData.getFromVersion().equals("HEAD")) {
                 KubeResourceManager.get().createResourceWithWait(KafkaUserTemplates.tlsUser(componentsNamespaceName, USER_NAME, CLUSTER_NAME).build());
             } else {
+                // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
                 if (upgradeData.getConvertCrsAndCrds()) {
                     kafkaUserYaml = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "kafka-user.yaml");
                 } else {
@@ -420,6 +426,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
             if (upgradeData.getFromVersion().equals("HEAD")) {
                 kafkaTopicYaml = new File(dir, PATH_TO_PACKAGING_EXAMPLES + "/topic/kafka-topic.yaml");
             } else if (upgradeData.getConvertCrsAndCrds()) {
+                // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
                 kafkaTopicYaml = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "kafka-topic.yaml");
             } else {
                 kafkaTopicYaml = new File(dir, upgradeData.getFromExamples() + "/examples/topic/kafka-topic.yaml");
@@ -481,6 +488,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
                 // resource stored in `systemtest/src/test/resources/upgrade/conversion/kafka-connect.yaml`
                 // In order to not map the file to v1 KafkaConnect (which is default when you are using the object) we need to use
                 // GenericKubernetesResource and append all the changes related to the Connect Build (for running the file-sink connector).
+                // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
                 if (acrossUpgradeData.getConvertCrsAndCrds()) {
                     kafkaConnectYaml = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "kafka-connect.yaml");
 
@@ -886,6 +894,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      *
      * @param componentsNamespaceName   Namespace where the conversion tool will run and where are all the operands.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     protected void convertCrsAndCrds(String componentsNamespaceName) {
         // create RBAC resources needed for running the conversion Job
         createConversionToolRbacResources(componentsNamespaceName);
@@ -903,6 +912,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      *
      * @param componentsNamespaceName   Namespace where the conversion tool will run and where are all the operands.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     protected void convertCrdsOnly(String componentsNamespaceName) {
         // create RBAC resources needed for running the conversion Job
         createConversionToolRbacResources(componentsNamespaceName);
@@ -921,6 +931,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      *
      * @param componentsNamespaceName   Namespace where the conversion tool will run and where are all the operands.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     private void convertCrs(String componentsNamespaceName) {
         runConversion(componentsNamespaceName, "convert-resource");
 
@@ -946,6 +957,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      *
      * @param componentsNamespaceName Namespace where the conversion tool will run and where are all the operands.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     private void convertCrds(String componentsNamespaceName) {
         runConversion(componentsNamespaceName, "crd-upgrade");
 
@@ -971,6 +983,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      * @param componentsNamespaceName   Namespace where the conversion tool will run and where are all the operands.
      * @param command                   Command that should be executed by the conversion tool.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     private void runConversion(String componentsNamespaceName, String command) {
         String jobResourceYaml = buildConversionToolJob(componentsNamespaceName, command);
         KubeResourceManager.get().kubeCmdClient().inNamespace(componentsNamespaceName).applyContent(jobResourceYaml);
@@ -984,6 +997,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      *
      * @param componentsNamespaceName Namespace where the conversion tool will run and where are all the operands.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     private void createConversionToolRbacResources(String componentsNamespaceName) {
         File conversionToolFile = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "conversion-tool-rbac.yaml");
 
@@ -1022,6 +1036,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      *
      * @return  Job YAML of the conversion tool, updated with Namespace and command.
      */
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     private String buildConversionToolJob(String componentsNamespaceName, String command) {
         File conversionToolFile = new File(PATH_TO_CONVERSION_RESOURCES_FILES + "conversion-tool.yaml");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -168,9 +168,6 @@ public class AbstractKRaftUpgradeST extends AbstractST {
         if (upgradeDowngradeData.getConvertCrsAndCrds()) {
             // convert CRs and CRDs to v1
             convertCrsAndCrds(testStorage.getNamespaceName());
-        } else if (!upgradeDowngradeData.getFromVersion().equals("HEAD")) {
-            // convert just CRDs to v1 as we are upgrading from storage being v1beta2
-            convertCrdsOnly(testStorage.getNamespaceName());
         }
 
         // 5. Upgrade CO to HEAD and wait for readiness of ClusterOperator
@@ -413,7 +410,11 @@ public class AbstractKRaftUpgradeST extends AbstractST {
                 }
                 LOGGER.info("Deploying KafkaUser from: {}", kafkaUserYaml.getPath());
                 KubeResourceManager.get().kubeCmdClient().inNamespace(componentsNamespaceName).applyContent(KafkaUserUtils.removeKafkaUserPart(kafkaUserYaml, "authorization"));
-                KafkaUserUtils.waitForKafkaUserReadyForV1Beta2(componentsNamespaceName, USER_NAME);
+                if (upgradeData.getConvertCrsAndCrds()) {
+                    KafkaUserUtils.waitForKafkaUserReadyForV1Beta2(componentsNamespaceName, USER_NAME);
+                } else {
+                    KafkaUserUtils.waitForKafkaUserReady(componentsNamespaceName, USER_NAME);
+                }
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -169,6 +169,8 @@ public class AbstractKRaftUpgradeST extends AbstractST {
             // convert CRs and CRDs to v1
             convertCrsAndCrds(testStorage.getNamespaceName());
         } else if (upgradeDowngradeData.getFromVersion().equals("0.51.0")) {
+            // create RBAC resources needed for running the conversion Job
+            createConversionToolRbacResources(testStorage.getNamespaceName());
             // convert CRDs to v1
             convertCrds(testStorage.getNamespaceName());
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftStrimziUpgradeST.java
@@ -43,6 +43,12 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziUpgradeST.class);
     private final BundleVersionModificationData acrossUpgradeData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_UPGRADE).buildDataForUpgradeAcrossVersionsForKRaft();
+    private final BundleVersionModificationData conversionUpgradeData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_UPGRADE)
+        .getBundleUpgradeOrDowngradeDataList()
+        .stream()
+        .filter(data -> data.getFromVersion().equals("0.51.0"))
+        .findFirst()
+        .get();
 
     @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
     @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
@@ -65,7 +71,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
     @IsolatedTest
     void testUpgradeWithCrAndCrdConversion() throws IOException {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
-        BundleVersionModificationData crdUpgradeData = acrossUpgradeData;
+        BundleVersionModificationData crdUpgradeData = conversionUpgradeData;
         crdUpgradeData.setConvertCrsAndCrds(true);
 
         UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(crdUpgradeData.getDeployKafkaVersion());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftStrimziUpgradeST.java
@@ -43,6 +43,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziUpgradeST.class);
     private final BundleVersionModificationData acrossUpgradeData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_UPGRADE).buildDataForUpgradeAcrossVersionsForKRaft();
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     private final BundleVersionModificationData conversionUpgradeData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_UPGRADE)
         .getBundleUpgradeOrDowngradeDataList()
         .stream()
@@ -68,6 +69,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, upgradeData, upgradeKafkaVersion);
     }
 
+    // TODO: Remove this after 1.1.0 release - https://github.com/strimzi/strimzi-kafka-operator/issues/12692
     @IsolatedTest
     void testUpgradeWithCrAndCrdConversion() throws IOException {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftStrimziUpgradeST.java
@@ -100,9 +100,6 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         // Make snapshots of all Pods
         makeComponentsSnapshots(testStorage.getNamespaceName());
 
-        // Convert CRDs before upgrade
-        convertCrdsOnly(testStorage.getNamespaceName());
-
         // Upgrade CO
         changeClusterOperator(CO_NAMESPACE, testStorage.getNamespaceName(), acrossUpgradeData);
         logClusterOperatorPodImage(CO_NAMESPACE);
@@ -136,9 +133,6 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         // Make snapshots of all Pods
         makeComponentsSnapshots(testStorage.getNamespaceName());
 
-        // Convert CRDs before upgrade
-        convertCrdsOnly(testStorage.getNamespaceName());
-
         // Upgrade CO
         changeClusterOperator(CO_NAMESPACE, testStorage.getNamespaceName(), acrossUpgradeData);
 
@@ -166,9 +160,6 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
         // Setup env
         setupEnvAndUpgradeClusterOperator(CO_NAMESPACE, testStorage, acrossUpgradeData, null);
-
-        // Convert CRDs before upgrade
-        convertCrdsOnly(testStorage.getNamespaceName());
 
         // Upgrade CO
         changeClusterOperator(CO_NAMESPACE, testStorage.getNamespaceName(), acrossUpgradeData);

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -31,17 +31,17 @@
 #    toKafka: path to Kafka and KafkaNodePool resources, collected in one file, in the version of Strimzi, to which we are doing the downgrade
 # --- Structure ---
 - fromVersion: HEAD
-  toVersion: 0.51.0
+  toVersion: 1.0.0
   fromExamples: HEAD
-  toExamples: strimzi-0.51.0
+  toExamples: strimzi-1.0.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.51.0/strimzi-0.51.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/1.0.0/strimzi-1.0.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    kafka: strimzi/kafka:0.51.0-kafka-4.2.0
-    topicOperator: strimzi/operator:0.51.0
-    userOperator: strimzi/operator:0.51.0
+    kafka: strimzi/kafka:1.0.0-kafka-4.2.0
+    topicOperator: strimzi/operator:1.0.0
+    userOperator: strimzi/operator:1.0.0
   deployKafkaVersion: 4.2.0
   client:
     continuousClientsMessages: 400
@@ -51,47 +51,22 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   fromFeatureGates: ""
-  toFeatureGates: "+UseConnectBuildWithBuildah"
+  toFeatureGates: ""
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
 - fromVersion: HEAD
-  toVersion: 0.51.0
+  toVersion: 1.0.0
   fromExamples: HEAD
-  toExamples: strimzi-0.51.0
+  toExamples: strimzi-1.0.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.51.0/strimzi-0.51.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/1.0.0/strimzi-1.0.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    kafka: strimzi/kafka:0.51.0-kafka-4.2.0
-    topicOperator: strimzi/operator:0.51.0
-    userOperator: strimzi/operator:0.51.0
-  deployKafkaVersion: 4.2.0
-  client:
-    continuousClientsMessages: 400
-  environmentInfo:
-    maxK8sVersion: latest
-    status: stable
-    flakyEnvVariable: none
-    reason: Test is working on all environment used by QE.
-  fromFeatureGates: "-ServerSideApplyPhase1"
-  toFeatureGates: "+ServerSideApplyPhase1,+UseConnectBuildWithBuildah"
-  filePaths:
-    fromKafka: "/examples/kafka/kafka-persistent.yaml"
-    toKafka: "/examples/kafka/kafka-persistent.yaml"
-- fromVersion: HEAD
-  toVersion: 0.51.0
-  fromExamples: HEAD
-  toExamples: strimzi-0.51.0
-  fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.51.0/strimzi-0.51.0.zip
-  fromKafkaVersionsUrl: HEAD
-  additionalTopics: 2
-  imagesAfterOperations:
-    kafka: strimzi/kafka:0.51.0-kafka-4.2.0
-    topicOperator: strimzi/operator:0.51.0
-    userOperator: strimzi/operator:0.51.0
+    kafka: strimzi/kafka:1.0.0-kafka-4.2.0
+    topicOperator: strimzi/operator:1.0.0
+    userOperator: strimzi/operator:1.0.0
   deployKafkaVersion: 4.2.0
   client:
     continuousClientsMessages: 400
@@ -101,7 +76,7 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   fromFeatureGates: ""
-  toFeatureGates: "+ServerSideApplyPhase1,+UseConnectBuildWithBuildah"
+  toFeatureGates: "-ServerSideApplyPhase1,-UseConnectBuildWithBuildah"
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -76,7 +76,7 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   fromFeatureGates: ""
-  toFeatureGates: "-ServerSideApplyPhase1,-UseConnectBuildWithBuildah"
+  toFeatureGates: "-ServerSideApplyPhase1"
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -31,12 +31,11 @@
 #  fromKafka: path to Kafka and KafkaNodePool resources, collected in one file, in the version of Strimzi, from which we are doing the upgrade
 #  toKafka: path to Kafka and KafkaNodePool resources, collected in one file, in the version of Strimzi, to which we are doing the upgrade
 #  --- Structure ---
-
-- fromVersion: 0.51.0
-  fromExamples: strimzi-0.51.0
+- fromVersion: 1.0.0
+  fromExamples: strimzi-1.0.0
   deployKafkaVersion: 4.2.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.51.0/strimzi-0.51.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.51.0/kafka-versions.yaml
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/1.0.0/strimzi-1.0.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     kafka: strimzi/kafka:latest-kafka-4.2.0
@@ -49,11 +48,36 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
-  fromFeatureGates: "+UseConnectBuildWithBuildah"
+  fromFeatureGates: "-UseConnectBuildWithBuildah,-ServerSideApplyPhase1"
   toFeatureGates: ""
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"
     toKafka: "/examples/kafka/kafka-persistent.yaml"
+- fromVersion: 1.0.0
+  fromExamples: strimzi-1.0.0
+  deployKafkaVersion: 4.2.0
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/1.0.0/strimzi-1.0.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/kafka-versions.yaml
+  additionalTopics: 2
+  imagesAfterOperations:
+    kafka: strimzi/kafka:latest-kafka-4.2.0
+    topicOperator: strimzi/operator:latest
+    userOperator: strimzi/operator:latest
+  client:
+    continuousClientsMessages: 400
+  environmentInfo:
+    maxK8sVersion: latest
+    status: stable
+    flakyEnvVariable: none
+    reason: Test is working on environment, where k8s server version is < 1.22
+  fromFeatureGates: ""
+  toFeatureGates: ""
+  filePaths:
+    fromKafka: "/examples/kafka/kafka-persistent.yaml"
+    toKafka: "/examples/kafka/kafka-persistent.yaml"
+# We will keep 0.51.0 until release of 1.1.0.
+# This version is mainly used for the conversion tool ST, to verify that after the conversion is done,
+# we can upgrade to main (1.1.0) without problem.
 - fromVersion: 0.51.0
   fromExamples: strimzi-0.51.0
   deployKafkaVersion: 4.2.0
@@ -72,28 +96,6 @@
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
   fromFeatureGates: "+UseConnectBuildWithBuildah"
-  toFeatureGates: "-ServerSideApplyPhase1"
-  filePaths:
-    fromKafka: "/examples/kafka/kafka-persistent.yaml"
-    toKafka: "/examples/kafka/kafka-persistent.yaml"
-- fromVersion: 0.51.0
-  fromExamples: strimzi-0.51.0
-  deployKafkaVersion: 4.2.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.51.0/strimzi-0.51.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.51.0/kafka-versions.yaml
-  additionalTopics: 2
-  imagesAfterOperations:
-    kafka: strimzi/kafka:latest-kafka-4.2.0
-    topicOperator: strimzi/operator:latest
-    userOperator: strimzi/operator:latest
-  client:
-    continuousClientsMessages: 400
-  environmentInfo:
-    maxK8sVersion: latest
-    status: stable
-    flakyEnvVariable: none
-    reason: Test is working on environment, where k8s server version is < 1.22
-  fromFeatureGates: "+ServerSideApplyPhase1,+UseConnectBuildWithBuildah"
   toFeatureGates: ""
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -48,7 +48,7 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
-  fromFeatureGates: "-UseConnectBuildWithBuildah,-ServerSideApplyPhase1"
+  fromFeatureGates: "-ServerSideApplyPhase1"
   toFeatureGates: ""
   filePaths:
     fromKafka: "/examples/kafka/kafka-persistent.yaml"

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -16,13 +16,13 @@
 #  Kubernetes cluster.
 #  --- Prerequisites ---
 
-fromVersion: 0.51.0
-fromOlmChannelName: strimzi-0.51.x
-fromExamples: strimzi-0.51.0
-fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.51.0/strimzi-0.51.0.zip
-fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.51.0/kafka-versions.yaml
+fromVersion: 1.0.0
+fromOlmChannelName: strimzi-1.0.x
+fromExamples: strimzi-1.0.0
+fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/1.0.0/strimzi-1.0.0.zip
+fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/kafka-versions.yaml
 filePaths:
   fromKafka: "/examples/kafka/kafka-persistent.yaml"
   toKafka: "/examples/kafka/kafka-persistent.yaml"
-fromFeatureGates: "-ServerSideApplyPhase1"
+fromFeatureGates: "-ServerSideApplyPhase1,-UseConnectBuildWithBuildah"
 toFeatureGates: ""


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

This PR adds Strimzi 1.0.0 to the upgrade/downgrade tests after the release.
Also, it keeps one version in the version list for Strimzi upgrade tests to be `0.51.0` -> which will be used mainly by the conversion tool ST, which should be deleted once Strimzi 1.1.0 is out - tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/12692.

### Checklist

- [x] Make sure all tests pass

