### PR TITLE
[user-operator] Add spec.username to KafkaUser to decouple CR name from Kafka username

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
@@ -18,14 +18,29 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "authentication", "authorization", "quotas", "template" })
+@JsonPropertyOrder({ "username", "authentication", "authorization", "quotas", "template" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserSpec extends Spec {
+    private String username;
     private KafkaUserAuthentication authentication;
     private KafkaUserAuthorization authorization;
     private KafkaUserQuotas quotas;
     private KafkaUserTemplate template;
+
+    @Description("The name of the Kafka user. " +
+            "When absent this will default to the metadata.name of the KafkaUser resource. " +
+            "The username is used as the Kafka principal for ACLs, quotas, and SCRAM-SHA credentials. " +
+            "For TLS authentication, it is used as the Common Name (CN) in the certificate. " +
+            "Setting this field allows multiple KafkaUser resources in the same namespace to " +
+            "create users with the same Kafka username on different Kafka clusters.")
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
 
     @Description("Authentication mechanism enabled for this Kafka user. " +
             "The supported authentication mechanisms are `scram-sha-512`, `tls`, and `tls-external`. \n\n" +

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -61,8 +61,14 @@ public class KafkaUserModel {
      */
     public static final String KEY_SASL_JAAS_CONFIG = "sasl.jaas.config";
 
+    /**
+     * Annotation key for storing the resolved Kafka username on the generated Secret
+     */
+    public static final String ANNO_STRIMZI_IO_KAFKA_USERNAME = "strimzi.io/kafka-username";
+
     protected final String namespace;
     protected final String name;
+    protected final String username;
     protected final Labels labels;
 
     protected KafkaUserAuthentication authentication;
@@ -91,17 +97,38 @@ public class KafkaUserModel {
      * Constructor
      *
      * @param namespace Kubernetes namespace where Kafka Connect cluster resources are going to be created
-     * @param name   User name
+     * @param name   CR name (metadata.name)
+     * @param username Resolved Kafka username (from spec.username or metadata.name)
      * @param labels   Labels
+     * @param secretPrefix Secret prefix
      */
-    protected KafkaUserModel(String namespace, String name, Labels labels, String secretPrefix) {
+    protected KafkaUserModel(String namespace, String name, String username, Labels labels, String secretPrefix) {
         this.namespace = namespace;
         this.name = name;
+        this.username = username;
         this.labels = labels.withKubernetesName(KAFKA_USER_OPERATOR_NAME)
             .withKubernetesInstance(name)
             .withKubernetesPartOf(name)
             .withKubernetesManagedBy(KAFKA_USER_OPERATOR_NAME);
         this.secretPrefix = secretPrefix;
+    }
+
+    /**
+     * Resolves the Kafka username from the KafkaUser custom resource. If {@code spec.username} is set,
+     * it is used. Otherwise, the CR name ({@code metadata.name}) is used as the username.
+     *
+     * @param kafkaUser The KafkaUser custom resource
+     * @return The resolved Kafka username
+     */
+    public static String resolveUsername(KafkaUser kafkaUser) {
+        String un = null;
+        if (kafkaUser.getSpec() != null) {
+            un = kafkaUser.getSpec().getUsername();
+        }
+        if (un == null) {
+            un = kafkaUser.getMetadata().getName();
+        }
+        return un;
     }
 
     /**
@@ -118,11 +145,13 @@ public class KafkaUserModel {
                                          boolean aclsAdminApiSupported) {
         KafkaUserModel result = new KafkaUserModel(kafkaUser.getMetadata().getNamespace(),
                 kafkaUser.getMetadata().getName(),
+                resolveUsername(kafkaUser),
                 Labels.fromResource(kafkaUser).withStrimziKind(kafkaUser.getKind()),
                 secretPrefix);
 
         validateTlsUsername(kafkaUser);
         validateDesiredPassword(kafkaUser);
+        validateUnchangedUsername(kafkaUser);
 
         result.setOwnerReference(kafkaUser);
         result.setAuthentication(kafkaUser.getSpec().getAuthentication());
@@ -156,9 +185,24 @@ public class KafkaUserModel {
      */
     private static void validateTlsUsername(KafkaUser user)  {
         if (user.getSpec().getAuthentication() instanceof KafkaUserTlsClientAuthentication) {
-            if (user.getMetadata().getName().length() > OpenSslCertManager.MAXIMUM_CN_LENGTH)    {
-                throw new InvalidResourceException("Users with TLS client authentication can have a username (name of the KafkaUser custom resource) only up to 64 characters long.");
+            String resolvedName = resolveUsername(user);
+            if (resolvedName.length() > OpenSslCertManager.MAXIMUM_CN_LENGTH)    {
+                throw new InvalidResourceException("Users with TLS client authentication can have a username only up to 64 characters long.");
             }
+        }
+    }
+
+    /**
+     * Validates that the username has not been changed after initial creation. Changing the username is not supported
+     * because it would require recreating the Kafka user (ACLs, quotas, credentials) under the new name.
+     *
+     * @param user  The KafkaUser which should be validated
+     */
+    private static void validateUnchangedUsername(KafkaUser user)  {
+        if (user.getStatus() != null
+                && user.getStatus().getUsername() != null
+                && !resolveUsername(user).equals(decodeUsername(user.getStatus().getUsername()))) {
+            throw new InvalidResourceException("Changing spec.username is not supported");
         }
     }
 
@@ -283,9 +327,9 @@ public class KafkaUserModel {
 
     CertAndKey generateNewCertificate(Reconciliation reconciliation, Ca clientsCa) {
         try {
-            return clientsCa.generateSignedCert(name);
+            return clientsCa.generateSignedCert(username);
         } catch (IOException e) {
-            LOGGER.errorCr(reconciliation, "Error generating signed certificate for user {}", name, e);
+            LOGGER.errorCr(reconciliation, "Error generating signed certificate for user {}", username, e);
             return null;
         }
     }
@@ -307,7 +351,7 @@ public class KafkaUserModel {
         } else {
             // coming from an older operator version, the user secret exists but without keystore and password
             try {
-                return clientsCa.addKeyAndCertToKeyStore(name,
+                return clientsCa.addKeyAndCertToKeyStore(username,
                         decodeFromSecret(userSecret, "user.key"),
                         decodeFromSecret(userSecret, "user.crt"));
             } catch (IOException e) {
@@ -392,12 +436,14 @@ public class KafkaUserModel {
      * @return The secret.
      */
     protected Secret createSecret(Map<String, String> data) {
+        Map<String, String> annotations = new HashMap<>();
+        annotations.put(ANNO_STRIMZI_IO_KAFKA_USERNAME, username);
         return new SecretBuilder()
                 .withNewMetadata()
                     .withName(getSecretName())
                     .withNamespace(namespace)
                     .withLabels(Util.mergeLabelsOrAnnotations(labels.toMap(), templateSecretLabels))
-                    .withAnnotations(Util.mergeLabelsOrAnnotations(null, templateSecretAnnotations))
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(annotations, templateSecretAnnotations))
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withType("Opaque")
@@ -473,27 +519,36 @@ public class KafkaUserModel {
     }
 
     /**
-     * Gets the Username
+     * Gets the Kafka username (the principal used in Kafka for ACLs, quotas, etc.)
      *
-     * @return The user name.
+     * @return The Kafka user name.
      */
     public String getUserName()    {
         if (isTlsUser() || isTlsExternalUser()) {
-            return getTlsUserName(name);
+            return getTlsUserName(username);
         } else if (isScramUser()) {
-            return getScramUserName(name);
+            return getScramUserName(username);
         } else {
-            return getName();
+            return getResolvedUsername();
         }
     }
 
     /**
-     * Gets the name of the user.
+     * Gets the CR name (metadata.name) of the KafkaUser resource.
      *
-     * @return The name of the user.
+     * @return The CR name.
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Gets the resolved Kafka username (from spec.username or metadata.name).
+     *
+     * @return The resolved Kafka username.
+     */
+    public String getResolvedUsername() {
+        return username;
     }
 
     /**
@@ -678,7 +733,7 @@ public class KafkaUserModel {
      * @return The JAAS configuration string.
      */
     public String getSaslJsonConfig() {
-        return getSaslJsonConfig(getScramUserName(name), scramSha512Password);
+        return getSaslJsonConfig(getScramUserName(username), scramSha512Password);
     }
 
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -147,17 +147,25 @@ public class KafkaUserOperator {
     }
 
     /**
-     * Utility method to get all usernames based on the KafkaUser Kubernetes resources
+     * Utility method to get all usernames based on the KafkaUser Kubernetes resources.
+     * Returns both the CR names and the resolved Kafka usernames (from spec.username) to ensure
+     * that Kafka-side usernames matching a CR's resolved username are not treated as orphans
+     * during periodic reconciliation.
      *
      * @param namespace     Namespace where to look for the users
      *
-     * @return  Set of KafkaUser resource names
+     * @return  Set of CR names and resolved Kafka usernames
      */
     private CompletionStage<Set<String>> getAllKafkaUserUsernames(String namespace)  {
         return kafkaUserCrdOperator.listAsync(namespace, Labels.fromMap(selector.getMatchLabels()))
-            .thenApply(users -> users.stream()
-                    .map(resource -> resource.getMetadata().getName())
-                    .collect(Collectors.toSet()));
+            .thenApply(users -> {
+                Set<String> names = new HashSet<>();
+                for (KafkaUser user : users) {
+                    names.add(user.getMetadata().getName());
+                    names.add(KafkaUserModel.resolveUsername(user));
+                }
+                return names;
+            });
     }
 
     /**
@@ -188,33 +196,44 @@ public class KafkaUserOperator {
             // Create or update
             return createOrUpdate(reconciliation, kafkaUser, userSecret);
         } else {
-            // Delete the user from everywhere with both the TLS and SCRAM-SHa name variants
-            return delete(reconciliation).thenApply(i -> null);
+            // Delete the user from everywhere with both the TLS and SCRAM-SHA name variants
+            return delete(reconciliation, userSecret).thenApply(i -> null);
         }
     }
 
     /**
-     * Deletes the user
+     * Deletes the user. The resolved Kafka username is read from the Secret annotation if available,
+     * otherwise falls back to the reconciliation name (CR name).
      *
      * @param reconciliation    Reconciliation marker
+     * @param userSecret        The user secret (may be null if already deleted)
      *
      * @return A CompletionStage
      */
-    private CompletionStage<Void> delete(Reconciliation reconciliation) {
+    private CompletionStage<Void> delete(Reconciliation reconciliation, Secret userSecret) {
         String namespace = reconciliation.namespace();
-        String user = reconciliation.name();
-        String secretName = KafkaUserModel.getSecretName(config.getSecretPrefix(), user);
+        String crName = reconciliation.name();
+        String secretName = KafkaUserModel.getSecretName(config.getSecretPrefix(), crName);
 
-        LOGGER.debugCr(reconciliation, "Deleting User {} from namespace {}", user, namespace);
+        // Try to get the resolved username from the Secret annotation
+        String resolvedUsername = crName;
+        if (userSecret != null && userSecret.getMetadata().getAnnotations() != null) {
+            String annotatedUsername = userSecret.getMetadata().getAnnotations().get(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME);
+            if (annotatedUsername != null) {
+                resolvedUsername = annotatedUsername;
+            }
+        }
 
-        // Delete everything what can be deleted
+        LOGGER.debugCr(reconciliation, "Deleting User {} (Kafka username: {}) from namespace {}", crName, resolvedUsername, namespace);
+
+        // Delete everything what can be deleted using the resolved Kafka username
         return CompletableFuture.allOf(
                 secretOperator.deleteAsync(reconciliation, namespace, secretName, false).toCompletableFuture(),
-                config.isAclsAdminApiSupported() ? aclOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(user), null).toCompletableFuture() : CompletableFuture.completedFuture(ReconcileResult.noop(null)),
-                config.isAclsAdminApiSupported() ? aclOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture() : CompletableFuture.completedFuture(ReconcileResult.noop(null)),
-                scramCredentialsOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture(),
-                quotasOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(user), null).toCompletableFuture(),
-                quotasOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture()
+                config.isAclsAdminApiSupported() ? aclOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(resolvedUsername), null).toCompletableFuture() : CompletableFuture.completedFuture(ReconcileResult.noop(null)),
+                config.isAclsAdminApiSupported() ? aclOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(resolvedUsername), null).toCompletableFuture() : CompletableFuture.completedFuture(ReconcileResult.noop(null)),
+                scramCredentialsOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(resolvedUsername), null).toCompletableFuture(),
+                quotasOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(resolvedUsername), null).toCompletableFuture(),
+                quotasOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(resolvedUsername), null).toCompletableFuture()
         );
     }
 
@@ -383,12 +402,14 @@ public class KafkaUserOperator {
             scramOrNoneQuotas = user.getQuotas();
         }
 
+        String resolvedUsername = user.getResolvedUsername();
+
         // Reconcile the user SCRAM-SHA-512 credentials
-        CompletionStage<ReconcileResult<String>> scramCredentialsFuture = scramCredentialsOperator.reconcile(reconciliation, user.getName(), user.getScramSha512Password());
+        CompletionStage<ReconcileResult<String>> scramCredentialsFuture = scramCredentialsOperator.reconcile(reconciliation, resolvedUsername, user.getScramSha512Password());
 
         // Quotas need to reconciled for both regular and TLS username. It will be (possibly) set for one user and deleted for the other
-        CompletionStage<ReconcileResult<KafkaUserQuotas>> tlsQuotasFuture = quotasOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(reconciliation.name()), tlsQuotas);
-        CompletionStage<ReconcileResult<KafkaUserQuotas>> quotasFuture = quotasOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(reconciliation.name()), scramOrNoneQuotas);
+        CompletionStage<ReconcileResult<KafkaUserQuotas>> tlsQuotasFuture = quotasOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(resolvedUsername), tlsQuotas);
+        CompletionStage<ReconcileResult<KafkaUserQuotas>> quotasFuture = quotasOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(resolvedUsername), scramOrNoneQuotas);
 
         // Reconcile the user secret generated by the user operator with the credentials
         CompletionStage<ReconcileResult<Secret>> userSecretFuture = reconcileUserSecret(reconciliation, user, userSecret, userStatus);
@@ -398,8 +419,8 @@ public class KafkaUserOperator {
         CompletionStage<ReconcileResult<Set<SimpleAclRule>>> aclsScramUserFuture;
 
         if (config.isAclsAdminApiSupported()) {
-            aclsTlsUserFuture = aclOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(reconciliation.name()), tlsAcls);
-            aclsScramUserFuture = aclOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(reconciliation.name()), scramOrNoneAcls);
+            aclsTlsUserFuture = aclOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(resolvedUsername), tlsAcls);
+            aclsScramUserFuture = aclOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(resolvedUsername), scramOrNoneAcls);
         } else {
             aclsTlsUserFuture = CompletableFuture.completedFuture(ReconcileResult.noop(null));
             aclsScramUserFuture = CompletableFuture.completedFuture(ReconcileResult.noop(null));

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -145,7 +145,7 @@ public class KafkaUserModelTest {
 
         assertThat(generatedSecret.getMetadata().getName(), is(ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));
-        assertThat(generatedSecret.getMetadata().getAnnotations(), is(emptyMap()));
+        assertThat(generatedSecret.getMetadata().getAnnotations(), hasEntry(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME, ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getLabels(),
                 is(Labels.fromMap(ResourceUtils.LABELS)
                         .withStrimziKind(KafkaUser.RESOURCE_KIND)
@@ -169,7 +169,7 @@ public class KafkaUserModelTest {
 
         assertThat(generatedSecret.getMetadata().getName(), is(secretPrefix + ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));
-        assertThat(generatedSecret.getMetadata().getAnnotations(), is(emptyMap()));
+        assertThat(generatedSecret.getMetadata().getAnnotations(), hasEntry(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME, ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getLabels(),
                 is(Labels.fromMap(ResourceUtils.LABELS)
                         .withStrimziKind(KafkaUser.RESOURCE_KIND)
@@ -215,7 +215,8 @@ public class KafkaUserModelTest {
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .withAdditionalLabels(singletonMap("label1", "value1"))
                         .toMap()));
-        assertThat(generatedSecret.getMetadata().getAnnotations(), is(singletonMap("anno1", "value1")));
+        assertThat(generatedSecret.getMetadata().getAnnotations(), hasEntry("anno1", "value1"));
+        assertThat(generatedSecret.getMetadata().getAnnotations(), hasEntry(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME, ResourceUtils.NAME));
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generatedSecret);
     }
@@ -757,5 +758,175 @@ public class KafkaUserModelTest {
     public void testFromCrdAclsWithAclsAdminApiSupportMissing() {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.SECRET_PREFIX.defaultValue(), false));
         assertThat(e.getMessage(), is("Simple authorization ACL rules are configured but not supported in the Kafka cluster configuration."));
+    }
+
+    @Test
+    public void testResolveUsernameWithoutSpecUsername() {
+        assertThat(KafkaUserModel.resolveUsername(tlsUser), is(ResourceUtils.NAME));
+        assertThat(KafkaUserModel.resolveUsername(scramShaUser), is(ResourceUtils.NAME));
+    }
+
+    @Test
+    public void testResolveUsernameWithSpecUsername() {
+        KafkaUser userWithCustomUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("custom-kafka-user")
+                .endSpec()
+                .build();
+
+        assertThat(KafkaUserModel.resolveUsername(userWithCustomUsername), is("custom-kafka-user"));
+    }
+
+    @Test
+    public void testFromCrdWithCustomUsernameScramSha() {
+        KafkaUser userWithCustomUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("custom-kafka-user")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+
+        assertThat(model.getName(), is(ResourceUtils.NAME));
+        assertThat(model.getResolvedUsername(), is("custom-kafka-user"));
+        assertThat(model.getUserName(), is("custom-kafka-user"));
+        assertThat(model.getSecretName(), is(ResourceUtils.NAME));
+    }
+
+    @Test
+    public void testFromCrdWithCustomUsernameTls() {
+        KafkaUser userWithCustomUsername = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                    .withUsername("custom-tls-user")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+
+        assertThat(model.getName(), is(ResourceUtils.NAME));
+        assertThat(model.getResolvedUsername(), is("custom-tls-user"));
+        assertThat(model.getUserName(), is("CN=custom-tls-user"));
+        assertThat(model.getSecretName(), is(ResourceUtils.NAME));
+    }
+
+    @Test
+    public void testSecretAnnotationContainsResolvedUsername() {
+        KafkaUser userWithCustomUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("custom-kafka-user")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, null);
+        Secret generatedSecret = model.generateSecret();
+
+        assertThat(generatedSecret.getMetadata().getAnnotations(), hasEntry(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME, "custom-kafka-user"));
+        assertThat(generatedSecret.getMetadata().getName(), is(ResourceUtils.NAME));
+    }
+
+    @Test
+    public void testSaslJsonConfigUsesResolvedUsername() {
+        KafkaUser userWithCustomUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("custom-kafka-user")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithCustomUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, null);
+        Secret generatedSecret = model.generateSecret();
+
+        String password = "aaaaaaaaaa";
+        assertThat(Util.decodeFromBase64(generatedSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)),
+                is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"custom-kafka-user\" password=\"" + password + "\";"));
+    }
+
+    @Test
+    public void testTlsUsernameLengthValidationUsesResolvedUsername() {
+        KafkaUser userWithLongCustomUsername = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                    .withUsername("User-123456789012345678901234567890123456789012345678901234567890")
+                .endSpec()
+                .build();
+
+        assertThrows(InvalidResourceException.class, () -> {
+            KafkaUserModel.fromCrd(userWithLongCustomUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        });
+    }
+
+    @Test
+    public void testTlsUsernameLengthValidationPassesWithShortResolvedUsername() {
+        KafkaUser userWithLongCrNameButShortUsername = new KafkaUserBuilder(tlsUser)
+                .editMetadata()
+                    .withName("User-123456789012345678901234567890123456789012345678901234567890")
+                .endMetadata()
+                .editSpec()
+                    .withUsername("short-user")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithLongCrNameButShortUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        assertThat(model.getResolvedUsername(), is("short-user"));
+    }
+
+    @Test
+    public void testUsernameImmutabilityValidation() {
+        KafkaUser userWithChangedUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("new-username")
+                .endSpec()
+                .withNewStatus()
+                    .withUsername("old-username")
+                .endStatus()
+                .build();
+
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
+            KafkaUserModel.fromCrd(userWithChangedUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        });
+
+        assertThat(e.getMessage(), is("Changing spec.username is not supported"));
+    }
+
+    @Test
+    public void testUsernameImmutabilityPassesWhenUnchanged() {
+        KafkaUser userWithSameUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("my-user")
+                .endSpec()
+                .withNewStatus()
+                    .withUsername("my-user")
+                .endStatus()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithSameUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        assertThat(model.getResolvedUsername(), is("my-user"));
+    }
+
+    @Test
+    public void testUsernameImmutabilityPassesForTlsUserWithCnPrefix() {
+        KafkaUser tlsUserWithUsername = new KafkaUserBuilder(tlsUser)
+                .editSpec()
+                    .withUsername("my-tls-user")
+                .endSpec()
+                .withNewStatus()
+                    .withUsername("CN=my-tls-user")
+                .endStatus()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUserWithUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        assertThat(model.getResolvedUsername(), is("my-tls-user"));
+    }
+
+    @Test
+    public void testUsernameImmutabilitySkippedWithNoStatus() {
+        KafkaUser userWithNewUsername = new KafkaUserBuilder(scramShaUser)
+                .editSpec()
+                    .withUsername("any-username")
+                .endSpec()
+                .build();
+
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithNewUsername, UserOperatorConfig.SECRET_PREFIX.defaultValue(), Boolean.parseBoolean(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.defaultValue()));
+        assertThat(model.getResolvedUsername(), is("any-username"));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
@@ -1553,6 +1553,87 @@ public class KafkaUserOperatorMockTest {
         testReconciliationFailsWithMissingCaSecrets(ResourceUtils.CA_KEY_NAME);
     }
 
+    @Test
+    public void testCreateScramShaUserWithCustomUsername() throws ExecutionException, InterruptedException {
+        String customUsername = "custom-kafka-user";
+        KafkaUser user = new KafkaUserBuilder(ResourceUtils.createKafkaUserScramSha(namespace))
+                .editSpec()
+                    .withUsername(customUsername)
+                .endSpec()
+                .build();
+        user = Crds.kafkaUserOperation(client).resource(user).create();
+
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(namespace), mockCertManager, secretOps, kafkaUserOps, scramOps, quotasOps, aclOps);
+        CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, namespace, ResourceUtils.NAME), user, null);
+        KafkaUserStatus status = futureResult.toCompletableFuture().get();
+
+        // Assert KafkaUserStatus uses the custom username
+        assertThat(status, is(notNullValue()));
+        assertThat(status.getUsername(), is(customUsername));
+        assertThat(status.getSecret(), is(ResourceUtils.NAME));
+        assertThat(status.getConditions().size(), is(1));
+        assertThat(status.getConditions().get(0).getStatus(), is("True"));
+
+        // Assert the user secret is named after the CR name, not the custom username
+        Secret userSecret = secretOps.get(namespace, ResourceUtils.NAME);
+        assertThat(userSecret.getMetadata().getName(), is(ResourceUtils.NAME));
+
+        // Assert the secret has the kafka-username annotation
+        assertThat(userSecret.getMetadata().getAnnotations().get(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME), is(customUsername));
+
+        // Assert the mocked Kafka SCRAM-SHA credentials use the custom username
+        List<String> capturedScramNames = scramNameCaptor.getAllValues();
+        assertThat(capturedScramNames, hasSize(1));
+        assertThat(capturedScramNames.get(0), is(customUsername));
+
+        // Assert the mocked Kafka ACLs use the custom username
+        List<String> capturedAclNames = aclNameCaptor.getAllValues();
+        assertThat(capturedAclNames, hasSize(2));
+        assertThat(capturedAclNames.get(0), is(KafkaUserModel.getTlsUserName(customUsername)));
+        assertThat(capturedAclNames.get(1), is(KafkaUserModel.getScramUserName(customUsername)));
+
+        // Assert the mocked Kafka Quotas use the custom username
+        List<String> capturedQuotaNames = quotasNameCaptor.getAllValues();
+        assertThat(capturedQuotaNames, hasSize(2));
+        assertThat(capturedQuotaNames.get(0), is(KafkaUserModel.getTlsUserName(customUsername)));
+        assertThat(capturedQuotaNames.get(1), is(KafkaUserModel.getScramUserName(customUsername)));
+    }
+
+    @Test
+    public void testDeleteUserWithCustomUsernameFromSecretAnnotation() throws ExecutionException, InterruptedException {
+        String customUsername = "custom-kafka-user";
+        // Create a secret with the kafka-username annotation (simulating a previously reconciled user)
+        Secret existingUserSecret = new SecretBuilder(ResourceUtils.createUserSecretScramSha(namespace))
+                .editMetadata()
+                    .addToAnnotations(KafkaUserModel.ANNO_STRIMZI_IO_KAFKA_USERNAME, customUsername)
+                .endMetadata()
+                .build();
+        secretOps.resource(namespace, existingUserSecret).create();
+
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(namespace), mockCertManager, secretOps, kafkaUserOps, scramOps, quotasOps, aclOps);
+        CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, namespace, ResourceUtils.NAME), null, existingUserSecret);
+        KafkaUserStatus status = futureResult.toCompletableFuture().get();
+
+        assertThat(status, is(nullValue()));
+
+        // Assert the mocked Kafka ACLs use the custom username from the annotation
+        List<String> capturedAclNames = aclNameCaptor.getAllValues();
+        assertThat(capturedAclNames, hasSize(2));
+        assertThat(capturedAclNames.get(0), is(KafkaUserModel.getTlsUserName(customUsername)));
+        assertThat(capturedAclNames.get(1), is(KafkaUserModel.getScramUserName(customUsername)));
+
+        // Assert the mocked Kafka SCRAM-SHA credentials use the custom username
+        List<String> capturedScramNames = scramNameCaptor.getAllValues();
+        assertThat(capturedScramNames, hasSize(1));
+        assertThat(capturedScramNames.get(0), is(KafkaUserModel.getScramUserName(customUsername)));
+
+        // Assert the mocked Kafka Quotas use the custom username
+        List<String> capturedQuotaNames = quotasNameCaptor.getAllValues();
+        assertThat(capturedQuotaNames, hasSize(2));
+        assertThat(capturedQuotaNames.get(0), is(KafkaUserModel.getTlsUserName(customUsername)));
+        assertThat(capturedQuotaNames.get(1), is(KafkaUserModel.getScramUserName(customUsername)));
+    }
+
     // Utility method for resting with missing CA secret
     private void testReconciliationFailsWithMissingCaSecrets(String missingSecretName) {
         KafkaUser user = ResourceUtils.createKafkaUserTls(namespace);


### PR DESCRIPTION
### Motivation
When multiple Kafka clusters share the same Kubernetes namespace, KafkaUser CRs cannot have duplicate metadata.name values — this is a Kubernetes constraint. Since the User Operator currently uses metadata.name as the Kafka username, it's impossible to create users with the same Kafka username on different clusters in the same namespace.

KafkaTopic already solves an analogous problem with spec.topicName. This PR brings the same pattern to KafkaUser.

### Changes
Adds an optional spec.username field to KafkaUser. When set, it is used as the Kafka principal (for ACLs, quotas, SCRAM-SHA credentials, and TLS certificate CN) instead of metadata.name. When absent, metadata.name is used as before — fully backward compatible.

**Example**
```
apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaUser
metadata:
  name: my-app-user-cluster-a        # unique CR name
  labels:
    strimzi.io/cluster: cluster-a
spec:
  username: my-app-user              # actual Kafka username
  authentication:
    type: scram-sha-512
---
apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaUser
metadata:
  name: my-app-user-cluster-b        # different CR name
  labels:
    strimzi.io/cluster: cluster-b
spec:
  username: my-app-user              # same Kafka username, different cluster
  authentication:
    type: scram-sha-512
```    
### Implementation details
- API model (KafkaUserSpec): Added username field with getter/setter, following the KafkaTopicSpec.topicName pattern.
- KafkaUserModel: Introduced a username field separate from name (CR name). Added resolveUsername() to resolve from spec.username or fall back to metadata.name. All Kafka operations (getUserName(), certificate generation, SASL JAAS config) now use the resolved username. Kubernetes operations (secret naming, owner references, labels) continue to use the CR name.
- Secret annotation: The generated Secret now carries a strimzi.io/kafka-username annotation with the resolved Kafka username. This enables proper Kafka-side cleanup during deletion when the CR is already gone.
- KafkaUserOperator: reconcileCredentialsQuotasAndAcls() uses the resolved username for ACL, quota, and SCRAM operations. delete() reads the resolved username from the Secret annotation. getAllKafkaUserUsernames() returns both CR names and resolved usernames to prevent orphan false positives during periodic reconciliation.
- Immutability validation: Changing spec.username after initial creation is rejected (validated against status.username), following the same pattern as KafkaTopic.spec.topicName.
- TLS length validation: Updated to validate the resolved username length, not just the CR name.

### Backward compatibility
- Existing KafkaUser CRs without spec.username work identically — no behavioral change.
- Secret naming is unchanged (secretPrefix + metadata.name).
- The status.username field continues to reflect the effective Kafka username.
- No CRD migration required.

### Tests
KafkaUserModelTest: 10 new tests covering resolveUsername(), custom username with SCRAM-SHA and TLS, secret annotation, SASL JAAS config, TLS length validation with resolved username, immutability validation (including CN-prefix matching for TLS users), and skip-when-no-status.
KafkaUserOperatorMockTest: 2 new tests for creating a SCRAM-SHA user with custom username (verifying ACL/quota/SCRAM captors use the custom name) and deleting a user with custom username recovered from the Secret annotation.

