### PR TITLE
Fix dependency scope for Maven artifacts in Connect Build

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
@@ -154,7 +154,7 @@ public class KafkaConnectDockerfile {
                     String settingsXml = "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>" + escapeXml(repo) + "</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>";
 
                     Cmd cmd;
-                    String includeScopeParam = "-DincludeScope=" + (mvn.getIncludeScope() != null ? mvn.getIncludeScope().toValue() : "\"\"");
+                    String includeScopeParam = "-DincludeScope=" + (mvn.getIncludeScope() != null ? mvn.getIncludeScope().toValue() : "");
                     if (Boolean.TRUE.equals(mvn.getInsecure()))    {
                         // Insecure download => disables TLS certificate checks in curl and Maven commands
                         cmd = run("curl", "-f", "-k", "-L", "--create-dirs", "--output", "/tmp/" + artifactDir + "/pom.xml", assembleResourceUrl(repo, mvn, "pom"))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfileTest.java
@@ -534,12 +534,12 @@ public class KafkaConnectDockerfileTest {
                 "FROM quay.io/strimzi/maven-builder:latest AS downloadArtifacts\n" +
                 "RUN 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/my-connector-plugin/64cebd9c/pom.xml' 'https://repo1.maven.org/maven2/g1/a1/v1/a1-v1.pom' \\\n" +
                 "      && 'echo' '<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>https://repo1.maven.org/maven2/</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>' > '/tmp/64cebd9c.xml' \\\n" +
-                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=\"\"' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
+                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
                 "      && 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/artifacts/my-connector-plugin/64cebd9c/a1-v1.jar' 'https://repo1.maven.org/maven2/g1/a1/v1/a1-v1.jar'\n" +
                 "\n" +
                 "RUN 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/my-connector-plugin/9983060e/pom.xml' 'https://repo1.maven.org/maven2/g2/a2/v2/a2-v2.pom' \\\n" +
                 "      && 'echo' '<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>https://repo1.maven.org/maven2/</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>' > '/tmp/9983060e.xml' \\\n" +
-                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/9983060e.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/9983060e' '-DincludeScope=\"\"' '-f' '/tmp/my-connector-plugin/9983060e/pom.xml' \\\n" +
+                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/9983060e.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/9983060e' '-DincludeScope=' '-f' '/tmp/my-connector-plugin/9983060e/pom.xml' \\\n" +
                 "      && 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/artifacts/my-connector-plugin/9983060e/a2-v2.jar' 'https://repo1.maven.org/maven2/g2/a2/v2/a2-v2.jar'\n" +
                 "\n" +
                 "FROM myImage:latest\n" +
@@ -595,7 +595,7 @@ public class KafkaConnectDockerfileTest {
                 "FROM quay.io/strimzi/maven-builder:latest AS downloadArtifacts\n" +
                 "RUN 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/my-connector-plugin/64cebd9c/pom.xml' 'https://my-maven-repository.com/maven2/g1/a1/v1/a1-v1.pom' \\\n" +
                 "      && 'echo' '<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>https://my-maven-repository.com/maven2/</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>' > '/tmp/64cebd9c.xml' \\\n" +
-                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=\"\"' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
+                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
                 "      && 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/artifacts/my-connector-plugin/64cebd9c/a1-v1.jar' 'https://my-maven-repository.com/maven2/g1/a1/v1/a1-v1.jar'\n" +
                 "\n" +
                 "FROM myImage:latest\n" +
@@ -641,7 +641,7 @@ public class KafkaConnectDockerfileTest {
                 "FROM quay.io/strimzi/maven-builder:latest AS downloadArtifacts\n" +
                 "RUN 'curl' '-f' '-k' '-L' '--create-dirs' '--output' '/tmp/my-connector-plugin/64cebd9c/pom.xml' 'https://my-maven-repository.com/maven2/g1/a1/v1/a1-v1.pom' \\\n" +
                 "      && 'echo' '<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>https://my-maven-repository.com/maven2/</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>' > '/tmp/64cebd9c.xml' \\\n" +
-                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=\"\"' '-Daether.connector.https.securityMode=insecure' '-Dmaven.wagon.http.ssl.insecure=true' '-Dmaven.wagon.http.ssl.allowall=true' '-Dmaven.wagon.http.ssl.ignore.validity.dates=true' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
+                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=' '-Daether.connector.https.securityMode=insecure' '-Dmaven.wagon.http.ssl.insecure=true' '-Dmaven.wagon.http.ssl.allowall=true' '-Dmaven.wagon.http.ssl.ignore.validity.dates=true' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
                 "      && 'curl' '-f' '-k' '-L' '--create-dirs' '--output' '/tmp/artifacts/my-connector-plugin/64cebd9c/a1-v1.jar' 'https://my-maven-repository.com/maven2/g1/a1/v1/a1-v1.jar'\n" +
                 "\n" +
                 "FROM myImage:latest\n" +
@@ -686,7 +686,7 @@ public class KafkaConnectDockerfileTest {
                 "FROM quay.io/strimzi/maven-builder:latest AS downloadArtifacts\n" +
                 "RUN 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/my-connector-plugin/64cebd9c/pom.xml' 'https://my-maven-repository.com/maven2</hack>\"/repo/g1/a1/v1/a1-v1.pom' \\\n" +
                 "      && 'echo' '<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>https://my-maven-repository.com/maven2&lt;/hack&gt;&quot;/repo/</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>' > '/tmp/64cebd9c.xml' \\\n" +
-                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=\"\"' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
+                "      && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/64cebd9c.xml' '-DoutputDirectory=/tmp/artifacts/my-connector-plugin/64cebd9c' '-DincludeScope=' '-f' '/tmp/my-connector-plugin/64cebd9c/pom.xml' \\\n" +
                 "      && 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/artifacts/my-connector-plugin/64cebd9c/a1-v1.jar' 'https://my-maven-repository.com/maven2</hack>\"/repo/g1/a1/v1/a1-v1.jar'\n" +
                 "\n" +
                 "FROM myImage:latest\n" +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#12652 was not implemented properly and broke the way the Maven artifacts are included for the default scope. The `includeScope=""` option is not accepted as it has to be set as `-includeScope=` without any value.

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.557 s
[INFO] Finished at: 2026-05-01T09:49:05Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.7.1:copy-dependencies (default-cli) on project camel-timer-source-kafka-connector: Invalid Scope in includeScope: "" -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/camel-timer-connector/59c24b83/pom.xml' 'https://repo1.maven.org/maven2/org/apache/camel/kafkaconnector/camel-timer-source-kafka-connector/4.10.3/camel-timer-source-kafka-connector-4.10.3.pom'       && 'echo' '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"><profiles><profile><id>download</id><repositories><repository><id>custom-repo</id><url>https://repo1.maven.org/maven2/</url></repository></repositories></profile></profiles><activeProfiles><activeProfile>download</activeProfile></activeProfiles></settings>' > '/tmp/59c24b83.xml'       && 'mvn' 'dependency:copy-dependencies' '-s' '/tmp/59c24b83.xml' '-DoutputDirectory=/tmp/artifacts/camel-timer-connector/59c24b83' '-DincludeScope=""' '-f' '/tmp/camel-timer-connector/59c24b83/pom.xml'       && 'curl' '-f' '-L' '--create-dirs' '--output' '/tmp/artifacts/camel-timer-connector/59c24b83/camel-timer-source-kafka-connector-4.10.3.jar' 'https://repo1.maven.org/maven2/org/apache/camel/kafkaconnector/camel-timer-source-kafka-connector/4.10.3/camel-timer-source-kafka-connector-4.10.3.jar'": exit status 1
```

This PR fixes it by removing the empty `""`.

_Note: `ConnectBuilderST.testBuildPluginUsingMavenCoordinatesArtifacts` is currently disabled on Kind because of incompatibility. We should try if we cn re-enable it. But first we actually need to get the functionality working. So that can be done only in a subsequent PR._

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally