### PR TITLE
Check if Maven artfiacts in Connect Build now work on Kind

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -30,7 +30,6 @@ import io.strimzi.operator.common.Util;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.systemtest.annotations.KindNotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.annotations.ParallelTest;
@@ -532,7 +531,6 @@ class ConnectBuilderST extends AbstractST {
 
     @Tag(SANITY)
     @Tag(ACCEPTANCE)
-    @KindNotSupported("using kind we encounter (error building image: deleting file system after stage 0: unlinkat //product_uuid: device or resource busy)")
     @ParallelTest
     @TestDoc(
         description = @Desc("Test building a plugin using Maven coordinates artifacts."),

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -51,6 +51,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NetworkPolicyUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -74,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
 @Tag(CONNECT_COMPONENTS)
@@ -547,6 +549,9 @@ class ConnectBuilderST extends AbstractST {
         }
     )
     void testBuildPluginUsingMavenCoordinatesArtifacts() {
+        // This assumption could be removed when Buildah moves to GA
+        assumeFalse(KubeClusterResource.getInstance().isKind() && !Environment.isConnectBuildWithBuildahEnabled());
+
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
 
         final String imageName = getImageNameForTestCase();


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR enabled the Maven artifact in the Kafka Connect Build system test that was disabled on Kind a few years back. But it seems to work now, so we can enable it again.

### Checklist

- [x] Make sure all tests pass