### PR TITLE
Add releaseVersion to generated docs during release workflow

### DIFF
--- a/.github/actions/build/build-docs/action.yml
+++ b/.github/actions/build/build-docs/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Name of the documentation artifact to upload"
     required: false
     default: "documentation.tar"
+  releaseVersion:
+    description: "Release version to set within docs (i.e. 'latest', '0.46.0')"
+    required: false
+    default: "latest"
 
 runs:
   using: "composite"
@@ -13,6 +17,8 @@ runs:
     - name: Build documentation
       shell: bash
       run: make docu_html docu_htmlnoheader docu_pdf
+      env:
+        RELEASE_VERSION: ${{ inputs.releaseVersion }}
       
     - name: Create documentation archive
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         uses: ./.github/actions/build/build-docs
         with:
           artifactName: "documentation.tar"
+          releaseVersion: ${{ inputs.releaseVersion }}
 
   # Push Java artifacts to GHCR for long-term storage (for CVE rebuilds)
   push-java-artifacts-to-ghcr:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During 1.0.0 release @scholzj found that we do not set RELEASE_VERSION env var to set proper version in the docs. This PR resolves it. 

It should be cherry-picked / backported into `release-1.0.x`

### Checklist

- [ ] Make sure all tests pass

