### PR TITLE
Add Strimzi Drain Cleaner 1.6.0 to the operators repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support for dependency scope configuration of Maven artifacts in Kafka Connect Build
 * Add `UseBackgroundPodDeletion` feature gate (alpha, disabled by default) to use background deletion propagation when deleting pods during rolling updates. 
+* Strimzi Drain Cleaner updated to 1.6.0 (included in the Strimzi installation files)
 
 ### Major changes, deprecations, and removals
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -33,7 +33,7 @@
 :BridgeVersion: 1.0.0
 
 // Drain Cleaner Version
-:DrainCleanerVersion: 1.5.0
+:DrainCleanerVersion: 1.6.0
 
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub releases page^]

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.5.0
+          image: quay.io/strimzi/drain-cleaner:1.6.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.5.0
+          image: quay.io/strimzi/drain-cleaner:1.6.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.5.0
+          image: quay.io/strimzi/drain-cleaner:1.6.0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds Drain Cleaner 1.6.0 to the operators main branch after the release.

### Checklist

- [x] Make sure all tests pass
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Update CHANGELOG.md

