### PR TITLE
docs(scaling): clarifies auto-rebalancing triggers

### DIFF
--- a/documentation/assemblies/configuring/assembly-scaling-kafka-clusters.adoc
+++ b/documentation/assemblies/configuring/assembly-scaling-kafka-clusters.adoc
@@ -54,7 +54,12 @@ When adding brokers by changing the number of `replicas`, node IDs start at 0, a
 Removing brokers starts with the pod that has the highest node ID. 
 Additionally, when scaling clusters with node pools, you can xref:proc-managing-node-pools-ids-{context}[assign node IDs for scaling operations].
 
-Strimzi can automatically reassign partitions when brokers are added or removed if Cruise Control is deployed and auto-rebalancing is enabled in the Kafka resource. 
+Strimzi can automatically reassign partitions when brokers are added or removed by changing the `spec.replicas` value of an existing node pool. 
+Cruise Control must be deployed and auto-rebalancing enabled in the `Kafka` resource.
+
+Creating or deleting a `KafkaNodePool` resource does not trigger auto-rebalancing automatically. 
+For these operations, apply a `KafkaRebalance` resource configured to use `add-brokers` or `remove-brokers` mode.
+
 If auto-rebalancing is disabled, you can use Cruise Control to generate optimization proposals before manually rebalancing the cluster.
 
 Cruise Control provides `add-brokers` and `remove-brokers` modes for scaling:

--- a/documentation/modules/configuring/proc-moving-node-pools.adoc
+++ b/documentation/modules/configuring/proc-moving-node-pools.adoc
@@ -31,7 +31,8 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
 * xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
 * (Optional) xref:proc-automating-rebalances-{context}[Auto-rebalancing is enabled]. +
-If auto-rebalancing is enabled, partition reassignment happens automatically during the node scaling process, so you don't need to manually initiate the reassignment through Cruise Control.
+If auto-rebalancing is enabled, partition reassignment happens automatically when scaling node pools by changing the `spec.replicas` value, so you do not need to manually initiate reassignment through Cruise Control.
+Creating or deleting a `KafkaNodePool` resource does not trigger auto-rebalancing automatically.
 * (Optional) For scale up and scale down operations, xref:proc-managing-node-pools-ids-{context}[you can specify the range of node IDs to use]. +
 If you have assigned node IDs for the operation, the ID of the node being added or removed is determined by the sequence of nodes given. 
 Otherwise, the lowest available node ID across the cluster is used when adding nodes; and the node with the highest available ID in the node pool is removed. 

--- a/documentation/modules/cruise-control/proc-automating-rebalances.adoc
+++ b/documentation/modules/cruise-control/proc-automating-rebalances.adoc
@@ -8,21 +8,31 @@
 = Triggering auto-rebalances when scaling clusters
 
 [role="_abstract"]
-Set up auto-rebalancing to automatically redistribute topic partitions when scaling a cluster.
-You can scale a Kafka cluster by adjusting the number of brokers using the `spec.replicas` property in the `Kafka` or `KafkaNodePool` custom resource used in deployment. 
+Set up auto-rebalancing to automatically redistribute topic partitions when scaling a cluster by changing the number of brokers in an existing node pool.
+Scale a Kafka cluster by adjusting the number of brokers using the `spec.replicas` property in the `Kafka` or `KafkaNodePool` custom resource used in deployment. 
+For auto-rebalancing, a scaling event is a change to the `spec.replicas` value of an existing node pool.
+
 When auto-rebalancing is enabled, the cluster is rebalanced without further intervention.
 
 * After adding brokers, topic partitions are redistributed across the new brokers.
 * Before removing brokers, partitions are moved off the brokers being removed.
+
+Auto-rebalancing is not triggered when creating a new `KafkaNodePool` resource or deleting an existing one. 
+These actions are not treated as scaling events by the auto-rebalancing mechanism.
+
+When adding or removing node pools, manually trigger partition reassignment using Cruise Control by creating a `KafkaRebalance` resource with:
+
+* `add-brokers` mode when adding a node pool
+* `remove-brokers` mode when removing a node pool
 
 Auto-rebalancing helps maintain balanced load distribution across Kafka brokers during scaling operations, depending on how the rebalancing configuration is set up.
 
 Scaling operates in two modes: `add-brokers` and `remove-brokers`.
 Each mode can have its own auto-rebalancing configuration specified in the `Kafka` resource under `spec.cruiseControl.autoRebalance` properties. 
 Use the `template` property to specify a predefined `KafkaRebalance` resource, which serves as a rebalance configuration template.
-If a template is not specified in the `autorebalance` configuration, the default Cruise Control rebalancing configuration is used.
+If a template is not specified in the `autoRebalance` configuration, the default Cruise Control rebalancing configuration is used.
 You can apply the same template configuration for both scaling modes, use different configurations for each, or enable auto-rebalancing for only one mode.
-If `autorebalance` configuration is not set for a mode, auto-rebalancing will not occur for that mode.
+If `autoRebalance` is not configured for a mode, auto-rebalancing does not occur for that mode.
 
 The template `KafkaRebalance` resource must include the `strimzi.io/rebalance-template: "true"` annotation. 
 The template does not represent an actual rebalance request but holds the rebalancing configuration.
@@ -119,7 +129,10 @@ spec:
 . Apply the changes to the `Kafka` configuration. +
 Wait for the Cluster Operator to update the cluster.
 
-. Scale the cluster by adjusting the `spec.replicas` property representing the number of brokers in the cluster.
+. Scale the cluster by adjusting the `spec.replicas` property of an existing node pool.
++
+Only changes to `spec.replicas` trigger auto-rebalancing. 
+Creating or deleting node pools does not trigger auto-rebalancing.
 +
 The following example shows a node pool configuration for a cluster using three brokers (`replicas: 3`). 
 +
@@ -183,7 +196,7 @@ status:
 ----
 <1> The state of the rebalance, which shows `RebalanceOnScaleUp` when adding brokers, and `RebalanceOnScaleDown` when removing brokers. 
 Scale-down operations take precedence.
-Initial and final state (failed or successful) shows as `Idle`.
+The initial state and final state (successful or failed) are shown as `Idle`.
 <2> Rebalance operations grouped by mode, with a list of nodes to be added or removed.
 
 NOTE: During a rebalance, the status of the `KafkaRebalance` resource used for the rebalance is checked, and the auto-rebalance state is adjusted accordingly. 

--- a/documentation/modules/cruise-control/proc-automating-rebalances.adoc
+++ b/documentation/modules/cruise-control/proc-automating-rebalances.adoc
@@ -9,7 +9,7 @@
 
 [role="_abstract"]
 Set up auto-rebalancing to automatically redistribute topic partitions when scaling a cluster by changing the number of brokers in an existing node pool.
-Scale a Kafka cluster by adjusting the number of brokers using the `spec.replicas` property in the `Kafka` or `KafkaNodePool` custom resource used in deployment. 
+Scale a Kafka cluster by adjusting the number of brokers using the `spec.replicas` property in the `KafkaNodePool` custom resource. 
 For auto-rebalancing, a scaling event is a change to the `spec.replicas` value of an existing node pool.
 
 When auto-rebalancing is enabled, the cluster is rebalanced without further intervention.


### PR DESCRIPTION
**Documentation**

Updates the docs to clarify triggers for auto-rebalancing.
Creating or deleting a `KafkaNodePool` resource does not trigger auto-rebalancing automatically.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

