### PR TITLE
Remove unnecessary Kafka version from Connect Log4j2 unit test

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -1046,7 +1046,6 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
     public void testUpdateLoggingWithoutConnectorsWithLog4j2(VertxTestContext context)  {
         KafkaConnect connect = new KafkaConnectBuilder(CONNECT)
                 .editSpec()
-                    .withVersion("4.2.0")
                     .withNewInlineLogging()
                         .addToLoggers(Map.of("logger.mypackage.name", "io.mydomain.mypackage", "logger.mypackage.level", "WARN"))
                     .endInlineLogging()


### PR DESCRIPTION
### Type of change

- Task

### Description

One of the Connect Log4j2 tests has still Kafka version hardcoded in it - presumably from the time when it was needed for testing (when Log4j -> Log4j2 migration was in progress). This PR removes it so that we do not need to keep it up to date with every new Kafka version.

### Checklist

- [x] Make sure all tests pass