### PR TITLE
Added AI assistant Bob folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ hs_err_pid*
 # Cluster operator config models
 **/cluster-operator/src/main/resources/kafka-*-config-model.json
 
-# Claude configuration
+# AI assistants configuration
 .claude/
 .mcp.json
+.bob/


### PR DESCRIPTION
Trivial PR to have the `./bob` folder being ignored by Git.
As Claude Code from Anthropic (and we are already ignoring `./claude` folder right now), Bob is an AI code assistant by IBM.
