### PR TITLE
Add validation to make sure that goal list is empty when using `rebalanceDisk: true`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -291,7 +291,7 @@ public class KafkaRebalanceAssemblyOperator
             default:
                 rebalanceOptionsBuilder = new RebalanceOptions.RebalanceOptionsBuilder();
                 if (kafkaRebalanceSpec.isRebalanceDisk()) {
-                    if (!kafkaRebalanceSpec.getGoals().isEmpty()) {
+                    if (kafkaRebalanceSpec.getGoals() != null && !kafkaRebalanceSpec.getGoals().isEmpty()) {
                         throw new IllegalArgumentException("The goals list should be empty when using the `rebalanceDisk: true` configuration for intra-broker disk balancing");
                     }
                     ((RebalanceOptions.RebalanceOptionsBuilder) rebalanceOptionsBuilder).withRebalanceDisk();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -291,6 +291,9 @@ public class KafkaRebalanceAssemblyOperator
             default:
                 rebalanceOptionsBuilder = new RebalanceOptions.RebalanceOptionsBuilder();
                 if (kafkaRebalanceSpec.isRebalanceDisk()) {
+                    if (!kafkaRebalanceSpec.getGoals().isEmpty()) {
+                        throw new IllegalArgumentException("The goals list should be empty when using the `rebalanceDisk: true` configuration for intra-broker disk balancing");
+                    }
                     ((RebalanceOptions.RebalanceOptionsBuilder) rebalanceOptionsBuilder).withRebalanceDisk();
                 }
                 if (kafkaRebalanceSpec.getConcurrentIntraBrokerPartitionMovements() > 0) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1026,22 +1026,6 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
         this.krNewWithMissingHardGoalsAndRefresh(context, CruiseControlEndpoints.REMOVE_BROKER, kr);
     }
 
-    private void krRebalanceDiskWithGoals(VertxTestContext context, KafkaRebalance kr) {
-        Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
-        crdCreateKafka();
-        crdCreateCruiseControlSecrets();
-
-        Checkpoint checkpoint = context.checkpoint();
-        krao.reconcile(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, namespace, kr.getMetadata().getName()))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
-                    // the resource moved from New to NotReady due to validation error
-                    assertState(context, client, namespace, kr.getMetadata().getName(),
-                            KafkaRebalanceState.NotReady, IllegalArgumentException.class,
-                            "The goals list should be empty when using the `rebalanceDisk: true` configuration for intra-broker disk balancing");
-                    checkpoint.flag();
-                })));
-    }
-
     private void krNewWithMissingHardGoalsAndRefresh(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) {
         // Set up the rebalance endpoint to get error about hard goals
         cruiseControlServer.setupCCRebalanceBadGoalsError(endpoint);
@@ -1107,7 +1091,19 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
                 .build();
 
         KafkaRebalance kr = createKafkaRebalance(namespace, CLUSTER_NAME, RESOURCE_NAME, kafkaRebalanceSpec, false);
-        this.krRebalanceDiskWithGoals(context, kr);
+        Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
+        crdCreateKafka();
+        crdCreateCruiseControlSecrets();
+
+        Checkpoint checkpoint = context.checkpoint();
+        krao.reconcile(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, namespace, kr.getMetadata().getName()))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // the resource moved from New to NotReady due to validation error
+                    assertState(context, client, namespace, kr.getMetadata().getName(),
+                            KafkaRebalanceState.NotReady, IllegalArgumentException.class,
+                            "The goals list should be empty when using the `rebalanceDisk: true` configuration for intra-broker disk balancing");
+                    checkpoint.flag();
+                })));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1026,6 +1026,22 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
         this.krNewWithMissingHardGoalsAndRefresh(context, CruiseControlEndpoints.REMOVE_BROKER, kr);
     }
 
+    private void krRebalanceDiskWithGoals(VertxTestContext context, KafkaRebalance kr) {
+        Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
+        crdCreateKafka();
+        crdCreateCruiseControlSecrets();
+
+        Checkpoint checkpoint = context.checkpoint();
+        krao.reconcile(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, namespace, kr.getMetadata().getName()))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // the resource moved from New to NotReady due to validation error
+                    assertState(context, client, namespace, kr.getMetadata().getName(),
+                            KafkaRebalanceState.NotReady, IllegalArgumentException.class,
+                            "The goals list should be empty when using the `rebalanceDisk: true` configuration for intra-broker disk balancing");
+                    checkpoint.flag();
+                })));
+    }
+
     private void krNewWithMissingHardGoalsAndRefresh(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) {
         // Set up the rebalance endpoint to get error about hard goals
         cruiseControlServer.setupCCRebalanceBadGoalsError(endpoint);
@@ -1074,6 +1090,24 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
                     assertState(context, client, namespace, kr.getMetadata().getName(), KafkaRebalanceState.ProposalReady);
                     checkpoint.flag();
                 }));
+    }
+
+    /**
+     * Tests validation error when rebalanceDisk is true but goals are provided
+     *
+     * 1. A new KafkaRebalance resource is created with rebalanceDisk: true and some goals; it is in the 'New' state
+     * 2. The operator validates the spec and rejects it due to incompatible configuration
+     * 3. The KafkaRebalance resource moves to the 'NotReady' state with an error
+     */
+    @Test
+    public void testRebalanceDiskWithGoalsRebalance(VertxTestContext context) {
+        KafkaRebalanceSpec kafkaRebalanceSpec = new KafkaRebalanceSpecBuilder()
+                .withRebalanceDisk(true)
+                .withGoals("DiskCapacityGoal", "CpuCapacityGoal")
+                .build();
+
+        KafkaRebalance kr = createKafkaRebalance(namespace, CLUSTER_NAME, RESOURCE_NAME, kafkaRebalanceSpec, false);
+        this.krRebalanceDiskWithGoals(context, kr);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Validation

### Description

This PR fixes #12448. These changes aim to provide a better message reflecting that goals list should be empty when configuring the `rebalanceDisk: true` in the `KafkaRebalance` CR for intra broker balancing.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

