### PR TITLE
Add automatic offline log directory detection and rolling restart

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -250,6 +250,12 @@ public class ClusterOperatorConfig {
     public static final ConfigParameter<Boolean> POD_DISRUPTION_BUDGET_GENERATION = new ConfigParameter<>("STRIMZI_POD_DISRUPTION_BUDGET_GENERATION", BOOLEAN, "true", CONFIG_VALUES);
 
     /**
+     * Cooldown period in minutes before restarting a broker again for offline log directories.
+     * Prevents infinite restart loops when offline dirs are caused by permanent hardware failure.
+     */
+    public static final ConfigParameter<Long> OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES = new ConfigParameter<>("STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES", LONG, "30", CONFIG_VALUES);
+
+    /**
      * The configured Kafka versions
      */
     private final KafkaVersion.Lookup versions;
@@ -626,6 +632,15 @@ public class ClusterOperatorConfig {
      */
     public boolean isPodDisruptionBudgetGeneration() {
         return get(POD_DISRUPTION_BUDGET_GENERATION);
+    }
+
+    /**
+     * Gets the cooldown period in milliseconds before restarting a broker again for offline log directories.
+     *
+     * @return  cooldown in milliseconds
+     */
+    public long getOfflineLogDirRestartCooldownMs() {
+        return get(OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES) * 60_000L;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -250,10 +250,10 @@ public class ClusterOperatorConfig {
     public static final ConfigParameter<Boolean> POD_DISRUPTION_BUDGET_GENERATION = new ConfigParameter<>("STRIMZI_POD_DISRUPTION_BUDGET_GENERATION", BOOLEAN, "true", CONFIG_VALUES);
 
     /**
-     * Cooldown period in minutes before restarting a broker again for offline log directories.
+     * Cooldown period in milliseconds before restarting a broker again for offline log directories.
      * Prevents infinite restart loops when offline dirs are caused by permanent hardware failure.
      */
-    public static final ConfigParameter<Long> OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES = new ConfigParameter<>("STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES", LONG, "30", CONFIG_VALUES);
+    public static final ConfigParameter<Long> OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS = new ConfigParameter<>("STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS", LONG, "1800000", CONFIG_VALUES);
 
     /**
      * The configured Kafka versions
@@ -640,7 +640,7 @@ public class ClusterOperatorConfig {
      * @return  cooldown in milliseconds
      */
     public long getOfflineLogDirRestartCooldownMs() {
-        return get(OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES) * 60_000L;
+        return get(OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -665,6 +665,7 @@ public class ClusterOperatorConfig {
                 "\n\tpodSecurityProviderClass='" + getPodSecurityProviderClass() + '\'' +
                 "\n\tleaderElectionConfig='" + getLeaderElectionConfig() + '\'' +
                 "\n\tpodDisruptionBudgetGeneration=" + isPodDisruptionBudgetGeneration() +
+                "\n\tofflineLogDirRestartCooldownMs=" + getOfflineLogDirRestartCooldownMs() +
                 "}";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
@@ -81,7 +81,12 @@ public enum RestartReason {
     /**
      * Kafka TLS certificates changed
      */
-    KAFKA_CERTIFICATES_CHANGED("Kafka broker TLS certificates updated");
+    KAFKA_CERTIFICATES_CHANGED("Kafka broker TLS certificates updated"),
+
+    /**
+     * Broker has offline log directories that require a restart to recover
+     */
+    OFFLINE_LOG_DIRS("Broker has offline log directories");
 
     //Used in logging and Kubernetes event notes
     private final String defaultNote;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -73,6 +73,7 @@ public class CaReconciler {
 
     /* test */ final Reconciliation reconciliation;
     private final long operationTimeoutMs;
+    private final long offlineLogDirRestartCooldownMs;
 
     /* test */ final DeploymentOperator deploymentOperator;
     private final StrimziPodSetOperator strimziPodSetOperator;
@@ -124,6 +125,7 @@ public class CaReconciler {
     ) {
         this.reconciliation = reconciliation;
         this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.offlineLogDirRestartCooldownMs = config.getOfflineLogDirRestartCooldownMs();
 
         this.deploymentOperator = supplier.deploymentOperations;
         this.strimziPodSetOperator = supplier.strimziPodSetOperator;
@@ -519,7 +521,7 @@ public class CaReconciler {
                 null,
                 false,
                 eventPublisher,
-                operationTimeoutMs);
+                offlineLogDirRestartCooldownMs);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -518,7 +518,8 @@ public class CaReconciler {
                 brokerId -> null,
                 null,
                 false,
-                eventPublisher);
+                eventPublisher,
+                operationTimeoutMs);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -116,6 +116,7 @@ public class KafkaReconciler {
 
     // Various settings
     private final long operationTimeoutMs;
+    private final long offlineLogDirRestartCooldownMs;
     private final boolean isNetworkPolicyGeneration;
     private final boolean isPodDisruptionBudgetGeneration;
     private final List<String> maintenanceWindows;
@@ -196,6 +197,7 @@ public class KafkaReconciler {
         this.reconciliation = reconciliation;
         this.vertx = vertx;
         this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.offlineLogDirRestartCooldownMs = config.getOfflineLogDirRestartCooldownMs();
         this.kafkaNodePoolCrs = nodePools;
         this.kafka = kafka;
 
@@ -478,7 +480,8 @@ public class KafkaReconciler {
                     brokerId -> kafka.generatePerBrokerConfiguration(brokerId, kafkaAdvertisedHostnames, kafkaAdvertisedPorts),
                     kafka.getKafkaVersion(),
                     allowReconfiguration,
-                    eventsPublisher
+                    eventsPublisher,
+                    offlineLogDirRestartCooldownMs
             ).rollingRestart(podNeedsRestart));
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -12,6 +12,7 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
@@ -60,10 +61,31 @@ class KafkaAvailability {
      */
     CompletableFuture<Boolean> canRoll(int podId) {
         LOGGER.debugCr(reconciliation, "Determining whether broker {} can be rolled", podId);
-        return canRollBroker(descriptions, podId);
+        return canRollBroker(descriptions, podId, null);
     }
 
-    private CompletableFuture<Boolean> canRollBroker(CompletableFuture<Collection<TopicDescription>> descriptions, int podId) {
+    /**
+     * Determine whether the given broker can be rolled, excluding partitions on offline log directories
+     * from the availability check. Partitions not in {@code partitionsOnHealthyDirs} are assumed to be
+     * on offline dirs (already degraded) and are skipped — restarting can only help them.
+     *
+     * @param podId                     The broker ID to check
+     * @param partitionsOnHealthyDirs   The set of topic-partitions known to be on healthy log dirs
+     */
+    CompletableFuture<Boolean> canRollExcludingOfflineDirPartitions(int podId, Set<TopicPartition> partitionsOnHealthyDirs) {
+        LOGGER.debugCr(reconciliation, "Determining whether broker {} can be rolled (excluding partitions on offline dirs)", podId);
+        return canRollBroker(descriptions, podId, partitionsOnHealthyDirs);
+    }
+
+    /**
+     * Determines whether the given broker can be rolled, optionally excluding partitions on offline dirs.
+     *
+     * @param partitionsOnHealthyDirs   If non-null, partitions NOT in this set are excluded from the availability check
+     *                                  (they are assumed to be on offline dirs and already degraded).
+     *                                  If null, all partitions are checked (standard behavior).
+     */
+    private CompletableFuture<Boolean> canRollBroker(CompletableFuture<Collection<TopicDescription>> descriptions, int podId,
+                                                      Set<TopicPartition> partitionsOnHealthyDirs) {
         CompletableFuture<Set<TopicDescription>> topicsOnGivenBroker = descriptions
                 .whenComplete((r, error) -> {
                     if (error != null) {
@@ -82,7 +104,7 @@ class KafkaAvailability {
         // 5. join
         return topicsOnGivenBroker.thenCombine(topicConfigsOnGivenBroker, (tds, topicNameToConfig) -> {
             boolean canRoll = tds.stream().noneMatch(
-                td -> wouldAffectAvailability(podId, topicNameToConfig, td));
+                td -> wouldAffectAvailability(podId, topicNameToConfig, td, partitionsOnHealthyDirs));
             if (!canRoll) {
                 LOGGER.debugCr(reconciliation, "Restart pod {} would remove it from ISR, stalling producers with acks=all", podId);
             }
@@ -95,7 +117,13 @@ class KafkaAvailability {
         });
     }
 
-    private boolean wouldAffectAvailability(int broker, Map<String, Config> nameToConfig, TopicDescription td) {
+    /**
+     * Checks whether rolling the given broker would affect availability of a specific topic.
+     *
+     * @param partitionsOnHealthyDirs   If non-null, partitions NOT in this set are skipped (assumed to be on offline dirs).
+     */
+    private boolean wouldAffectAvailability(int broker, Map<String, Config> nameToConfig, TopicDescription td,
+                                             Set<TopicPartition> partitionsOnHealthyDirs) {
         Config config = nameToConfig.get(td.name());
         ConfigEntry minIsrConfig = config.get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG);
         int minIsr;
@@ -108,6 +136,13 @@ class KafkaAvailability {
         }
 
         for (TopicPartitionInfo pi : td.partitions()) {
+            // If we have a healthy-dirs set, skip partitions that are on offline dirs (not in the healthy set).
+            // These partitions are already degraded and restarting the broker can only help them recover.
+            if (partitionsOnHealthyDirs != null
+                    && !partitionsOnHealthyDirs.contains(new TopicPartition(td.name(), pi.partition()))) {
+                LOGGER.debugCr(reconciliation, "{}/{} is on an offline log directory, skipping availability check for this partition", td.name(), pi.partition());
+                continue;
+            }
             List<Node> isr = pi.isr();
             if (minIsr >= 0) {
                 if (pi.replicas().size() <= minIsr) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -30,11 +30,14 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -102,6 +105,9 @@ public class KafkaRoller {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaRoller.class);
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME = "controller.quorum.fetch.timeout.ms";
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT = "2000";
+    // Cooldown period after pod creation before triggering another restart for offline log dirs.
+    // Prevents infinite restart loops when offline dirs are caused by permanent hardware failure.
+    /* test */ static volatile long offlineLogDirRestartCooldownMs = Duration.ofMinutes(30).toMillis();
 
     private final PodOperator podOperations;
     private final long pollingIntervalMs;
@@ -428,6 +434,7 @@ public class KafkaRoller {
 
         try {
             checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext);
+            checkForOfflineLogDirs(nodeRef, isBroker, restartContext, pod);
             if (restartContext.forceRestart) {
                 LOGGER.debugCr(reconciliation, "Pod {} can be rolled now", nodeRef);
                 restartAndAwaitReadiness(pod, operationTimeoutMs, restartContext);
@@ -666,6 +673,100 @@ public class KafkaRoller {
 
         LOGGER.traceCr(reconciliation, "KafkaFuture for getting Kafka configuration for pod {} is null", nodeRef);
         return null;
+    }
+
+    /**
+     * Checks for offline log directories on a broker node and updates the restart context if any are found.
+     * This is a no-op for controller-only nodes, pods already marked for force-restart, or when the broker
+     * admin client is not available.
+     *
+     * <p>To prevent infinite restart loops when offline dirs are caused by permanent hardware failure,
+     * this method skips the check for pods created within the last {@link #offlineLogDirRestartCooldownMs}
+     * milliseconds.</p>
+     */
+    private void checkForOfflineLogDirs(NodeRef nodeRef, boolean isBroker, RestartContext restartContext, Pod pod)
+            throws InterruptedException {
+        if (!isBroker || restartContext.forceRestart || brokerAdminClient == null) {
+            return;
+        }
+
+        if (isPodWithinOfflineLogDirCooldown(pod)) {
+            LOGGER.debugCr(reconciliation, "Skipping offline log directory check for pod {} (created recently, within cooldown period)", nodeRef);
+            return;
+        }
+
+        try {
+            if (hasOfflineLogDirs(nodeRef)) {
+                restartContext.restartReasons.add(RestartReason.OFFLINE_LOG_DIRS);
+                restartContext.needsRestart = true;
+            }
+        } catch (InterruptedException e) {
+            throw e;
+        } catch (Exception e) {
+            LOGGER.warnCr(reconciliation, "Failed to check offline log directories for pod {}: {}", nodeRef, e.getMessage());
+        }
+    }
+
+    /**
+     * Checks whether the pod was created recently enough that it is still within the offline-log-dir
+     * restart cooldown window. If so, restarting for offline dirs should be skipped to avoid a
+     * tight restart loop when the underlying cause is permanent (e.g., dead disk).
+     */
+    private boolean isPodWithinOfflineLogDirCooldown(Pod pod) {
+        String creationTimestamp = pod.getMetadata().getCreationTimestamp();
+        if (creationTimestamp == null) {
+            return false;
+        }
+        try {
+            Instant createdAt = Instant.parse(creationTimestamp);
+            return Instant.now().toEpochMilli() - createdAt.toEpochMilli() < offlineLogDirRestartCooldownMs;
+        } catch (Exception e) {
+            LOGGER.debugCr(reconciliation, "Could not parse pod creation timestamp '{}', skipping cooldown check", creationTimestamp);
+            return false;
+        }
+    }
+
+    /**
+     * Checks whether the given broker has any offline log directories.
+     *
+     * @param nodeRef   Reference to the broker node to check
+     *
+     * @return  true if the broker has at least one offline log directory
+     *
+     * @throws ForceableProblem     If there is an error querying the log directories
+     * @throws InterruptedException If the thread is interrupted while waiting
+     */
+    /* test */ boolean hasOfflineLogDirs(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
+        DescribeLogDirsResult result = brokerAdminClient.describeLogDirs(singletonList(nodeRef.nodeId()));
+        Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> descriptions = result.descriptions();
+        KafkaFuture<Map<String, LogDirDescription>> future = descriptions.get(nodeRef.nodeId());
+
+        if (future == null) {
+            LOGGER.traceCr(reconciliation, "KafkaFuture for describing log dirs for pod {} is null", nodeRef);
+            return false;
+        }
+
+        Map<String, LogDirDescription> logDirs = await(future.toCompletionStage().toCompletableFuture(),
+                30_000,
+                error -> new ForceableProblem("Error describing log dirs for pod " + nodeRef + ": " + error, error)
+        );
+
+        if (logDirs == null) {
+            return false;
+        }
+
+        List<String> offlineDirs = logDirs.entrySet().stream()
+                .filter(entry -> entry.getValue().error() != null)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        if (!offlineDirs.isEmpty()) {
+            LOGGER.warnCr(reconciliation, "Pod {} has {} offline log director{}: {}",
+                    nodeRef, offlineDirs.size(), offlineDirs.size() == 1 ? "y" : "ies", offlineDirs);
+            return true;
+        }
+
+        return false;
     }
 
     /* test */ void dynamicUpdateKafkaConfig(NodeRef nodeRef, Admin ac, KafkaConfigurationDiff configurationDiff)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -108,7 +108,7 @@ public class KafkaRoller {
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT = "2000";
     // Cooldown period after pod creation before triggering another restart for offline log dirs.
     // Prevents infinite restart loops when offline dirs are caused by permanent hardware failure.
-    /* test */ static volatile long offlineLogDirRestartCooldownMs = Duration.ofMinutes(30).toMillis();
+    private final long offlineLogDirRestartCooldownMs;
 
     private final PodOperator podOperations;
     private final long pollingIntervalMs;
@@ -150,13 +150,15 @@ public class KafkaRoller {
      * @param kafkaAgentClientProvider  Kafka Agent client provider
      * @param kafkaConfigProvider       Kafka configuration provider
      * @param kafkaVersion              Kafka version
-     * @param allowReconfiguration      Flag indicting whether reconfiguration is allowed or not
-     * @param eventsPublisher           Kubernetes Events publisher for publishing events about pod restarts
+     * @param allowReconfiguration              Flag indicting whether reconfiguration is allowed or not
+     * @param eventsPublisher                   Kubernetes Events publisher for publishing events about pod restarts
+     * @param offlineLogDirRestartCooldownMs    Cooldown in milliseconds before restarting a broker again for offline log dirs
      */
     public KafkaRoller(Reconciliation reconciliation, PodOperator podOperations,
                        long pollingIntervalMs, long operationTimeoutMs, Supplier<BackOff> backOffSupplier, Set<NodeRef> nodes,
                        TlsPemIdentity coTlsPemIdentity, AdminClientProvider adminClientProvider, KafkaAgentClientProvider kafkaAgentClientProvider,
-                       Function<Integer, String> kafkaConfigProvider, KafkaVersion kafkaVersion, boolean allowReconfiguration, KubernetesRestartEventPublisher eventsPublisher) {
+                       Function<Integer, String> kafkaConfigProvider, KafkaVersion kafkaVersion, boolean allowReconfiguration,
+                       KubernetesRestartEventPublisher eventsPublisher, long offlineLogDirRestartCooldownMs) {
         this.namespace = reconciliation.namespace();
         this.cluster = reconciliation.name();
         this.nodes = nodes;
@@ -175,6 +177,7 @@ public class KafkaRoller {
         this.kafkaVersion = kafkaVersion;
         this.reconciliation = reconciliation;
         this.allowReconfiguration = allowReconfiguration;
+        this.offlineLogDirRestartCooldownMs = offlineLogDirRestartCooldownMs;
     }
 
     private final ScheduledExecutorService singleExecutor = Executors.newSingleThreadScheduledExecutor(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -463,8 +463,9 @@ public class KafkaRoller {
                         throw new UnforceableProblem("Pod " + nodeRef.podName() + " cannot be updated right now.");
                     }
                 } else {
-                    // Check for rollability before trying a dynamic update so that if the dynamic update fails we can go to a full restart
-                    if (!maybeDynamicUpdateBrokerConfig(nodeRef, restartContext, isController && !isBroker)) {
+                    // If a restart is required (not just a reconfig), skip dynamic update and go straight to restart.
+                    // Otherwise, try a dynamic update first so that if it fails we can fall back to a full restart.
+                    if (restartContext.needsRestart || !maybeDynamicUpdateBrokerConfig(nodeRef, restartContext, isController && !isBroker)) {
                         LOGGER.infoCr(reconciliation, "Rolling Pod {} due to {}", nodeRef, restartContext.restartReasons.getAllReasonNotes());
                         restartAndAwaitReadiness(pod, operationTimeoutMs, restartContext);
                     } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -107,6 +107,7 @@ public class KafkaRoller {
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME = "controller.quorum.fetch.timeout.ms";
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT = "2000";
     private static final long ADMIN_API_TIMEOUT_MS = 30_000;
+    private static final long AVAILABILITY_CHECK_TIMEOUT_MS = 60_000;
     // Cooldown period after pod creation before triggering another restart for offline log dirs.
     // Prevents infinite restart loops when offline dirs are caused by permanent hardware failure.
     private final long offlineLogDirRestartCooldownMs;
@@ -692,6 +693,12 @@ public class KafkaRoller {
     }
 
     /**
+     * Cached log dir status from the most recent checkForOfflineLogDirs call, used by the weaker
+     * availability check to avoid a second describeLogDirs round trip.
+     */
+    private LogDirStatus lastLogDirStatus;
+
+    /**
      * Checks for offline log directories on a broker node and updates the restart context if any are found.
      * This is a no-op for controller-only nodes, pods already marked for force-restart, or when the broker
      * admin client is not available.
@@ -700,12 +707,6 @@ public class KafkaRoller {
      * this method skips the check for pods created within the last {@link #offlineLogDirRestartCooldownMs}
      * milliseconds.</p>
      */
-    /**
-     * Cached log dir status from the most recent checkForOfflineLogDirs call, used by the weaker
-     * availability check to avoid a second describeLogDirs round trip.
-     */
-    private LogDirStatus lastLogDirStatus;
-
     private void checkForOfflineLogDirs(NodeRef nodeRef, boolean isBroker, RestartContext restartContext, Pod pod)
             throws InterruptedException {
         lastLogDirStatus = null;
@@ -897,7 +898,7 @@ public class KafkaRoller {
 
     private boolean canRoll(int nodeId, boolean isController, boolean isBroker, boolean ignoreSslError, RestartContext restartContext)
             throws ForceableProblem, InterruptedException, UnforceableProblem {
-        long timeoutMs = 60_000;
+        long timeoutMs = AVAILABILITY_CHECK_TIMEOUT_MS;
         try {
             if (isBroker && isController) {
                 boolean canRollController = await(restartContext.quorumCheck.canRollController(nodeId), timeoutMs,
@@ -1052,7 +1053,7 @@ public class KafkaRoller {
                 : Set.of();
         LOGGER.infoCr(reconciliation, "Pod {} has {} partitions on healthy log dirs; checking availability excluding offline-dir partitions",
                 nodeRef, healthyPartitions.size());
-        long timeoutMs = 60_000;
+        long timeoutMs = AVAILABILITY_CHECK_TIMEOUT_MS;
         return await(kafkaAvailability.canRollExcludingOfflineDirPartitions(nodeRef.nodeId(), healthyPartitions),
                 timeoutMs,
                 t -> new ForceableProblem("Error checking availability excluding offline dir partitions for pod " + nodeRef, t));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
 import org.apache.kafka.clients.admin.LogDirDescription;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 
@@ -443,8 +444,18 @@ public class KafkaRoller {
                     LOGGER.debugCr(reconciliation, "Pod {} is the active controller and there are other pods to verify first.", nodeRef);
                     throw new ForceableProblem("Pod " + nodeRef.podName() + " is the active controller and there are other pods to verify first");
                 } else if (!canRoll(nodeRef.nodeId(), isController, isBroker, false, restartContext)) {
-                    LOGGER.debugCr(reconciliation, "Pod {} cannot be updated right now", nodeRef);
-                    throw new UnforceableProblem("Pod " + nodeRef.podName() + " cannot be updated right now.");
+                    // Standard availability check failed. If the sole reason is OFFLINE_LOG_DIRS,
+                    // try a weaker check that excludes partitions on offline dirs (they're already
+                    // degraded and restarting can only help them).
+                    if (restartContext.restartReasons.getReasons().equals(Set.of(RestartReason.OFFLINE_LOG_DIRS))
+                            && isBroker
+                            && canRollExcludingOfflineDirPartitions(nodeRef, restartContext)) {
+                        LOGGER.infoCr(reconciliation, "Rolling Pod {} for offline log dir recovery (URPs on offline dirs excluded from availability check)", nodeRef);
+                        restartAndAwaitReadiness(pod, operationTimeoutMs, restartContext);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "Pod {} cannot be updated right now", nodeRef);
+                        throw new UnforceableProblem("Pod " + nodeRef.podName() + " cannot be updated right now.");
+                    }
                 } else {
                     // Check for rollability before trying a dynamic update so that if the dynamic update fails we can go to a full restart
                     if (!maybeDynamicUpdateBrokerConfig(nodeRef, restartContext, isController && !isBroker)) {
@@ -1002,6 +1013,53 @@ public class KafkaRoller {
 
     /* test */ KafkaAvailability availability(Admin ac) {
         return new KafkaAvailability(reconciliation, ac);
+    }
+
+    /**
+     * Collects the set of topic-partitions on healthy (non-offline) log directories for the given broker.
+     * This is used to determine which partitions can be excluded from the availability check when
+     * restarting for offline log dir recovery.
+     */
+    /* test */ Set<TopicPartition> getPartitionsOnHealthyDirs(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
+        DescribeLogDirsResult result = brokerAdminClient.describeLogDirs(singletonList(nodeRef.nodeId()));
+        KafkaFuture<Map<String, LogDirDescription>> future = result.descriptions().get(nodeRef.nodeId());
+
+        if (future == null) {
+            return Set.of();
+        }
+
+        Map<String, LogDirDescription> logDirs = await(future.toCompletionStage().toCompletableFuture(),
+                30_000,
+                error -> new ForceableProblem("Error describing log dirs for pod " + nodeRef + ": " + error, error)
+        );
+
+        if (logDirs == null) {
+            return Set.of();
+        }
+
+        Set<TopicPartition> healthyPartitions = new HashSet<>();
+        for (LogDirDescription dir : logDirs.values()) {
+            if (dir.error() == null) {
+                healthyPartitions.addAll(dir.replicaInfos().keySet());
+            }
+        }
+        return healthyPartitions;
+    }
+
+    /**
+     * Checks if the broker can be rolled when considering only partitions on healthy log directories.
+     * Partitions on offline directories are excluded from the ISR availability check because they are
+     * already degraded and the restart is intended to recover them.
+     */
+    private boolean canRollExcludingOfflineDirPartitions(NodeRef nodeRef, RestartContext restartContext)
+            throws ForceableProblem, InterruptedException, UnforceableProblem {
+        Set<TopicPartition> healthyPartitions = getPartitionsOnHealthyDirs(nodeRef);
+        LOGGER.infoCr(reconciliation, "Pod {} has {} partitions on healthy log dirs; checking availability excluding offline-dir partitions",
+                nodeRef, healthyPartitions.size());
+        long timeoutMs = 60_000;
+        return await(availability(brokerAdminClient).canRollExcludingOfflineDirPartitions(nodeRef.nodeId(), healthyPartitions),
+                timeoutMs,
+                t -> new ForceableProblem("Error checking availability excluding offline dir partitions for pod " + nodeRef, t));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -106,6 +106,7 @@ public class KafkaRoller {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaRoller.class);
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME = "controller.quorum.fetch.timeout.ms";
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT = "2000";
+    private static final long ADMIN_API_TIMEOUT_MS = 30_000;
     // Cooldown period after pod creation before triggering another restart for offline log dirs.
     // Prevents infinite restart loops when offline dirs are caused by permanent hardware failure.
     private final long offlineLogDirRestartCooldownMs;
@@ -150,9 +151,9 @@ public class KafkaRoller {
      * @param kafkaAgentClientProvider  Kafka Agent client provider
      * @param kafkaConfigProvider       Kafka configuration provider
      * @param kafkaVersion              Kafka version
-     * @param allowReconfiguration              Flag indicting whether reconfiguration is allowed or not
-     * @param eventsPublisher                   Kubernetes Events publisher for publishing events about pod restarts
-     * @param offlineLogDirRestartCooldownMs    Cooldown in milliseconds before restarting a broker again for offline log dirs
+     * @param allowReconfiguration      Flag indicating whether reconfiguration is allowed or not
+     * @param eventsPublisher           Kubernetes Events publisher for publishing events about pod restarts
+     * @param offlineLogDirRestartCooldownMs  Cooldown in milliseconds before restarting a broker again for offline log dirs
      */
     public KafkaRoller(Reconciliation reconciliation, PodOperator podOperations,
                        long pollingIntervalMs, long operationTimeoutMs, Supplier<BackOff> backOffSupplier, Set<NodeRef> nodes,
@@ -449,10 +450,11 @@ public class KafkaRoller {
                 } else if (!canRoll(nodeRef.nodeId(), isController, isBroker, false, restartContext)) {
                     // Standard availability check failed. If the sole reason is OFFLINE_LOG_DIRS,
                     // try a weaker check that excludes partitions on offline dirs (they're already
-                    // degraded and restarting can only help them).
+                    // degraded and restarting can only help them). Reuses the same KafkaAvailability
+                    // instance to avoid re-fetching topic metadata.
                     if (restartContext.restartReasons.getReasons().equals(Set.of(RestartReason.OFFLINE_LOG_DIRS))
                             && isBroker
-                            && canRollExcludingOfflineDirPartitions(nodeRef, restartContext)) {
+                            && canRollExcludingOfflineDirPartitions(nodeRef, availability(brokerAdminClient))) {
                         LOGGER.infoCr(reconciliation, "Rolling Pod {} for offline log dir recovery (URPs on offline dirs excluded from availability check)", nodeRef);
                         restartAndAwaitReadiness(pod, operationTimeoutMs, restartContext);
                     } else {
@@ -670,7 +672,7 @@ public class KafkaRoller {
             KafkaFuture<Config> configFuture = controllerAdminClient.describeConfigs(singletonList(resource)).values().get(resource);
             if (configFuture != null) {
                 return await(configFuture.toCompletionStage().toCompletableFuture(),
-                        30_000,
+                        ADMIN_API_TIMEOUT_MS,
                         error -> new ForceableProblem("Error getting controller config: " + error, error)
                 );
             }
@@ -679,7 +681,7 @@ public class KafkaRoller {
             KafkaFuture<Config> configFuture = brokerAdminClient.describeConfigs(singletonList(resource)).values().get(resource);
             if (configFuture != null) {
                 return await(configFuture.toCompletionStage().toCompletableFuture(),
-                        30_000,
+                        ADMIN_API_TIMEOUT_MS,
                         error -> new ForceableProblem("Error getting broker config: " + error, error)
                 );
             }
@@ -698,8 +700,16 @@ public class KafkaRoller {
      * this method skips the check for pods created within the last {@link #offlineLogDirRestartCooldownMs}
      * milliseconds.</p>
      */
+    /**
+     * Cached log dir status from the most recent checkForOfflineLogDirs call, used by the weaker
+     * availability check to avoid a second describeLogDirs round trip.
+     */
+    private LogDirStatus lastLogDirStatus;
+
     private void checkForOfflineLogDirs(NodeRef nodeRef, boolean isBroker, RestartContext restartContext, Pod pod)
             throws InterruptedException {
+        lastLogDirStatus = null;
+
         if (!isBroker || restartContext.forceRestart || brokerAdminClient == null) {
             return;
         }
@@ -710,7 +720,8 @@ public class KafkaRoller {
         }
 
         try {
-            if (hasOfflineLogDirs(nodeRef)) {
+            lastLogDirStatus = describeLogDirStatus(nodeRef);
+            if (lastLogDirStatus.hasOfflineDirs()) {
                 restartContext.restartReasons.add(RestartReason.OFFLINE_LOG_DIRS);
                 restartContext.needsRestart = true;
             }
@@ -741,46 +752,55 @@ public class KafkaRoller {
     }
 
     /**
-     * Checks whether the given broker has any offline log directories.
+     * Result of inspecting a broker's log directories via describeLogDirs().
      *
-     * @param nodeRef   Reference to the broker node to check
-     *
-     * @return  true if the broker has at least one offline log directory
-     *
-     * @throws ForceableProblem     If there is an error querying the log directories
-     * @throws InterruptedException If the thread is interrupted while waiting
+     * @param hasOfflineDirs          Whether any log dirs have a non-null error
+     * @param partitionsOnHealthyDirs The set of topic-partitions on healthy (non-offline) log dirs
      */
-    /* test */ boolean hasOfflineLogDirs(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
+    /* test */ record LogDirStatus(boolean hasOfflineDirs, Set<TopicPartition> partitionsOnHealthyDirs) {
+        static final LogDirStatus EMPTY = new LogDirStatus(false, Set.of());
+    }
+
+    /**
+     * Queries describeLogDirs() for the given broker and returns both offline status and healthy-dir partitions
+     * in a single Admin API call.
+     */
+    /* test */ LogDirStatus describeLogDirStatus(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
         DescribeLogDirsResult result = brokerAdminClient.describeLogDirs(singletonList(nodeRef.nodeId()));
         Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> descriptions = result.descriptions();
         KafkaFuture<Map<String, LogDirDescription>> future = descriptions.get(nodeRef.nodeId());
 
         if (future == null) {
             LOGGER.traceCr(reconciliation, "KafkaFuture for describing log dirs for pod {} is null", nodeRef);
-            return false;
+            return LogDirStatus.EMPTY;
         }
 
         Map<String, LogDirDescription> logDirs = await(future.toCompletionStage().toCompletableFuture(),
-                30_000,
+                ADMIN_API_TIMEOUT_MS,
                 error -> new ForceableProblem("Error describing log dirs for pod " + nodeRef + ": " + error, error)
         );
 
         if (logDirs == null) {
-            return false;
+            return LogDirStatus.EMPTY;
         }
 
-        List<String> offlineDirs = logDirs.entrySet().stream()
-                .filter(entry -> entry.getValue().error() != null)
-                .map(Map.Entry::getKey)
-                .toList();
+        List<String> offlineDirs = new ArrayList<>();
+        Set<TopicPartition> healthyPartitions = new HashSet<>();
+
+        for (Map.Entry<String, LogDirDescription> entry : logDirs.entrySet()) {
+            if (entry.getValue().error() != null) {
+                offlineDirs.add(entry.getKey());
+            } else {
+                healthyPartitions.addAll(entry.getValue().replicaInfos().keySet());
+            }
+        }
 
         if (!offlineDirs.isEmpty()) {
             LOGGER.warnCr(reconciliation, "Pod {} has {} offline log director{}: {}",
                     nodeRef, offlineDirs.size(), offlineDirs.size() == 1 ? "y" : "ies", offlineDirs);
-            return true;
         }
 
-        return false;
+        return new LogDirStatus(!offlineDirs.isEmpty(), healthyPartitions);
     }
 
     /* test */ void dynamicUpdateKafkaConfig(NodeRef nodeRef, Admin ac, KafkaConfigurationDiff configurationDiff)
@@ -798,7 +818,7 @@ public class KafkaRoller {
             KafkaFuture<Void> brokerConfigFuture = alterBrokerConfigResult.values().get(getBrokersConfig(nodeRef.nodeId()));
 
             if (brokerConfigFuture != null) {
-                await(brokerConfigFuture.toCompletionStage().toCompletableFuture(), 30_000, error -> {
+                await(brokerConfigFuture.toCompletionStage().toCompletableFuture(), ADMIN_API_TIMEOUT_MS, error -> {
                     LOGGER.errorCr(reconciliation, "Error updating Kafka configuration for pod {}", nodeRef, error);
                     return new ForceableProblem("Error updating Kafka configuration for pod " + nodeRef, error);
                 });
@@ -820,7 +840,7 @@ public class KafkaRoller {
             KafkaFuture<Void> clusterConfigFuture = alterClusterConfigResult.values().get(getClusterWideConfig());
 
             if (clusterConfigFuture != null) {
-                await(clusterConfigFuture.toCompletionStage().toCompletableFuture(), 30_000, error -> {
+                await(clusterConfigFuture.toCompletionStage().toCompletableFuture(), ADMIN_API_TIMEOUT_MS, error -> {
                     LOGGER.errorCr(reconciliation, "Error updating cluster-wide configuration", error);
                     return new ForceableProblem("Error updating cluster-wide configuration", error);
                 });
@@ -1019,48 +1039,21 @@ public class KafkaRoller {
     }
 
     /**
-     * Collects the set of topic-partitions on healthy (non-offline) log directories for the given broker.
-     * This is used to determine which partitions can be excluded from the availability check when
-     * restarting for offline log dir recovery.
-     */
-    /* test */ Set<TopicPartition> getPartitionsOnHealthyDirs(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
-        DescribeLogDirsResult result = brokerAdminClient.describeLogDirs(singletonList(nodeRef.nodeId()));
-        KafkaFuture<Map<String, LogDirDescription>> future = result.descriptions().get(nodeRef.nodeId());
-
-        if (future == null) {
-            return Set.of();
-        }
-
-        Map<String, LogDirDescription> logDirs = await(future.toCompletionStage().toCompletableFuture(),
-                30_000,
-                error -> new ForceableProblem("Error describing log dirs for pod " + nodeRef + ": " + error, error)
-        );
-
-        if (logDirs == null) {
-            return Set.of();
-        }
-
-        Set<TopicPartition> healthyPartitions = new HashSet<>();
-        for (LogDirDescription dir : logDirs.values()) {
-            if (dir.error() == null) {
-                healthyPartitions.addAll(dir.replicaInfos().keySet());
-            }
-        }
-        return healthyPartitions;
-    }
-
-    /**
      * Checks if the broker can be rolled when considering only partitions on healthy log directories.
      * Partitions on offline directories are excluded from the ISR availability check because they are
      * already degraded and the restart is intended to recover them.
+     * Uses the cached LogDirStatus from the most recent checkForOfflineLogDirs call and the
+     * provided KafkaAvailability instance to avoid redundant Admin API calls.
      */
-    private boolean canRollExcludingOfflineDirPartitions(NodeRef nodeRef, RestartContext restartContext)
-            throws ForceableProblem, InterruptedException, UnforceableProblem {
-        Set<TopicPartition> healthyPartitions = getPartitionsOnHealthyDirs(nodeRef);
+    private boolean canRollExcludingOfflineDirPartitions(NodeRef nodeRef, KafkaAvailability kafkaAvailability)
+            throws ForceableProblem, InterruptedException {
+        Set<TopicPartition> healthyPartitions = lastLogDirStatus != null
+                ? lastLogDirStatus.partitionsOnHealthyDirs()
+                : Set.of();
         LOGGER.infoCr(reconciliation, "Pod {} has {} partitions on healthy log dirs; checking availability excluding offline-dir partitions",
                 nodeRef, healthyPartitions.size());
         long timeoutMs = 60_000;
-        return await(availability(brokerAdminClient).canRollExcludingOfflineDirPartitions(nodeRef.nodeId(), healthyPartitions),
+        return await(kafkaAvailability.canRollExcludingOfflineDirPartitions(nodeRef.nodeId(), healthyPartitions),
                 timeoutMs,
                 t -> new ForceableProblem("Error checking availability excluding offline dir partitions for pod " + nodeRef, t));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RestartReasonTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RestartReasonTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_HAS_OLD_GENERATION;
 import static io.strimzi.operator.cluster.model.RestartReason.FILE_SYSTEM_RESIZE_NEEDED;
+import static io.strimzi.operator.cluster.model.RestartReason.OFFLINE_LOG_DIRS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -17,5 +18,6 @@ class RestartReasonTest {
     void testPascalCasedReason() {
         assertThat(CA_CERT_HAS_OLD_GENERATION.pascalCased(), is("CaCertHasOldGeneration"));
         assertThat(FILE_SYSTEM_RESIZE_NEEDED.pascalCased(), is("FileSystemResizeNeeded"));
+        assertThat(OFFLINE_LOG_DIRS.pascalCased(), is("OfflineLogDirs"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -866,11 +866,12 @@ public class KafkaRollerTest {
     public void testOfflineLogDirCooldownPreventsRestart() {
         // Pods with recent creation timestamp should not be restarted for offline log dirs
         PodOperator podOps = mockPodOpsWithTimestamp(podId -> CompletableFuture.completedFuture(null), java.time.Instant.now().toString());
+        // Use a 30-minute cooldown so the freshly-created pod is within the cooldown window
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
                 new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
-                Set.of(2));
+                Set.of(2), 30 * 60_000L);
         // Pod 2 has offline log dirs BUT was created recently (within cooldown) -> should NOT be restarted
         doSuccessfulRollingRestart(kafkaRoller,
                 emptyList(),
@@ -1064,6 +1065,24 @@ public class KafkaRollerTest {
                                    KafkaAgentClientProvider kafkaAgentClientProvider,
                                    boolean delegateAdminClientCall, BrokerState brokerState, int activeController,
                                    Set<Integer> brokersWithOfflineLogDirs) {
+            this(nodes, podOps, acOpenException, acCloseException, controllerException, alterConfigsException,
+                    getConfigsException, canRollFn, adminClientProvider, kafkaAgentClientProvider,
+                    delegateAdminClientCall, brokerState, activeController, brokersWithOfflineLogDirs, 0L);
+        }
+
+        @SuppressWarnings("checkstyle:ParameterNumber")
+        private TestingKafkaRoller(Set<NodeRef> nodes,
+                                   PodOperator podOps,
+                                   Function<Set<NodeRef>, RuntimeException> acOpenException,
+                                   Throwable acCloseException,
+                                   Function<Integer, Throwable> controllerException,
+                                   Function<Integer, ForceableProblem> alterConfigsException,
+                                   Function<Integer, ForceableProblem> getConfigsException,
+                                   Function<Integer, CompletableFuture<Boolean>> canRollFn,
+                                   AdminClientProvider adminClientProvider,
+                                   KafkaAgentClientProvider kafkaAgentClientProvider,
+                                   boolean delegateAdminClientCall, BrokerState brokerState, int activeController,
+                                   Set<Integer> brokersWithOfflineLogDirs, long cooldownMs) {
             super(
                     new Reconciliation("test", "Kafka", stsNamespace(), clusterName()),
                     podOps,
@@ -1077,7 +1096,8 @@ public class KafkaRollerTest {
                     brokerId -> "compression.type=gzip",
                     KafkaVersionTestUtils.getLatestVersion(),
                     true,
-                    mock(KubernetesRestartEventPublisher.class));
+                    mock(KubernetesRestartEventPublisher.class),
+                    cooldownMs);
             this.delegateAdminClientCall = delegateAdminClientCall;
             this.activeController = activeController;
             this.controllerCall = 0;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -889,7 +889,8 @@ public class KafkaRollerTest {
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
                 new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
-                Set.of(2), 30 * 60_000L);
+                Set.of(2), 30 * 60_000L,
+                brokerId -> CompletableFuture.completedFuture(true));
         // Pod 2 has offline log dirs BUT was created recently (within cooldown) -> should NOT be restarted
         doSuccessfulRollingRestart(kafkaRoller,
                 emptyList(),
@@ -1004,16 +1005,13 @@ public class KafkaRollerTest {
     private PodOperator mockPodOpsWithTimestamp(Function<Integer, CompletableFuture<Void>> readiness, String creationTimestamp) {
         PodOperator podOps = mock(PodOperator.class);
         when(podOps.get(any(), any())).thenAnswer(
-                invocation -> {
-                    PodBuilder builder = new PodBuilder()
-                            .withNewMetadata()
+                invocation -> new PodBuilder()
+                        .withNewMetadata()
                             .withNamespace(invocation.getArgument(0))
-                            .withName(invocation.getArgument(1));
-                    if (creationTimestamp != null) {
-                        builder.withCreationTimestamp(creationTimestamp);
-                    }
-                    return builder.endMetadata().build();
-                }
+                            .withName(invocation.getArgument(1))
+                            .withCreationTimestamp(creationTimestamp)
+                        .endMetadata()
+                        .build()
         );
 
         when(podOps.readiness(any(), any(), any(), anyLong(), anyLong())).thenAnswer(invocationOnMock -> {
@@ -1236,7 +1234,7 @@ public class KafkaRollerTest {
         }
 
         @Override
-        LogDirStatus describeLogDirStatus(NodeRef nodeRef) {
+        LogDirStatus describeLogDirStatus(NodeRef nodeRef) throws ForceableProblem {
             boolean hasOffline = brokersWithOfflineLogDirs.contains(nodeRef.nodeId());
             return new LogDirStatus(hasOffline, Set.of());
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -855,11 +855,12 @@ public class KafkaRollerTest {
                 brokerId -> brokerId == 2 ? CompletableFuture.completedFuture(false) : CompletableFuture.completedFuture(true),
                 new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
                 Set.of(2));
-        // Both MANUAL_ROLLING_UPDATE and OFFLINE_LOG_DIRS reasons → weaker check not used → blocked
+        // Both MANUAL_ROLLING_UPDATE and OFFLINE_LOG_DIRS reasons → weaker check not used → broker 2 blocked.
+        // Other brokers have no restart reasons and are dynamically reconfigured (not restarted).
         doFailingRollingRestart(kafkaRoller,
                 singletonList(2),  // manual rolling update for broker 2
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
-                asList(0, 1, 3, 4));
+                emptyList());
     }
 
     @Test
@@ -873,11 +874,12 @@ public class KafkaRollerTest {
                 new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
                 Set.of(2), 0L,
                 brokerId -> CompletableFuture.completedFuture(false));
-        // Both checks fail -> broker 2 should NOT be restarted
+        // Both checks fail -> broker 2 should NOT be restarted.
+        // Other brokers have no restart reasons and are dynamically reconfigured (not restarted).
         doFailingRollingRestart(kafkaRoller,
                 emptyList(),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
-                asList(0, 1, 3, 4));
+                emptyList());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -785,21 +785,21 @@ public class KafkaRollerTest {
     @Test
     public void testOfflineLogDirCheckErrorIsSwallowed() {
         PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
-        // Create a roller where hasOfflineLogDirs throws for broker 1
+        // Create a roller where describeLogDirStatus throws ForceableProblem for broker 1
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
                 new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
                 Set.of()) {
             @Override
-            boolean hasOfflineLogDirs(NodeRef nodeRef) throws ForceableProblem {
+            LogDirStatus describeLogDirStatus(NodeRef nodeRef) throws ForceableProblem {
                 if (nodeRef.nodeId() == 1) {
                     throw new ForceableProblem("Simulated Admin API error");
                 }
-                return false;
+                return LogDirStatus.EMPTY;
             }
         };
-        // Broker 1 throws from hasOfflineLogDirs, but the error should be swallowed (best-effort).
+        // Broker 1 throws from describeLogDirStatus, but the error should be swallowed (best-effort).
         // No brokers need restart from the original list, and the error path should not cause any restarts.
         doSuccessfulRollingRestart(kafkaRoller,
                 emptyList(),
@@ -815,14 +815,14 @@ public class KafkaRollerTest {
                 new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
                 Set.of()) {
             @Override
-            boolean hasOfflineLogDirs(NodeRef nodeRef) {
+            LogDirStatus describeLogDirStatus(NodeRef nodeRef) {
                 if (nodeRef.nodeId() == 2) {
                     throw new RuntimeException("Admin client closed unexpectedly");
                 }
-                return false;
+                return LogDirStatus.EMPTY;
             }
         };
-        // RuntimeException from hasOfflineLogDirs should be caught by catch(Exception e) and not disrupt rolling
+        // RuntimeException from describeLogDirStatus should be caught by catch(Exception e) and not disrupt rolling
         doSuccessfulRollingRestart(kafkaRoller,
                 emptyList(),
                 emptyList());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -863,6 +863,24 @@ public class KafkaRollerTest {
     }
 
     @Test
+    public void testOfflineLogDirWeakerCheckAlsoFailsBlocksRestart() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        // Broker 2 has offline dirs. Standard canRoll returns false AND weaker check also returns false
+        // (healthy-dir partitions are also at min ISR).
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> brokerId == 2 ? CompletableFuture.completedFuture(false) : CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(2), 0L,
+                brokerId -> CompletableFuture.completedFuture(false));
+        // Both checks fail -> broker 2 should NOT be restarted
+        doFailingRollingRestart(kafkaRoller,
+                emptyList(),
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
+                asList(0, 1, 3, 4));
+    }
+
+    @Test
     public void testOfflineLogDirCooldownPreventsRestart() {
         // Pods with recent creation timestamp should not be restarted for offline log dirs
         PodOperator podOps = mockPodOpsWithTimestamp(podId -> CompletableFuture.completedFuture(null), java.time.Instant.now().toString());
@@ -1034,6 +1052,7 @@ public class KafkaRollerTest {
         private final int activeController;
         private final BrokerState brokerState;
         private final Set<Integer> brokersWithOfflineLogDirs;
+        private final Function<Integer, CompletableFuture<Boolean>> weakerCheckFn;
 
         @SuppressWarnings("checkstyle:ParameterNumber")
         private TestingKafkaRoller(Set<NodeRef> nodes,
@@ -1067,7 +1086,8 @@ public class KafkaRollerTest {
                                    Set<Integer> brokersWithOfflineLogDirs) {
             this(nodes, podOps, acOpenException, acCloseException, controllerException, alterConfigsException,
                     getConfigsException, canRollFn, adminClientProvider, kafkaAgentClientProvider,
-                    delegateAdminClientCall, brokerState, activeController, brokersWithOfflineLogDirs, 0L);
+                    delegateAdminClientCall, brokerState, activeController, brokersWithOfflineLogDirs, 0L,
+                    brokerId -> CompletableFuture.completedFuture(true));
         }
 
         @SuppressWarnings("checkstyle:ParameterNumber")
@@ -1082,7 +1102,8 @@ public class KafkaRollerTest {
                                    AdminClientProvider adminClientProvider,
                                    KafkaAgentClientProvider kafkaAgentClientProvider,
                                    boolean delegateAdminClientCall, BrokerState brokerState, int activeController,
-                                   Set<Integer> brokersWithOfflineLogDirs, long cooldownMs) {
+                                   Set<Integer> brokersWithOfflineLogDirs, long cooldownMs,
+                                   Function<Integer, CompletableFuture<Boolean>> weakerCheckFn) {
             super(
                     new Reconciliation("test", "Kafka", stsNamespace(), clusterName()),
                     podOps,
@@ -1098,6 +1119,7 @@ public class KafkaRollerTest {
                     true,
                     mock(KubernetesRestartEventPublisher.class),
                     cooldownMs);
+            this.weakerCheckFn = weakerCheckFn;
             this.delegateAdminClientCall = delegateAdminClientCall;
             this.activeController = activeController;
             this.controllerCall = 0;
@@ -1170,8 +1192,7 @@ public class KafkaRollerTest {
 
                 @Override
                 CompletableFuture<Boolean> canRollExcludingOfflineDirPartitions(int podId, Set<org.apache.kafka.common.TopicPartition> partitionsOnHealthyDirs) {
-                    // For the weaker check, always allow the roll (the offline-dir partitions have been excluded)
-                    return CompletableFuture.completedFuture(true);
+                    return weakerCheckFn.apply(podId);
                 }
             };
         }
@@ -1215,13 +1236,9 @@ public class KafkaRollerTest {
         }
 
         @Override
-        boolean hasOfflineLogDirs(NodeRef nodeRef) {
-            return brokersWithOfflineLogDirs.contains(nodeRef.nodeId());
-        }
-
-        @Override
-        Set<org.apache.kafka.common.TopicPartition> getPartitionsOnHealthyDirs(NodeRef nodeRef) {
-            return Set.of();
+        LogDirStatus describeLogDirStatus(NodeRef nodeRef) {
+            boolean hasOffline = brokersWithOfflineLogDirs.contains(nodeRef.nodeId());
+            return new LogDirStatus(hasOffline, Set.of());
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -726,6 +726,124 @@ public class KafkaRollerTest {
     }
 
     @Test
+    public void testBrokerWithOfflineLogDirsGetsRolled() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(2));
+        // Pod 2 has offline log dirs and should be restarted even though it wasn't in the original restart list
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                singletonList(2));
+    }
+
+    @Test
+    public void testMultipleBrokersWithOfflineLogDirsGetRolled() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(1, 3));
+        // Pods 1 and 3 have offline log dirs
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                asList(1, 3));
+    }
+
+    @Test
+    public void testCombinedNodeWithOfflineLogDirsGetsRolled() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(1));
+        // Combined node 1 has offline log dirs
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                singletonList(1));
+    }
+
+    @Test
+    public void testControllerOnlyNodeWithOfflineLogDirsNotChecked() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        // Controller-only nodes (not brokers) should not be checked for offline log dirs
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(2));
+        // Controller-only node 2 is in the offline set but should NOT be checked (only brokers are checked)
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                emptyList());
+    }
+
+    @Test
+    public void testOfflineLogDirCheckErrorIsSwallowed() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        // Create a roller where hasOfflineLogDirs throws for broker 1
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of()) {
+            @Override
+            boolean hasOfflineLogDirs(NodeRef nodeRef) throws ForceableProblem {
+                if (nodeRef.nodeId() == 1) {
+                    throw new ForceableProblem("Simulated Admin API error");
+                }
+                return false;
+            }
+        };
+        // Broker 1 throws from hasOfflineLogDirs, but the error should be swallowed (best-effort).
+        // No brokers need restart from the original list, and the error path should not cause any restarts.
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                emptyList());
+    }
+
+    @Test
+    public void testOfflineLogDirCheckRuntimeExceptionIsSwallowed() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of()) {
+            @Override
+            boolean hasOfflineLogDirs(NodeRef nodeRef) {
+                if (nodeRef.nodeId() == 2) {
+                    throw new RuntimeException("Admin client closed unexpectedly");
+                }
+                return false;
+            }
+        };
+        // RuntimeException from hasOfflineLogDirs should be caught by catch(Exception e) and not disrupt rolling
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                emptyList());
+    }
+
+    @Test
+    public void testOfflineLogDirCooldownPreventsRestart() {
+        // Pods with recent creation timestamp should not be restarted for offline log dirs
+        PodOperator podOps = mockPodOpsWithTimestamp(podId -> CompletableFuture.completedFuture(null), java.time.Instant.now().toString());
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(2));
+        // Pod 2 has offline log dirs BUT was created recently (within cooldown) -> should NOT be restarted
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                emptyList());
+    }
+
+    @Test
     public void testRollUnreadyPodFirstAllRoles() {
         AtomicBoolean pod1Unready = new AtomicBoolean(true);
         AtomicBoolean pod4Unready = new AtomicBoolean(true);
@@ -827,14 +945,22 @@ public class KafkaRollerTest {
     }
 
     private PodOperator mockPodOps(Function<Integer, CompletableFuture<Void>> readiness) {
+        return mockPodOpsWithTimestamp(readiness, null);
+    }
+
+    private PodOperator mockPodOpsWithTimestamp(Function<Integer, CompletableFuture<Void>> readiness, String creationTimestamp) {
         PodOperator podOps = mock(PodOperator.class);
         when(podOps.get(any(), any())).thenAnswer(
-                invocation -> new PodBuilder()
-                        .withNewMetadata()
-                        .withNamespace(invocation.getArgument(0))
-                        .withName(invocation.getArgument(1))
-                        .endMetadata()
-                        .build()
+                invocation -> {
+                    PodBuilder builder = new PodBuilder()
+                            .withNewMetadata()
+                            .withNamespace(invocation.getArgument(0))
+                            .withName(invocation.getArgument(1));
+                    if (creationTimestamp != null) {
+                        builder.withCreationTimestamp(creationTimestamp);
+                    }
+                    return builder.endMetadata().build();
+                }
         );
 
         when(podOps.readiness(any(), any(), any(), anyLong(), anyLong())).thenAnswer(invocationOnMock -> {
@@ -872,6 +998,7 @@ public class KafkaRollerTest {
         private final boolean delegateAdminClientCall;
         private final int activeController;
         private final BrokerState brokerState;
+        private final Set<Integer> brokersWithOfflineLogDirs;
 
         @SuppressWarnings("checkstyle:ParameterNumber")
         private TestingKafkaRoller(Set<NodeRef> nodes,
@@ -885,6 +1012,24 @@ public class KafkaRollerTest {
                                    AdminClientProvider adminClientProvider,
                                    KafkaAgentClientProvider kafkaAgentClientProvider,
                                    boolean delegateAdminClientCall, BrokerState brokerState, int activeController) {
+            this(nodes, podOps, acOpenException, acCloseException, controllerException, alterConfigsException,
+                    getConfigsException, canRollFn, adminClientProvider, kafkaAgentClientProvider,
+                    delegateAdminClientCall, brokerState, activeController, Set.of());
+        }
+
+        @SuppressWarnings("checkstyle:ParameterNumber")
+        private TestingKafkaRoller(Set<NodeRef> nodes,
+                                   PodOperator podOps,
+                                   Function<Set<NodeRef>, RuntimeException> acOpenException,
+                                   Throwable acCloseException,
+                                   Function<Integer, Throwable> controllerException,
+                                   Function<Integer, ForceableProblem> alterConfigsException,
+                                   Function<Integer, ForceableProblem> getConfigsException,
+                                   Function<Integer, CompletableFuture<Boolean>> canRollFn,
+                                   AdminClientProvider adminClientProvider,
+                                   KafkaAgentClientProvider kafkaAgentClientProvider,
+                                   boolean delegateAdminClientCall, BrokerState brokerState, int activeController,
+                                   Set<Integer> brokersWithOfflineLogDirs) {
             super(
                     new Reconciliation("test", "Kafka", stsNamespace(), clusterName()),
                     podOps,
@@ -911,6 +1056,7 @@ public class KafkaRollerTest {
             this.canRollFn = canRollFn;
             this.unclosedAdminClients = new IdentityHashMap<>();
             this.brokerState = brokerState;
+            this.brokersWithOfflineLogDirs = brokersWithOfflineLogDirs;
         }
 
         @Override
@@ -1006,6 +1152,11 @@ public class KafkaRollerTest {
             if (problem != null) {
                 throw problem;
             } else return new Config(emptyList());
+        }
+
+        @Override
+        boolean hasOfflineLogDirs(NodeRef nodeRef) {
+            return brokersWithOfflineLogDirs.contains(nodeRef.nodeId());
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -829,6 +829,40 @@ public class KafkaRollerTest {
     }
 
     @Test
+    public void testOfflineLogDirWeakerCheckAllowsRestartWhenStandardCheckBlocked() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        // Broker 2 has offline dirs. Standard canRoll returns false (URPs on offline dirs block it).
+        // The weaker check (excluding offline-dir partitions) should allow the restart.
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> brokerId == 2 ? CompletableFuture.completedFuture(false) : CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(2));
+        // Broker 2 has offline dirs AND canRoll returns false, but the weaker check allows it
+        doSuccessfulRollingRestart(kafkaRoller,
+                emptyList(),
+                singletonList(2));
+    }
+
+    @Test
+    public void testOfflineLogDirWeakerCheckNotUsedWhenMultipleReasonsExist() {
+        PodOperator podOps = mockPodOps(podId -> CompletableFuture.completedFuture(null));
+        // Broker 2 has offline dirs AND another restart reason (manual rolling update).
+        // Standard canRoll returns false. The weaker check should NOT be used because
+        // OFFLINE_LOG_DIRS is not the sole reason.
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> brokerId == 2 ? CompletableFuture.completedFuture(false) : CompletableFuture.completedFuture(true),
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1,
+                Set.of(2));
+        // Both MANUAL_ROLLING_UPDATE and OFFLINE_LOG_DIRS reasons → weaker check not used → blocked
+        doFailingRollingRestart(kafkaRoller,
+                singletonList(2),  // manual rolling update for broker 2
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
+                asList(0, 1, 3, 4));
+    }
+
+    @Test
     public void testOfflineLogDirCooldownPreventsRestart() {
         // Pods with recent creation timestamp should not be restarted for offline log dirs
         PodOperator podOps = mockPodOpsWithTimestamp(podId -> CompletableFuture.completedFuture(null), java.time.Instant.now().toString());
@@ -1113,6 +1147,12 @@ public class KafkaRollerTest {
                 CompletableFuture<Boolean> canRoll(int podId) {
                     return canRollFn.apply(podId);
                 }
+
+                @Override
+                CompletableFuture<Boolean> canRollExcludingOfflineDirPartitions(int podId, Set<org.apache.kafka.common.TopicPartition> partitionsOnHealthyDirs) {
+                    // For the weaker check, always allow the roll (the offline-dir partitions have been excluded)
+                    return CompletableFuture.completedFuture(true);
+                }
             };
         }
 
@@ -1157,6 +1197,11 @@ public class KafkaRollerTest {
         @Override
         boolean hasOfflineLogDirs(NodeRef nodeRef) {
             return brokersWithOfflineLogDirs.contains(nodeRef.nodeId());
+        }
+
+        @Override
+        Set<org.apache.kafka.common.TopicPartition> getPartitionsOnHealthyDirs(NodeRef nodeRef) {
+            return Set.of();
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -552,7 +552,7 @@ public class KubernetesRestartEventsMockTest {
 
         // Use a config with cooldown=0 so the freshly-created test pod is eligible for restart
         ClusterOperatorConfig zeroCooldownConfig = new ClusterOperatorConfigBuilder(clusterOperatorConfig, KafkaVersionTestUtils.getKafkaVersionLookup())
-                .with(ClusterOperatorConfig.OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES.key(), "0")
+                .with(ClusterOperatorConfig.OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS.key(), "0")
                 .build();
 
         KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(reconciliation,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -35,6 +35,7 @@ import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.ClusterOperatorConfigBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
@@ -49,7 +50,6 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaClusterCreator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaReconciler;
 import io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController;
-import io.strimzi.operator.cluster.operator.resource.KafkaRoller;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
@@ -547,40 +547,33 @@ public class KubernetesRestartEventsMockTest {
 
     @Test
     void testEventEmittedWhenBrokerHasOfflineLogDirs(Vertx vertx, VertxTestContext context) {
-        // Disable cooldown so the freshly-created test pod is eligible for the offline-dir restart
-        long originalCooldown = KafkaRoller.offlineLogDirRestartCooldownMs;
-        KafkaRoller.offlineLogDirRestartCooldownMs = 0;
+        Admin adminClient = withOfflineLogDirs(ResourceUtils.adminClientProvider().createAdminClient(null, null, null));
+        ResourceOperatorSupplier supplierWithModifiedAdmin = supplierWithAdmin(vertx, () -> adminClient);
 
-        try {
-            Admin adminClient = withOfflineLogDirs(ResourceUtils.adminClientProvider().createAdminClient(null, null, null));
-            ResourceOperatorSupplier supplierWithModifiedAdmin = supplierWithAdmin(vertx, () -> adminClient);
+        // Use a config with cooldown=0 so the freshly-created test pod is eligible for restart
+        ClusterOperatorConfig zeroCooldownConfig = new ClusterOperatorConfigBuilder(clusterOperatorConfig, KafkaVersionTestUtils.getKafkaVersionLookup())
+                .with(ClusterOperatorConfig.OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES.key(), "0")
+                .build();
 
-            KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(reconciliation,
-                    kafka,
-                    List.of(kafkaNodePool),
-                    Map.of(),
-                    KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
-                    VERSIONS,
-                    supplier.sharedEnvironmentProvider);
-            KafkaReconciler reconciler = new KafkaReconciler(reconciliation,
-                    kafka,
-                    List.of(kafkaNodePool),
-                    kafkaCluster,
-                    clusterCa,
-                    clientsCa,
-                    clusterOperatorConfig,
-                    supplierWithModifiedAdmin,
-                    PFA,
-                    vertx);
+        KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(reconciliation,
+                kafka,
+                List.of(kafkaNodePool),
+                Map.of(),
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                VERSIONS,
+                supplier.sharedEnvironmentProvider);
+        KafkaReconciler reconciler = new KafkaReconciler(reconciliation,
+                kafka,
+                List.of(kafkaNodePool),
+                kafkaCluster,
+                clusterCa,
+                clientsCa,
+                zeroCooldownConfig,
+                supplierWithModifiedAdmin,
+                PFA,
+                vertx);
 
-            reconciler.reconcile(new KafkaStatus(), Clock.systemUTC()).onComplete(ar -> {
-                KafkaRoller.offlineLogDirRestartCooldownMs = originalCooldown;
-                verifyEventPublished(OFFLINE_LOG_DIRS, context).handle(ar);
-            });
-        } catch (Exception e) {
-            KafkaRoller.offlineLogDirRestartCooldownMs = originalCooldown;
-            context.failNow(e);
-        }
+        reconciler.reconcile(new KafkaStatus(), Clock.systemUTC()).onComplete(verifyEventPublished(OFFLINE_LOG_DIRS, context));
     }
 
     private Admin withOfflineLogDirs(Admin preMockedAdminClient) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -49,6 +49,7 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaClusterCreator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaReconciler;
 import io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController;
+import io.strimzi.operator.cluster.operator.resource.KafkaRoller;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
@@ -74,9 +75,12 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.KafkaStorageException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -109,12 +113,14 @@ import static io.strimzi.operator.cluster.model.RestartReason.CONFIG_CHANGE_REQU
 import static io.strimzi.operator.cluster.model.RestartReason.FILE_SYSTEM_RESIZE_NEEDED;
 import static io.strimzi.operator.cluster.model.RestartReason.KAFKA_CERTIFICATES_CHANGED;
 import static io.strimzi.operator.cluster.model.RestartReason.MANUAL_ROLLING_UPDATE;
+import static io.strimzi.operator.cluster.model.RestartReason.OFFLINE_LOG_DIRS;
 import static io.strimzi.operator.cluster.model.RestartReason.POD_HAS_OLD_REVISION;
 import static io.strimzi.operator.cluster.model.RestartReason.POD_STUCK;
 import static io.strimzi.operator.cluster.model.RestartReason.POD_UNRESPONSIVE;
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -537,6 +543,60 @@ public class KubernetesRestartEventsMockTest {
                 PFA,
                 vertx);
         reconciler.reconcile(new KafkaStatus(), Clock.systemUTC()).onComplete(verifyEventPublished(KAFKA_CERTIFICATES_CHANGED, context));
+    }
+
+    @Test
+    void testEventEmittedWhenBrokerHasOfflineLogDirs(Vertx vertx, VertxTestContext context) {
+        // Disable cooldown so the freshly-created test pod is eligible for the offline-dir restart
+        long originalCooldown = KafkaRoller.offlineLogDirRestartCooldownMs;
+        KafkaRoller.offlineLogDirRestartCooldownMs = 0;
+
+        try {
+            Admin adminClient = withOfflineLogDirs(ResourceUtils.adminClientProvider().createAdminClient(null, null, null));
+            ResourceOperatorSupplier supplierWithModifiedAdmin = supplierWithAdmin(vertx, () -> adminClient);
+
+            KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(reconciliation,
+                    kafka,
+                    List.of(kafkaNodePool),
+                    Map.of(),
+                    KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                    VERSIONS,
+                    supplier.sharedEnvironmentProvider);
+            KafkaReconciler reconciler = new KafkaReconciler(reconciliation,
+                    kafka,
+                    List.of(kafkaNodePool),
+                    kafkaCluster,
+                    clusterCa,
+                    clientsCa,
+                    clusterOperatorConfig,
+                    supplierWithModifiedAdmin,
+                    PFA,
+                    vertx);
+
+            reconciler.reconcile(new KafkaStatus(), Clock.systemUTC()).onComplete(ar -> {
+                KafkaRoller.offlineLogDirRestartCooldownMs = originalCooldown;
+                verifyEventPublished(OFFLINE_LOG_DIRS, context).handle(ar);
+            });
+        } catch (Exception e) {
+            KafkaRoller.offlineLogDirRestartCooldownMs = originalCooldown;
+            context.failNow(e);
+        }
+    }
+
+    private Admin withOfflineLogDirs(Admin preMockedAdminClient) {
+        DescribeLogDirsResult mockResult = mock(DescribeLogDirsResult.class);
+
+        // Simulate one healthy log dir and one offline log dir for broker 0
+        LogDirDescription healthyDir = new LogDirDescription(null, Map.of());
+        LogDirDescription offlineDir = new LogDirDescription(new KafkaStorageException("Log directory offline"), Map.of());
+
+        KafkaFuture<Map<String, LogDirDescription>> future = KafkaFuture.completedFuture(
+                Map.of("/var/kafka-data-0/data", healthyDir, "/var/kafka-data-1/data", offlineDir)
+        );
+
+        when(mockResult.descriptions()).thenReturn(Map.of(0, future));
+        when(preMockedAdminClient.describeLogDirs(any())).thenReturn(mockResult);
+        return preMockedAdminClient;
     }
 
     private <T> Handler<AsyncResult<T>> verifyEventPublished(RestartReason expectedReason, VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -35,7 +35,6 @@ import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.ClusterOperatorConfigBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
@@ -551,9 +550,9 @@ public class KubernetesRestartEventsMockTest {
         ResourceOperatorSupplier supplierWithModifiedAdmin = supplierWithAdmin(vertx, () -> adminClient);
 
         // Use a config with cooldown=0 so the freshly-created test pod is eligible for restart
-        ClusterOperatorConfig zeroCooldownConfig = new ClusterOperatorConfigBuilder(clusterOperatorConfig, KafkaVersionTestUtils.getKafkaVersionLookup())
-                .with(ClusterOperatorConfig.OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS.key(), "0")
-                .build();
+        ClusterOperatorConfig zeroCooldownConfig = ClusterOperatorConfig.buildFromMap(
+                Map.of(ClusterOperatorConfig.OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS.key(), "0"),
+                KafkaVersionTestUtils.getKafkaVersionLookup());
 
         KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(reconciliation,
                 kafka,

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -160,6 +160,10 @@ spec:
             - name: STRIMZI_POD_DISRUPTION_BUDGET_GENERATION
               value: {{ .Values.generatePodDisruptionBudget | quote }}
             {{- end }}
+            {{- if ne (int .Values.offlineLogDirRestartCooldownMinutes) 30 }}
+            - name: STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES
+              value: {{ .Values.offlineLogDirRestartCooldownMinutes | int64 | quote }}
+            {{- end }}
             {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 12 }}
             {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -160,9 +160,9 @@ spec:
             - name: STRIMZI_POD_DISRUPTION_BUDGET_GENERATION
               value: {{ .Values.generatePodDisruptionBudget | quote }}
             {{- end }}
-            {{- if ne (int .Values.offlineLogDirRestartCooldownMinutes) 30 }}
-            - name: STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MINUTES
-              value: {{ .Values.offlineLogDirRestartCooldownMinutes | int64 | quote }}
+            {{- if ne (int .Values.offlineLogDirRestartCooldownMs) 1800000 }}
+            - name: STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS
+              value: {{ .Values.offlineLogDirRestartCooldownMs | int64 | quote }}
             {{- end }}
             {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 12 }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -24,6 +24,7 @@ logConfiguration: ""
 logLevel: ${env:STRIMZI_LOG_LEVEL:-INFO}
 fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000
+offlineLogDirRestartCooldownMinutes: 30
 kubernetesServiceDnsDomain: cluster.local
 featureGates: ""
 tmpDirSizeLimit: 1Mi

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -24,7 +24,7 @@ logConfiguration: ""
 logLevel: ${env:STRIMZI_LOG_LEVEL:-INFO}
 fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000
-offlineLogDirRestartCooldownMinutes: 30
+offlineLogDirRestartCooldownMs: 1800000
 kubernetesServiceDnsDomain: cluster.local
 featureGates: ""
 tmpDirSizeLimit: 1Mi


### PR DESCRIPTION
## Summary

During each reconciliation, the KafkaRoller now checks each broker for offline log directories via the Admin API's `describeLogDirs()`. If a broker has directories with a non-null error (typically `KafkaStorageException`), it is added to the rolling restart queue with the new `OFFLINE_LOG_DIRS` restart reason. This eliminates the need for manual broker restarts when log directories go offline.

## Motivation

Offline log directories are a common operational issue in Kafka clusters, especially those using JBOD storage. Currently, the only recovery path is a manual broker restart. This change automates that recovery, reducing mean time to repair and eliminating the need for operator intervention.

## Safety mechanisms

- **ISR-aware rolling**: Uses `needsRestart` (not `forceRestart`), so the existing `KafkaAvailability` ISR check gates every restart -- no broker is restarted if it would drop any topic below `min.insync.replicas`
- **Weaker check for offline-dir URPs**: When the only restart reason is `OFFLINE_LOG_DIRS` and `canRoll()` blocks due to URPs on the offline dir itself, a weaker availability check excludes those partitions (they're already degraded -- restarting can only help). Partitions on healthy dirs still get the full ISR check. This breaks the catch-22 where offline dirs cause URPs that block the very restart that would fix them.
- **Broker-only nodes**: The weaker check applies only to broker-only nodes (`isBroker && !isController`). Combined controller+broker nodes always respect the KRaft quorum check -- the weaker path cannot bypass quorum safety.
- **Sequential restarts**: The KafkaRoller's one-at-a-time + await-readiness design ensures sequential restarts with ISR recovery between each
- **Configurable cooldown**: A configurable cooldown (default 30 min) prevents infinite restart loops when offline dirs are caused by permanent hardware failure (dead disk). Uses pod creation timestamp to detect recently-restarted brokers.
- **Best-effort check**: All exceptions from the Admin API are caught (`catch (Exception e)`) so a `describeLogDirs` failure never blocks normal rolling restart flow
- **Interrupt safety**: `InterruptedException` is correctly re-thrown to preserve the interrupt propagation chain
- **Restart takes precedence over reconfig**: When both `needsRestart` (from offline dirs) and `needsReconfig` (from config diff) are set, the pod is restarted rather than dynamically reconfigured, because offline dirs require a full restart to recover

## Configuration

| Layer | Config | Default |
|---|---|---|
| Helm | `offlineLogDirRestartCooldownMs` | `1800000` (30 min) |
| Env var | `STRIMZI_OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS` | `1800000` |
| Java | `ClusterOperatorConfig.OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS` | `1800000` |

Set to `0` to disable the cooldown entirely.

## Architecture

The detection integrates into the existing KafkaRoller reconciliation loop:

1. `checkIfRestartOrReconfigureRequired()` -- existing checks (config diff, cert changes, etc.)
2. `checkForOfflineLogDirs()` -- **new**: calls `describeLogDirStatus()` (single Admin API call) which returns both offline status and healthy-dir partitions via the `LogDirStatus` record
3. Decision: if `needsRestart=true`, skip dynamic reconfig and go straight to restart
4. If `canRoll()` blocks and `OFFLINE_LOG_DIRS` is the sole reason on a broker-only node, fall back to `canRollExcludingOfflineDirPartitions()` using cached log-dir status
5. K8s Event published with reason `OfflineLogDirs`

Key design decisions:
- **Single `describeLogDirs` call**: The `LogDirStatus` record caches both `hasOfflineDirs` and `partitionsOnHealthyDirs` from one API call, avoiding redundant round trips
- **Weaker check only for sole reason on broker-only nodes**: Preserves full ISR + quorum safety for other restart scenarios and combined nodes
- **Pod-age cooldown**: Uses `pod.metadata.creationTimestamp` vs `Instant.now()` to detect recently-created pods, avoiding annotation-based state tracking
- **Named timeout constants**: `ADMIN_API_TIMEOUT_MS` (30s) for single API calls, `AVAILABILITY_CHECK_TIMEOUT_MS` (60s) for compound availability checks

## Changes

| File | Change |
|---|---|
| `RestartReason.java` | Add `OFFLINE_LOG_DIRS` enum value |
| `KafkaRoller.java` | Add `describeLogDirStatus()`, `checkForOfflineLogDirs()`, `isPodWithinOfflineLogDirCooldown()`, `canRollExcludingOfflineDirPartitions()`, `LogDirStatus` record, timeout constants; `needsRestart` precedence over `needsReconfig` |
| `KafkaAvailability.java` | Add `canRollExcludingOfflineDirPartitions()` with partition exclusion in `wouldAffectAvailability()` |
| `KafkaReconciler.java` | Wire cooldown from `ClusterOperatorConfig` |
| `CaReconciler.java` | Wire cooldown from `ClusterOperatorConfig` |
| `ClusterOperatorConfig.java` | Add `OFFLINE_LOG_DIR_RESTART_COOLDOWN_MS` parameter + getter + toString |
| `KafkaRollerTest.java` | 12 unit tests |
| `KubernetesRestartEventsMockTest.java` | MockKube3 integration test |
| `RestartReasonTest.java` | Verify `pascalCased()` output |
| Helm values + template | `offlineLogDirRestartCooldownMs` configuration |

## Testing

- **12 unit tests** in `KafkaRollerTest`: single broker, multiple brokers, combined nodes, controller-only skip, ForceableProblem swallowed, RuntimeException swallowed, cooldown prevents restart, weaker check allows restart, weaker check not used with multiple reasons, weaker check also fails, offline dir detection
- **1 MockKube3 integration test** in `KubernetesRestartEventsMockTest`: end-to-end KafkaReconciler -> KafkaRoller -> K8s Event pipeline with mocked `describeLogDirs` returning offline dirs
- **1 assertion** in `RestartReasonTest`: `OFFLINE_LOG_DIRS.pascalCased()` returns `"OfflineLogDirs"`