### PR TITLE
Use PEM directly accessed from secrets in Bridge

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeResources.java
@@ -71,4 +71,28 @@ public class KafkaBridgeResources {
     public static String initContainerClusterRoleBindingName(String clusterName, String namespace) {
         return "strimzi-" + namespace + "-" + componentName(clusterName) + "-init";
     }
+
+    /**
+     * Get the name of the internal secret that contains TLS trusted certificates.
+     * The operator copies user specified secrets for trusted certificates into
+     * a single secret with this name. It is then used when configuring Bridge.
+     *
+     * @param clusterName The cluster name.
+     *
+     * @return Name of the internal secret that contains TLS trusted certificates.
+     */
+    public static String internalTlsTrustedCertsSecretName(String clusterName) {
+        return componentName(clusterName) + "-tls-trusted-certs";
+    }
+
+    /**
+     * Get the name of the Kafka Bridge role binding given the name of the {@code cluster}.
+     *
+     * @param clusterName  The cluster name.
+     *
+     * @return The name of Kafka Bridge role binding.
+     */
+    public static String bridgeRoleBindingName(String clusterName) {
+        return componentName(clusterName) + "-role";
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -5,19 +5,32 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Subject;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.strimzi.api.kafka.model.common.ClientTls;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationPlain;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScram;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.operator.common.model.InvalidResourceException;
+import io.strimzi.operator.common.model.Labels;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
 
@@ -182,5 +195,107 @@ public class AuthenticationUtils {
             }
         }
         return moduleName + " required " + joiner + ";";
+    }
+
+    /**
+     * Collects the names of Secrets that need to be accessible for authentication and TLS configuration.
+     * This includes trusted certificates for TLS connections and authentication credentials.
+     *
+     * @param tls                           The TLS configuration containing trusted certificates
+     * @param authentication                The authentication configuration (TLS, PLAIN, or SCRAM)
+     * @param tlsTrustedCertsSecretName     The name of the secret containing TLS trusted certificates (component-specific)
+     * @return List of secret names that need to be accessible
+     */
+    public static Set<String> getAuthenticationSecretsToAccess(ClientTls tls, KafkaClientAuthentication authentication, String tlsTrustedCertsSecretName) {
+        Set<String> secretNames = new HashSet<>();
+
+        // Add TLS trusted certificates secret if configured
+        if (tls != null && tls.getTrustedCertificates() != null && !tls.getTrustedCertificates().isEmpty()) {
+            secretNames.add(tlsTrustedCertsSecretName);
+        }
+
+        // Add authentication secrets based on authentication type
+        if (authentication != null) {
+            if (authentication instanceof KafkaClientAuthenticationTls tlsAuth && tlsAuth.getCertificateAndKey() != null) {
+                secretNames.add(tlsAuth.getCertificateAndKey().getSecretName());
+            } else if (authentication instanceof KafkaClientAuthenticationPlain plainAuth) {
+                secretNames.add(plainAuth.getPasswordSecret().getSecretName());
+            } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
+                secretNames.add(scramAuth.getPasswordSecret().getSecretName());
+            }
+        }
+
+        return secretNames;
+    }
+
+    /**
+     * Generates a Kubernetes Role for accessing authentication secrets.
+     * The Role grants "get" permission on specific secrets needed for authentication and TLS.
+     * Returns null if no secrets need to be accessed.
+     *
+     * @param componentName     The name of the component (used as role name)
+     * @param namespace         The namespace where the role will be created
+     * @param secretNames       List of secret names that need to be accessible
+     * @param labels            Labels to apply to the role
+     * @param ownerReference    Owner reference for the role
+     * @return Role resource or null if no secrets need to be accessed
+     */
+    public static Role generateAuthenticationSecretsRole(
+            String componentName,
+            String namespace,
+            Set<String> secretNames,
+            Labels labels,
+            OwnerReference ownerReference) {
+        if (secretNames.isEmpty()) {
+            return null;
+        }
+
+        List<PolicyRule> rules = List.of(new PolicyRuleBuilder()
+                .withApiGroups("")
+                .withResources("secrets")
+                .withVerbs("get")
+                .withResourceNames(secretNames.stream().toList())
+                .build());
+
+        return RbacUtils.createRole(componentName, namespace, rules, labels, ownerReference, null);
+    }
+
+    /**
+     * Generates a Kubernetes RoleBinding for the authentication secrets Role.
+     * Binds the ServiceAccount to the Role created for the component.
+     * Returns null if no secrets need to be accessed.
+     *
+     * @param roleBindingName   The name of the role binding
+     * @param componentName     The name of the component (used as service account name)
+     * @param namespace         The namespace where the role binding will be created
+     * @param secretNames       List of secret names that need to be accessible
+     * @param labels            Labels to apply to the role binding
+     * @param ownerReference    Owner reference for the role binding
+     * @return RoleBinding resource or null if no secrets need to be accessed
+     */
+    public static RoleBinding generateAuthenticationSecretsRoleBinding(
+            String roleBindingName,
+            String componentName,
+            String namespace,
+            Set<String> secretNames,
+            Labels labels,
+            OwnerReference ownerReference) {
+        if (secretNames.isEmpty()) {
+            return null;
+        }
+
+        Subject subject = new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName(componentName)
+                .withNamespace(namespace)
+                .build();
+
+        RoleRef roleRef = new RoleRefBuilder()
+                .withName(componentName)
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("Role")
+                .build();
+
+        return RbacUtils.createRoleBinding(roleBindingName, namespace, roleRef, List.of(subject), labels, ownerReference, null);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -32,25 +31,11 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.function.Function;
 
 /**
  * Utils for working with different authentication types
  */
 public class AuthenticationUtils {
-    /**
-     * Key for a SASL username
-     */
-    public static final String SASL_USERNAME = "SASL_USERNAME";
-
-    /**
-     * Key for a SASL mechanism
-     */
-    public static final String SASL_MECHANISM = "SASL_MECHANISM";
-
-    private static final String TLS_AUTH_CERT = "TLS_AUTH_CERT";
-    private static final String TLS_AUTH_KEY = "TLS_AUTH_KEY";
-    private static final String SASL_PASSWORD_FILE = "SASL_PASSWORD_FILE";
 
     private AuthenticationUtils() { }
 
@@ -144,30 +129,6 @@ public class AuthenticationUtils {
     }
 
     /**
-     * Configured environment variables related to authentication in Kafka clients within Strimzi-based containers
-     *
-     * @param authentication    Authentication object with auth configuration
-     * @param varList   List where the new environment variables should be added
-     * @param envVarNamer   Function for naming the environment variables (ech components is using different names)
-     */
-    public static void configureClientAuthenticationEnvVars(KafkaClientAuthentication authentication, List<EnvVar> varList, Function<String, String> envVarNamer)   {
-        if (authentication != null) {
-            if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(TLS_AUTH_CERT), String.format("%s/%s", tlsAuth.getCertificateAndKey().getSecretName(), tlsAuth.getCertificateAndKey().getCertificate())));
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(TLS_AUTH_KEY), String.format("%s/%s", tlsAuth.getCertificateAndKey().getSecretName(), tlsAuth.getCertificateAndKey().getKey())));
-            } else if (authentication instanceof KafkaClientAuthenticationPlain passwordAuth) {
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(SASL_USERNAME), passwordAuth.getUsername()));
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(SASL_PASSWORD_FILE), String.format("%s/%s", passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword())));
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(SASL_MECHANISM), KafkaClientAuthenticationPlain.TYPE_PLAIN));
-            } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(SASL_USERNAME), scramAuth.getUsername()));
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(SASL_PASSWORD_FILE), String.format("%s/%s", scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword())));
-                varList.add(ContainerUtils.createEnvVar(envVarNamer.apply(SASL_MECHANISM), scramAuth.getType()));
-            }
-        }
-    }
-
-    /**
      * Generates a JAAS configuration string based on the provided module name and options.
      * The flag will always be "required".
      *
@@ -248,16 +209,16 @@ public class AuthenticationUtils {
             OwnerReference ownerReference) {
         if (secretNames.isEmpty()) {
             return null;
+        } else {
+            List<PolicyRule> rules = List.of(new PolicyRuleBuilder()
+                    .withApiGroups("")
+                    .withResources("secrets")
+                    .withVerbs("get")
+                    .withResourceNames(secretNames.stream().toList())
+                    .build());
+
+            return RbacUtils.createRole(componentName, namespace, rules, labels, ownerReference, null);
         }
-
-        List<PolicyRule> rules = List.of(new PolicyRuleBuilder()
-                .withApiGroups("")
-                .withResources("secrets")
-                .withVerbs("get")
-                .withResourceNames(secretNames.stream().toList())
-                .build());
-
-        return RbacUtils.createRole(componentName, namespace, rules, labels, ownerReference, null);
     }
 
     /**
@@ -282,20 +243,20 @@ public class AuthenticationUtils {
             OwnerReference ownerReference) {
         if (secretNames.isEmpty()) {
             return null;
+        } else {
+            Subject subject = new SubjectBuilder()
+                    .withKind("ServiceAccount")
+                    .withName(componentName)
+                    .withNamespace(namespace)
+                    .build();
+
+            RoleRef roleRef = new RoleRefBuilder()
+                    .withName(componentName)
+                    .withApiGroup("rbac.authorization.k8s.io")
+                    .withKind("Role")
+                    .build();
+
+            return RbacUtils.createRoleBinding(roleBindingName, namespace, roleRef, List.of(subject), labels, ownerReference, null);
         }
-
-        Subject subject = new SubjectBuilder()
-                .withKind("ServiceAccount")
-                .withName(componentName)
-                .withNamespace(namespace)
-                .build();
-
-        RoleRef roleRef = new RoleRefBuilder()
-                .withName(componentName)
-                .withApiGroup("rbac.authorization.k8s.io")
-                .withKind("Role")
-                .build();
-
-        return RbacUtils.createRoleBinding(roleBindingName, namespace, roleRef, List.of(subject), labels, ownerReference, null);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -18,6 +19,8 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
@@ -67,6 +70,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Kafka Bridge model class
@@ -91,9 +95,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
     protected static final String REST_API_PORT_NAME = "rest-api";
     /* test */ static final String REST_API_MANAGEMENT_PORT_NAME = "rest-api-mgmt";
     /* test */ static final int REST_API_MANAGEMENT_PORT = 8081;
-    protected static final String TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/strimzi/bridge-certs/";
     protected static final String HTTP_SERVER_CERTS_BASE_VOLUME_MOUNT = "/opt/strimzi/bridge-http-certs/";
-    protected static final String PASSWORD_VOLUME_MOUNT = "/opt/strimzi/bridge-password/";
     protected static final String ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY = "INIT_FOLDER";
     private static final String KAFKA_BRIDGE_CONFIG_VOLUME_NAME = "kafka-bridge-configurations";
 
@@ -101,9 +103,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
     protected static final String CO_ENV_VAR_CUSTOM_SERVICE_LABELS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS";
     protected static final String CO_ENV_VAR_CUSTOM_SERVICE_ANNOTATIONS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS";
 
-    // Kafka Bridge configuration keys (EnvVariables)
-    protected static final String ENV_VAR_PREFIX = "KAFKA_BRIDGE_";
-    protected static final String ENV_VAR_KAFKA_BRIDGE_TRUSTED_CERTS = "KAFKA_BRIDGE_TRUSTED_CERTS";
     protected static final String KAFKA_BRIDGE_CONFIG_VOLUME_MOUNT = "/opt/strimzi/custom-config/";
     protected static final String CO_ENV_VAR_CUSTOM_BRIDGE_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS";
     protected static final String INIT_VOLUME_MOUNT = "/opt/strimzi/init";
@@ -319,10 +318,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         volumeList.add(VolumeUtils.createTempDirVolume(templatePod));
         volumeList.add(VolumeUtils.createConfigMapVolume(KAFKA_BRIDGE_CONFIG_VOLUME_NAME, KafkaBridgeResources.configMapName(cluster)));
 
-        if (tls != null) {
-            CertUtils.createTrustedCertificatesVolumes(volumeList, tls.getTrustedCertificates(), isOpenShift);
-        }
-
         if (http != null && http.getTls() != null) {
             if (http.getTls().getCertificateAndKey() != null) {
                 String secretName = http.getTls().getCertificateAndKey().getSecretName();
@@ -340,8 +335,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
             volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
         }
 
-        AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, isOpenShift, "");
-
         TemplateUtils.addAdditionalVolumes(templatePod, volumeList);
 
         return volumeList;
@@ -352,10 +345,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
 
         volumeMountList.add(VolumeUtils.createTempDirVolumeMount());
         volumeMountList.add(VolumeUtils.createVolumeMount(KAFKA_BRIDGE_CONFIG_VOLUME_NAME, KAFKA_BRIDGE_CONFIG_VOLUME_MOUNT));
-
-        if (tls != null) {
-            CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, tls.getTrustedCertificates(), TLS_CERTS_BASE_VOLUME_MOUNT);
-        }
 
         if (http != null && http.getTls() != null) {
             if (http.getTls().getCertificateAndKey() != null) {
@@ -370,8 +359,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         if (rack instanceof TopologyLabelRack) {
             volumeMountList.add(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT));
         }
-
-        AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, "");
 
         TemplateUtils.addAdditionalVolumeMounts(volumeMountList, templateContainer);
 
@@ -466,13 +453,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         JvmOptionUtils.javaOptions(varList, jvmOptions);
 
-        if (tls != null && tls.getTrustedCertificates() != null && !tls.getTrustedCertificates().isEmpty()) {
-            varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_BRIDGE_TRUSTED_CERTS, CertUtils.trustedCertsEnvVar(tls.getTrustedCertificates())));
-        }
-
-        // Client authentication env var is needed to generate truststore certificates in PKCS12 format in container script
-        AuthenticationUtils.configureClientAuthenticationEnvVars(authentication, varList, name -> ENV_VAR_PREFIX + name);
-
         // Add shared environment variables used for all containers
         varList.addAll(sharedEnvironmentProvider.variables());
 
@@ -496,6 +476,15 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
      */
     protected void setTls(ClientTls tls) {
         this.tls = tls;
+    }
+
+    /**
+     * Gets the tls configuration with the certificate to trust
+     *
+     * @return tls trusted certificates list
+     */
+    public ClientTls getTls() {
+        return tls;
     }
 
     /**
@@ -584,6 +573,64 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         }
     }
 
+    /**
+     * Gets the list of Secrets the Pods need to access through the Kubernetes API.
+     *
+     * @return  The list of Secrets the Pods will need access to through Kubernetes API to load their values using
+     *          configuration providers.
+     */
+    /* test */ public Set<String> secretsToAllowAccessTo() {
+        return AuthenticationUtils.getAuthenticationSecretsToAccess(
+                tls,
+                authentication,
+                KafkaBridgeResources.internalTlsTrustedCertsSecretName(cluster));
+    }
+
+    /**
+     * Creates a Role for reading TLS certificate secrets in the same namespace as the resource.
+     * This is used for loading certificates from secrets directly.
+     **
+     * @return role for the Kafka Bridge
+     */
+    public Role generateRole() {
+        return AuthenticationUtils.generateAuthenticationSecretsRole(
+                componentName, namespace, secretsToAllowAccessTo(), labels, ownerReference);
+    }
+
+    /**
+     * Generates the Kafka Bridge Role Binding
+     *
+     * @return  Role Binding for the Kafka Bridge
+     */
+    public RoleBinding generateRoleBindingForRole() {
+        return AuthenticationUtils.generateAuthenticationSecretsRoleBinding(
+                getRoleBindingName(), componentName, namespace, secretsToAllowAccessTo(), labels, ownerReference);
+    }
+
+    /**
+     * Gets the name of the RoleBinding for the Kafka Bridge.
+     *
+     * @return The name of the RoleBinding for the Kafka Bridge
+     */
+    public String getRoleBindingName() {
+        return KafkaBridgeResources.bridgeRoleBindingName(getCluster());
+    }
+
+    /**
+     * Creates a secret that contains the TLS certificates from one or more secrets
+     * in the same namespace as the resource.
+     * This is used for loading truststore certificates from the secret directly.
+     **
+     * @param secretData secret data
+     * @param secretName secret name
+     *
+     * @return secret for tls certificates
+     */
+    public Secret generateTlsTrustedCertsSecret(Map<String, String> secretData, String secretName) {
+        return ModelUtils.createSecret(secretName, namespace, labels, ownerReference, secretData, Map.of(), Map.of());
+    }
+
+
     protected List<EnvVar> getInitContainerEnvVars(TopologyLabelRack topologyLabelRack) {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVarFromFieldRef(ENV_VAR_KAFKA_INIT_NODE_NAME, "spec.nodeName"));
@@ -614,7 +661,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         KafkaBridgeConfigurationBuilder builder =
                 new KafkaBridgeConfigurationBuilder(reconciliation, cluster, bootstrapServers)
                         .withTracing(tracing)
-                        .withTls(tls)
+                        .withTls(tls, cluster)
                         .withAuthentication(authentication)
                         .withKafkaAdminClient(kafkaBridgeAdminClient)
                         .withKafkaProducer(kafkaBridgeProducer)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
@@ -8,9 +8,9 @@ import io.strimzi.api.kafka.model.bridge.KafkaBridgeAdminClientSpec;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeConsumerSpec;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeHttpConfig;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeProducerSpec;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.common.ClientTls;
 import io.strimzi.api.kafka.model.common.EnvironmentVariableRack;
-import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.api.kafka.model.common.Rack;
 import io.strimzi.api.kafka.model.common.TopologyLabelRack;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
@@ -43,12 +43,8 @@ import static io.strimzi.operator.cluster.model.KafkaBridgeCluster.KAFKA_BRIDGE_
  */
 @SuppressWarnings("checkstyle:CyclomaticComplexity")
 public class KafkaBridgeConfigurationBuilder {
-
-    // placeholders expanded through config providers inside the bridge node
-    private static final String PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR = "${strimzienv:CERTS_STORE_PASSWORD}";
-    private static final String PASSWORD_VOLUME_MOUNT = "/opt/strimzi/bridge-password/";
-    // the volume mounted secret file template includes: <volume_mount>/<secret_name>/<secret_key>
-    private static final String PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR = "${strimzidir:%s%s:%s}";
+    // the secrets file template: <namespace>/<secret_name>:<secret_key>
+    private static final String PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER = "${strimzisecrets:%s/%s:%s}";
 
     private final Reconciliation reconciliation;
     private final StringWriter stringWriter = new StringWriter();
@@ -121,18 +117,18 @@ public class KafkaBridgeConfigurationBuilder {
      * Adds the TLS/SSL configuration for the bridge to connect to the Kafka cluster.
      * The configuration includes the trusted certificates store for TLS connection (server authentication).
      *
-     * @param tls   client TLS configuration
-     * @return  the builder instance
+     * @param tls         client TLS configuration
+     * @param bridgeId    bridge ID
+     * @return the builder instance
      */
-    public KafkaBridgeConfigurationBuilder withTls(ClientTls tls) {
+    public KafkaBridgeConfigurationBuilder withTls(ClientTls tls, String bridgeId) {
         if (tls != null) {
             securityProtocol = "SSL";
 
             if (tls.getTrustedCertificates() != null && !tls.getTrustedCertificates().isEmpty()) {
                 printSectionHeader("TLS/SSL");
-                writer.println("kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12");
-                writer.println("kafka.ssl.truststore.password=" + PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR);
-                writer.println("kafka.ssl.truststore.type=PKCS12");
+                writer.println("kafka.ssl.truststore.certificates=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), KafkaBridgeResources.internalTlsTrustedCertsSecretName(bridgeId), "ca.crt"));
+                writer.println("kafka.ssl.truststore.type=PEM");
             }
         }
         return this;
@@ -149,9 +145,9 @@ public class KafkaBridgeConfigurationBuilder {
             printSectionHeader("Authentication configuration");
             // configuring mTLS (client TLS authentication, together with server authentication already set)
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth && tlsAuth.getCertificateAndKey() != null) {
-                writer.println("kafka.ssl.keystore.location=/tmp/strimzi/bridge.keystore.p12");
-                writer.println("kafka.ssl.keystore.password=" + PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR);
-                writer.println("kafka.ssl.keystore.type=PKCS12");
+                writer.println("kafka.ssl.keystore.certificate.chain=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), tlsAuth.getCertificateAndKey().getSecretName(), tlsAuth.getCertificateAndKey().getCertificate()));
+                writer.println("kafka.ssl.keystore.key=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), tlsAuth.getCertificateAndKey().getSecretName(), tlsAuth.getCertificateAndKey().getKey()));
+                writer.println("kafka.ssl.keystore.type=PEM");
             } else if (authentication instanceof KafkaClientAuthenticationCustom customAuth) { // Configure custom authentication
                 if (customAuth.isSasl())    {
                     // If this authentication uses SASL, we need to update the security protocol to combine the SASL
@@ -174,7 +170,8 @@ public class KafkaBridgeConfigurationBuilder {
 
                 if (authentication instanceof KafkaClientAuthenticationPlain passwordAuth) {
                     saslMechanism = "PLAIN";
-                    jaasConfig.append("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + passwordAuth.getUsername() + "\" password=\"" + formatPasswordTemplate(passwordAuth.getPasswordSecret(), PASSWORD_VOLUME_MOUNT) + "\";");
+                    String passwordAuthConfigProvider = String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword());
+                    jaasConfig.append("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + passwordAuth.getUsername() + "\" password=\"" + passwordAuthConfigProvider + "\";");
                 } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
 
                     if (scramAuth.getType().equals(KafkaClientAuthenticationScramSha256.TYPE_SCRAM_SHA_256)) {
@@ -182,8 +179,8 @@ public class KafkaBridgeConfigurationBuilder {
                     } else if (scramAuth.getType().equals(KafkaClientAuthenticationScramSha512.TYPE_SCRAM_SHA_512)) {
                         saslMechanism = "SCRAM-SHA-512";
                     }
-
-                    jaasConfig.append("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + scramAuth.getUsername() + "\" password=\"" + formatPasswordTemplate(scramAuth.getPasswordSecret(), PASSWORD_VOLUME_MOUNT) + "\";");
+                    String passwordAuthConfigProvider = String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword());
+                    jaasConfig.append("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + scramAuth.getUsername() + "\" password=\"" + passwordAuthConfigProvider + "\";");
                 }
 
                 writer.println("kafka.sasl.mechanism=" + saslMechanism);
@@ -195,10 +192,6 @@ public class KafkaBridgeConfigurationBuilder {
         return this;
     }
 
-    private String formatPasswordTemplate(PasswordSecretSource secret, String volumeMountPath) {
-        return String.format(PLACEHOLDER_VOLUME_MOUNTED_SECRET_TEMPLATE_CONFIG_PROVIDER_DIR, volumeMountPath, secret.getSecretName(), secret.getPassword());
-    }
-
     /**
      * Configures the Kafka configuration providers
      *
@@ -208,7 +201,7 @@ public class KafkaBridgeConfigurationBuilder {
      */
     private void configProvider(AbstractConfiguration userConfig, String prefix) {
         printSectionHeader("Config providers");
-        String strimziConfigProviders = "strimzienv,strimzifile,strimzidir";
+        String strimziConfigProviders = "strimzienv,strimzifile,strimzidir,strimzisecrets";
         // configure user provided config providers together with the Strimzi ones ...
         if (userConfig != null
                 && !userConfig.getConfiguration().isEmpty()
@@ -225,6 +218,7 @@ public class KafkaBridgeConfigurationBuilder {
         writer.println(prefix + ".config.providers.strimzifile.param.allowed.paths=/opt/strimzi");
         writer.println(prefix + ".config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider");
         writer.println(prefix + ".config.providers.strimzidir.param.allowed.paths=/opt/strimzi");
+        writer.println(prefix + ".config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider");
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -23,6 +23,8 @@ import io.strimzi.operator.cluster.model.KafkaBridgeCluster;
 import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.DeploymentOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.RoleBindingOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.RoleOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
@@ -52,6 +54,8 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
     private final DeploymentOperator deploymentOperations;
     private final SharedEnvironmentProvider sharedEnvironmentProvider;
     private final boolean isPodDisruptionBudgetGeneration;
+    private final RoleOperator roleOperations;
+    private final RoleBindingOperator roleBindingOperations;
 
     /**
      * Constructs a new KafkaBridgeAssemblyOperator.
@@ -71,6 +75,8 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         this.deploymentOperations = supplier.deploymentOperations;
         this.sharedEnvironmentProvider = supplier.sharedEnvironmentProvider;
         this.isPodDisruptionBudgetGeneration = config.isPodDisruptionBudgetGeneration();
+        this.roleOperations = supplier.roleOperations;
+        this.roleBindingOperations = supplier.roleBindingOperations;
     }
 
     @Override
@@ -102,8 +108,11 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         LOGGER.debugCr(reconciliation, "Updating Kafka Bridge cluster");
         kafkaBridgeServiceAccount(reconciliation, namespace, bridge)
             .compose(i -> bridgeInitClusterRoleBinding(reconciliation, initCrbName, initCrb))
+            .compose(i -> bridgeRole(reconciliation, namespace, bridge))
+            .compose(i -> bridgeRoleBinding(reconciliation, namespace, bridge))
             .compose(i -> deploymentOperations.scaleDown(reconciliation, namespace, bridge.getComponentName(), bridge.getReplicas(), operationTimeoutMs))
             .compose(scale -> serviceOperations.reconcile(reconciliation, namespace, KafkaBridgeResources.serviceName(bridge.getCluster()), bridge.generateService()))
+            .compose(i -> tlsTrustedCertsSecret(reconciliation, namespace, bridge))
             .compose(i -> MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, bridge.logging(), bridge.metrics()))
             .compose(metricsAndLogging -> {
                 ConfigMap configMap = bridge.generateBridgeConfigMap(metricsAndLogging);
@@ -142,6 +151,32 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         return createOrUpdatePromise.future();
     }
 
+    /**
+     * Generates or reconciles the secret that combines secrets and certificates
+     * provided for Kafka Bridge truststore if TLS is enabled.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    private Future<Void> tlsTrustedCertsSecret(Reconciliation reconciliation, String namespace, KafkaBridgeCluster bridge) {
+        if (bridge.getTls() != null) {
+            return ReconcilerUtils.trustedCertificates(reconciliation, secretOperations, bridge.getTls().getTrustedCertificates())
+                    .compose(certificates -> {
+                        if (certificates != null) {
+                            return secretOperations.reconcile(
+                                            reconciliation,
+                                            namespace,
+                                            KafkaBridgeResources.internalTlsTrustedCertsSecretName(bridge.getCluster()),
+                                            bridge.generateTlsTrustedCertsSecret(Map.of("ca.crt", Util.encodeToBase64(certificates)), KafkaBridgeResources.internalTlsTrustedCertsSecretName(bridge.getCluster())))
+                                    .mapEmpty();
+                        } else {
+                            return Future.succeededFuture();
+                        }
+                    });
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
 
     /**
      * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
@@ -170,5 +205,25 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
 
     protected Future<ReconcileResult<ClusterRoleBinding>> bridgeInitClusterRoleBinding(Reconciliation reconciliation, String crbName, ClusterRoleBinding crb) {
         return ReconcilerUtils.withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, crbName, crb), crb);
+    }
+
+    private Future<Void> bridgeRole(Reconciliation reconciliation, String namespace, KafkaBridgeCluster bridge) {
+        return roleOperations.
+                reconcile(
+                        reconciliation,
+                        namespace,
+                        bridge.getComponentName(),
+                        bridge.generateRole()
+                ).mapEmpty();
+    }
+
+    private Future<Void> bridgeRoleBinding(Reconciliation reconciliation, String namespace, KafkaBridgeCluster bridge) {
+        return roleBindingOperations
+                .reconcile(
+                        reconciliation,
+                        namespace,
+                        bridge.getRoleBindingName(),
+                        bridge.generateRoleBindingForRole()
+                ).mapEmpty();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -70,6 +70,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.strimzi.operator.cluster.model.KafkaBridgeCluster.BRIDGE_CONFIGURATION_FILENAME;
 import static io.strimzi.operator.cluster.model.KafkaBridgeCluster.ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY;
@@ -78,6 +79,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -222,6 +224,9 @@ public class KafkaBridgeClusterTest {
     public void testGenerateDeployment()   {
         Deployment dep = KBC.generateDeployment(new HashMap<>(), true, null, null);
 
+        Set<String> secretsToAccess = KBC.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(0));
+
         assertThat(dep.getMetadata().getName(), is(KafkaBridgeResources.componentName(CLUSTER)));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         Map<String, String> expectedDeploymentLabels = expectedLabels(KafkaBridgeResources.componentName(CLUSTER));
@@ -266,17 +271,15 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
-        Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
 
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("my-another-secret"));
+        Set<String> secretsToAccess = kbc.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(1));
+        assertThat(secretsToAccess, hasItems("foo-bridge-tls-trusted-certs"));
 
-        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
-
-        assertThat(containers.get(0).getVolumeMounts().get(2).getMountPath(), is(KafkaBridgeCluster.TLS_CERTS_BASE_VOLUME_MOUNT + "my-secret"));
-        assertThat(containers.get(0).getVolumeMounts().get(3).getMountPath(), is(KafkaBridgeCluster.TLS_CERTS_BASE_VOLUME_MOUNT + "my-another-secret"));
-
-        assertThat(io.strimzi.operator.cluster.TestUtils.containerEnvVars(containers.get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_TRUSTED_CERTS), is("my-secret/cert.crt;my-secret/new-cert.crt;my-another-secret/another-cert.crt"));
+        ConfigMap configMap = kbc.generateBridgeConfigMap(METRICS_AND_LOGGING);
+        String bridgeConfigurations = configMap.getData().get(BRIDGE_CONFIGURATION_FILENAME);
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.truststore.certificates=${strimzisecrets:namespace/foo-bridge-tls-trusted-certs:ca.crt}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.truststore.type=PEM"));
     }
 
     @Test
@@ -297,19 +300,18 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
-        Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
 
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("user-secret"));
-
-        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
-
-        assertThat(containers.get(0).getVolumeMounts().get(3).getMountPath(), is(KafkaBridgeCluster.TLS_CERTS_BASE_VOLUME_MOUNT + "user-secret"));
+        Set<String> secretsToAccess = kbc.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(2));
+        assertThat(secretsToAccess, hasItems("user-secret", "foo-bridge-tls-trusted-certs"));
 
         ConfigMap configMap = kbc.generateBridgeConfigMap(METRICS_AND_LOGGING);
         String bridgeConfigurations = configMap.getData().get(BRIDGE_CONFIGURATION_FILENAME);
-        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.location=/tmp/strimzi/bridge.keystore.p12"));
-        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.password=${strimzienv:CERTS_STORE_PASSWORD}"));
-        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.type=PKCS12"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.truststore.certificates=${strimzisecrets:namespace/foo-bridge-tls-trusted-certs:ca.crt}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.truststore.type=PEM"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.certificate.chain=${strimzisecrets:namespace/user-secret:user.crt}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.key=${strimzisecrets:namespace/user-secret:user.key}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.type=PEM"));
     }
 
     @Test
@@ -330,11 +332,18 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
-        Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
 
-        // 2 = 1 volume from logging/metrics + just 1 from above certs Secret
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(3));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
+        Set<String> secretsToAccess = kbc.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(2));
+        assertThat(secretsToAccess, hasItems("my-secret", "foo-bridge-tls-trusted-certs"));
+
+        ConfigMap configMap = kbc.generateBridgeConfigMap(METRICS_AND_LOGGING);
+        String bridgeConfigurations = configMap.getData().get(BRIDGE_CONFIGURATION_FILENAME);
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.truststore.certificates=${strimzisecrets:namespace/foo-bridge-tls-trusted-certs:ca.crt}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.truststore.type=PEM"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.certificate.chain=${strimzisecrets:namespace/my-secret:user.crt}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.key=${strimzisecrets:namespace/my-secret:user.key}"));
+        assertThat(bridgeConfigurations, containsString("kafka.ssl.keystore.type=PEM"));
     }
 
     @Test
@@ -351,18 +360,14 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
-        Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
-
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("user1-secret"));
-
-        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
-
-        assertThat(containers.get(0).getVolumeMounts().get(2).getMountPath(), is(KafkaBridgeCluster.PASSWORD_VOLUME_MOUNT + "user1-secret"));
+        Set<String> secretsToAccess = kbc.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(1));
+        assertThat(secretsToAccess, hasItems("user1-secret"));
 
         ConfigMap configMap = kbc.generateBridgeConfigMap(METRICS_AND_LOGGING);
         String bridgeConfigurations = configMap.getData().get(BRIDGE_CONFIGURATION_FILENAME);
         assertThat(bridgeConfigurations, containsString("kafka.sasl.mechanism=SCRAM-SHA-512"));
-        assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/user1-secret:password}\";"));
+        assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/user1-secret:password}\";"));
     }
 
     @Test
@@ -379,18 +384,15 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
-        Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
 
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("user1-secret"));
-
-        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
-
-        assertThat(containers.get(0).getVolumeMounts().get(2).getMountPath(), is(KafkaBridgeCluster.PASSWORD_VOLUME_MOUNT + "user1-secret"));
+        Set<String> secretsToAccess = kbc.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(1));
+        assertThat(secretsToAccess, hasItems("user1-secret"));
 
         ConfigMap configMap = kbc.generateBridgeConfigMap(METRICS_AND_LOGGING);
         String bridgeConfigurations = configMap.getData().get(BRIDGE_CONFIGURATION_FILENAME);
         assertThat(bridgeConfigurations, containsString("kafka.sasl.mechanism=SCRAM-SHA-256"));
-        assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/user1-secret:password}\";"));
+        assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/user1-secret:password}\";"));
     }
 
     @Test
@@ -407,18 +409,15 @@ public class KafkaBridgeClusterTest {
             .endSpec()
             .build();
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
-        Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
 
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("user1-secret"));
-
-        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
-
-        assertThat(containers.get(0).getVolumeMounts().get(2).getMountPath(), is(KafkaBridgeCluster.PASSWORD_VOLUME_MOUNT + "user1-secret"));
+        Set<String> secretsToAccess = kbc.secretsToAllowAccessTo();
+        assertThat(secretsToAccess.size(), is(1));
+        assertThat(secretsToAccess, hasItems("user1-secret"));
 
         ConfigMap configMap = kbc.generateBridgeConfigMap(METRICS_AND_LOGGING);
         String bridgeConfigurations = configMap.getData().get(BRIDGE_CONFIGURATION_FILENAME);
         assertThat(bridgeConfigurations, containsString("kafka.sasl.mechanism=PLAIN"));
-        assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/user1-secret:password}\";"));
+        assertThat(bridgeConfigurations, containsString("kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/user1-secret:password}\";"));
     }
 
     @Test
@@ -1035,40 +1034,6 @@ public class KafkaBridgeClusterTest {
         ClusterRoleBinding crb = cluster.generateClusterRoleBinding();
 
         assertThat(crb, is(nullValue()));
-    }
-
-    @Test
-    public void testKafkaBridgeContainerEnvVarsConflict() {
-        ContainerEnvVar envVar1 = new ContainerEnvVar();
-        String testEnvKey = KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_TRUSTED_CERTS;
-        String testEnvValue = "PEM certs";
-        envVar1.setName(testEnvKey);
-        envVar1.setValue(testEnvValue);
-
-        List<ContainerEnvVar> testEnvs = new ArrayList<>();
-        testEnvs.add(envVar1);
-        ContainerTemplate kafkaBridgeContainer = new ContainerTemplate();
-        kafkaBridgeContainer.setEnv(testEnvs);
-
-        KafkaBridge resource = new KafkaBridgeBuilder(RESOURCE)
-                .editSpec()
-                .withNewTls()
-                    .addNewTrustedCertificate()
-                        .withSecretName("tls-trusted-certificate")
-                        .withCertificate("pem-content")
-                    .endTrustedCertificate()
-                .endTls()
-                .withNewTemplate()
-                    .withBridgeContainer(kafkaBridgeContainer)
-                .endTemplate()
-                .endSpec()
-                .build();
-
-        List<EnvVar> kafkaEnvVars = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER).getEnvVars();
-
-        assertThat("Failed to prevent over writing existing container environment variable: " + testEnvKey,
-                kafkaEnvVars.stream().filter(env -> testEnvKey.equals(env.getName()))
-                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvValue), is(false));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -36,6 +36,8 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.bridge.KafkaBridge;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeConsumerSpecBuilder;
@@ -1034,6 +1036,52 @@ public class KafkaBridgeClusterTest {
         ClusterRoleBinding crb = cluster.generateClusterRoleBinding();
 
         assertThat(crb, is(nullValue()));
+    }
+
+    @Test
+    public void testRoleAbdRoleBindingNoSecrets() {
+        assertThat(KBC.generateRole(), is(nullValue()));
+        assertThat(KBC.generateRoleBindingForRole(), is(nullValue()));
+    }
+
+    @Test
+    public void testRoleAndRoleBinding() {
+        KafkaBridge resource = new KafkaBridgeBuilder(RESOURCE)
+                .editSpec()
+                .editOrNewTls()
+                .addToTrustedCertificates(new CertSecretSourceBuilder().withSecretName("my-secret").withCertificate("cert.crt").build())
+                .endTls()
+                .withAuthentication(
+                        new KafkaClientAuthenticationTlsBuilder()
+                                .withNewCertificateAndKey()
+                                .withSecretName("user-secret")
+                                .withCertificate("user.crt")
+                                .withKey("user.key")
+                                .endCertificateAndKey()
+                                .build())
+                .endSpec()
+                .build();
+        KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
+
+        Role r = kbc.generateRole();
+        assertThat(r.getMetadata().getName(), is(kbc.componentName));
+        assertThat(r.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(r.getRules().size(), is(1));
+        assertThat(r.getRules().get(0).getApiGroups(), is(List.of("")));
+        assertThat(r.getRules().get(0).getResources(), is(List.of("secrets")));
+        assertThat(r.getRules().get(0).getVerbs(), is(List.of("get")));
+        assertThat(r.getRules().get(0).getResourceNames(), is(List.of("foo-bridge-tls-trusted-certs", "user-secret")));
+        assertThat(r.getRules().get(0).getVerbs(), is(List.of("get")));
+
+        RoleBinding rb = kbc.generateRoleBindingForRole();
+        assertThat(rb.getMetadata().getName(), is(KafkaBridgeResources.bridgeRoleBindingName(CLUSTER)));
+        assertThat(rb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(rb.getSubjects().size(), is(1));
+        assertThat(rb.getSubjects().get(0).getKind(), is("ServiceAccount"));
+        assertThat(rb.getSubjects().get(0).getName(), is(kbc.componentName));
+        assertThat(rb.getSubjects().get(0).getNamespace(), is(NAMESPACE));
+        assertThat(rb.getRoleRef().getKind(), is("Role"));
+        assertThat(rb.getRoleRef().getName(), is(kbc.componentName));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
@@ -72,27 +72,30 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "bridge.id=my-bridge",
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=PLAINTEXT",
-                "kafka.admin.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.admin.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.admin.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.admin.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.admin.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.admin.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.admin.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "kafka.admin.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
-                "kafka.producer.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.admin.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider",
+                "kafka.producer.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.producer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.producer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.producer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.producer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.producer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "kafka.producer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
-                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.producer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider",
+                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.consumer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.consumer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.consumer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.consumer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.consumer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi"
+                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
+                "kafka.consumer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
     }
 
@@ -125,39 +128,38 @@ public class KafkaBridgeConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withTls(clientTls)
+                .withTls(clientTls, BRIDGE_CLUSTER)
                 .build();
         assertThat(configuration, isEquivalent(
                 "bridge.id=my-bridge",
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SSL",
-                "kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12",
-                "kafka.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "kafka.ssl.truststore.type=PKCS12"
+                "kafka.ssl.truststore.certificates=${strimzisecrets:namespace/my-bridge-bridge-tls-trusted-certs:ca.crt}",
+                "kafka.ssl.truststore.type=PEM"
         ));
 
         // test TLS with mutual authentication (mTLS, server and client authentication)
         KafkaClientAuthenticationTls tlsAuth = new KafkaClientAuthenticationTlsBuilder()
                 .withNewCertificateAndKey()
                     .withSecretName("tls-keystore")
+                    .withKey("pem-key")
                     .withCertificate("pem-content")
                 .endCertificateAndKey()
                 .build();
 
         configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withTls(clientTls)
+                .withTls(clientTls, BRIDGE_CLUSTER)
                 .withAuthentication(tlsAuth)
                 .build();
         assertThat(configuration, isEquivalent(
                 "bridge.id=my-bridge",
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SSL",
-                "kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12",
-                "kafka.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "kafka.ssl.truststore.type=PKCS12",
-                "kafka.ssl.keystore.location=/tmp/strimzi/bridge.keystore.p12",
-                "kafka.ssl.keystore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "kafka.ssl.keystore.type=PKCS12"
+                "kafka.ssl.truststore.certificates=${strimzisecrets:namespace/my-bridge-bridge-tls-trusted-certs:ca.crt}",
+                "kafka.ssl.truststore.type=PEM",
+                "kafka.ssl.keystore.certificate.chain=${strimzisecrets:namespace/tls-keystore:pem-content}",
+                "kafka.ssl.keystore.key=${strimzisecrets:namespace/tls-keystore:pem-key}",
+                "kafka.ssl.keystore.type=PEM"
         ));
 
         // test custom authentication without SASL
@@ -167,16 +169,15 @@ public class KafkaBridgeConfigurationBuilderTest {
                 .build();
 
         configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withTls(clientTls)
+                .withTls(clientTls, BRIDGE_CLUSTER)
                 .withAuthentication(customAuth)
                 .build();
         assertThat(configuration, isEquivalent(
                 "bridge.id=my-bridge",
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SSL",
-                "kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12",
-                "kafka.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "kafka.ssl.truststore.type=PKCS12",
+                "kafka.ssl.truststore.certificates=${strimzisecrets:namespace/my-bridge-bridge-tls-trusted-certs:ca.crt}",
+                "kafka.ssl.truststore.type=PEM",
                 "kafka.ssl.keystore.location=/mnt/certs/keystore",
                 "kafka.ssl.keystore.password=changeme"
         ));
@@ -200,7 +201,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=PLAIN",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key}\";"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/my-auth-secret:my-password-key}\";"
         ));
 
         // test plain authentication but with TLS as well (server authentication only, encryption)
@@ -211,7 +212,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 .endTrustedCertificate()
                 .build();
         configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withTls(clientTls)
+                .withTls(clientTls, BRIDGE_CLUSTER)
                 .withAuthentication(authPlain)
                 .build();
         assertThat(configuration, isEquivalent(
@@ -219,10 +220,9 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_SSL",
                 "kafka.sasl.mechanism=PLAIN",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key}\";",
-                "kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12",
-                "kafka.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
-                "kafka.ssl.truststore.type=PKCS12"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/my-auth-secret:my-password-key}\";",
+                "kafka.ssl.truststore.certificates=${strimzisecrets:namespace/my-bridge-bridge-tls-trusted-certs:ca.crt}",
+                "kafka.ssl.truststore.type=PEM"
                 ));
 
         // test scram-sha-256 authentication
@@ -241,7 +241,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=SCRAM-SHA-256",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key}\";"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/my-auth-secret:my-password-key}\";"
         ));
 
         // test scram-sha-512 authentication
@@ -260,7 +260,7 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=SASL_PLAINTEXT",
                 "kafka.sasl.mechanism=SCRAM-SHA-512",
-                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzidir:/opt/strimzi/bridge-password/my-auth-secret:my-password-key}\";"
+                "kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user1\" password=\"${strimzisecrets:namespace/my-auth-secret:my-password-key}\";"
         ));
 
         // test custom authentication
@@ -309,13 +309,14 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.producer.linger.ms=100",
                 "kafka.producer.key.serializer=my-producer-key-serializer",
                 "kafka.producer.value.serializer=my-producer-value-serializer",
-                "kafka.producer.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.producer.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.producer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.producer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.producer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.producer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.producer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "kafka.producer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi"
+                "kafka.producer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
+                "kafka.producer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
 
         // Kafka Producer with config providers
@@ -341,14 +342,15 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.producer.linger.ms=100",
                 "kafka.producer.key.serializer=my-producer-key-serializer",
                 "kafka.producer.value.serializer=my-producer-value-serializer",
-                "kafka.producer.config.providers=env,strimzienv,strimzifile,strimzidir",
+                "kafka.producer.config.providers=env,strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.producer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.producer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.producer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.producer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.producer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "kafka.producer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
-                "kafka.producer.config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider"
+                "kafka.producer.config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
+                "kafka.producer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
     }
 
@@ -378,13 +380,14 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.consumer.auto.offset.reset=earliest",
                 "kafka.consumer.key.deserializer=my-consumer-key-deserializer",
                 "kafka.consumer.value.deserializer=my-consumer-value-deserializer",
-                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.consumer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.consumer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.consumer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.consumer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.consumer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi"
+                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
+                "kafka.consumer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
 
         // Kafka Consumer with config providers
@@ -408,14 +411,15 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.consumer.auto.offset.reset=earliest",
                 "kafka.consumer.key.deserializer=my-consumer-key-deserializer",
                 "kafka.consumer.value.deserializer=my-consumer-value-deserializer",
-                "kafka.consumer.config.providers=env,strimzienv,strimzifile,strimzidir",
+                "kafka.consumer.config.providers=env,strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.consumer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.consumer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.consumer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.consumer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.consumer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
-                "kafka.consumer.config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider"
+                "kafka.consumer.config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
+                "kafka.consumer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
 
         // Kafka Consumer with topology-label-based rack
@@ -430,13 +434,14 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=PLAINTEXT",
                 "kafka.consumer.client.rack=${strimzidir:/opt/strimzi/init:rack.id}",
-                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.consumer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.consumer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.consumer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.consumer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.consumer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi"
+                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
+                "kafka.consumer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
 
         // Kafka Consumer with envvar-based rack
@@ -451,13 +456,14 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092",
                 "kafka.security.protocol=PLAINTEXT",
                 "kafka.consumer.client.rack=${strimzienv:MY_RACK_ID}",
-                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.consumer.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.consumer.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.consumer.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.consumer.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.consumer.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.consumer.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi"
+                "kafka.consumer.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
+                "kafka.consumer.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
     }
 
@@ -485,13 +491,14 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.security.protocol=PLAINTEXT",
                 "kafka.admin.client.id=my-admin-client",
                 "kafka.admin.bootstrap.controllers=my-bootstrap-controllers",
-                "kafka.admin.config.providers=strimzienv,strimzifile,strimzidir",
+                "kafka.admin.config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.admin.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.admin.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.admin.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.admin.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.admin.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
-                "kafka.admin.config.providers.strimzidir.param.allowed.paths=/opt/strimzi"
+                "kafka.admin.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
+                "kafka.admin.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
 
         // Kafka Admin with config providers
@@ -513,14 +520,15 @@ public class KafkaBridgeConfigurationBuilderTest {
                 "kafka.security.protocol=PLAINTEXT",
                 "kafka.admin.client.id=my-admin-client",
                 "kafka.admin.bootstrap.controllers=my-bootstrap-controllers",
-                "kafka.admin.config.providers=env,strimzienv,strimzifile,strimzidir",
+                "kafka.admin.config.providers=env,strimzienv,strimzifile,strimzidir,strimzisecrets",
                 "kafka.admin.config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
                 "kafka.admin.config.providers.strimzienv.param.allowlist.pattern=.*",
                 "kafka.admin.config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "kafka.admin.config.providers.strimzifile.param.allowed.paths=/opt/strimzi",
                 "kafka.admin.config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "kafka.admin.config.providers.strimzidir.param.allowed.paths=/opt/strimzi",
-                "kafka.admin.config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider"
+                "kafka.admin.config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider",
+                "kafka.admin.config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
         ));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -178,7 +178,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 assertThat(dc.getMetadata().getName(), is(bridge.getComponentName()));
                 assertThat(dc, is(bridge.generateDeployment(Map.of(
                         Annotations.ANNO_STRIMZI_AUTH_HASH, "0",
-                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "c8cc2862"
+                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "ae3369a9"
                         ), true, null, null)));
 
                 // Verify PodDisruptionBudget
@@ -344,7 +344,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 assertThat(dc.getMetadata().getName(), is(compareTo.getComponentName()));
                 assertThat(dc, is(compareTo.generateDeployment(Map.of(
                         Annotations.ANNO_STRIMZI_AUTH_HASH, "0",
-                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "c8cc2862"
+                        Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, "ae3369a9"
                 ), true, null, null)));
 
                 // Verify PodDisruptionBudget


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

- Remove PKCS12 usage in Bridge so that it uses PEM from secrets directly accessed using KubernetesSecretConfigProvider instead. Also authentication clients secrets are accessed directly instead of volume mounting them. 
- AuthenticationUtils is refactored to common methods to get list of secrets need to be accessed and to create role/rolebinding resources for them. This methods will be used by KafkaConnect (MirrorMaker) later on. 

Closes https://github.com/strimzi/strimzi-kafka-operator/issues/12607

Note: There will be a follow up PR to also access HTTP server certificate directly instead of volume mounting them to make configuration more consistent across all authentications. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

