### PR TITLE
Simplify `KafkaVersionTestUtils` class

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -15,34 +15,39 @@ import java.util.stream.Collectors;
 
 public class KafkaVersionTestUtils {
     private static final String KAFKA_IMAGE_STR = "strimzi/kafka:latest-kafka-";
-    private static final String KAFKA_CONNECT_IMAGE_STR = "strimzi/kafka-connect:latest-kafka-";
-    private static final String KAFKA_MIRROR_MAKER_2_IMAGE_STR = "strimzi/kafka-connect:latest-kafka-";
-
     private static final Set<String> SUPPORTED_VERSIONS = new KafkaVersion.Lookup(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()).supportedVersions();
 
-    public static final String LATEST_KAFKA_VERSION = "4.2.0";
-    public static final String LATEST_FORMAT_VERSION = "4.2";
-    public static final String LATEST_PROTOCOL_VERSION = "4.2";
-    public static final String LATEST_METADATA_VERSION = "4.2-IV1";
-    public static final String LATEST_CHECKSUM = "ABCD1234";
-    public static final String LATEST_THIRD_PARTY_VERSION = "4.2.x";
-    public static final String LATEST_KAFKA_IMAGE = KAFKA_IMAGE_STR + LATEST_KAFKA_VERSION;
-    public static final String LATEST_KAFKA_CONNECT_IMAGE = KAFKA_CONNECT_IMAGE_STR + LATEST_KAFKA_VERSION;
-    public static final String LATEST_KAFKA_MIRROR_MAKER_2_IMAGE = KAFKA_MIRROR_MAKER_2_IMAGE_STR + LATEST_KAFKA_VERSION;
+    public static final String LATEST_KAFKA_VERSION;
+    public static final String LATEST_METADATA_VERSION;
+    public static final String LATEST_KAFKA_IMAGE;
+    static {
+        String v = SUPPORTED_VERSIONS.stream().max(KafkaVersion::compareDottedVersions).orElseThrow(() -> new RuntimeException("Failed to find the latest Kafka version"));
+        KafkaVersion version = getKafkaVersionLookup().version(v);
+        LATEST_KAFKA_VERSION = version.version();
+        LATEST_METADATA_VERSION = version.metadataVersion();
+        LATEST_KAFKA_IMAGE = KAFKA_IMAGE_STR + version.version();
+    }
 
-    public static final String PREVIOUS_KAFKA_VERSION = "4.1.2";
-    public static final String PREVIOUS_FORMAT_VERSION = "4.1";
-    public static final String PREVIOUS_PROTOCOL_VERSION = "4.1";
-    public static final String PREVIOUS_METADATA_VERSION = "4.1-IV1";
-    public static final String PREVIOUS_CHECKSUM = "ABCD1234";
-    public static final String PREVIOUS_THIRD_PARTY_VERSION = "4.1.x";
-    public static final String PREVIOUS_KAFKA_IMAGE = KAFKA_IMAGE_STR + PREVIOUS_KAFKA_VERSION;
-    public static final String PREVIOUS_KAFKA_CONNECT_IMAGE = KAFKA_CONNECT_IMAGE_STR + PREVIOUS_KAFKA_VERSION;
-    public static final String PREVIOUS_KAFKA_MIRROR_MAKER_2_IMAGE = KAFKA_MIRROR_MAKER_2_IMAGE_STR + PREVIOUS_KAFKA_VERSION;
+    public static final String PREVIOUS_KAFKA_VERSION;
+    public static final String PREVIOUS_METADATA_VERSION;
+    public static final String PREVIOUS_KAFKA_IMAGE;
+    static {
+        String v = SUPPORTED_VERSIONS.stream().min(KafkaVersion::compareDottedVersions).orElseThrow(() -> new RuntimeException("Failed to find the latest Kafka version"));
+        KafkaVersion version = getKafkaVersionLookup().version(v);
+        PREVIOUS_KAFKA_VERSION = version.version();
+        PREVIOUS_METADATA_VERSION = version.metadataVersion();
+        PREVIOUS_KAFKA_IMAGE = KAFKA_IMAGE_STR + version.version();
+    }
 
-    public static final String DEFAULT_KAFKA_VERSION = LATEST_KAFKA_VERSION;
-    public static final String DEFAULT_KAFKA_IMAGE = LATEST_KAFKA_IMAGE;
-    public static final String DEFAULT_KAFKA_CONNECT_IMAGE = LATEST_KAFKA_CONNECT_IMAGE;
+    public static final String DEFAULT_KAFKA_VERSION;
+    public static final String DEFAULT_METADATA_VERSION;
+    public static final String DEFAULT_KAFKA_IMAGE;
+    static {
+        KafkaVersion version = getKafkaVersionLookup().defaultVersion();
+        DEFAULT_KAFKA_VERSION = version.version();
+        DEFAULT_METADATA_VERSION = version.metadataVersion();
+        DEFAULT_KAFKA_IMAGE = KAFKA_IMAGE_STR + version.version();
+    }
     
     public static final String HIGH_UNKNOWN_KAFKA_VERSION = "99.0.0";
     public static final String LOW_UNKNOWN_KAFKA_VERSION = "3.99.0";
@@ -54,11 +59,11 @@ public class KafkaVersionTestUtils {
     }
 
     private static Map<String, String> getKafkaConnectImageMap() {
-        return getImageMap(KAFKA_CONNECT_IMAGE_STR);
+        return getImageMap(KAFKA_IMAGE_STR);
     }
 
     private static Map<String, String> getKafkaMirrorMaker2ImageMap() {
-        return getImageMap(KAFKA_MIRROR_MAKER_2_IMAGE_STR);
+        return getImageMap(KAFKA_IMAGE_STR);
     }
 
     private static String envVarFromMap(Map<String, String> imageMap)   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -192,7 +192,7 @@ public class KafkaConnectClusterTest {
             .build();
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, connect, VERSIONS, SHARED_ENV_PROVIDER);
 
-        assertThat(kc.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_CONNECT_IMAGE));
+        assertThat(kc.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_IMAGE));
         assertThat(kc.getReplicas(), is(3)); // Once only v1 API is supported, there should be no default replicas number as it is a required field in v1
         assertThat(kc.readinessProbeOptions.getInitialDelaySeconds(), is(60));
         assertThat(kc.readinessProbeOptions.getTimeoutSeconds(), is(5));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -172,7 +172,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
     @Test
     public void testDefaultValues() {
-        assertThat(KMM2.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_CONNECT_IMAGE));
+        assertThat(KMM2.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_IMAGE));
         assertThat(KMM2.getReplicas(), is(3));
         assertThat(KMM2.readinessProbeOptions.getInitialDelaySeconds(), is(60));
         assertThat(KMM2.readinessProbeOptions.getTimeoutSeconds(), is(5));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
@@ -257,7 +257,7 @@ public class KafkaAssemblyOperatorKRaftMockTest {
         Kafka k = Crds.kafkaOperation(client).inNamespace(namespace).withName(CLUSTER_NAME).get();
         assertThat(k.getStatus(), is(notNullValue()));
         assertThat(Kafka.isReady().test(k), is(true));
-        assertThat(k.getStatus().getKafkaMetadataVersion(), startsWith(VERSIONS.defaultVersion().metadataVersion() + "-IV"));
+        assertThat(k.getStatus().getKafkaMetadataVersion(), startsWith(VERSIONS.defaultVersion().metadataVersion()));
         assertThat(k.getStatus().getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
         assertThat(k.getStatus().getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
         assertThat(k.getStatus().getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("brokers", "controllers")));

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -267,28 +267,28 @@
   supported: false
   default: false
 - version: 4.1.0
-  metadata: 4.1
+  metadata: 4.1-IV1
   url: https://archive.apache.org/dist/kafka/4.1.0/kafka_2.13-4.1.0.tgz
   checksum: 2F611FA1117747A3567AB5D8E59C24A3DC5CD3C0D50A67CF718AB5203BD5CA69D9A1E2C705EE07B8363D71DE48964BFD65FAC31100A91B458FBD6A2EB3C8EDE5
   third-party-libs: 4.1.x
   supported: true
   default: false
 - version: 4.1.1
-  metadata: 4.1
+  metadata: 4.1-IV1
   url: https://archive.apache.org/dist/kafka/4.1.1/kafka_2.13-4.1.1.tgz
   checksum: EB2433E5330E4915A777FCC47447780E81A5041AACF0F787E5B5D06D767DA7D484AFB9F2CA8651E61769F2256F36967F6481BAF17429B289BC2B1E6962640DEB
   third-party-libs: 4.1.x
   supported: true
   default: false
 - version: 4.1.2
-  metadata: 4.1
+  metadata: 4.1-IV1
   url: https://archive.apache.org/dist/kafka/4.1.2/kafka_2.13-4.1.2.tgz
   checksum: 78AC6E488B1071122F9608DFDB363F6FE50E1DBBC492347002C0398DFBF77E0D8CAA5BF794C5937379721004DFE92025937D238B0FAF4EB715529417FD43B491
   third-party-libs: 4.1.2 # we need to use a separate 3rd party libs directory cause Kafka 4.1.2 is using log4j 2.25.3 and Jackson 2.19.4 rather than log4j 2.24.3 and Jackson 2.19.0 used by previous Kafka 4.1.x versions
   supported: true
   default: false
 - version: 4.2.0
-  metadata: 4.2
+  metadata: 4.2-IV1
   url: https://archive.apache.org/dist/kafka/4.2.0/kafka_2.13-4.2.0.tgz
   checksum: 16CE46E590BA915F01B720EA514445E49C88BF129CF4CEAB88878B122D54EF24F0DEDB88D0EB178957F58057A6C6A9ADBEA8B8059307585DAEA13129B85BA1D8
   third-party-libs: 4.2.x


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors the `KafkaVersionTestUtils` class. It does the following changes:
* Removes the unused fields
* Automatically loads the latest supported version, the default version, and the oldest supported version (as previous) and initializes the versions information from there

This change should simplify the tasks when adding or removing Kafka versions as we will not need to update this class anymore and it would auto-update itself.

It also updated the `kafka-versions.yaml` file to keep the full metadata version including the `IV` marker. We use the full version in the examples, but had it only partial in the YAML file.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally