### PR TITLE
Mount certificate Secret volumes as read-only

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -119,13 +119,13 @@ public class AuthenticationUtils {
             if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
                 // skipping if a volume mount with same Secret name was already added
                 if (volumeMountList.stream().noneMatch(vm -> vm.getName().equals(volumeNamePrefix + tlsAuth.getCertificateAndKey().getSecretName()))) {
-                    volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + tlsAuth.getCertificateAndKey().getSecretName(),
+                    volumeMountList.add(VolumeUtils.createReadOnlyVolumeMount(volumeNamePrefix + tlsAuth.getCertificateAndKey().getSecretName(),
                             tlsVolumeMount + tlsAuth.getCertificateAndKey().getSecretName()));
                 }
             } else if (authentication instanceof KafkaClientAuthenticationPlain passwordAuth) {
-                volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + passwordAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + passwordAuth.getPasswordSecret().getSecretName()));
+                volumeMountList.add(VolumeUtils.createReadOnlyVolumeMount(volumeNamePrefix + passwordAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + passwordAuth.getPasswordSecret().getSecretName()));
             } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
-                volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + scramAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + scramAuth.getPasswordSecret().getSecretName()));
+                volumeMountList.add(VolumeUtils.createReadOnlyVolumeMount(volumeNamePrefix + scramAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + scramAuth.getPasswordSecret().getSecretName()));
             }
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -233,7 +233,7 @@ public class CertUtils {
      * @param prefix                Prefix used to generate the volume name
      */
     private static void maybeAddTrustedCertificateVolumeMount(List<VolumeMount> volumeMountList, CertSecretSource certSecretSource, String tlsVolumeMountPath, String prefix) {
-        VolumeMount secretVolumeMount = VolumeUtils.createVolumeMount(
+        VolumeMount secretVolumeMount = VolumeUtils.createReadOnlyVolumeMount(
             trustedCertificateVolumeName(certSecretSource, prefix),
             tlsVolumeMountPath + certSecretSource.getSecretName());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -343,9 +343,9 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
     protected List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeMounts = new ArrayList<>();
         volumeMounts.add(VolumeUtils.createTempDirVolumeMount());
-        volumeMounts.add(VolumeUtils.createVolumeMount(CruiseControl.TLS_CC_CERTS_VOLUME_NAME, CruiseControl.TLS_CC_CERTS_VOLUME_MOUNT));
-        volumeMounts.add(VolumeUtils.createVolumeMount(CruiseControl.TLS_CA_CERTS_VOLUME_NAME, CruiseControl.TLS_CA_CERTS_VOLUME_MOUNT));
-        volumeMounts.add(VolumeUtils.createVolumeMount(CruiseControl.API_AUTH_CONFIG_VOLUME_NAME, CruiseControl.API_AUTH_CONFIG_VOLUME_MOUNT));
+        volumeMounts.add(VolumeUtils.createReadOnlyVolumeMount(CruiseControl.TLS_CC_CERTS_VOLUME_NAME, CruiseControl.TLS_CC_CERTS_VOLUME_MOUNT));
+        volumeMounts.add(VolumeUtils.createReadOnlyVolumeMount(CruiseControl.TLS_CA_CERTS_VOLUME_NAME, CruiseControl.TLS_CA_CERTS_VOLUME_MOUNT));
+        volumeMounts.add(VolumeUtils.createReadOnlyVolumeMount(CruiseControl.API_AUTH_CONFIG_VOLUME_NAME, CruiseControl.API_AUTH_CONFIG_VOLUME_MOUNT));
         volumeMounts.add(VolumeUtils.createVolumeMount(CONFIG_VOLUME_NAME, CONFIG_VOLUME_MOUNT));
 
         TemplateUtils.addAdditionalVolumeMounts(volumeMounts, templateContainer);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -257,8 +257,8 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
         result.add(VolumeUtils.createVolumeMount(LOG_AND_METRICS_CONFIG_VOLUME_NAME, LOG_AND_METRICS_CONFIG_VOLUME_MOUNT));
 
         if (this.cruiseControlEnabled) {
-            result.add(VolumeUtils.createVolumeMount(ETO_CA_CERTS_VOLUME_NAME, ETO_CA_CERTS_VOLUME_MOUNT));
-            result.add(VolumeUtils.createVolumeMount(ETO_CC_API_VOLUME_NAME, ETO_CC_API_VOLUME_MOUNT));
+            result.add(VolumeUtils.createReadOnlyVolumeMount(ETO_CA_CERTS_VOLUME_NAME, ETO_CA_CERTS_VOLUME_MOUNT));
+            result.add(VolumeUtils.createReadOnlyVolumeMount(ETO_CC_API_VOLUME_NAME, ETO_CC_API_VOLUME_MOUNT));
         }
 
         TemplateUtils.addAdditionalVolumeMounts(result, templateContainer);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -277,8 +277,8 @@ public class KafkaExporter extends AbstractModel {
     private List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeList = new ArrayList<>(3);
         volumeList.add(VolumeUtils.createTempDirVolumeMount());
-        volumeList.add(VolumeUtils.createVolumeMount(KAFKA_EXPORTER_CERTS_VOLUME_NAME, KAFKA_EXPORTER_CERTS_VOLUME_MOUNT));
-        volumeList.add(VolumeUtils.createVolumeMount(CLUSTER_CA_CERTS_VOLUME_NAME, CLUSTER_CA_CERTS_VOLUME_MOUNT));
+        volumeList.add(VolumeUtils.createReadOnlyVolumeMount(KAFKA_EXPORTER_CERTS_VOLUME_NAME, KAFKA_EXPORTER_CERTS_VOLUME_MOUNT));
+        volumeList.add(VolumeUtils.createReadOnlyVolumeMount(CLUSTER_CA_CERTS_VOLUME_NAME, CLUSTER_CA_CERTS_VOLUME_MOUNT));
 
         TemplateUtils.addAdditionalVolumeMounts(volumeList, templateContainer);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -266,6 +266,23 @@ public class VolumeUtils {
     }
 
     /**
+     * Creates a read-only Volume mount
+     *
+     * @param name Name of the Volume mount
+     * @param path volume mount path
+     * @return The Volume mount created
+     */
+    public static VolumeMount createReadOnlyVolumeMount(String name, String path) {
+        String validName = getValidVolumeName(name);
+
+        return new VolumeMountBuilder()
+                .withName(validName)
+                .withMountPath(path)
+                .withReadOnly(true)
+                .build();
+    }
+
+    /**
      * Creates the volume mount for the temp directory with a default volume name
      *
      * @return  Volume mount for the temp directory

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AuthenticationUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AuthenticationUtilsTest.java
@@ -4,19 +4,57 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationPlainBuilder;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha512Builder;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import org.junit.jupiter.api.Test;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AuthenticationUtilsTest {
+    @Test
+    public void testClientAuthenticationVolumeMountsAreReadOnly() {
+        List<VolumeMount> volumeMounts = new ArrayList<>();
+
+        AuthenticationUtils.configureClientAuthenticationVolumeMounts(new KafkaClientAuthenticationTlsBuilder()
+                .withNewCertificateAndKey()
+                    .withSecretName("tls-secret")
+                    .withCertificate("tls.crt")
+                    .withKey("tls.key")
+                .endCertificateAndKey()
+                .build(), volumeMounts, "/mnt/tls/", "/mnt/password/", "");
+        AuthenticationUtils.configureClientAuthenticationVolumeMounts(new KafkaClientAuthenticationPlainBuilder()
+                .withUsername("plain-user")
+                .withNewPasswordSecret()
+                    .withSecretName("plain-secret")
+                    .withPassword("password")
+                .endPasswordSecret()
+                .build(), volumeMounts, "/mnt/tls/", "/mnt/password/", "");
+        AuthenticationUtils.configureClientAuthenticationVolumeMounts(new KafkaClientAuthenticationScramSha512Builder()
+                .withUsername("scram-user")
+                .withNewPasswordSecret()
+                    .withSecretName("scram-secret")
+                    .withPassword("password")
+                .endPasswordSecret()
+                .build(), volumeMounts, "/mnt/tls/", "/mnt/password/", "");
+
+        assertEquals(3, volumeMounts.size());
+        assertEquals(Boolean.TRUE, volumeMounts.get(0).getReadOnly());
+        assertEquals(Boolean.TRUE, volumeMounts.get(1).getReadOnly());
+        assertEquals(Boolean.TRUE, volumeMounts.get(2).getReadOnly());
+    }
+
     @Test
     public void testValidJaasConfig() {
         Map<String, String> options = new HashMap<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CertUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CertUtilsTest.java
@@ -231,8 +231,10 @@ public class CertUtilsTest {
         assertThat(mounts.size(), is(2));
         assertThat(mounts.get(0).getName(), is("prefixed-first-certificate"));
         assertThat(mounts.get(0).getMountPath(), is("/my/path/first-certificate"));
+        assertThat(mounts.get(0).getReadOnly(), is(true));
         assertThat(mounts.get(1).getName(), is("prefixed-second-certificate"));
         assertThat(mounts.get(1).getMountPath(), is("/my/path/second-certificate"));
+        assertThat(mounts.get(1).getReadOnly(), is(true));
     }
 
     @Test
@@ -258,8 +260,10 @@ public class CertUtilsTest {
         assertThat(mounts.size(), is(2));
         assertThat(mounts.get(0).getName(), is("first-certificate"));
         assertThat(mounts.get(0).getMountPath(), is("/my/path/first-certificate"));
+        assertThat(mounts.get(0).getReadOnly(), is(true));
         assertThat(mounts.get(1).getName(), is("second-certificate"));
         assertThat(mounts.get(1).getMountPath(), is("/my/path/second-certificate"));
+        assertThat(mounts.get(1).getReadOnly(), is(true));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -284,14 +284,17 @@ public class CruiseControlTest {
         VolumeMount volumeMount = volumesMounts.stream().filter(vol -> CruiseControl.TLS_CC_CERTS_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
         assertThat(volumeMount.getMountPath(), is(CruiseControl.TLS_CC_CERTS_VOLUME_MOUNT));
+        assertThat(volumeMount.getReadOnly(), is(true));
 
         volumeMount = volumesMounts.stream().filter(vol -> CruiseControl.TLS_CA_CERTS_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
         assertThat(volumeMount.getMountPath(), is(CruiseControl.TLS_CA_CERTS_VOLUME_MOUNT));
+        assertThat(volumeMount.getReadOnly(), is(true));
 
         volumeMount = volumesMounts.stream().filter(vol -> CruiseControl.API_AUTH_CONFIG_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
         assertThat(volumeMount.getMountPath(), is(CruiseControl.API_AUTH_CONFIG_VOLUME_MOUNT));
+        assertThat(volumeMount.getReadOnly(), is(true));
 
         volumeMount = volumesMounts.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.common.InlineLogging;
 import io.strimzi.api.kafka.model.common.JvmOptions;
@@ -312,6 +313,16 @@ public class EntityTopicOperatorTest {
             EntityTopicOperator.ETO_CA_CERTS_VOLUME_NAME, EntityTopicOperator.ETO_CA_CERTS_VOLUME_MOUNT,
             EntityTopicOperator.ETO_CC_API_VOLUME_NAME, EntityTopicOperator.ETO_CC_API_VOLUME_MOUNT
         )));
+        VolumeMount clusterCaVolumeMount = container.getVolumeMounts().stream()
+                .filter(volumeMount -> EntityTopicOperator.ETO_CA_CERTS_VOLUME_NAME.equals(volumeMount.getName()))
+                .findFirst()
+                .orElseThrow();
+        VolumeMount ccApiVolumeMount = container.getVolumeMounts().stream()
+                .filter(volumeMount -> EntityTopicOperator.ETO_CC_API_VOLUME_NAME.equals(volumeMount.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(clusterCaVolumeMount.getReadOnly(), is(true));
+        assertThat(ccApiVolumeMount.getReadOnly(), is(true));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -202,10 +202,12 @@ public class KafkaExporterTest {
         volumeMount = volumesMounts.stream().filter(vol -> KafkaExporter.CLUSTER_CA_CERTS_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
         assertThat(volumeMount.getMountPath(), is(KafkaExporter.CLUSTER_CA_CERTS_VOLUME_MOUNT));
+        assertThat(volumeMount.getReadOnly(), is(true));
 
         volumeMount = volumesMounts.stream().filter(vol -> KafkaExporter.KAFKA_EXPORTER_CERTS_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
         assertThat(volumeMount.getMountPath(), is(KafkaExporter.KAFKA_EXPORTER_CERTS_VOLUME_MOUNT));
+        assertThat(volumeMount.getReadOnly(), is(true));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/VolumeUtilsTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorage;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
@@ -164,6 +165,15 @@ public class VolumeUtilsTest {
         assertThat(volumeFromPvc.getName(), is("my-volume"));
         assertThat(volumeFromPvc.getPersistentVolumeClaim(), is(notNullValue()));
         assertThat(volumeFromPvc.getPersistentVolumeClaim().getClaimName(), is("my-pvc"));
+    }
+
+    @Test
+    public void testCreateReadOnlyVolumeMount() {
+        VolumeMount volumeMount = VolumeUtils.createReadOnlyVolumeMount("my-secret", "/mnt/secret");
+
+        assertThat(volumeMount.getName(), is("my-secret"));
+        assertThat(volumeMount.getMountPath(), is("/mnt/secret"));
+        assertThat(volumeMount.getReadOnly(), is(true));
     }
 
     ////////////////////


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #12711.

This PR marks certificate and authentication Secret volume mounts as read-only in generated operands. It adds a read-only volume mount helper and uses it for trusted certificate mounts, client authentication Secrets, Cruise Control cert/API Secret mounts, Kafka Exporter cert mounts, and Entity Topic Operator Cruise Control Secret mounts.

Validation:

- `JAVA_HOME=/opt/temurin-21 PATH=/opt/temurin-21/bin:$PATH mvn -pl crd-generator -am -DskipTests package`
- `JAVA_HOME=/opt/temurin-21 PATH=/opt/temurin-21/bin:$PATH mvn -pl cluster-operator -am -DskipITs -Dtest=VolumeUtilsTest,CertUtilsTest,AuthenticationUtilsTest,CruiseControlTest,KafkaExporterTest,EntityTopicOperatorTest -Dsurefire.failIfNoSpecifiedTests=false test`

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards
