### PR TITLE
Run internal create, update and server side apply on a Vert.x worker thread

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
@@ -261,14 +261,14 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      */
     protected Future<ReconcileResult<T>> internalUpdate(Reconciliation reconciliation, String namespace, String name, T current, T desired) {
         if (needsPatching(reconciliation, name, current, desired))  {
-            try {
+            return resourceSupport.executeBlocking(() -> {
                 T result = patchOrReplace(namespace, name, desired);
                 LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been patched", resourceKind, name, namespace);
-                return Future.succeededFuture(wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result));
-            } catch (Exception e) {
+                return wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result);
+            }).recover(e -> {
                 LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
                 return Future.failedFuture(e);
-            }
+            });
         } else {
             LOGGER.debugCr(reconciliation, "{} {} in namespace {} did not changed and doesn't need patching", resourceKind, name, namespace);
             return Future.succeededFuture(ReconcileResult.noop(current));
@@ -283,9 +283,8 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * First patch attempt is done without force, however if there is a conflict, operator will try again using force.
      */
     protected Future<ReconcileResult<T>> internalServerSideApply(Reconciliation reconciliation, String namespace, String name, T desired) {
-        R resourceOp = operation().inNamespace(namespace).withName(name);
-
-        try {
+        return resourceSupport.executeBlocking(() -> {
+            R resourceOp = operation().inNamespace(namespace).withName(name);
             T result;
 
             try {
@@ -303,12 +302,13 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
                 }
             }
 
+            ReconcileResult<T> reconcileResult = ReconcileResult.patchedWithServerSideApply(result);
             LOGGER.debugCr(reconciliation, "{} {}/{} has been patched", resourceKind, namespace, name);
-            return Future.succeededFuture(ReconcileResult.patchedWithServerSideApply(result));
-        } catch (Exception e) {
+            return reconcileResult;
+        }).recover(e -> {
             LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);
-        }
+        });
     }
 
     /**
@@ -344,14 +344,14 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * and completes the given future accordingly.
      */
     protected Future<ReconcileResult<T>> internalCreate(Reconciliation reconciliation, String namespace, String name, T desired) {
-        try {
+        return resourceSupport.executeBlocking(() -> {
             ReconcileResult<T> result = ReconcileResult.created(operation().inNamespace(namespace).resource(desired).create());
             LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been created", resourceKind, name, namespace);
-            return Future.succeededFuture(result);
-        } catch (Exception e) {
+            return result;
+        }).recover(e -> {
             LOGGER.debugCr(reconciliation, "Caught exception while creating {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
While investigating on a user/customer issue, I noticed that some Kubernetes client calls are happening within the Vert.x event loop. It means that if, for any reasons, the Kubernetes API server is slow or times out, the Vert.x thread checker kicks in and shows the usual warning about the event loop being blocked for more 2000 ms.

```shell
2026-05-08 10:13:45 WARN  BlockedThreadChecker: - Thread Thread[vert.x-eventloop-thread-6,5,main] has been blocked for 40798 ms, time limit is 2000 ms
io.vertx.core.VertxException: Thread blocked
```

I noticed it when running the `AbstractNamespacedResourceOperator.internalUpdate` (and then calling the `patchOrReplace`). By adding some logging it's clear that they are executed within the Vert.x event loop.

```shell
2026-05-12 12:58:10 INFO  AbstractNamespacedResourceOperator:111 - Reconciliation #1(watch) Kafka(myproject/my-cluster): **** reconcile Thread = Thread[#46,vert.x-eventloop-thread-1,5,main]
2026-05-12 12:58:10 INFO  Main:206 - Cluster Operator verticle started in namespace myproject without label selector
2026-05-12 12:58:10 INFO  KafkaAssemblyOperator:779 - Reconciliation #4(watch) Kafka(myproject/my-cluster): KafkaNodePool broker in namespace myproject was ADDED
2026-05-12 12:58:10 INFO  AbstractNamespacedResourceOperator:115 - Reconciliation #1(watch) Kafka(myproject/my-cluster): **** reconcile.getAsync.compose Thread = Thread[#46,vert.x-eventloop-thread-1,5,main]
2026-05-12 12:58:10 INFO  AbstractNamespacedResourceOperator:266 - Reconciliation #1(watch) Kafka(myproject/my-cluster): **** internalUpdate Thread = Thread[#46,vert.x-eventloop-thread-1,5,main]
```

This PR fixes the issue by running the Kubernetes client related calls within a Vert.x worker thread.
It fixes the same issues for the `internalServerSideApply` and `internalCreate` methods as well.

Running these calls asynchronously was already done within the `AbstractNamespacedResourceOperator` we have in the `operator-common` package which is used only by TO and UO. They are Vert.x free so using CompletableFuture/CompletableStage pattern now (see here https://github.com/strimzi/strimzi-kafka-operator/blob/main/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java).