### PR TITLE
Update to Fabric8 Kubernetes Client 7.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,10 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.6.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.6.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.6.1</fabric8.kubernetes-model.version>
-        <fabric8.zjsonpatch.version>7.6.1</fabric8.zjsonpatch.version>
+        <fabric8.kubernetes-client.version>7.7.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.7.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.7.0</fabric8.kubernetes-model.version>
+        <fabric8.zjsonpatch.version>7.7.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.21.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.21.2</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.21.2</fasterxml.jackson-dataformat.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to 7.7.0. That should unlock the implementation of the Gateway API / TLSRoutes proposal.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally