### PR TITLE
Use new labels for CNCF runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,16 +6,12 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   # Add other runners if needed
   labels:
-    # container runners
-    - oracle-2cpu-8gb-arm64
-    - oracle-2cpu-8gb-x86_64
-    # VM runners
-    - oracle-vm-2cpu-8gb-x86-64
-    - oracle-vm-2cpu-8gb-arm64
-    - oracle-vm-4cpu-16gb-x86-64
-    - oracle-vm-4cpu-16gb-arm64
-    - oracle-vm-8cpu-32gb-x86-64
-    - oracle-vm-8cpu-32gb-arm64
+    - cncf-ubuntu-2-8-x86
+    - cncf-ubuntu-4-16-x86
+    - cncf-ubuntu-8-32-x86
+    - cncf-ubuntu-2-8-arm
+    - cncf-ubuntu-4-16-arm
+    - cncf-ubuntu-8-32-arm
 
 # Path-specific configurations.
 paths:

--- a/.github/actions/systemtests/generate-matrix/pipelines.yaml
+++ b/.github/actions/systemtests/generate-matrix/pipelines.yaml
@@ -18,7 +18,7 @@ pipelines:
   ### Regression ###
   ##################
   # x86-64
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "regression"
     profile: "brokers-and-security"
@@ -27,7 +27,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "regression"
     profile: "operators"
@@ -36,7 +36,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "regression"
     profile: "operands"
@@ -46,7 +46,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 4
   # arm64
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "regression"
     profile: "brokers-and-security"
@@ -55,7 +55,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "regression"
     profile: "operators"
@@ -64,7 +64,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "regression"
     profile: "operands"
@@ -78,7 +78,7 @@ pipelines:
   #############
   # Smoke pipelines can use smaller agents as the tests are not running in parallel even if configured
   # x86-64
-  - agent: "oracle-vm-2cpu-8gb-x86-64"
+  - agent: "cncf-ubuntu-2-8-x86"
     arch: "amd64"
     pipeline: "smoke"
     profile: "smoke"
@@ -88,7 +88,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 1
   # arm64
-  - agent: "oracle-vm-2cpu-8gb-arm64"
+  - agent: "cncf-ubuntu-2-8-arm"
     arch: "arm64"
     pipeline: "smoke"
     profile: "smoke"
@@ -101,7 +101,7 @@ pipelines:
   ### Upgrade ###
   ###############
   # x86-64
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "upgrade"
     profile: "azp_kraft_upgrade"
@@ -110,7 +110,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "upgrade"
     profile: "azp_kafka_upgrade"
@@ -120,7 +120,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 1
   # arm64
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "upgrade"
     profile: "azp_kraft_upgrade"
@@ -129,7 +129,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "upgrade"
     profile: "azp_kafka_upgrade"
@@ -143,7 +143,7 @@ pipelines:
   ##################
   # Acceptance pipelines can use smaller agents as the tests are not running in parallel even if configured
   # x86-64
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "acceptance"
     profile: "acceptance"
@@ -153,7 +153,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 2
   # arm64
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "acceptance"
     profile: "acceptance"
@@ -166,7 +166,7 @@ pipelines:
   ### Acceptance Helm ###
   #######################
   # x86-64
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "acceptance-helm"
     profile: "acceptance"
@@ -176,7 +176,7 @@ pipelines:
     cluster_operator_install_type: "helm"
     parallel: 2
   # arm64
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "acceptance-helm"
     profile: "acceptance"
@@ -192,7 +192,7 @@ pipelines:
   # Each of the pipeline use a specific profile as we use also on Azure
   # In case we will need to adjust the profiles, we should update or create one in systemtest-settings.xml in .azure folder
   # x86-64
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_kafka_oauth"
@@ -202,7 +202,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_security"
@@ -212,7 +212,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_dynconfig_listeners_tracing_watcher"
@@ -222,7 +222,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_operators"
@@ -232,7 +232,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_rolling_update_bridge"
@@ -242,7 +242,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_connect_mirrormaker"
@@ -252,7 +252,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "regression-rbac"
     profile: "azp_rbac_remaining"
@@ -263,7 +263,7 @@ pipelines:
     excluded_groups: 'nodeport'
     parallel: 1
   # arm64
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_kafka_oauth"
@@ -273,7 +273,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_security"
@@ -283,7 +283,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_dynconfig_listeners_tracing_watcher"
@@ -293,7 +293,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_operators"
@@ -303,7 +303,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_rolling_update_bridge"
@@ -313,7 +313,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_connect_mirrormaker"
@@ -323,7 +323,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     excluded_groups: 'nodeport'
     parallel: 1
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "regression-rbac"
     profile: "azp_rbac_remaining"
@@ -337,7 +337,7 @@ pipelines:
   ### Regression Feature Gates ###
   ################################
   # x86-64
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "regression-fg"
     profile: "brokers-and-security"
@@ -346,7 +346,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 3
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "regression-fg"
     profile: "operators"
@@ -355,7 +355,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "regression-fg"
     profile: "operands"
@@ -365,7 +365,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 3
   # arm64
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "regression-fg"
     profile: "brokers-and-security"
@@ -374,7 +374,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "regression-fg"
     profile: "operators"
@@ -383,7 +383,7 @@ pipelines:
     strimzi_rbac_scope: "CLUSTER"
     cluster_operator_install_type: "yaml"
     parallel: 4
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "regression-fg"
     profile: "operands"
@@ -396,7 +396,7 @@ pipelines:
   ### Performance ###
   ###################
   # x86-64
-  - agent: "oracle-vm-8cpu-32gb-x86-64"
+  - agent: "cncf-ubuntu-8-32-x86"
     arch: "amd64"
     pipeline: "performance"
     profile: "performance"
@@ -406,7 +406,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 1
   # arm64
-  - agent: "oracle-vm-8cpu-32gb-arm64"
+  - agent: "cncf-ubuntu-8-32-arm"
     arch: "arm64"
     pipeline: "performance"
     profile: "performance"
@@ -420,7 +420,7 @@ pipelines:
   ##############
   # Bridge pipelines can use smaller agents similar to acceptance
   # x86-64
-  - agent: "oracle-vm-4cpu-16gb-x86-64"
+  - agent: "cncf-ubuntu-4-16-x86"
     arch: "amd64"
     pipeline: "bridge"
     profile: "azp_bridge"
@@ -430,7 +430,7 @@ pipelines:
     cluster_operator_install_type: "yaml"
     parallel: 2
   # arm64
-  - agent: "oracle-vm-4cpu-16gb-arm64"
+  - agent: "cncf-ubuntu-4-16-arm"
     arch: "arm64"
     pipeline: "bridge"
     profile: "azp_bridge"

--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -34,7 +34,7 @@ This actions has to be called separately for each architecture with matrix strat
     strategy:
       matrix:
         architecture: [amd64, arm64]
-    runs-on: oracle-vm-2cpu-8gb-arm64
+    runs-on: cncf-ubuntu-2-8-arm
     steps:
       - uses: actions/checkout@v6
       - uses: strimzi/github-actions/.github/actions/build/build-containers@v1
@@ -42,7 +42,7 @@ This actions has to be called separately for each architecture with matrix strat
           architecture: ${{ matrix.architecture }}
 ```
 
-As a runner we use `oracle-vm-2cpu-8gb-arm64` which is basically a small arm-based VM.
+As a runner we use `cncf-ubuntu-2-8-arm` which is basically a small arm-based VM.
 This runner allows us to build multi-arch images without any tweaks in our build mechanism (container runners from oracle cloud doesn't allow it).
 
 ## Supporting actions

--- a/.github/tests/expected/generate-matrix/matrix_pipelines_expected.json
+++ b/.github/tests/expected/generate-matrix/matrix_pipelines_expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "brokers-and-security",
@@ -12,7 +12,7 @@
     "jobName": "regression-brokers-and-security-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "operators",
@@ -24,7 +24,7 @@
     "jobName": "regression-operators-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "operands",
@@ -36,7 +36,7 @@
     "jobName": "regression-operands-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression",
     "profile": "brokers-and-security",
@@ -48,7 +48,7 @@
     "jobName": "regression-brokers-and-security-arm64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression",
     "profile": "operators",
@@ -60,7 +60,7 @@
     "jobName": "regression-operators-arm64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression",
     "profile": "operands",
@@ -72,7 +72,7 @@
     "jobName": "regression-operands-arm64"
   },
   {
-    "agent": "oracle-vm-2cpu-8gb-x86-64",
+    "agent": "cncf-ubuntu-2-8-x86",
     "arch": "amd64",
     "pipeline": "smoke",
     "profile": "smoke",
@@ -84,7 +84,7 @@
     "jobName": "smoke-amd64"
   },
   {
-    "agent": "oracle-vm-2cpu-8gb-arm64",
+    "agent": "cncf-ubuntu-2-8-arm",
     "arch": "arm64",
     "pipeline": "smoke",
     "profile": "smoke",

--- a/.github/tests/expected/generate-matrix/matrix_priority_expected.json
+++ b/.github/tests/expected/generate-matrix/matrix_priority_expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-2cpu-8gb-x86-64",
+    "agent": "cncf-ubuntu-2-8-x86",
     "arch": "amd64",
     "pipeline": "smoke",
     "profile": "smoke",
@@ -12,7 +12,7 @@
     "jobName": "smoke-amd64"
   },
   {
-    "agent": "oracle-vm-2cpu-8gb-arm64",
+    "agent": "cncf-ubuntu-2-8-arm",
     "arch": "arm64",
     "pipeline": "smoke",
     "profile": "smoke",

--- a/.github/tests/expected/generate-matrix/matrix_profiles_expected.json
+++ b/.github/tests/expected/generate-matrix/matrix_profiles_expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "operators",
@@ -12,7 +12,7 @@
     "jobName": "regression-operators-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression",
     "profile": "operators",
@@ -24,7 +24,7 @@
     "jobName": "regression-operators-arm64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "brokers-and-security",
@@ -36,7 +36,7 @@
     "jobName": "regression-brokers-and-security-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression",
     "profile": "brokers-and-security",
@@ -48,7 +48,7 @@
     "jobName": "regression-brokers-and-security-arm64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression-fg",
     "profile": "operators",
@@ -60,7 +60,7 @@
     "jobName": "regression-fg-operators-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression-fg",
     "profile": "operators",
@@ -72,7 +72,7 @@
     "jobName": "regression-fg-operators-arm64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression-fg",
     "profile": "brokers-and-security",
@@ -84,7 +84,7 @@
     "jobName": "regression-fg-brokers-and-security-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-arm64",
+    "agent": "cncf-ubuntu-8-32-arm",
     "arch": "arm64",
     "pipeline": "regression-fg",
     "profile": "brokers-and-security",

--- a/.github/tests/expected/generate-matrix/matrix_single_pipeline_expected.json
+++ b/.github/tests/expected/generate-matrix/matrix_single_pipeline_expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-4cpu-16gb-x86-64",
+    "agent": "cncf-ubuntu-4-16-x86",
     "arch": "amd64",
     "pipeline": "upgrade",
     "profile": "azp_kraft_upgrade",
@@ -12,7 +12,7 @@
     "jobName": "upgrade-azp_kraft_upgrade-amd64"
   },
   {
-    "agent": "oracle-vm-4cpu-16gb-x86-64",
+    "agent": "cncf-ubuntu-4-16-x86",
     "arch": "amd64",
     "pipeline": "upgrade",
     "profile": "azp_kafka_upgrade",
@@ -24,7 +24,7 @@
     "jobName": "upgrade-azp_kafka_upgrade-amd64"
   },
   {
-    "agent": "oracle-vm-4cpu-16gb-arm64",
+    "agent": "cncf-ubuntu-4-16-arm",
     "arch": "arm64",
     "pipeline": "upgrade",
     "profile": "azp_kraft_upgrade",
@@ -36,7 +36,7 @@
     "jobName": "upgrade-azp_kraft_upgrade-arm64"
   },
   {
-    "agent": "oracle-vm-4cpu-16gb-arm64",
+    "agent": "cncf-ubuntu-4-16-arm",
     "arch": "arm64",
     "pipeline": "upgrade",
     "profile": "azp_kafka_upgrade",

--- a/.github/tests/expected/generate-matrix/matrix_single_profile_expected.json
+++ b/.github/tests/expected/generate-matrix/matrix_single_profile_expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-2cpu-8gb-x86-64",
+    "agent": "cncf-ubuntu-2-8-x86",
     "arch": "amd64",
     "pipeline": "smoke",
     "profile": "smoke",
@@ -12,7 +12,7 @@
     "jobName": "smoke-amd64"
   },
   {
-    "agent": "oracle-vm-2cpu-8gb-arm64",
+    "agent": "cncf-ubuntu-2-8-arm",
     "arch": "arm64",
     "pipeline": "smoke",
     "profile": "smoke",

--- a/.github/tests/inputs/validate-matrix/valid_multiple.json
+++ b/.github/tests/inputs/validate-matrix/valid_multiple.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "brokers-and-security",
@@ -12,7 +12,7 @@
     "jobName": "regression-brokers-and-security-amd64"
   },
   {
-    "agent": "oracle-vm-8cpu-32gb-x86-64",
+    "agent": "cncf-ubuntu-8-32-x86",
     "arch": "amd64",
     "pipeline": "regression",
     "profile": "operators",
@@ -24,7 +24,7 @@
     "jobName": "regression-operators-amd64"
   },
   {
-    "agent": "oracle-vm-2cpu-8gb-x86-64",
+    "agent": "cncf-ubuntu-2-8-x86",
     "arch": "amd64",
     "pipeline": "smoke",
     "profile": "smoke",

--- a/.github/tests/inputs/validate-matrix/valid_single.json
+++ b/.github/tests/inputs/validate-matrix/valid_single.json
@@ -1,6 +1,6 @@
 [
   {
-    "agent": "oracle-vm-2cpu-8gb-x86-64",
+    "agent": "cncf-ubuntu-2-8-x86",
     "arch": "amd64",
     "pipeline": "smoke",
     "profile": "smoke",

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -270,7 +270,7 @@ jobs:
     strategy:
       matrix:
         architecture: [amd64, arm64]
-    runs-on: oracle-vm-2cpu-8gb-arm64
+    runs-on: cncf-ubuntu-2-8-arm
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

It seems that runners we currently uses are deprecated - https://cloud-native.slack.com/docs/T08PSQ7BQ/F09QFEJFPR8 . We should you new ones that are already available for us. AFAIK this should affect only this repository as on the other repos we use `ubuntu-latest`

### Checklist

- [x] Make sure all tests pass
- [ ] Update documentation

