### PR TITLE
Generate all CRDs in one go

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -177,41 +177,14 @@
                                 <argument>--yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.kafka.Kafka=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}040-Crd-kafka.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.connect.KafkaConnect=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}041-Crd-kafkaconnect.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.topic.KafkaTopic=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}043-Crd-kafkatopic.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.user.KafkaUser=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}044-Crd-kafkauser.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.bridge.KafkaBridge=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}046-Crd-kafkabridge.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.connector.KafkaConnector=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}047-Crd-kafkaconnector.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}048-Crd-kafkamirrormaker2.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.rebalance.KafkaRebalance=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}049-Crd-kafkarebalance.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.podset.StrimziPodSet=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}042-Crd-strimzipodset.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.nodepool.KafkaNodePool=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}045-Crd-kafkanodepool.yaml</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- This step generates CRDs apiextensions/v1 for resources which keep v1alpha1 and v1beta1.
-                             These should be only KafkaUser and KafkaTopic CRDs which need to keep the older versions
-                             in order to allow smooth upgrade of Topic and User Operators without deleting the operands
-                             (topics and users inside Kafka) when the CRDs are upgraded from apiextensions/v1beta1
-                             to apiextensions/v1. -->
-                        <id>generate-crd-co-install-v1-eo</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>java</executable>
-                            <arguments>
-                                <argument>-classpath</argument>
-                                <argument>${project.basedir}${file.separator}target${file.separator}classes${path.separator}${project.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
-                                <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
-                                <argument>--label</argument><argument>app:strimzi</argument>
-                                <argument>--label</argument><argument>strimzi.io/crd-install:true</argument>
-                                <argument>--target-kube</argument><argument>1.16+</argument>
-                                <argument>--crd-api-version</argument><argument>v1</argument>
-                                <argument>--api-versions</argument><argument>v1</argument>
-                                <argument>--storage-version</argument><argument>v1</argument>
-                                <argument>--yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.topic.KafkaTopic=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}043-Crd-kafkatopic.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.user.KafkaUser=${project.basedir}${file.separator}..${file.separator}packaging${file.separator}install${file.separator}cluster-operator${file.separator}044-Crd-kafkauser.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### Type of change

- Task

### Description

Historically, we have been generating `KafkaUser` and `KafkaTopic` CRDs in a separate run from the other CRDs. This is because they until 1.0.0 release supported also the super old `v1alpha1` and v1beta1` versions. That is not the case anymore. So this PR marges both runs together and generates all CRDs in one go.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally