### PR TITLE
per broker listener annotation and label template implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * New Cluster operator configuration option `STRIMZI_PKCS12_KEYSTORE_GENERATION` to disable generating PKCS12 stores in CA and Kafka user `Secret` resources.
 * Support for dependency scope configuration of Maven artifacts in Kafka Connect Build
+* Support for configuring per-broker listener annotation and label templates.
 * Add `UseBackgroundPodDeletion` feature gate (alpha, disabled by default) to use background deletion propagation when deleting pods during rolling updates. 
 * Strimzi Drain Cleaner updated to 1.6.0 (included in the Strimzi installation files)
 * Strimzi Access Operator updated to 0.3.0 - included in Strimzi installation files, examples, and documentation

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -30,7 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"brokerCertChainAndKey", "class", "externalTrafficPolicy", "loadBalancerSourceRanges", "bootstrap",
     "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService", "finalizers", "useServiceDnsDomain",
     "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType", "publishNotReadyAddresses",
-    "hostTemplate", "advertisedHostTemplate", "advertisedPortTemplate", "allocateLoadBalancerNodePorts"})
+    "perBrokerAnnotationsTemplate", "perBrokerLabelsTemplate", "hostTemplate", "advertisedHostTemplate", "advertisedPortTemplate", "allocateLoadBalancerNodePorts"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,
@@ -54,6 +54,8 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private List<IpFamily> ipFamilies;
     private Boolean createBootstrapService = true;
     private Boolean publishNotReadyAddresses;
+    private Map<String, String> perBrokerAnnotationsTemplate;
+    private Map<String, String> perBrokerLabelsTemplate;
     private String hostTemplate;
     private String advertisedHostTemplate;
     private String advertisedPortTemplate;
@@ -256,6 +258,28 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
 
     public void setPublishNotReadyAddresses(Boolean publishNotReadyAddresses) {
         this.publishNotReadyAddresses = publishNotReadyAddresses;
+    }
+
+    @Description("Configures the template for generating the annotations of the individual brokers. " +
+            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getPerBrokerAnnotationsTemplate() {
+        return perBrokerAnnotationsTemplate;
+    }
+
+    public void setPerBrokerAnnotationsTemplate(Map<String, String> perBrokerAnnotationsTemplate) {
+        this.perBrokerAnnotationsTemplate = perBrokerAnnotationsTemplate;
+    }
+
+    @Description("Configures the template for generating the labels of the individual brokers. " +
+            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getPerBrokerLabelsTemplate() {
+        return perBrokerLabelsTemplate;
+    }
+
+    public void setPerBrokerLabelsTemplate(Map<String, String> perBrokerLabelsTemplate) {
+        this.perBrokerLabelsTemplate = perBrokerLabelsTemplate;
     }
 
     @Description("Configures the template for generating the hostnames of the individual brokers. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -260,9 +260,9 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
         this.publishNotReadyAddresses = publishNotReadyAddresses;
     }
 
-    @Description("Configures the template for generating the annotations of the individual brokers. " +
-            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. " +
-            "Templating is only available for annotation values")
+    @Description("Configures the template used to generate annotations for individual brokers. " +
+            "You can use the `{nodeId}` and `{nodePodName}` placeholders in annotation values. " +
+            "Templating applies only to annotation values.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getPerBrokerAnnotationsTemplate() {
         return perBrokerAnnotationsTemplate;
@@ -272,9 +272,9 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
         this.perBrokerAnnotationsTemplate = perBrokerAnnotationsTemplate;
     }
 
-    @Description("Configures the template for generating the labels of the individual brokers. " +
-            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. " +
-            "Templating is only available for label values")
+    @Description("Configures the template used to generate labels for individual brokers. " +
+            "You can use the `{nodeId}` and `{nodePodName}` placeholders in label values. " +
+            "Templating applies only to label values.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getPerBrokerLabelsTemplate() {
         return perBrokerLabelsTemplate;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -261,7 +261,8 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     }
 
     @Description("Configures the template for generating the annotations of the individual brokers. " +
-            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`")
+            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. " +
+            "Templating is only available for annotation values")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getPerBrokerAnnotationsTemplate() {
         return perBrokerAnnotationsTemplate;
@@ -272,7 +273,8 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     }
 
     @Description("Configures the template for generating the labels of the individual brokers. " +
-            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`")
+            "Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. " +
+            "Templating is only available for label values")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getPerBrokerLabelsTemplate() {
         return perBrokerLabelsTemplate;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -819,8 +819,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                                 ports,
                                 pool.labels.strimziSelectorLabels().withStrimziPodName(node.podName()),
                                 ListenersUtils.serviceType(listener),
-                                ListenersUtils.brokerLabels(listener, node.nodeId()),
-                                ListenersUtils.brokerAnnotations(listener, node.nodeId()),
+                                ListenersUtils.brokerLabels(listener, node),
+                                ListenersUtils.brokerAnnotations(listener, node),
                                 ListenersUtils.ipFamilyPolicy(listener),
                                 ListenersUtils.ipFamilies(listener),
                                 ListenersUtils.publishNotReadyAddresses(listener)
@@ -943,8 +943,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                         Route route = new RouteBuilder()
                                 .withNewMetadata()
                                     .withName(routeName)
-                                    .withLabels(pool.labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(TemplateUtils.labels(pool.templatePerBrokerRoute), ListenersUtils.brokerLabels(listener, node.nodeId()))).toMap())
-                                    .withAnnotations(Util.mergeLabelsOrAnnotations(TemplateUtils.annotations(pool.templatePerBrokerRoute), ListenersUtils.brokerAnnotations(listener, node.nodeId())))
+                                    .withLabels(pool.labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(TemplateUtils.labels(pool.templatePerBrokerRoute), ListenersUtils.brokerLabels(listener, node))).toMap())
+                                    .withAnnotations(Util.mergeLabelsOrAnnotations(TemplateUtils.annotations(pool.templatePerBrokerRoute), ListenersUtils.brokerAnnotations(listener, node)))
                                     .withNamespace(namespace)
                                     .withOwnerReferences(pool.ownerReference)
                                 .endMetadata()
@@ -1081,8 +1081,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                         Ingress ingress = new IngressBuilder()
                                 .withNewMetadata()
                                     .withName(ingressName)
-                                    .withLabels(pool.labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(TemplateUtils.labels(pool.templatePerBrokerIngress), ListenersUtils.brokerLabels(listener, node.nodeId()))).toMap())
-                                    .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), TemplateUtils.annotations(pool.templatePerBrokerIngress), ListenersUtils.brokerAnnotations(listener, node.nodeId())))
+                                    .withLabels(pool.labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(TemplateUtils.labels(pool.templatePerBrokerIngress), ListenersUtils.brokerLabels(listener, node))).toMap())
+                                    .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), TemplateUtils.annotations(pool.templatePerBrokerIngress), ListenersUtils.brokerAnnotations(listener, node)))
                                     .withNamespace(namespace)
                                     .withOwnerReferences(pool.ownerReference)
                                 .endMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -376,6 +376,41 @@ public class ListenersUtils {
     }
 
     /**
+     * Renders a metadata template map for a specific Kafka node.
+     *
+     * @param template  Metadata template map whose values might contain placeholders
+     * @param node      Node for which the values should be rendered
+     * @return          Rendered metadata map or an empty map when no template is configured
+     */
+    private static Map<String, String> renderTemplateMap(Map<String, String> template, NodeRef node) {
+        if (template == null || template.isEmpty()) {
+            return Collections.emptyMap();
+        } else {
+            return template.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> renderHostTemplate(entry.getValue(), node)));
+        }
+    }
+
+    /**
+     * Finds broker service annotations. If no per-broker annotations are configured for the broker, the
+     * per-broker annotation template is rendered and returned instead.
+     *
+     * @param listener  Listener for which the annotations should be found
+     * @param node      Node reference for which we should get the configuration option
+     * @return          Map with DNS annotations or empty map if not specified
+     */
+    public static Map<String, String> brokerAnnotations(GenericKafkaListener listener, NodeRef node)    {
+        if (listener.getConfiguration() != null) {
+            Map<String, String> annotations = brokerAnnotations(listener, node.nodeId());
+            Map<String, String> renderedAnnotationsFromTemplate = renderTemplateMap(listener.getConfiguration().getPerBrokerAnnotationsTemplate(), node);
+
+            return annotations.isEmpty() ? renderedAnnotationsFromTemplate : annotations;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
      * Finds bootstrap service labels
      *
      * @param listener  Listener for which the load balancer IP should be found
@@ -406,6 +441,25 @@ public class ListenersUtils {
                     .map(GenericKafkaListenerConfigurationBroker::getLabels)
                     .findAny()
                     .orElse(Collections.emptyMap());
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Finds broker service labels. If no per-broker labels are configured for the broker, the per-broker label
+     * template is rendered and returned instead.
+     *
+     * @param listener  Listener for which the labels should be found
+     * @param node      Node reference for which we should get the configuration option
+     * @return          Map with labels or empty map if not specified
+     */
+    public static Map<String, String> brokerLabels(GenericKafkaListener listener, NodeRef node)    {
+        if (listener.getConfiguration() != null) {
+            Map<String, String> labels = brokerLabels(listener, node.nodeId());
+            Map<String, String> renderedLabels = renderTemplateMap(listener.getConfiguration().getPerBrokerLabelsTemplate(), node);
+
+            return labels.isEmpty() ? renderedLabels : labels;
         } else {
             return Collections.emptyMap();
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -402,9 +402,8 @@ public class ListenersUtils {
     public static Map<String, String> brokerAnnotations(GenericKafkaListener listener, NodeRef node)    {
         if (listener.getConfiguration() != null) {
             Map<String, String> annotations = brokerAnnotations(listener, node.nodeId());
-            Map<String, String> renderedAnnotationsFromTemplate = renderTemplateMap(listener.getConfiguration().getPerBrokerAnnotationsTemplate(), node);
 
-            return annotations.isEmpty() ? renderedAnnotationsFromTemplate : annotations;
+            return annotations.isEmpty() ? renderTemplateMap(listener.getConfiguration().getPerBrokerAnnotationsTemplate(), node) : annotations;
         } else {
             return Collections.emptyMap();
         }
@@ -457,9 +456,8 @@ public class ListenersUtils {
     public static Map<String, String> brokerLabels(GenericKafkaListener listener, NodeRef node)    {
         if (listener.getConfiguration() != null) {
             Map<String, String> labels = brokerLabels(listener, node.nodeId());
-            Map<String, String> renderedLabels = renderTemplateMap(listener.getConfiguration().getPerBrokerLabelsTemplate(), node);
 
-            return labels.isEmpty() ? renderedLabels : labels;
+            return labels.isEmpty() ? renderTemplateMap(listener.getConfiguration().getPerBrokerLabelsTemplate(), node) : labels;
         } else {
             return Collections.emptyMap();
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -362,7 +362,7 @@ public class ListenersUtils {
      * @param pod       Pod ID for which we should get the configuration option
      * @return          Map with DNS annotations or empty map if not specified
      */
-    public static Map<String, String> brokerAnnotations(GenericKafkaListener listener, int pod)    {
+    /* test */ static Map<String, String> brokerAnnotations(GenericKafkaListener listener, int pod)    {
         if (listener.getConfiguration() != null
                 && listener.getConfiguration().getBrokers() != null) {
             return listener.getConfiguration().getBrokers().stream()
@@ -433,7 +433,7 @@ public class ListenersUtils {
      * @param pod       Pod ID for which we should get the configuration option
      * @return          Map with labels or empty map if not specified
      */
-    public static Map<String, String> brokerLabels(GenericKafkaListener listener, int pod)    {
+    /* test */ static Map<String, String> brokerLabels(GenericKafkaListener listener, int pod)    {
         if (listener.getConfiguration() != null
                 && listener.getConfiguration().getBrokers() != null) {
             return listener.getConfiguration().getBrokers().stream()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -82,6 +82,7 @@ public class ListenersValidator {
                 validatePublishNotReadyAddresses(errors, listener);
                 validateCreateBootstrapService(errors, listener);
                 validateBrokerHostTemplate(errors, listener);
+                validatePerBrokerLabelsAndAnnotationsTemplates(errors, listener);
 
                 if (listener.getConfiguration().getBootstrap() != null) {
                     validateBootstrapHost(errors, listener);
@@ -345,6 +346,24 @@ public class ListenersValidator {
         if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()))
                 && listener.getConfiguration().getHostTemplate() != null)    {
             errors.add("listener " + listener.getName() + " cannot configure hostTemplate because it is not Route or Ingress based listener");
+        }
+    }
+
+    private static void validatePerBrokerLabelsAndAnnotationsTemplates(Set<String> errors, GenericKafkaListener listener) {
+        if (!KafkaListenerType.LOADBALANCER.equals(listener.getType())
+                && !KafkaListenerType.NODEPORT.equals(listener.getType())
+                && !KafkaListenerType.ROUTE.equals(listener.getType())
+                && !KafkaListenerType.INGRESS.equals(listener.getType())
+                && !KafkaListenerType.CLUSTER_IP.equals(listener.getType())) {
+            if (listener.getConfiguration().getPerBrokerLabelsTemplate() != null
+                    && !listener.getConfiguration().getPerBrokerLabelsTemplate().isEmpty()) {
+                errors.add("listener " + listener.getName() + " cannot configure perBrokerLabelsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");
+            }
+
+            if (listener.getConfiguration().getPerBrokerAnnotationsTemplate() != null
+                    && !listener.getConfiguration().getPerBrokerAnnotationsTemplate().isEmpty()) {
+                errors.add("listener " + listener.getName() + " cannot configure perBrokerAnnotationsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");
+            }
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -350,11 +350,7 @@ public class ListenersValidator {
     }
 
     private static void validatePerBrokerLabelsAndAnnotationsTemplates(Set<String> errors, GenericKafkaListener listener) {
-        if (!KafkaListenerType.LOADBALANCER.equals(listener.getType())
-                && !KafkaListenerType.NODEPORT.equals(listener.getType())
-                && !KafkaListenerType.ROUTE.equals(listener.getType())
-                && !KafkaListenerType.INGRESS.equals(listener.getType())
-                && !KafkaListenerType.CLUSTER_IP.equals(listener.getType())) {
+        if (KafkaListenerType.INTERNAL.equals(listener.getType())) {
             if (listener.getConfiguration().getPerBrokerLabelsTemplate() != null
                     && !listener.getConfiguration().getPerBrokerLabelsTemplate().isEmpty()) {
                 errors.add("listener " + listener.getName() + " cannot configure perBrokerLabelsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -769,7 +770,7 @@ public class KafkaClusterListenersTest {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
-        
+
         podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
             List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
             if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
@@ -956,7 +957,6 @@ public class KafkaClusterListenersTest {
         assertThat(brt.getMetadata().getName(), is(KafkaResources.bootstrapServiceName(CLUSTER)));
         assertThat(brt.getMetadata().getAnnotations().get("anno"), is("anno-value"));
         assertThat(brt.getMetadata().getLabels().get("label"), is("label-value"));
-
         // Check per pod router
         List<Route> routes = kc.generateExternalRoutes();
         assertThat(routes.size(), is(5));
@@ -976,6 +976,41 @@ public class KafkaClusterListenersTest {
                 assertThat(route.getMetadata().getLabels().get("label"), is(nullValue()));
             }
         }
+    }
+
+    @Test
+    public void testPerBrokerMetadataTemplates() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName("external")
+                                .withPort(9094)
+                                .withType(KafkaListenerType.LOADBALANCER)
+                                .withTls(true)
+                                .withNewConfiguration()
+                                    .withPerBrokerAnnotationsTemplate(Map.of("dns-anno", "dns-{nodeId}-{nodePodName}"))
+                                    .withPerBrokerLabelsTemplate(Map.of("label", "label-{nodeId}"))
+                                    .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                            .withBroker(3)
+                                            .withAnnotations(Map.of("dns-anno", "explicit-dns"))
+                                            .withLabels(Map.of("label", "explicit-label"))
+                                            .build())
+                                .endConfiguration()
+                                .build())
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+
+        Map<String, Service> services = kc.generatePerPodServices().stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
+
+        assertThat(services.get("foo-mixed-4").getMetadata().getAnnotations().get("dns-anno"), is("dns-4-foo-mixed-4"));
+        assertThat(services.get("foo-mixed-4").getMetadata().getLabels().get("label"), is("label-4"));
+        assertThat(services.get("foo-mixed-3").getMetadata().getAnnotations().get("dns-anno"), is("explicit-dns"));
+        assertThat(services.get("foo-mixed-3").getMetadata().getLabels().get("label"), is("explicit-label"));
     }
 
     @Test
@@ -1418,7 +1453,7 @@ public class KafkaClusterListenersTest {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
-        
+
         podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
             List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
@@ -1548,7 +1583,7 @@ public class KafkaClusterListenersTest {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
-        
+
         podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
             // Check Init container
             Container initCont = pod.getSpec().getInitContainers().stream().findAny().orElse(null);
@@ -1606,7 +1641,7 @@ public class KafkaClusterListenersTest {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
-        
+
         podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
             List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
@@ -2118,9 +2153,9 @@ public class KafkaClusterListenersTest {
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
-        
+
         assertThat(kc.getListeners().stream().findFirst().orElseThrow().getType(), is(KafkaListenerType.CLUSTER_IP));
-        
+
         List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
 
         podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -228,6 +229,33 @@ public class ListenersUtilsTest {
                                 .withLoadBalancerIP("130.211.204.1")
                                 .withAnnotations(Collections.singletonMap("dns-anno-2", "dns-value"))
                                 .withLabels(Collections.singletonMap("label-2", "label-value"))
+                                .build())
+            .endConfiguration()
+            .build();
+
+    private final GenericKafkaListener newLoadBalancerWithTemplates = new GenericKafkaListenerBuilder()
+            .withName("lb3")
+            .withPort(9907)
+            .withType(KafkaListenerType.LOADBALANCER)
+            .withTls(true)
+            .withNewConfiguration()
+                .withPerBrokerAnnotationsTemplate(Map.of("dns-anno", "dns-{nodeId}-{nodePodName}"))
+                .withPerBrokerLabelsTemplate(Map.of("label", "label-{nodeId}-{nodePodName}"))
+            .endConfiguration()
+            .build();
+
+    private final GenericKafkaListener newLoadBalancerWithTemplateOverrides = new GenericKafkaListenerBuilder()
+            .withName("lb4")
+            .withPort(9908)
+            .withType(KafkaListenerType.LOADBALANCER)
+            .withTls(true)
+            .withNewConfiguration()
+                .withPerBrokerAnnotationsTemplate(Map.of("dns-anno", "dns-{nodeId}", "dns-ttl", "60"))
+                .withPerBrokerLabelsTemplate(Map.of("label", "label-{nodeId}", "label-zone", "primary"))
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1)
+                                .withAnnotations(Collections.singletonMap("dns-anno", "explicit-dns"))
+                                .withLabels(Collections.singletonMap("label", "explicit-label"))
                                 .build())
             .endConfiguration()
             .build();
@@ -539,6 +567,14 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.brokerLabels(newTls, 1), is(emptyMap()));
         assertThat(ListenersUtils.brokerLabels(newNodePort, 1), is(emptyMap()));
         assertThat(ListenersUtils.brokerLabels(newNodePort3, 1), is(emptyMap()));
+
+        assertThat(ListenersUtils.brokerAnnotations(newLoadBalancerWithTemplates, NODE_1), is(Map.of("dns-anno", "dns-1-my-cluster-kafka-1")));
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancerWithTemplates, NODE_1), is(Map.of("label", "label-1-my-cluster-kafka-1")));
+
+        assertThat(ListenersUtils.brokerAnnotations(newLoadBalancerWithTemplateOverrides, NODE_0), is(Map.of("dns-anno", "dns-0", "dns-ttl", "60")));
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancerWithTemplateOverrides, NODE_0), is(Map.of("label", "label-0", "label-zone", "primary")));
+        assertThat(ListenersUtils.brokerAnnotations(newLoadBalancerWithTemplateOverrides, NODE_1), is(Map.of("dns-anno", "explicit-dns")));
+        assertThat(ListenersUtils.brokerLabels(newLoadBalancerWithTemplateOverrides, NODE_1), is(Map.of("label", "explicit-label")));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -233,6 +234,8 @@ public class ListenersValidatorTest {
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
+                    .withPerBrokerAnnotationsTemplate(Map.of("anno", "value-{nodeId}"))
+                    .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -274,6 +277,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
+                "listener " + name + " cannot configure perBrokerAnnotationsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
+                "listener " + name + " cannot configure perBrokerLabelsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
                 "listener " + name + " cannot configure hostTemplate because it is not Route or Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
@@ -312,6 +317,8 @@ public class ListenersValidatorTest {
                     .withAllocateLoadBalancerNodePorts(false)
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
+                    .withPerBrokerAnnotationsTemplate(Map.of("anno", "value-{nodeId}"))
+                    .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -394,6 +401,8 @@ public class ListenersValidatorTest {
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
                     .withAllocateLoadBalancerNodePorts(false)
+                    .withPerBrokerAnnotationsTemplate(Map.of("anno", "value-{nodeId}"))
+                    .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -482,6 +491,8 @@ public class ListenersValidatorTest {
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
+                    .withPerBrokerAnnotationsTemplate(Map.of("anno", "value-{nodeId}"))
+                    .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -587,6 +598,8 @@ public class ListenersValidatorTest {
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
                     .withAllocateLoadBalancerNodePorts(false)
+                    .withPerBrokerAnnotationsTemplate(Map.of("anno", "value-{nodeId}"))
+                    .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -850,6 +863,8 @@ public class ListenersValidatorTest {
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
+                    .withPerBrokerAnnotationsTemplate(Map.of("anno", "value-{nodeId}"))
+                    .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAllocateLoadBalancerNodePorts(false)
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -317,6 +317,12 @@ This property is used to select the preferred address type, which is checked fir
 |publishNotReadyAddresses
 |boolean
 |Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+|perBrokerAnnotationsTemplate
+|map
+|Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`.
+|perBrokerLabelsTemplate
+|map
+|Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`.
 |hostTemplate
 |string
 |Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -319,10 +319,10 @@ This property is used to select the preferred address type, which is checked fir
 |Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
 |perBrokerAnnotationsTemplate
 |map
-|Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for annotation values.
+|Configures the template used to generate annotations for individual brokers. You can use the `{nodeId}` and `{nodePodName}` placeholders in annotation values. Templating applies only to annotation values.
 |perBrokerLabelsTemplate
 |map
-|Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for label values.
+|Configures the template used to generate labels for individual brokers. You can use the `{nodeId}` and `{nodePodName}` placeholders in label values. Templating applies only to label values.
 |hostTemplate
 |string
 |Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -319,10 +319,10 @@ This property is used to select the preferred address type, which is checked fir
 |Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
 |perBrokerAnnotationsTemplate
 |map
-|Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`.
+|Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for annotation values.
 |perBrokerLabelsTemplate
 |map
-|Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`.
+|Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for label values.
 |hostTemplate
 |string
 |Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -307,12 +307,12 @@ spec:
                                 additionalProperties:
                                   type: string
                                 type: object
-                                description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for annotation values."
+                                description: "Configures the template used to generate annotations for individual brokers. You can use the `{nodeId}` and `{nodePodName}` placeholders in annotation values. Templating applies only to annotation values."
                               perBrokerLabelsTemplate:
                                 additionalProperties:
                                   type: string
                                 type: object
-                                description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for label values."
+                                description: "Configures the template used to generate labels for individual brokers. You can use the `{nodeId}` and `{nodePodName}` placeholders in label values. Templating applies only to label values."
                               hostTemplate:
                                 type: string
                                 description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -307,12 +307,12 @@ spec:
                                 additionalProperties:
                                   type: string
                                 type: object
-                                description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
+                                description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for annotation values."
                               perBrokerLabelsTemplate:
                                 additionalProperties:
                                   type: string
                                 type: object
-                                description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
+                                description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for label values."
                               hostTemplate:
                                 type: string
                                 description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -303,6 +303,16 @@ spec:
                               publishNotReadyAddresses:
                                 type: boolean
                                 description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+                              perBrokerAnnotationsTemplate:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
+                              perBrokerLabelsTemplate:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
                               hostTemplate:
                                 type: string
                                 description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -302,6 +302,16 @@ spec:
                             publishNotReadyAddresses:
                               type: boolean
                               description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+                            perBrokerAnnotationsTemplate:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
+                            perBrokerLabelsTemplate:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
                             hostTemplate:
                               type: string
                               description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -306,12 +306,12 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                              description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for annotation values."
+                              description: "Configures the template used to generate annotations for individual brokers. You can use the `{nodeId}` and `{nodePodName}` placeholders in annotation values. Templating applies only to annotation values."
                             perBrokerLabelsTemplate:
                               additionalProperties:
                                 type: string
                               type: object
-                              description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for label values."
+                              description: "Configures the template used to generate labels for individual brokers. You can use the `{nodeId}` and `{nodePodName}` placeholders in label values. Templating applies only to label values."
                             hostTemplate:
                               type: string
                               description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -306,12 +306,12 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                              description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
+                              description: "Configures the template for generating the annotations of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for annotation values."
                             perBrokerLabelsTemplate:
                               additionalProperties:
                                 type: string
                               type: object
-                              description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`."
+                              description: "Configures the template for generating the labels of the individual brokers. Valid placeholders that you can use in the template values are `{nodeId}` and `{nodePodName}`. Templating is only available for label values."
                             hostTemplate:
                               type: string
                               description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."


### PR DESCRIPTION
### Type of change

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This PR fixes https://github.com/strimzi/strimzi-kafka-operator/issues/12167 and implements proposal https://github.com/strimzi/proposals/blob/main/142-per-broker-annotation-and-label-templates.md

The new listener configuration fields are:

* `perBrokerAnnotationsTemplate`
* `perBrokerLabelsTemplate`

These fields let users generate repeated metadata for per-broker listener resources without configuring the same keys separately for every broker. Template values support:

* `{nodeId}` - replaced with the Kafka node ID
* `{nodePodName}` - replaced with the Kafka pod name

Broker-specific `brokers[].annotations` and `brokers[].labels` continue to take precedence for the matching broker. Bootstrap metadata remains configured separately through `configuration.bootstrap` and is not affected by the per-broker templates.

The new template fields are validated so they are only accepted for listener types that create per-broker resources:

* `loadbalancer`
* `nodeport`
* `route`
* `ingress`
* `cluster-ip`

This PR updates the Kafka CRD schema, Helm chart CRD schema, generated API reference, and changelog entry.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles (no RBAC changes required)
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally (Kubernetes / Colima steps included below; OpenShift not run)
- [x] Reference relevant issue(s) and close them after merging (N/A: no linked issue)
- [x] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards (N/A: no visual changes)

### Testing

Generated CRDs were refreshed and checked:

```shell
make crd_install
```

Focused listener tests passed:

```shell
mvn -pl cluster-operator -am -DskipITs -Dtest=KafkaClusterListenersTest,ListenersUtilsTest,ListenersValidatorTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result:

```text
Tests run: 95, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Manual Kubernetes validation with Colima

These steps validate the change in a real local Kubernetes cluster by installing the branch operator image, creating a lightweight Kafka cluster with a `cluster-ip` listener, and checking the generated per-broker `Service` metadata. 

1. Start Colima with Docker and Kubernetes:

```shell
colima start --runtime docker --kubernetes
kubectl config use-context colima
kubectl get nodes
docker info --format 'Docker architecture: {{.Architecture}}'
```

2. Built the Maven distribution ZIPs required by the operator image:

```shell
make MVN_ARGS="-DskipTests" java_install

ls docker-images/artifacts/binaries/topic-operator-1.1.0-SNAPSHOT-dist.zip \
   docker-images/artifacts/binaries/user-operator-1.1.0-SNAPSHOT-dist.zip \
   docker-images/artifacts/binaries/cluster-operator-1.1.0-SNAPSHOT-dist.zip \
   docker-images/artifacts/binaries/kafka-init-1.1.0-SNAPSHOT-dist.zip
```

3. Built the local Strimzi images.

```shell
make -C docker-images/operator clean
DOCKER_ARCHITECTURE=arm64 DOCKER_BUILD_ARGS="--no-cache --build-arg TARGETOS=linux --build-arg TARGETARCH=arm64" make -C docker-images/base docker_build
DOCKER_ARCHITECTURE=arm64 DOCKER_BUILD_ARGS=--no-cache make -C docker-images/operator docker_build
```

4. Install the operator into a validation namespace. 

```shell
NS=strimzi-pr-validation
TMP_INSTALL="$(mktemp -d)"

kubectl create namespace "${NS}"
cp packaging/install/cluster-operator/*.yaml "${TMP_INSTALL}/"
sed -i.bak "s/namespace: myproject/namespace: ${NS}/g" "${TMP_INSTALL}"/*.yaml
rm "${TMP_INSTALL}"/*.bak

kubectl apply -n "${NS}" -f "${TMP_INSTALL}"

kubectl -n "${NS}" set image deployment/strimzi-cluster-operator \
  strimzi-cluster-operator=strimzi/operator:latest

kubectl -n "${NS}" patch deployment strimzi-cluster-operator --type=merge -p \
  '{"spec":{"template":{"spec":{"containers":[{"name":"strimzi-cluster-operator","imagePullPolicy":"IfNotPresent"}]}}}}'

kubectl -n "${NS}" rollout status deployment/strimzi-cluster-operator --timeout=180s
```

6. Confirmed the installed Kafka CRD contains the new fields:

```shell
kubectl get crd kafkas.kafka.strimzi.io -o yaml | grep perBrokerAnnotationsTemplate
kubectl get crd kafkas.kafka.strimzi.io -o yaml | grep perBrokerLabelsTemplate
```

7. Applied Kafka cluster CR's that uses the new templates:

```shell
kubectl apply -n "${NS}" -f - <<'EOF'
apiVersion: kafka.strimzi.io/v1
kind: KafkaNodePool
metadata:
  name: dual-role
  labels:
    strimzi.io/cluster: my-cluster
spec:
  replicas: 1
  roles:
    - controller
    - broker
  storage:
    type: jbod
    volumes:
      - id: 0
        type: ephemeral
        kraftMetadata: shared
---
apiVersion: kafka.strimzi.io/v1
kind: Kafka
metadata:
  name: my-cluster
spec:
  kafka:
    version: 4.2.0
    metadataVersion: 4.2-IV1
    listeners:
      - name: plain
        port: 9092
        type: internal
        tls: false
      - name: clusterip
        port: 9094
        type: cluster-ip
        tls: false
        configuration:
          perBrokerAnnotationsTemplate:
            validation.strimzi.io/node: "node-{nodeId}"
            validation.strimzi.io/pod: "pod-{nodePodName}"
          perBrokerLabelsTemplate:
            validation-node: "node-{nodeId}"
            validation-pod: "pod-{nodePodName}"
    config:
      offsets.topic.replication.factor: 1
      transaction.state.log.replication.factor: 1
      transaction.state.log.min.isr: 1
      default.replication.factor: 1
      min.insync.replicas: 1
EOF
```

8. Wait for readiness and list the generated services:

```shell
kubectl -n "${NS}" wait kafka/my-cluster --for=condition=Ready --timeout=900s
kubectl -n "${NS}" get pods -l strimzi.io/cluster=my-cluster -o wide
kubectl -n "${NS}" get svc -l strimzi.io/cluster=my-cluster -o wide
```

9. Validate that the per-broker `ClusterIP` service has metadata rendered from `{nodeId}` and `{nodePodName}`:

<img width="2451" height="146" alt="Screenshot 2026-05-13 at 4 56 56 PM" src="https://github.com/user-attachments/assets/89968a0a-58ba-4cd5-acdd-5436a502ba00" />

```shell
kubectl -n "${NS}" get svc my-cluster-dual-role-clusterip-0 -o jsonpath='labels.validation-node={.metadata.labels.validation-node}{"\n"}labels.validation-pod={.metadata.labels.validation-pod}{"\n"}annotations.validation.strimzi.io/node={.metadata.annotations.validation\.strimzi\.io/node}{"\n"}annotations.validation.strimzi.io/pod={.metadata.annotations.validation\.strimzi\.io/pod}{"\n"}'
```

Expected output:

```text
labels.validation-node=node-0
labels.validation-pod=pod-my-cluster-dual-role-0
annotations.validation.strimzi.io/node=node-0
annotations.validation.strimzi.io/pod=pod-my-cluster-dual-role-0
```

10. Validate the same generated service metadata from inside a Kubernetes Pod:

<img width="2444" height="238" alt="Screenshot 2026-05-13 at 4 57 12 PM" src="https://github.com/user-attachments/assets/cc117ffa-6f46-4781-9d73-93f20e30ade1" />

```shell
kubectl -n "${NS}" run kubectl-check --rm -i --restart=Never \
  --image=registry.k8s.io/kubectl:v1.30.2 \
  --overrides='{"spec":{"serviceAccountName":"strimzi-cluster-operator"}}' \
  -- get svc my-cluster-dual-role-clusterip-0 \
  -o jsonpath='labels.validation-node={.metadata.labels.validation-node}{"\n"}labels.validation-pod={.metadata.labels.validation-pod}{"\n"}annotations.validation.strimzi.io/node={.metadata.annotations.validation\.strimzi\.io/node}{"\n"}annotations.validation.strimzi.io/pod={.metadata.annotations.validation\.strimzi\.io/pod}{"\n"}'
```

Expected output:

```text
labels.validation-node=node-0
labels.validation-pod=pod-my-cluster-dual-role-0
annotations.validation.strimzi.io/node=node-0
annotations.validation.strimzi.io/pod=pod-my-cluster-dual-role-0
pod "kubectl-check" deleted
```