### PR TITLE
fix typo in keycloak-authorization examples

### DIFF
--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz-metrics.yaml
@@ -66,7 +66,7 @@ spec:
         volumes:
           - name: oauth-certs
             secret:
-              name: oauth-server-cert
+              secretName: oauth-server-cert
       kafkaContainer:
         volumeMounts:
           - name: oauth-certs

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -66,7 +66,7 @@ spec:
         volumes:
           - name: oauth-certs
             secret:
-              name: oauth-server-cert
+              secretName: oauth-server-cert
       kafkaContainer:
         volumeMounts:
           - name: oauth-certs


### PR DESCRIPTION
closes #12745

### Type of change

_Select the type of your PR_

- Documentation

### Description

Fix typo in examples/security/keycloak-authorization as reported in https://github.com/strimzi/strimzi-kafka-operator/issues/12745

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

