### PR TITLE
Add TLSRoute type listener (Gateway API support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Apache Kafka 4.3.0 and remove support for Kafka 4.1.x
 * New Cluster operator configuration option `STRIMZI_PKCS12_KEYSTORE_GENERATION` to disable generating PKCS12 stores in CA and Kafka user `Secret` resources.
+* Support for Gateway API-based `type: tlsroute` listener
 * Support for dependency scope configuration of Maven artifacts in Kafka Connect Build
 * Support for configuring per-broker listener annotation and label templates.
 * Add `UseBackgroundPodDeletion` feature gate (alpha, disabled by default) to use background deletion propagation when deleting pods during rolling updates. 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>kubernetes-model-apiextensions</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-gatewayapi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -337,9 +337,9 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
         this.allocateLoadBalancerNodePorts = allocateLoadBalancerNodePorts;
     }
 
-    @Description("Configures the resource(s) TLSRoutes created by this listener will be attached to.\n" +
-            "Typically this would be Gateway resource.\n" +
-            "For `tlsroute` listeners only.")
+    @Description("For `tlsroute` listeners only.\n" +
+            "Configures the Gateway API resource or resources that generated `TLSRoute` resources attach to.\n" +
+            "Typically, this is a `Gateway` resource.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @ExternalLink(url = "https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#parentreference")
     public List<ParentReference> getParentRefs() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.ExternalLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -340,6 +341,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
             "Typically this would be Gateway resource.\n" +
             "For `tlsroute` listeners only.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @ExternalLink(url = "https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#parentreference")
     public List<ParentReference> getParentRefs() {
         return parentRefs;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.kafka.listener;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReference;
 import io.strimzi.api.kafka.model.common.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
@@ -30,7 +31,8 @@ import java.util.Map;
 @JsonPropertyOrder({"brokerCertChainAndKey", "class", "externalTrafficPolicy", "loadBalancerSourceRanges", "bootstrap",
     "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService", "finalizers", "useServiceDnsDomain",
     "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType", "publishNotReadyAddresses",
-    "perBrokerAnnotationsTemplate", "perBrokerLabelsTemplate", "hostTemplate", "advertisedHostTemplate", "advertisedPortTemplate", "allocateLoadBalancerNodePorts"})
+    "perBrokerAnnotationsTemplate", "perBrokerLabelsTemplate", "hostTemplate", "advertisedHostTemplate",
+    "advertisedPortTemplate", "allocateLoadBalancerNodePorts", "parentRefs"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,
@@ -61,6 +63,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private String advertisedPortTemplate;
     private Map<String, Object> additionalProperties;
     private Boolean allocateLoadBalancerNodePorts;
+    private List<ParentReference> parentRefs;
 
     @Description("Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. " +
             "The certificate can optionally contain the whole chain. " +
@@ -333,6 +336,17 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
         this.allocateLoadBalancerNodePorts = allocateLoadBalancerNodePorts;
     }
 
+    @Description("Configures the resource(s) TLSRoutes created by this listener will be attached to.\n" +
+            "Typically this would be Gateway resource.\n" +
+            "For `tlsroute` listeners only.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<ParentReference> getParentRefs() {
+        return parentRefs;
+    }
+
+    public void setParentRefs(List<ParentReference> parentRefs) {
+        this.parentRefs = parentRefs;
+    }
 
     @Override
     public Map<String, Object> getAdditionalProperties() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerType.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum KafkaListenerType {
     INTERNAL,
     ROUTE,
+    TLSROUTE,
     LOADBALANCER,
     NODEPORT,
     INGRESS,
@@ -17,41 +18,28 @@ public enum KafkaListenerType {
 
     @JsonCreator
     public static KafkaListenerType forValue(String value) {
-        switch (value) {
-            case "internal":
-                return INTERNAL;
-            case "route":
-                return ROUTE;
-            case "loadbalancer":
-                return LOADBALANCER;
-            case "nodeport":
-                return NODEPORT;
-            case "ingress":
-                return INGRESS;
-            case "cluster-ip":
-                return CLUSTER_IP;
-            default:
-                return null;
-        }
+        return switch (value) {
+            case "internal" -> INTERNAL;
+            case "route" -> ROUTE;
+            case "tlsroute" -> TLSROUTE;
+            case "loadbalancer" -> LOADBALANCER;
+            case "nodeport" -> NODEPORT;
+            case "ingress" -> INGRESS;
+            case "cluster-ip" -> CLUSTER_IP;
+            default -> null;
+        };
     }
 
     @JsonValue
     public String toValue() {
-        switch (this) {
-            case INTERNAL:
-                return "internal";
-            case ROUTE:
-                return "route";
-            case LOADBALANCER:
-                return "loadbalancer";
-            case NODEPORT:
-                return "nodeport";
-            case INGRESS:
-                return "ingress";
-            case CLUSTER_IP:
-                return "cluster-ip";
-            default:
-                return null;
-        }
+        return switch (this) {
+            case INTERNAL -> "internal";
+            case ROUTE -> "route";
+            case TLSROUTE -> "tlsroute";
+            case LOADBALANCER -> "loadbalancer";
+            case NODEPORT -> "nodeport";
+            case INGRESS -> "ingress";
+            case CLUSTER_IP -> "cluster-ip";
+        };
     }
 }

--- a/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaCrdIT.java
@@ -101,7 +101,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 KubernetesClientException.class,
                 () -> createDeleteCustomResource("Kafka-with-invalid-listener.yaml"));
 
-        assertThat(exception.getMessage(), containsStringIgnoringCase("spec.kafka.listeners[1].type: Unsupported value: \"foobar\": supported values: \"internal\", \"route\", \"loadbalancer\", \"nodeport\", \"ingress\", \"cluster-ip\""));
+        assertThat(exception.getMessage(), containsStringIgnoringCase("spec.kafka.listeners[1].type: Unsupported value: \"foobar\": supported values: \"internal\", \"route\", \"tlsroute\", \"loadbalancer\", \"nodeport\", \"ingress\", \"cluster-ip\""));
     }
 
     @Test

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -96,6 +96,10 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-gatewayapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.strimzi.operator.common.Util;
@@ -28,6 +29,7 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
     private boolean routes = false;
     private boolean builds = false;
     private boolean images = false;
+    private boolean tlsRoutes = false;
     private KubernetesVersion kubernetesVersion;
 
     /**
@@ -59,6 +61,9 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
             return checkApiAvailability(vertx, client, "image.openshift.io", "v1");
         }).compose(supported -> {
             pfa.setImages(supported);
+            return checkApiAvailability(vertx, client, "gateway.networking.k8s.io", "v1", "TLSRoute");
+        }).compose(supported -> {
+            pfa.setTLSRoutes(supported);
             return Future.succeededFuture(pfa);
         }).onComplete(pfaPromise);
 
@@ -162,16 +167,64 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
         });
     }
 
+    /**
+     * Checks whether a specific resource kind is supported or not. This check is useful for APIs where different
+     * resources use different API versions and chercking the group support is not sufficient (such as Gateway API).
+     *
+     * @param vertx     Vert.x instance
+     * @param client    Kubernetes client
+     * @param group     API group to check
+     * @param version   API version to check
+     * @param kind      Resource kind to check
+     *
+     * @return  Future that completes with true when the resource kind is supported in version or false when not.
+     */
+    private static Future<Boolean> checkApiAvailability(Vertx vertx, KubernetesClient client, String group, String version, String kind)   {
+        return vertx.executeBlocking(() -> {
+            try {
+                APIResourceList apiGroupResources = client.getApiResources(group + "/" + version);
+                boolean supported;
+
+                if (apiGroupResources != null)   {
+                    supported = apiGroupResources.getResources().stream().anyMatch(r -> kind.equals(r.getKind()));
+                } else {
+                    supported = false;
+                }
+
+                LOGGER.warn("Kind {} in API Group {} is {}supported", kind, group, supported ? "" : "not ");
+                return supported;
+            } catch (Exception e) {
+                LOGGER.error("Detection of API availability failed.", e);
+                throw e;
+            }
+        });
+    }
+
     private PlatformFeaturesAvailability() {}
 
     /**
      * This constructor is used in tests. It sets all OpenShift APIs to true or false depending on the isOpenShift parameter
      *
-     * @param isOpenShift           Set all OpenShift APIs to true
-     * @param kubernetesVersion     Set the Kubernetes version
+     * @param isOpenShift       Set all OpenShift APIs to true
+     * @param kubernetesVersion Set the Kubernetes version
      */
     public PlatformFeaturesAvailability(boolean isOpenShift, KubernetesVersion kubernetesVersion) {
         this.kubernetesVersion = kubernetesVersion;
+        this.routes = isOpenShift;
+        this.images = isOpenShift;
+        this.builds = isOpenShift;
+    }
+
+    /**
+     * This constructor is used in tests. It sets all OpenShift APIs to true or false depending on the isOpenShift parameter
+     *
+     * @param isOpenShift       Set all OpenShift APIs to true
+     * @param hasTlsRoutes      Set TLS Routes support
+     * @param kubernetesVersion Set the Kubernetes version
+     */
+    public PlatformFeaturesAvailability(boolean isOpenShift, boolean hasTlsRoutes, KubernetesVersion kubernetesVersion) {
+        this.kubernetesVersion = kubernetesVersion;
+        this.tlsRoutes = hasTlsRoutes;
         this.routes = isOpenShift;
         this.images = isOpenShift;
         this.builds = isOpenShift;
@@ -239,6 +292,19 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
         return hasBuilds() && hasImages();
     }
 
+    /**
+     * Checks if Gateway API v1 TLSRoutes are supported on this cluster.
+     *
+     * @return  True if Gateway API v1 TLSRoutes are supported on this cluster
+     */
+    public boolean hasTLSRoutes() {
+        return tlsRoutes;
+    }
+
+    private void setTLSRoutes(boolean tlsRoutes) {
+        this.tlsRoutes = tlsRoutes;
+    }
+
     @Override
     public String toString() {
         return "PlatformFeaturesAvailability(" +
@@ -246,6 +312,7 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
                 ",OpenShiftRoutes=" + routes +
                 ",OpenShiftBuilds=" + builds +
                 ",OpenShiftImageStreams=" + images +
+                ",TLSRoutes=" + tlsRoutes +
                 ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -17,6 +17,10 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.BackendRefBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRoute;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRouteBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRouteRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPath;
 import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPathBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
@@ -169,6 +173,11 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      * Port used by the Ingress listeners
      */
     public static final int INGRESS_PORT = 443;
+
+    /**
+     * Port used by the TLSRoute listeners
+     */
+    public static final int TLSROUTE_PORT = 443;
 
     protected static final String KAFKA_NAME = "kafka";
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_NAME = "kafka-metrics-and-logging";
@@ -966,6 +975,84 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                         if (host != null) {
                             route.getSpec().setHost(host);
                         }
+
+                        routes.add(route);
+                    }
+                }
+            }
+        }
+
+        return routes;
+    }
+
+    /**
+     * Generates a list of bootstrap TLS Route which can be used to bootstrap clients outside a Gateway APi enabled
+     * Kubernetes cluster.
+     *
+     * @return The list of generated TLSRoutes
+     */
+    public List<TLSRoute> generateExternalBootstrapTlsRoutes() {
+        List<GenericKafkaListener> routeListeners = ListenersUtils.tlsRouteListeners(listeners);
+        List<TLSRoute> routes = new ArrayList<>(routeListeners.size());
+
+        for (GenericKafkaListener listener : routeListeners)   {
+            TLSRoute route = new TLSRouteBuilder()
+                    .withNewMetadata()
+                        .withName(ListenersUtils.backwardsCompatibleBootstrapRouteOrIngressName(cluster, listener))
+                        .withLabels(Util.mergeLabelsOrAnnotations(labels.withAdditionalLabels(TemplateUtils.labels(templateBootstrapRoute)).toMap(), ListenersUtils.bootstrapLabels(listener)))
+                        .withAnnotations(Util.mergeLabelsOrAnnotations(TemplateUtils.annotations(templateBootstrapRoute), ListenersUtils.bootstrapAnnotations(listener)))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(ownerReference)
+                    .endMetadata()
+                    .withNewSpec()
+                        .withParentRefs(listener.getConfiguration().getParentRefs())
+                        .withHostnames(ListenersUtils.bootstrapHost(listener))
+                        .withRules(new TLSRouteRuleBuilder()
+                                .withBackendRefs(new BackendRefBuilder()
+                                        .withName(ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener))
+                                        .withPort(listener.getPort())
+                                        .build())
+                                .build())
+                    .endSpec()
+                    .build();
+            routes.add(route);
+        }
+
+        return routes;
+    }
+
+    /**
+     * Generates list of per-pod TLS Routes. These Routes are used for exposing the Kafka cluster externally using Gateway API.
+     *
+     * @return The list with generated TLSRoutes
+     */
+    public List<TLSRoute> generateExternalTlsRoutes() {
+        List<GenericKafkaListener> routeListeners = ListenersUtils.tlsRouteListeners(listeners);
+        List<TLSRoute> routes = new ArrayList<>();
+
+        for (GenericKafkaListener listener : routeListeners)   {
+            for (KafkaPool pool : nodePools)    {
+                if (pool.isBroker()) {
+                    for (NodeRef node : pool.nodes()) {
+                        TLSRoute route = new TLSRouteBuilder()
+                                .withNewMetadata()
+                                    .withName(ListenersUtils.backwardsCompatiblePerBrokerServiceName(pool.componentName, node.nodeId(), listener))
+                                    .withLabels(pool.labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(TemplateUtils.labels(pool.templatePerBrokerRoute), ListenersUtils.brokerLabels(listener, node))).toMap())
+                                    .withAnnotations(Util.mergeLabelsOrAnnotations(TemplateUtils.annotations(pool.templatePerBrokerRoute), ListenersUtils.brokerAnnotations(listener, node)))
+                                    .withNamespace(namespace)
+                                    .withOwnerReferences(pool.ownerReference)
+                                .endMetadata()
+                                .withNewSpec()
+                                    .withParentRefs(listener.getConfiguration().getParentRefs())
+                                    .withHostnames(ListenersUtils.brokerHost(listener, node))
+                                    .withRules(new TLSRouteRuleBuilder()
+                                            .withBackendRefs(new BackendRefBuilder()
+                                                    .withName(ListenersUtils.backwardsCompatiblePerBrokerServiceName(pool.componentName, node.nodeId(), listener))
+                                                    .withPort(listener.getPort())
+                                                    .build())
+                                            .build())
+                                .endSpec()
+                                .build();
 
                         routes.add(route);
                     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -986,7 +986,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
-     * Generates a list of bootstrap TLS Route which can be used to bootstrap clients outside a Gateway APi enabled
+     * Generates a list of bootstrap TLS Route which can be used to bootstrap clients outside a Gateway API enabled
      * Kubernetes cluster.
      *
      * @return The list of generated TLSRoutes

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -80,6 +80,17 @@ public class ListenersUtils {
     }
 
     /**
+     * Returns list of all TLSRoute type listeners
+     *
+     * @param listeners List of all listeners
+     *
+     * @return          List of route listeners
+     */
+    public static List<GenericKafkaListener> tlsRouteListeners(List<GenericKafkaListener> listeners)    {
+        return listenersByType(listeners, KafkaListenerType.TLSROUTE);
+    }
+
+    /**
      * Returns list of all LoadBalancer type listeners
      *
      * @param listeners List of all listeners

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -80,11 +80,11 @@ public class ListenersUtils {
     }
 
     /**
-     * Returns list of all TLSRoute type listeners
+     * Returns a list of all Gateway API TLS Route type listeners
      *
      * @param listeners List of all listeners
      *
-     * @return          List of route listeners
+     * @return          List of Gateway API TLS Route type listeners
      */
     public static List<GenericKafkaListener> tlsRouteListeners(List<GenericKafkaListener> listeners)    {
         return listenersByType(listeners, KafkaListenerType.TLSROUTE);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -83,6 +83,7 @@ public class ListenersValidator {
                 validateCreateBootstrapService(errors, listener);
                 validateBrokerHostTemplate(errors, listener);
                 validatePerBrokerLabelsAndAnnotationsTemplates(errors, listener);
+                validateParentRefs(errors, listener);
 
                 if (listener.getConfiguration().getBootstrap() != null) {
                     validateBootstrapHost(errors, listener);
@@ -111,6 +112,10 @@ public class ListenersValidator {
 
             if (KafkaListenerType.INGRESS.equals(listener.getType()))    {
                 validateIngress(errors, brokerNodes, listener);
+            }
+
+            if (KafkaListenerType.TLSROUTE.equals(listener.getType()))    {
+                validateTlsRoute(errors, brokerNodes, listener);
             }
         }
 
@@ -186,6 +191,45 @@ public class ListenersValidator {
             }
         } else {
             errors.add("listener " + listener.getName() + " is missing a configuration with host properties which are required for Ingress based listeners");
+        }
+    }
+
+    /**
+     * Validates that TLSRoute type listener has the right host configurations
+     *
+     * @param errors        List where any found errors will be added
+     * @param brokerNodes   Broker nodes which are part of this Kafka cluster
+     * @param listener      Listener which needs to be validated
+     */
+    private static void validateTlsRoute(Set<String> errors, Set<NodeRef> brokerNodes, GenericKafkaListener listener) {
+        if (listener.getConfiguration() != null)    {
+            GenericKafkaListenerConfiguration conf = listener.getConfiguration();
+
+            if (conf.getParentRefs() == null)   {
+                errors.add("listener " + listener.getName() + " is missing a parent references property which is required for TLSRoute based listeners");
+            }
+
+            if (conf.getBootstrap() == null
+                    || conf.getBootstrap().getHost() == null)   {
+                errors.add("listener " + listener.getName() + " is missing a bootstrap host property which is required for TLSRoute based listeners");
+            }
+
+            if (conf.getHostTemplate() != null) {
+                // nothing to do => when the template is set, we do not care about the per-broker configurations
+            } else if (conf.getBrokers() != null) {
+                for (NodeRef node : brokerNodes)    {
+                    GenericKafkaListenerConfigurationBroker broker = conf.getBrokers().stream().filter(b -> b.getBroker() == node.nodeId()).findFirst().orElse(null);
+
+                    if (broker == null || broker.getHost() == null) {
+                        errors.add("listener " + listener.getName() + " is missing a broker host property for broker with ID " + node.nodeId() + " which is required for TLSRoute based listeners");
+                    }
+                }
+            } else {
+                errors.add("listener " + listener.getName() + " is missing a broker configuration with host properties which are required for TLSRoute based listeners");
+            }
+        } else {
+            errors.add("listener " + listener.getName() + " is missing a configuration with host properties which are required for TLSRoute based listeners");
+            errors.add("listener " + listener.getName() + " is missing a parent references property which is required for TLSRoute based listeners");
         }
     }
 
@@ -337,15 +381,15 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that hostTemplate is used only with Route or Ingress type listener
+     * Validates that hostTemplate is used only with TLSRoute, Route, or Ingress type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
      */
     private static void validateBrokerHostTemplate(Set<String> errors, GenericKafkaListener listener) {
-        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()))
+        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()) && !KafkaListenerType.TLSROUTE.equals(listener.getType()))
                 && listener.getConfiguration().getHostTemplate() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure hostTemplate because it is not Route or Ingress based listener");
+            errors.add("listener " + listener.getName() + " cannot configure hostTemplate because it is not TLSRoute, Route, or Ingress based listener");
         }
     }
 
@@ -364,15 +408,28 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that bootstrap.host is used only with Route or Ingress type listener
+     * Validates that parent reference is used only with TLSRoute type listener
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validateParentRefs(Set<String> errors, GenericKafkaListener listener) {
+        if (!KafkaListenerType.TLSROUTE.equals(listener.getType())
+                && listener.getConfiguration().getParentRefs() != null)    {
+            errors.add("listener " + listener.getName() + " cannot configure parentRefs because it is not TLSRoute based listener");
+        }
+    }
+
+    /**
+     * Validates that bootstrap.host is used only with TLSRoute, Route, or Ingress type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
      */
     private static void validateBootstrapHost(Set<String> errors, GenericKafkaListener listener) {
-        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()))
+        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()) && !KafkaListenerType.TLSROUTE.equals(listener.getType()))
                 && listener.getConfiguration().getBootstrap().getHost() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure bootstrap.host because it is not Route or Ingress based listener");
+            errors.add("listener " + listener.getName() + " cannot configure bootstrap.host because it is not TLSRoute, Route, or Ingress based listener");
         }
     }
 
@@ -417,8 +474,8 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that bootstrap.annotations and bootstrap.labels are used only with LoadBalancer, NodePort, Route, or
-     * Ingress type listener
+     * Validates that bootstrap.annotations and bootstrap.labels are used only with LoadBalancer, NodePort, Route,
+     * TLSRoute, or Ingress type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
@@ -427,31 +484,32 @@ public class ListenersValidator {
         if (!KafkaListenerType.LOADBALANCER.equals(listener.getType())
                 && !KafkaListenerType.NODEPORT.equals(listener.getType())
                 && !KafkaListenerType.ROUTE.equals(listener.getType())
+                && !KafkaListenerType.TLSROUTE.equals(listener.getType())
                 && !KafkaListenerType.INGRESS.equals(listener.getType())
                 && !KafkaListenerType.CLUSTER_IP.equals(listener.getType())) {
             if (listener.getConfiguration().getBootstrap().getLabels() != null
                     && !listener.getConfiguration().getBootstrap().getLabels().isEmpty()) {
-                errors.add("listener " + listener.getName() + " cannot configure bootstrap.labels because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");
+                errors.add("listener " + listener.getName() + " cannot configure bootstrap.labels because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener");
             }
 
             if (listener.getConfiguration().getBootstrap().getAnnotations() != null
                     && !listener.getConfiguration().getBootstrap().getAnnotations().isEmpty()) {
-                errors.add("listener " + listener.getName() + " cannot configure bootstrap.annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");
+                errors.add("listener " + listener.getName() + " cannot configure bootstrap.annotations because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener");
             }
         }
     }
 
     /**
-     * Validates that brokers[].host is used only with Route or Ingress type listener
+     * Validates that brokers[].host is used only with TLSRoute, Route, or Ingress type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
      * @param broker    Broker configuration which needs to be validated
      */
     private static void validateBrokerHost(Set<String> errors, GenericKafkaListener listener, GenericKafkaListenerConfigurationBroker broker) {
-        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()))
+        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()) && !KafkaListenerType.TLSROUTE.equals(listener.getType()))
                 && broker.getHost() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure brokers[].host because it is not Route or Ingress based listener");
+            errors.add("listener " + listener.getName() + " cannot configure brokers[].host because it is not TLSRoute, Route, or Ingress based listener");
         }
     }
 
@@ -499,8 +557,8 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that brokers[].annotations and brokers[].labels are used only with LoadBalancer, NodePort, Route or
-     * Ingress type listener
+     * Validates that brokers[].annotations and brokers[].labels are used only with LoadBalancer, NodePort, Route,
+     * TLSRoute or Ingress type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
@@ -510,16 +568,17 @@ public class ListenersValidator {
         if (!KafkaListenerType.LOADBALANCER.equals(listener.getType())
                 && !KafkaListenerType.NODEPORT.equals(listener.getType())
                 && !KafkaListenerType.ROUTE.equals(listener.getType())
+                && !KafkaListenerType.TLSROUTE.equals(listener.getType())
                 && !KafkaListenerType.INGRESS.equals(listener.getType())
                 && !KafkaListenerType.CLUSTER_IP.equals(listener.getType()))  {
             if (broker.getLabels() != null
                     && !broker.getLabels().isEmpty()) {
-                errors.add("listener " + listener.getName() + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");
+                errors.add("listener " + listener.getName() + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener");
             }
 
             if (broker.getAnnotations() != null
                     && !broker.getAnnotations().isEmpty()) {
-                errors.add("listener " + listener.getName() + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener");
+                errors.add("listener " + listener.getName() + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener");
             }
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -171,8 +171,7 @@ public class ListenersValidator {
         if (listener.getConfiguration() != null)    {
             GenericKafkaListenerConfiguration conf = listener.getConfiguration();
 
-            if (conf.getBootstrap() == null
-                    || conf.getBootstrap().getHost() == null)   {
+            if (conf.getBootstrap() == null || conf.getBootstrap().getHost() == null)   {
                 errors.add("listener " + listener.getName() + " is missing a bootstrap host property which is required for Ingress based listeners");
             }
 
@@ -209,8 +208,7 @@ public class ListenersValidator {
                 errors.add("listener " + listener.getName() + " is missing a parent references property which is required for TLSRoute based listeners");
             }
 
-            if (conf.getBootstrap() == null
-                    || conf.getBootstrap().getHost() == null)   {
+            if (conf.getBootstrap() == null || conf.getBootstrap().getHost() == null)   {
                 errors.add("listener " + listener.getName() + " is missing a bootstrap host property which is required for TLSRoute based listeners");
             }
 
@@ -228,7 +226,7 @@ public class ListenersValidator {
                 errors.add("listener " + listener.getName() + " is missing a broker configuration with host properties which are required for TLSRoute based listeners");
             }
         } else {
-            errors.add("listener " + listener.getName() + " is missing a configuration with host properties which are required for TLSRoute based listeners");
+            errors.add("listener " + listener.getName() + " is missing a configuration with bootstrap and broker host properties which are required for TLSRoute based listeners");
             errors.add("listener " + listener.getName() + " is missing a parent references property which is required for TLSRoute based listeners");
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRoute;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.openshift.api.model.Route;
 import io.strimzi.api.kafka.model.common.CertAndKeySecretSource;
@@ -27,6 +28,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.IngressOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.RouteOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.TLSRouteOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
@@ -61,6 +63,7 @@ public class KafkaListenersReconciler {
     private final SecretOperator secretOperator;
     private final ServiceOperator serviceOperator;
     private final RouteOperator routeOperator;
+    private final TLSRouteOperator tlsRouteOperator;
     private final IngressOperator ingressOperator;
 
     /* test */ final ReconciliationResult result;
@@ -75,7 +78,8 @@ public class KafkaListenersReconciler {
      * @param operationTimeoutMs        Timeout for Kubernetes operations
      * @param secretOperator            The Secret operator for working with Kubernetes Secrets
      * @param serviceOperator           The Service operator for working with Kubernetes Services
-     * @param routeOperator             The Route operator for working with Kubernetes Route
+     * @param routeOperator             The Route operator for working with OpenShift Route
+     * @param tlsRouteOperator          The TLSRoute operator for working with Gateway API TLSRoute
      * @param ingressOperator           The Ingress operator for working with Kubernetes Ingress
      */
     public KafkaListenersReconciler(
@@ -89,6 +93,7 @@ public class KafkaListenersReconciler {
             SecretOperator secretOperator,
             ServiceOperator serviceOperator,
             RouteOperator routeOperator,
+            TLSRouteOperator tlsRouteOperator,
             IngressOperator ingressOperator
     ) {
         this.reconciliation = reconciliation;
@@ -102,6 +107,7 @@ public class KafkaListenersReconciler {
         this.serviceOperator = serviceOperator;
         this.routeOperator = routeOperator;
         this.ingressOperator = ingressOperator;
+        this.tlsRouteOperator = tlsRouteOperator;
 
         // Initialize the result object
         this.result = new ReconciliationResult();
@@ -119,11 +125,13 @@ public class KafkaListenersReconciler {
     public Future<ReconciliationResult> reconcile()    {
         return services()
                 .compose(i -> routes())
+                .compose(i -> tlsRoutes())
                 .compose(i -> ingresses())
                 .compose(i -> internalServicesReady())
                 .compose(i -> loadBalancerServicesReady())
                 .compose(i -> nodePortServicesReady())
                 .compose(i -> routesReady())
+                .compose(i -> tlsRoutesReady())
                 .compose(i -> ingressesReady())
                 .compose(i -> clusterIPServicesReady())
                 .compose(i -> customListenerCertificates())
@@ -163,6 +171,27 @@ public class KafkaListenersReconciler {
             if (!routes.isEmpty()) {
                 LOGGER.warnCr(reconciliation, "The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster {} using routes is not possible.", reconciliation.name());
                 return Future.failedFuture("The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster " + reconciliation.name() + " using routes is not possible.");
+            } else {
+                return Future.succeededFuture();
+            }
+        }
+    }
+
+    /**
+     * Makes sure all desired routes are updated and the rest is deleted.
+     *
+     * @return Future which completes when all routes are created or deleted.
+     */
+    protected Future<Void> tlsRoutes() {
+        List<TLSRoute> routes = new ArrayList<>(kafka.generateExternalBootstrapTlsRoutes());
+        routes.addAll(kafka.generateExternalTlsRoutes());
+
+        if (pfa.hasTLSRoutes()) {
+            return tlsRouteOperator.batchReconcile(reconciliation, reconciliation.namespace(), routes, kafka.getSelectorLabels()).mapEmpty();
+        } else {
+            if (!routes.isEmpty()) {
+                LOGGER.warnCr(reconciliation, "The Gateway API TLSRoute resource is not available in this Kubernetes cluster. Exposing Kafka cluster {} using TLSRoutes is not possible.", reconciliation.name());
+                return Future.failedFuture("The Gateway API TLSRoute resource is not available in this Kubernetes cluster. Exposing Kafka cluster " + reconciliation.name() + " using TLSRoutes is not possible.");
             } else {
                 return Future.succeededFuture();
             }
@@ -612,6 +641,80 @@ public class KafkaListenersReconciler {
                         }
 
                         return Future.join(perPodFutures);
+                    });
+
+            listenerFutures.add(perListenerFut);
+        }
+
+        return Future
+                .join(listenerFutures)
+                .mapEmpty();
+    }
+
+    /**
+     * Makes sure all routes are ready and collects their addresses for Statuses,
+     * certificates and advertised addresses. This method for all routes:
+     *      1) Checks if the bootstrap route has been provisioned and has at least one parent
+     *      2) Collects the relevant addresses and stores them for use in certificates and in CR status
+     *      3) Checks it the broker routes have been provisioned and have at least one parent
+     *      4) Collects the route addresses for certificates and advertised hostnames
+     *
+     * @return  Future which completes when all TLSRoutes are ready and their addresses are collected
+     */
+    protected Future<Void> tlsRoutesReady() {
+        List<GenericKafkaListener> routeListeners = ListenersUtils.tlsRouteListeners(kafka.getListeners());
+        List<Future<?>> listenerFutures = new ArrayList<>(routeListeners.size());
+
+        for (GenericKafkaListener listener : routeListeners) {
+            String bootstrapRouteName = ListenersUtils.backwardsCompatibleBootstrapRouteOrIngressName(reconciliation.name(), listener);
+
+            @SuppressWarnings({ "rawtypes" }) // Has to use Raw type because of the CompositeFuture
+            Future perListenerFut = tlsRouteOperator.hasParents(reconciliation, reconciliation.namespace(), bootstrapRouteName, 1_000, operationTimeoutMs)
+                    .compose(i -> {
+                        String bootstrapAddress = listener.getConfiguration().getBootstrap().getHost();
+                        LOGGER.debugCr(reconciliation, "Using address {} for TLSRoute {}", bootstrapAddress, bootstrapRouteName);
+
+                        result.bootstrapDnsNames.add(bootstrapAddress);
+
+                        ListenerStatus ls = new ListenerStatusBuilder()
+                                .withName(listener.getName())
+                                .withAddresses(new ListenerAddressBuilder()
+                                        .withHost(bootstrapAddress)
+                                        .withPort(KafkaCluster.TLSROUTE_PORT)
+                                        .build())
+                                .build();
+                        result.listenerStatuses.add(ls);
+
+                        return Future.succeededFuture();
+                    })
+                    .compose(res -> {
+                        List<Future<Void>> perPodFutures = new ArrayList<>();
+
+                        for (NodeRef node : kafka.brokerNodes()) {
+                            perPodFutures.add(
+                                    tlsRouteOperator.hasParents(reconciliation, reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener), 1_000, operationTimeoutMs)
+                            );
+                        }
+
+                        return Future.join(perPodFutures);
+                    })
+                    .compose(res -> {
+                        for (NodeRef node : kafka.brokerNodes()) {
+                            String brokerAddress = ListenersUtils.brokerHost(listener, node);
+                            LOGGER.debugCr(reconciliation, "Using address {} for TLSRoute {}", brokerAddress, ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener));
+
+                            result.brokerDnsNames.computeIfAbsent(node.nodeId(), k -> new HashSet<>(2)).add(brokerAddress);
+
+                            String advertisedHostname = ListenersUtils.brokerAdvertisedHost(listener, node);
+                            if (advertisedHostname != null) {
+                                result.brokerDnsNames.get(node.nodeId()).add(advertisedHostname);
+                            }
+
+                            registerAdvertisedHostname(node.nodeId(), listener, advertisedHostname, brokerAddress);
+                            registerAdvertisedPort(node.nodeId(), listener, KafkaCluster.TLSROUTE_PORT);
+                        }
+
+                        return Future.succeededFuture();
                     });
 
             listenerFutures.add(perListenerFut);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -178,9 +178,9 @@ public class KafkaListenersReconciler {
     }
 
     /**
-     * Makes sure all desired routes are updated and the rest is deleted.
+     * Makes sure all desired Gateway API TLS Routes are updated and the rest is deleted.
      *
-     * @return Future which completes when all routes are created or deleted.
+     * @return Future that completes when all Gateway API TLS Routes are created or deleted.
      */
     protected Future<Void> tlsRoutes() {
         List<TLSRoute> routes = new ArrayList<>(kafka.generateExternalBootstrapTlsRoutes());
@@ -654,12 +654,12 @@ public class KafkaListenersReconciler {
     /**
      * Makes sure all routes are ready and collects their addresses for Statuses,
      * certificates and advertised addresses. This method for all routes:
-     *      1) Checks if the bootstrap route has been provisioned and has at least one parent
+     *      1) Checks if the bootstrap Gateway API TLS Route has been provisioned and has at least one parent
      *      2) Collects the relevant addresses and stores them for use in certificates and in CR status
-     *      3) Checks it the broker routes have been provisioned and have at least one parent
+     *      3) Checks it the broker Gateway API TLS Routes have been provisioned and have at least one parent
      *      4) Collects the route addresses for certificates and advertised hostnames
      *
-     * @return  Future which completes when all TLSRoutes are ready and their addresses are collected
+     * @return  Future which completes when all Gateway API TLS Routes are ready and their addresses are collected
      */
     protected Future<Void> tlsRoutesReady() {
         List<GenericKafkaListener> routeListeners = ListenersUtils.tlsRouteListeners(kafka.getListeners());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -67,6 +67,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceAccountOp
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StorageClassOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.TLSRouteOperator;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.BackOff;
@@ -148,6 +149,7 @@ public class KafkaReconciler {
     private final RoleOperator roleOperator;
     private final RoleBindingOperator roleBindingOperator;
     private final RouteOperator routeOperator;
+    private final TLSRouteOperator tlsRouteOperator;
     private final IngressOperator ingressOperator;
     private final NodeOperator nodeOperator;
     private final CrdOperator<KubernetesClient, KafkaNodePool, KafkaNodePoolList> kafkaNodePoolOperator;
@@ -225,6 +227,7 @@ public class KafkaReconciler {
         this.roleBindingOperator = supplier.roleBindingOperations;
         this.roleOperator = supplier.roleOperations;
         this.routeOperator = supplier.routeOperations;
+        this.tlsRouteOperator = supplier.tlsRouteOperations;
         this.ingressOperator = supplier.ingressOperations;
         this.nodeOperator = supplier.nodeOperator;
         this.kafkaNodePoolOperator = supplier.kafkaNodePoolOperator;
@@ -639,6 +642,7 @@ public class KafkaReconciler {
                 secretOperator,
                 serviceOperator,
                 routeOperator,
+                tlsRouteOperator,
                 ingressOperator
         );
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -46,6 +46,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceAccountOp
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StorageClassOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.TLSRouteOperator;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.MetricsProvider;
@@ -162,7 +163,6 @@ public class ResourceOperatorSupplier {
      */
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
 
-
     /**
      * Pod operator
      */
@@ -192,6 +192,11 @@ public class ResourceOperatorSupplier {
      * Node operator
      */
     public final NodeOperator nodeOperator;
+
+    /**
+     * TLSRoute operator
+     */
+    public final TLSRouteOperator tlsRouteOperations;
 
     /**
      * Metrics provider
@@ -324,6 +329,7 @@ public class ResourceOperatorSupplier {
                 new StrimziPodSetOperator(vertx, client),
                 new StorageClassOperator(vertx, client),
                 new NodeOperator(vertx, client),
+                new TLSRouteOperator(vertx, client),
                 kafkaAgentClientProvider,
                 metricsProvider,
                 adminClientProvider,
@@ -362,6 +368,7 @@ public class ResourceOperatorSupplier {
      * @param strimziPodSetOperator                 StrimziPodSet operator
      * @param storageClassOperator                  StorageClass operator
      * @param nodeOperator                          Node operator
+     * @param tlsRouteOperator                      TLSRoute operator
      * @param kafkaAgentClientProvider              Kafka Agent client provider
      * @param metricsProvider                       Metrics provider
      * @param adminClientProvider                   Kafka Admin client provider
@@ -397,6 +404,7 @@ public class ResourceOperatorSupplier {
                                     StrimziPodSetOperator strimziPodSetOperator,
                                     StorageClassOperator storageClassOperator,
                                     NodeOperator nodeOperator,
+                                    TLSRouteOperator tlsRouteOperator,
                                     KafkaAgentClientProvider kafkaAgentClientProvider,
                                     MetricsProvider metricsProvider,
                                     AdminClientProvider adminClientProvider,
@@ -430,6 +438,7 @@ public class ResourceOperatorSupplier {
         this.kafkaNodePoolOperator = kafkaNodePoolOperator;
         this.strimziPodSetOperator = strimziPodSetOperator;
         this.nodeOperator = nodeOperator;
+        this.tlsRouteOperations = tlsRouteOperator;
         this.kafkaAgentClientProvider = kafkaAgentClientProvider;
         this.metricsProvider = metricsProvider;
         this.adminClientProvider = adminClientProvider;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/TLSRouteOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/TLSRouteOperator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRoute;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRouteList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Reconciliation;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * Operations for {@code TLSRoute}s.
+ */
+public class TLSRouteOperator extends AbstractNamespacedResourceOperator<KubernetesClient, TLSRoute, TLSRouteList, Resource<TLSRoute>> {
+    /**
+     * Constructor
+     *
+     * @param vertx     The Vertx instance
+     * @param client    The Kubernetes client
+     */
+    public TLSRouteOperator(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "TLSRoute");
+    }
+
+    @Override
+    protected MixedOperation<TLSRoute, TLSRouteList, Resource<TLSRoute>> operation() {
+        return client.resources(TLSRoute.class, TLSRouteList.class);
+    }
+
+    /**
+     * Succeeds when the TLSRoute has at least one assigned parent
+     *
+     * @param reconciliation    The reconciliation
+     * @param namespace         Namespace
+     * @param name              Name of the TLSRoute
+     * @param pollIntervalMs    Interval in which we poll
+     * @param timeoutMs         Timeout
+     *
+     * @return A future that succeeds when the TLSRoute has at least one parent.
+     */
+    public Future<Void> hasParents(Reconciliation reconciliation, String namespace, String name, long pollIntervalMs, long timeoutMs) {
+        return waitFor(reconciliation, namespace, name, "addressable", pollIntervalMs, timeoutMs, this::hasParents);
+    }
+
+    /**
+     * Checks if the TLSRoute already has at least one parent.
+     *
+     * @param namespace     The namespace.
+     * @param name          The TLSRoute name.
+     *
+     * @return Whether the TLSRoute is ready.
+     */
+    private boolean hasParents(String namespace, String name) {
+        TLSRoute resource = get(namespace, name);
+
+        return resource != null
+                && resource.getStatus() != null
+                && resource.getStatus().getParents() != null
+                && !resource.getStatus().getParents().isEmpty();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -8,6 +8,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.APIGroup;
 import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIResource;
+import io.fabric8.kubernetes.api.model.APIResourceBuilder;
+import io.fabric8.kubernetes.api.model.APIResourceList;
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
 import io.fabric8.kubernetes.api.model.GroupVersionForDiscovery;
 import io.fabric8.kubernetes.api.model.GroupVersionForDiscoveryBuilder;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -29,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -63,7 +66,7 @@ public class PlatformFeaturesAvailabilityTest {
                 }"""
                 .formatted(KubernetesVersion.MINIMAL_SUPPORTED_MAJOR, KubernetesVersion.MINIMAL_SUPPORTED_MINOR, KubernetesVersion.MINIMAL_SUPPORTED_MAJOR, KubernetesVersion.MINIMAL_SUPPORTED_MINOR);
 
-        startMockApi(vertx, version, Collections.emptyList());
+        startMockApi(vertx, version, List.of(), List.of());
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -91,7 +94,7 @@ public class PlatformFeaturesAvailabilityTest {
                 }"""
                 .formatted(KubernetesVersion.MINIMAL_SUPPORTED_MAJOR, KubernetesVersion.MINIMAL_SUPPORTED_MINOR, KubernetesVersion.MINIMAL_SUPPORTED_MAJOR, KubernetesVersion.MINIMAL_SUPPORTED_MINOR);
 
-        startMockApi(vertx, version, Collections.emptyList());
+        startMockApi(vertx, version, List.of(), List.of());
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -107,7 +110,7 @@ public class PlatformFeaturesAvailabilityTest {
     public void testVersionDetectionWrongVersion(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
         String version = "Not a proper version JSON";
 
-        startMockApi(vertx, version, Collections.emptyList());
+        startMockApi(vertx, version, List.of(), List.of());
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -140,7 +143,7 @@ public class PlatformFeaturesAvailabilityTest {
         apis.add(buildAPIGroup("route.openshift.io", "v1"));
         apis.add(buildAPIGroup("build.openshift.io", "v1"));
 
-        startMockApi(vertx, apis);
+        startMockApi(vertx, apis, List.of());
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -155,13 +158,16 @@ public class PlatformFeaturesAvailabilityTest {
     }
 
     @Test
-    public void testApiDetectionOpenshift(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
+    public void testApiDetectionPresent(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
         List<APIGroup> apis = new ArrayList<>();
         apis.add(buildAPIGroup("route.openshift.io", "v1"));
         apis.add(buildAPIGroup("build.openshift.io", "v1"));
         apis.add(buildAPIGroup("image.openshift.io", "v1"));
 
-        startMockApi(vertx, apis);
+        List<APIResourceList> apiLists = new ArrayList<>();
+        apiLists.add(buildAPIResourceList("gateway.networking.k8s.io", "v1", "HTTPRoute", "TLSRoute"));
+
+        startMockApi(vertx, apis, apiLists);
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -171,6 +177,7 @@ public class PlatformFeaturesAvailabilityTest {
             assertThat(pfa.hasRoutes(), is(true));
             assertThat(pfa.hasBuilds(), is(true));
             assertThat(pfa.hasImages(), is(true));
+            assertThat(pfa.hasTLSRoutes(), is(true));
             async.flag();
         })));
     }
@@ -182,7 +189,11 @@ public class PlatformFeaturesAvailabilityTest {
         apis.add(buildAPIGroup("build.openshift.io", "v1"));
         apis.add(buildAPIGroup("image.openshift.io", "v1"));
 
-        startMockApi(vertx, apis);
+        List<APIResourceList> apiLists = new ArrayList<>();
+        apiLists.add(buildAPIResourceList("gateway.networking.k8s.io", "v1alpha3", "HTTPRoute"));
+        apiLists.add(buildAPIResourceList("gateway.networking.k8s.io", "v1alpha2", "TLSRoute"));
+
+        startMockApi(vertx, apis, apiLists);
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -192,13 +203,14 @@ public class PlatformFeaturesAvailabilityTest {
             assertThat(pfa.hasRoutes(), is(false));
             assertThat(pfa.hasBuilds(), is(true));
             assertThat(pfa.hasImages(), is(true));
+            assertThat(pfa.hasTLSRoutes(), is(false));
             async.flag();
         })));
     }
 
     @Test
-    public void testApiDetectionKubernetes(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
-        startMockApi(vertx, Collections.emptyList());
+    public void testApiDetectionNotPresent(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
+        startMockApi(vertx, List.of(), List.of());
 
         KubernetesClient client = buildKubernetesClient("127.0.0.1:" + server.actualPort());
 
@@ -208,6 +220,7 @@ public class PlatformFeaturesAvailabilityTest {
             assertThat(pfa.hasRoutes(), is(false));
             assertThat(pfa.hasBuilds(), is(false));
             assertThat(pfa.hasImages(), is(false));
+            assertThat(pfa.hasTLSRoutes(), is(false));
             async.flag();
         })));
     }
@@ -278,8 +291,9 @@ public class PlatformFeaturesAvailabilityTest {
         return new KubernetesClientBuilder().withConfig(new ConfigBuilder().withMasterUrl(masterUrl).withHttp2Disable().build()).build();
     }
 
-    void startMockApi(Vertx vertx, String version, List<APIGroup> apis) throws InterruptedException, ExecutionException {
+    void startMockApi(Vertx vertx, String version, List<APIGroup> apis, List<APIResourceList> apiResourceLists) throws InterruptedException, ExecutionException {
         Set<String> groupsPaths = apis.stream().map(api -> "/apis/" + api.getName()).collect(Collectors.toSet());
+        Set<String> apiResourcePaths = apiResourceLists.stream().map(api -> "/apis/" + api.getGroupVersion()).collect(Collectors.toSet());
 
         HttpServer httpServer = vertx.createHttpServer().requestHandler(request -> {
             if (HttpMethod.GET.equals(request.method()) && groupsPaths.contains(request.uri())) {
@@ -288,6 +302,15 @@ public class PlatformFeaturesAvailabilityTest {
 
                 try {
                     request.response().setStatusCode(200).end(OBJECTMAPPER.writeValueAsString(group));
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                }
+            } else if (HttpMethod.GET.equals(request.method()) && apiResourcePaths.contains(request.uri())) {
+                String groupVersion = request.uri().substring(request.uri().indexOf("/", 2) + 1);
+                APIResourceList list = apiResourceLists.stream().filter(l -> groupVersion.equals(l.getGroupVersion())).findFirst().orElse(null);
+
+                try {
+                    request.response().setStatusCode(200).end(OBJECTMAPPER.writeValueAsString(list));
                 } catch (JsonProcessingException e) {
                     e.printStackTrace();
                 }
@@ -300,7 +323,7 @@ public class PlatformFeaturesAvailabilityTest {
         server = httpServer.listen(0).toCompletionStage().toCompletableFuture().get();
     }
 
-    void startMockApi(Vertx vertx, List<APIGroup> apis) throws InterruptedException, ExecutionException {
+    void startMockApi(Vertx vertx, List<APIGroup> apis, List<APIResourceList> apiResourceLists) throws InterruptedException, ExecutionException {
         String version = """
                 {
                   "major": "1",
@@ -314,7 +337,7 @@ public class PlatformFeaturesAvailabilityTest {
                   "platform": "linux/amd64"
                 }""";
 
-        startMockApi(vertx, version, apis);
+        startMockApi(vertx, version, apis, apiResourceLists);
     }
 
     private APIGroup buildAPIGroup(String group, String... versions)    {
@@ -336,6 +359,21 @@ public class PlatformFeaturesAvailabilityTest {
         apiGroup.setVersions(groupVersions);
 
         return apiGroup;
+    }
+
+    private APIResourceList buildAPIResourceList(String group, String version, String... kinds)    {
+        List<APIResource> apiResources = new ArrayList<>();
+
+        for (String kind : kinds) {
+            apiResources.add(
+                    new APIResourceBuilder().withKind(kind).build()
+            );
+        }
+
+        return new APIResourceListBuilder()
+                .withGroupVersion(group + "/" + version)
+                .withResources(apiResources)
+                .build();
     }
 
     void startFailingMockApi(Vertx vertx) throws InterruptedException, ExecutionException {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -43,6 +43,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceAccountOp
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StorageClassOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.TLSRouteOperator;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
@@ -347,6 +348,7 @@ public class ResourceUtils {
                 mock(StrimziPodSetOperator.class),
                 mock(StorageClassOperator.class),
                 mock(NodeOperator.class),
+                mock(TLSRouteOperator.class),
                 kafkaAgentClientProvider(),
                 metricsProvider(),
                 adminClientProvider(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -2453,7 +2453,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         }
 
-        // Check bootstrap ingress
+        // Check bootstrap Gateway API TLS Route
         List<TLSRoute> bootstrapRoutes = kc.generateExternalBootstrapTlsRoutes();
         assertThat(bootstrapRoutes.size(), is(1));
 
@@ -2473,7 +2473,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getNamespace(), is("envoy-gateway-system"));
         io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
 
-        // Check per pod ingress
+        // Check per pod Gateway API TLS Route
         List<TLSRoute> routes = kc.generateExternalTlsRoutes();
         assertThat(routes.size(), is(5));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -11,6 +11,8 @@ import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReferenceBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRoute;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.openshift.api.model.Route;
 import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
@@ -2355,5 +2357,187 @@ public class KafkaClusterListenersTest {
 
         String controllerConfig = kc.generatePerBrokerConfiguration(0, Map.of(0, Map.of("CONTROLPLANE_9090", "controller-0")), Map.of(0, Map.of("CONTROLPLANE_9090", "9090")));
         assertThat(controllerConfig, not(containsString("listener.name.tls-9093")));
+    }
+
+    @Test
+    public void testExternalTLSRoutes() {
+        GenericKafkaListenerConfigurationBroker broker5 = new GenericKafkaListenerConfigurationBrokerBuilder()
+                .withHost("my-custom-kafka-broker-5.com")
+                .withLabels(Map.of("label", "custom-label-value-5"))
+                .withAnnotations(Map.of("dns-annotation", "my-custom-kafka-broker-5.com"))
+                .withBroker(5)
+                .build();
+
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName("external")
+                                .withPort(9094)
+                                .withType(KafkaListenerType.TLSROUTE)
+                                .withTls(true)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("my-kafka-bootstrap.com")
+                                        .withAnnotations(Map.of("dns-annotation", "my-kafka-bootstrap.com"))
+                                        .withLabels(Map.of("label", "label-value"))
+                                    .endBootstrap()
+                                    .withBrokers(broker5)
+                                    .withHostTemplate("my-kafka-broker-{nodeId}.com")
+                                    .withPerBrokerLabelsTemplate(Map.of("label", "label-value-{nodeId}"))
+                                    .withPerBrokerAnnotationsTemplate(Map.of("dns-annotation", "my-kafka-broker-{nodeId}.com"))
+                                    .withParentRefs(new ParentReferenceBuilder()
+                                            .withKind("Gateway")
+                                            .withGroup("gateway.networking.k8s.io")
+                                            .withName("envoy-gateway")
+                                            .withNamespace("envoy-gateway-system")
+                                            .build())
+                                .endConfiguration()
+                                .build())
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+
+        assertThat(kc.getListeners().stream().findFirst().orElseThrow().getType(), is(KafkaListenerType.TLSROUTE));
+
+        List<StrimziPodSet> podSets = kc.generatePodSets(null, null, node -> Map.of());
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
+
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
+            }
+        }));
+
+        // Check external bootstrap service
+        List<Service> bootstrapServices = kc.generateExternalBootstrapServices();
+        assertThat(bootstrapServices.size(), is(1));
+
+        assertThat(bootstrapServices.get(0).getMetadata().getName(), is(CLUSTER + "-kafka-external-bootstrap"));
+        assertThat(bootstrapServices.get(0).getSpec().getType(), is("ClusterIP"));
+        assertThat(bootstrapServices.get(0).getSpec().getSelector(), is(expectedBrokerSelectorLabels()));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().size(), is(1));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+        assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+
+        // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+        assertThat(services.size(), is(5));
+
+        for (Service service : services)    {
+            if (service.getMetadata().getName().contains("foo-brokers-")) {
+                assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
+                assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+            } else {
+                assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
+                assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+            }
+
+            assertThat(service.getSpec().getType(), is("ClusterIP"));
+            assertThat(service.getSpec().getPorts().size(), is(1));
+            assertThat(service.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+            assertThat(service.getSpec().getPorts().get(0).getPort(), is(9094));
+            assertThat(service.getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
+            assertThat(service.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+            assertThat(service.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
+        }
+
+        // Check bootstrap ingress
+        List<TLSRoute> bootstrapRoutes = kc.generateExternalBootstrapTlsRoutes();
+        assertThat(bootstrapRoutes.size(), is(1));
+
+        assertThat(bootstrapRoutes.get(0).getMetadata().getName(), is(KafkaResources.bootstrapServiceName(CLUSTER)));
+        assertThat(bootstrapRoutes.get(0).getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-bootstrap.com"));
+        assertThat(bootstrapRoutes.get(0).getMetadata().getLabels().get("label"), is("label-value"));
+        assertThat(bootstrapRoutes.get(0).getSpec().getHostnames().size(), is(1));
+        assertThat(bootstrapRoutes.get(0).getSpec().getHostnames().get(0), is("my-kafka-bootstrap.com"));
+        assertThat(bootstrapRoutes.get(0).getSpec().getRules().size(), is(1));
+        assertThat(bootstrapRoutes.get(0).getSpec().getRules().get(0).getBackendRefs().size(), is(1));
+        assertThat(bootstrapRoutes.get(0).getSpec().getRules().get(0).getBackendRefs().get(0).getName(), is(CLUSTER + "-kafka-external-bootstrap"));
+        assertThat(bootstrapRoutes.get(0).getSpec().getRules().get(0).getBackendRefs().get(0).getPort(), is(9094));
+        assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().size(), is(1));
+        assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getKind(), is("Gateway"));
+        assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getGroup(), is("gateway.networking.k8s.io"));
+        assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getName(), is("envoy-gateway"));
+        assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getNamespace(), is("envoy-gateway-system"));
+        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
+
+        // Check per pod ingress
+        List<TLSRoute> routes = kc.generateExternalTlsRoutes();
+        assertThat(routes.size(), is(5));
+
+        for (TLSRoute route : routes)    {
+            if (route.getMetadata().getName().contains("foo-brokers-")) {
+                assertThat(route.getMetadata().getName(), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_BROKERS);
+            } else {
+                assertThat(route.getMetadata().getName(), oneOf("foo-mixed-3", "foo-mixed-4"));
+                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_MIXED);
+            }
+
+            if (route.getMetadata().getName().contains("foo-brokers-5")) {
+                assertThat(route.getMetadata().getAnnotations().get("dns-annotation"), is("my-custom-kafka-broker-5.com"));
+                assertThat(route.getMetadata().getLabels().get("label"), is("custom-label-value-5"));
+                assertThat(route.getSpec().getHostnames().size(), is(1));
+                assertThat(route.getSpec().getHostnames().get(0), is("my-custom-kafka-broker-5.com"));
+            } else {
+                assertThat(route.getMetadata().getAnnotations().get("dns-annotation"), oneOf("my-kafka-broker-3.com", "my-kafka-broker-4.com", "my-kafka-broker-6.com", "my-kafka-broker-7.com"));
+                assertThat(route.getMetadata().getLabels().get("label"), oneOf("label-value-3", "label-value-4", "label-value-6", "label-value-7"));
+                assertThat(route.getSpec().getHostnames().size(), is(1));
+                assertThat(route.getSpec().getHostnames().get(0), oneOf("my-kafka-broker-3.com", "my-kafka-broker-4.com", "my-kafka-broker-6.com", "my-kafka-broker-7.com"));
+            }
+
+            assertThat(route.getSpec().getRules().size(), is(1));
+            assertThat(route.getSpec().getRules().get(0).getBackendRefs().size(), is(1));
+            assertThat(route.getSpec().getRules().get(0).getBackendRefs().get(0).getName(), oneOf("foo-mixed-3", "foo-mixed-4", "foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
+            assertThat(route.getSpec().getRules().get(0).getBackendRefs().get(0).getPort(), is(9094));
+            assertThat(route.getSpec().getParentRefs().size(), is(1));
+            assertThat(route.getSpec().getParentRefs().get(0).getKind(), is("Gateway"));
+            assertThat(route.getSpec().getParentRefs().get(0).getGroup(), is("gateway.networking.k8s.io"));
+            assertThat(route.getSpec().getParentRefs().get(0).getName(), is("envoy-gateway"));
+            assertThat(route.getSpec().getParentRefs().get(0).getNamespace(), is("envoy-gateway-system"));
+        }
+    }
+
+    @Test
+    public void testExternalTLSRouteMissingConfiguration() {
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName("external")
+                                .withPort(9094)
+                                .withType(KafkaListenerType.TLSROUTE)
+                                .withTls(true)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("my-kafka-bootstrap.com")
+                                        .withAnnotations(Map.of("dns-annotation", "my-kafka-bootstrap.com"))
+                                        .withLabels(Map.of("label", "label-value"))
+                                    .endBootstrap()
+                                    .withHostTemplate("my-kafka-broker-{nodeId}.com")
+                                    .withPerBrokerLabelsTemplate(Map.of("label", "label-value-{nodeId}"))
+                                    .withPerBrokerAnnotationsTemplate(Map.of("dns-annotation", "my-kafka-broker-{nodeId}.com"))
+                                .endConfiguration()
+                                .build())
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        assertThrows(InvalidResourceException.class, () -> {
+            List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+        });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -1012,7 +1012,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<String> expectedErrors = List.of(
-                "listener " + name + " is missing a configuration with host properties which are required for TLSRoute based listeners",
+                "listener " + name + " is missing a configuration with bootstrap and broker host properties which are required for TLSRoute based listeners",
                 "listener " + name + " is missing a parent references property which is required for TLSRoute based listeners"
         );
 
@@ -1047,7 +1047,7 @@ public class ListenersValidatorTest {
                 .build();
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder(
-                "listener tlsroute is missing a configuration with host properties which are required for TLSRoute based listeners",
+                "listener tlsroute is missing a configuration with bootstrap and broker host properties which are required for TLSRoute based listeners",
                 "listener tlsroute is missing a parent references property which is required for TLSRoute based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReferenceBuilder;
 import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
@@ -238,6 +239,7 @@ public class ListenersValidatorTest {
                     .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -279,20 +281,21 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure perBrokerAnnotationsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
                 "listener " + name + " cannot configure perBrokerLabelsTemplate because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
-                "listener " + name + " cannot configure hostTemplate because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
+                "listener " + name + " cannot configure hostTemplate because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.host because it is not TLSRoute, Route, or Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure bootstrap.annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
-                "listener " + name + " cannot configure bootstrap.labels because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.annotations because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener",
+                "listener " + name + " cannot configure bootstrap.labels because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not TLSRoute, Route, or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
-                "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
+                "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener",
+                "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, TLSRoute, Route, Ingress, or ClusterIP based listener",
                 "listener " + name + " cannot configure ipFamilyPolicy because it is internal listener",
                 "listener " + name + " cannot configure ipFamilies because it is internal listener",
-                "listener " + name + " cannot configure publishNotReadyAddresses because it is internal listener"
+                "listener " + name + " cannot configure publishNotReadyAddresses because it is internal listener",
+                "listener " + name + " cannot configure parentRefs because it is not TLSRoute based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -321,6 +324,7 @@ public class ListenersValidatorTest {
                     .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -354,9 +358,10 @@ public class ListenersValidatorTest {
         List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
-                "listener " + name + " cannot configure hostTemplate because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
+                "listener " + name + " cannot configure hostTemplate because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.host because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure parentRefs because it is not TLSRoute based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -405,6 +410,7 @@ public class ListenersValidatorTest {
                     .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -440,12 +446,13 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure hostTemplate because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
+                "listener " + name + " cannot configure hostTemplate because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.host because it is not TLSRoute, Route, or Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not TLSRoute, Route, or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure parentRefs because it is not TLSRoute based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -495,6 +502,7 @@ public class ListenersValidatorTest {
                     .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -539,7 +547,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure parentRefs because it is not TLSRoute based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -602,6 +611,7 @@ public class ListenersValidatorTest {
                     .withPerBrokerLabelsTemplate(Map.of("label", "value-{nodePodName}"))
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -642,7 +652,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure parentRefs because it is not TLSRoute based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -868,6 +879,7 @@ public class ListenersValidatorTest {
                     .withHostTemplate("my-host-{nodeId}")
                     .withAllocateLoadBalancerNodePorts(false)
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -903,18 +915,206 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
-                "listener " + name + " cannot configure hostTemplate because it is not Route or Ingress based listener",
+                "listener " + name + " cannot configure hostTemplate because it is not TLSRoute, Route, or Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
+                "listener " + name + " cannot configure bootstrap.host because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not TLSRoute, Route, or Ingress based listener",
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure parentRefs because it is not TLSRoute based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+    }
+
+    @Test
+    public void testTlsRouteListener() {
+        String name = "tlsroute";
+
+        GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
+                .withName(name)
+                .withPort(9092)
+                .withType(KafkaListenerType.TLSROUTE)
+                .withTls(true)
+                .withNewConfiguration()
+                    .withControllerClass("my-ingress")
+                    .withUseServiceDnsDomain(true)
+                    .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                    .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                    .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
+                    .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
+                    .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                    .withPublishNotReadyAddresses(true)
+                    .withAllocateLoadBalancerNodePorts(false)
+                    .withHostTemplate("my-host-{nodeId}")
+                    .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
+                    .withNewBootstrap()
+                        .withAlternativeNames(List.of("my-name-1", "my-name-2"))
+                        .withLoadBalancerIP("130.211.204.1")
+                        .withNodePort(32189)
+                        .withHost("my-host")
+                        .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                    .endBootstrap()
+                    .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                    .withBroker(0)
+                                    .withAdvertisedHost("advertised-host")
+                                    .withAdvertisedPort(9092)
+                                    .withLoadBalancerIP("130.211.204.1")
+                                    .withNodePort(32189)
+                                    .withHost("my-host")
+                                    .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                    .build(),
+                            new GenericKafkaListenerConfigurationBrokerBuilder()
+                                    .withBroker(1)
+                                    .withAdvertisedHost("advertised-host")
+                                    .withAdvertisedPort(9092)
+                                    .withLoadBalancerIP("130.211.204.1")
+                                    .withNodePort(32189)
+                                    .withHost("my-host")
+                                    .withAnnotations(Collections.singletonMap("dns-anno", "dns-value"))
+                                    .build())
+                .endConfiguration()
+                .build();
+
+        List<GenericKafkaListener> listeners = List.of(listener1);
+
+        List<String> expectedErrors = List.of(
+                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
+                "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
+                "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
+                "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
+                "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
+                "listener " + name + " is missing a parent references property which is required for TLSRoute based listeners"
+        );
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+    }
+
+    @Test
+    public void testTlsRouteListenerMissingRequired() {
+        String name = "tlsroute";
+
+        GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
+                .withName(name)
+                .withPort(9092)
+                .withType(KafkaListenerType.TLSROUTE)
+                .withTls(true)
+                .build();
+
+        List<String> expectedErrors = List.of(
+                "listener " + name + " is missing a configuration with host properties which are required for TLSRoute based listeners",
+                "listener " + name + " is missing a parent references property which is required for TLSRoute based listeners"
+        );
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener1)), containsInAnyOrder(expectedErrors.toArray()));
+
+        GenericKafkaListener listener2 = new GenericKafkaListenerBuilder()
+                .withName(name)
+                .withPort(9092)
+                .withType(KafkaListenerType.TLSROUTE)
+                .withTls(true)
+                .withNewConfiguration()
+                .endConfiguration()
+                .build();
+
+        expectedErrors = List.of(
+                "listener " + name + " is missing a broker configuration with host properties which are required for TLSRoute based listeners",
+                "listener " + name + " is missing a bootstrap host property which is required for TLSRoute based listeners",
+                "listener " + name + " is missing a parent references property which is required for TLSRoute based listeners"
+        );
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener2)), containsInAnyOrder(expectedErrors.toArray()));
+    }
+
+
+    @Test
+    public void testTlsRouteListenerHostNamesInNodePools() {
+        GenericKafkaListener listener = new GenericKafkaListenerBuilder()
+                .withName("tlsroute")
+                .withPort(9092)
+                .withType(KafkaListenerType.TLSROUTE)
+                .withTls(true)
+                .build();
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder(
+                "listener tlsroute is missing a configuration with host properties which are required for TLSRoute based listeners",
+                "listener tlsroute is missing a parent references property which is required for TLSRoute based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
+                .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener tlsroute is missing a bootstrap host property which is required for TLSRoute based listeners",
+                "listener tlsroute is missing a broker configuration with host properties which are required for TLSRoute based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
+                .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
+                                .build())
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1000)
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2000)
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2001)
+                                .build())
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener tlsroute is missing a bootstrap host property which is required for TLSRoute based listeners",
+                "listener tlsroute is missing a broker host property for broker with ID 1000 which is required for TLSRoute based listeners",
+                "listener tlsroute is missing a broker host property for broker with ID 2000 which is required for TLSRoute based listeners",
+                "listener tlsroute is missing a broker host property for broker with ID 2001 which is required for TLSRoute based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
+                .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
+                        .withHost("bootstrap-host")
+                        .build())
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1000)
+                                .withHost("host-1000")
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2001)
+                                .withHost("host-2001")
+                                .build())
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener tlsroute is missing a broker host property for broker with ID 2000 which is required for TLSRoute based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
+                .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
+                        .withHost("bootstrap-host")
+                        .build())
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1000)
+                                .withHost("host-1000")
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2000)
+                                .withHost("host-2000")
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2001)
+                                .withHost("host-2001")
+                                .build())
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), hasSize(0));
     }
 
     @Test
@@ -991,7 +1191,32 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = List.of(internal, route, lb, np, inq);
+        GenericKafkaListener tlsRoute = new GenericKafkaListenerBuilder()
+                .withName("tlsroute")
+                .withPort(9097)
+                .withType(KafkaListenerType.TLSROUTE)
+                .withTls(true)
+                .withNewConfiguration()
+                    .withParentRefs(new ParentReferenceBuilder().withName("my-gateway").withSectionName("tls-sni").build())
+                    .withNewBootstrap()
+                        .withHost("my-host")
+                    .endBootstrap()
+                    .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                    .withBroker(0)
+                                    .withHost("my-host")
+                                    .build(),
+                            new GenericKafkaListenerConfigurationBrokerBuilder()
+                                    .withBroker(1)
+                                    .withHost("my-host")
+                                    .build(),
+                            new GenericKafkaListenerConfigurationBrokerBuilder()
+                                    .withBroker(2)
+                                    .withHost("my-host")
+                                    .build())
+                .endConfiguration()
+                .build();
+
+        List<GenericKafkaListener> listeners = List.of(internal, route, lb, np, inq, tlsRoute);
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), empty());
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTLSRoutesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTLSRoutesTest.java
@@ -5,7 +5,9 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.openshift.api.model.Route;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReferenceBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.RouteParentStatus;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRoute;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
@@ -40,10 +42,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.notNull;
@@ -54,14 +58,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
-public class KafkaListenerReconcilerRoutesTest {
+public class KafkaListenerReconcilerTLSRoutesTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     public static final String NAMESPACE = "test";
     public static final String CLUSTER_NAME = "my-kafka";
-    public static final String DNS_NAME_FOR_BROKER_10 = "broker-10-route.test.dns.name";
-    public static final String DNS_NAME_FOR_BROKER_11 = "broker-11-route.test.dns.name";
-    public static final String DNS_NAME_FOR_BROKER_12 = "broker-12-reout.test.dns.name";
-    public static final String DNS_NAME_FOR_BOOTSTRAP_SERVICE = "bootstrap-route.test.dns.name";
+    public static final String DNS_NAME_FOR_BOOTSTRAP_SERVICE = "my-kafka-bootstrap.com";
     public static final int LISTENER_PORT = 9094;
     private static final Kafka KAFKA = new KafkaBuilder()
                 .withNewMetadata()
@@ -114,15 +115,31 @@ public class KafkaListenerReconcilerRoutesTest {
                 .build();
 
     @Test
-    public void testRoutesNotSupported(VertxTestContext context) {
+    public void testTLSRoutesNotSupported(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
                         .withListeners(new GenericKafkaListenerBuilder()
                                 .withName("external")
                                 .withPort(LISTENER_PORT)
+                                .withType(KafkaListenerType.TLSROUTE)
                                 .withTls(true)
-                                .withType(KafkaListenerType.ROUTE)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("my-kafka-bootstrap.com")
+                                        .withAnnotations(Map.of("dns-annotation", "my-kafka-bootstrap.com"))
+                                        .withLabels(Map.of("label", "label-value"))
+                                    .endBootstrap()
+                                    .withHostTemplate("my-kafka-broker-{nodeId}.com")
+                                    .withPerBrokerLabelsTemplate(Map.of("label", "label-value-{nodeId}"))
+                                    .withPerBrokerAnnotationsTemplate(Map.of("dns-annotation", "my-kafka-broker-{nodeId}.com"))
+                                    .withParentRefs(new ParentReferenceBuilder()
+                                            .withKind("Gateway")
+                                            .withGroup("gateway.networking.k8s.io")
+                                            .withName("envoy-gateway")
+                                            .withNamespace("envoy-gateway-system")
+                                            .build())
+                                .endConfiguration()
                                 .build())
                     .endKafka()
                 .endSpec()
@@ -154,7 +171,7 @@ public class KafkaListenerReconcilerRoutesTest {
         MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
                 reconciliation,
                 kafkaCluster,
-                new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                new PlatformFeaturesAvailability(true, false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
@@ -165,21 +182,37 @@ public class KafkaListenerReconcilerRoutesTest {
         Checkpoint async = context.checkpoint();
         reconciler.reconcile()
                 .onComplete(context.failing(res -> context.verify(() -> {
-                    assertThat(res.getMessage(), is("The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster my-kafka using routes is not possible."));
+                    assertThat(res.getMessage(), is("The Gateway API TLSRoute resource is not available in this Kubernetes cluster. Exposing Kafka cluster my-kafka using TLSRoutes is not possible."));
                     async.flag();
                 })));
     }
 
     @Test
-    public void testRoutes(VertxTestContext context) {
+    public void testTLSRoutes(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
                         .withListeners(new GenericKafkaListenerBuilder()
                                 .withName("external")
                                 .withPort(LISTENER_PORT)
+                                .withType(KafkaListenerType.TLSROUTE)
                                 .withTls(true)
-                                .withType(KafkaListenerType.ROUTE)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("my-kafka-bootstrap.com")
+                                        .withAnnotations(Map.of("dns-annotation", "my-kafka-bootstrap.com"))
+                                        .withLabels(Map.of("label", "label-value"))
+                                    .endBootstrap()
+                                    .withHostTemplate("my-kafka-broker-{nodeId}.com")
+                                    .withPerBrokerLabelsTemplate(Map.of("label", "label-value-{nodeId}"))
+                                    .withPerBrokerAnnotationsTemplate(Map.of("dns-annotation", "my-kafka-broker-{nodeId}.com"))
+                                    .withParentRefs(new ParentReferenceBuilder()
+                                            .withKind("Gateway")
+                                            .withGroup("gateway.networking.k8s.io")
+                                            .withName("envoy-gateway")
+                                            .withNamespace("envoy-gateway-system")
+                                            .build())
+                                .endConfiguration()
                                 .build())
                     .endKafka()
                 .endSpec()
@@ -197,22 +230,28 @@ public class KafkaListenerReconcilerRoutesTest {
         when(mockServiceOperator.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
 
         // Mock the RouteOperator for the OpenShift routes
-        RouteOperator mockRouteOperator = supplier.routeOperations;
+        TLSRouteOperator mockRouteOperator = supplier.tlsRouteOperations;
         // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
         when(mockRouteOperator.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
-        // Mock getting of routes and their readiness
-        Route mockRouteBootstrap = mock(Route.class, RETURNS_DEEP_STUBS);
-        Route mockRouteBroker0 = mock(Route.class, RETURNS_DEEP_STUBS);
-        Route mockRouteBroker1 = mock(Route.class, RETURNS_DEEP_STUBS);
-        Route mockRouteBroker2 = mock(Route.class, RETURNS_DEEP_STUBS);
-        when(mockRouteBootstrap.getStatus().getIngress().get(0).getHost()).thenReturn(DNS_NAME_FOR_BOOTSTRAP_SERVICE);
-        when(mockRouteBroker0.getStatus().getIngress().get(0).getHost()).thenReturn(DNS_NAME_FOR_BROKER_10);
-        when(mockRouteBroker1.getStatus().getIngress().get(0).getHost()).thenReturn(DNS_NAME_FOR_BROKER_11);
-        when(mockRouteBroker2.getStatus().getIngress().get(0).getHost()).thenReturn(DNS_NAME_FOR_BROKER_12);
-        when(mockRouteOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"))).thenReturn(Future.succeededFuture(mockRouteBootstrap));
-        when(mockRouteOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"))).thenReturn(Future.succeededFuture(mockRouteBroker0));
-        when(mockRouteOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"))).thenReturn(Future.succeededFuture(mockRouteBroker1));
-        when(mockRouteOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"))).thenReturn(Future.succeededFuture(mockRouteBroker2));
+        // Mock getting of routes
+        TLSRoute mockRouteBootstrap = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker0 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker1 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker2 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        when(mockRouteBootstrap.getStatus().getParents()).thenReturn(List.of(new RouteParentStatus()));
+        when(mockRouteBroker0.getStatus().getParents()).thenReturn(List.of(new RouteParentStatus()));
+        when(mockRouteBroker1.getStatus().getParents()).thenReturn(List.of(new RouteParentStatus()));
+        when(mockRouteBroker2.getStatus().getParents()).thenReturn(List.of(new RouteParentStatus()));
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"))).thenReturn(mockRouteBootstrap);
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"))).thenReturn(mockRouteBroker0);
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"))).thenReturn(mockRouteBroker1);
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"))).thenReturn(mockRouteBroker2);
+        when(mockRouteOperator.hasParents(any(), eq(NAMESPACE), any(), anyLong(), anyLong())).thenCallRealMethod();
+        when(mockRouteOperator.waitFor(any(), eq(NAMESPACE), any(), eq("addressable"), anyLong(), anyLong(), any())).then(i -> {
+            BiPredicate<String, String> predicate = i.getArgument(6);
+            boolean result = predicate.test(i.getArgument(1), i.getArgument(2));
+            return result ? Future.succeededFuture() : Future.failedFuture(new RuntimeException("failed"));
+        });
         // Mock listing of routes
         when(mockRouteOperator.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
         // Mock route creation / update
@@ -233,7 +272,7 @@ public class KafkaListenerReconcilerRoutesTest {
         MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
                 reconciliation,
                 kafkaCluster,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                new PlatformFeaturesAvailability(false, true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
@@ -259,17 +298,17 @@ public class KafkaListenerReconcilerRoutesTest {
                     verify(supplier.serviceOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), notNull());
 
                     // Check creation of routes
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"), notNull());
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"), notNull());
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"), notNull());
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), notNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"), notNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"), notNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"), notNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), notNull());
 
                     async.flag();
                 })));
     }
 
     @Test
-    public void testRouteDeletion(VertxTestContext context) {
+    public void testTLSRouteDeletion(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
@@ -313,14 +352,19 @@ public class KafkaListenerReconcilerRoutesTest {
         });
 
         // Mock the RouteOperator for the OpenShift routes
-        RouteOperator mockRouteOperator = supplier.routeOperations;
+        TLSRouteOperator mockRouteOperator = supplier.tlsRouteOperations;
         // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
         when(mockRouteOperator.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
+        // Mock the check if the TLSRoute has been accepted or not
+        when(mockRouteOperator.hasParents(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockRouteOperator.hasParents(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockRouteOperator.hasParents(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockRouteOperator.hasParents(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         // Mock listing of routes
-        Route mockRouteBootstrap = mock(Route.class, RETURNS_DEEP_STUBS);
-        Route mockRouteBroker0 = mock(Route.class, RETURNS_DEEP_STUBS);
-        Route mockRouteBroker1 = mock(Route.class, RETURNS_DEEP_STUBS);
-        Route mockRouteBroker2 = mock(Route.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBootstrap = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker0 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker1 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker2 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
         when(mockRouteBootstrap.getMetadata().getName()).thenReturn(CLUSTER_NAME + "-kafka-bootstrap");
         when(mockRouteBroker0.getMetadata().getName()).thenReturn(CLUSTER_NAME + "-brokers-10");
         when(mockRouteBroker1.getMetadata().getName()).thenReturn(CLUSTER_NAME + "-brokers-11");
@@ -344,7 +388,7 @@ public class KafkaListenerReconcilerRoutesTest {
         MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
                 reconciliation,
                 kafkaCluster,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                new PlatformFeaturesAvailability(false, true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
@@ -367,10 +411,113 @@ public class KafkaListenerReconcilerRoutesTest {
                     verify(supplier.serviceOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), isNull());
 
                     // Check creation of routes
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"), isNull());
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"), isNull());
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"), isNull());
-                    verify(supplier.routeOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), isNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"), isNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"), isNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"), isNull());
+                    verify(supplier.tlsRouteOperations, times(1)).reconcile(any(), eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"), isNull());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testTLSRoutesNotReady(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName("external")
+                                .withPort(LISTENER_PORT)
+                                .withType(KafkaListenerType.TLSROUTE)
+                                .withTls(true)
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("my-kafka-bootstrap.com")
+                                        .withAnnotations(Map.of("dns-annotation", "my-kafka-bootstrap.com"))
+                                        .withLabels(Map.of("label", "label-value"))
+                                    .endBootstrap()
+                                    .withHostTemplate("my-kafka-broker-{nodeId}.com")
+                                    .withPerBrokerLabelsTemplate(Map.of("label", "label-value-{nodeId}"))
+                                    .withPerBrokerAnnotationsTemplate(Map.of("dns-annotation", "my-kafka-broker-{nodeId}.com"))
+                                    .withParentRefs(new ParentReferenceBuilder()
+                                            .withKind("Gateway")
+                                            .withGroup("gateway.networking.k8s.io")
+                                            .withName("envoy-gateway")
+                                            .withNamespace("envoy-gateway-system")
+                                            .build())
+                                .endConfiguration()
+                                .build())
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
+
+        // Mock the ServiceOperator for the kafka services.
+        ServiceOperator mockServiceOperator = supplier.serviceOperations;
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockServiceOperator.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
+        // Mock listing of services
+        when(mockServiceOperator.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        // Mock service creation / update
+        when(mockServiceOperator.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock the RouteOperator for the OpenShift routes
+        TLSRouteOperator mockRouteOperator = supplier.tlsRouteOperations;
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockRouteOperator.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
+        // Mock getting of routes
+        TLSRoute mockRouteBootstrap = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker0 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker1 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        TLSRoute mockRouteBroker2 = mock(TLSRoute.class, RETURNS_DEEP_STUBS);
+        when(mockRouteBootstrap.getStatus().getParents()).thenReturn(List.of(new RouteParentStatus()));
+        when(mockRouteBroker0.getStatus().getParents()).thenReturn(null);
+        when(mockRouteBroker1.getStatus().getParents()).thenReturn(List.of());
+        when(mockRouteBroker2.getStatus().getParents()).thenReturn(List.of(new RouteParentStatus()));
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-bootstrap"))).thenReturn(mockRouteBootstrap);
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-10"))).thenReturn(mockRouteBroker0);
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-11"))).thenReturn(mockRouteBroker1);
+        when(mockRouteOperator.get(eq(NAMESPACE), eq(CLUSTER_NAME + "-brokers-12"))).thenReturn(mockRouteBroker2);
+        when(mockRouteOperator.hasParents(any(), eq(NAMESPACE), any(), anyLong(), anyLong())).thenCallRealMethod();
+        when(mockRouteOperator.waitFor(any(), eq(NAMESPACE), any(), eq("addressable"), anyLong(), anyLong(), any())).then(i -> {
+            BiPredicate<String, String> predicate = i.getArgument(6);
+            boolean result = predicate.test(i.getArgument(1), i.getArgument(2));
+            return result ? Future.succeededFuture() : Future.failedFuture(new RuntimeException(i.getArgument(2) + " is not addressable"));
+        });
+        // Mock listing of routes
+        when(mockRouteOperator.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        // Mock route creation / update
+        when(mockRouteOperator.reconcile(any(), eq(NAMESPACE), any(), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME);
+
+        KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(
+                reconciliation,
+                kafka,
+                List.of(POOL_CONTROLLERS, POOL_BROKERS),
+                Map.of(),
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                VERSIONS,
+                supplier.sharedEnvironmentProvider
+        );
+
+        MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
+                reconciliation,
+                kafkaCluster,
+                new PlatformFeaturesAvailability(false, true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier.secretOperations,
+                supplier.serviceOperations,
+                supplier.routeOperations,
+                supplier.tlsRouteOperations,
+                supplier.ingressOperations
+        );
+
+        Checkpoint async = context.checkpoint();
+        reconciler.reconcile()
+                .onComplete(context.failing(e -> context.verify(() -> {
+                    // Check status
+                    assertThat(e.getMessage(), is("my-kafka-brokers-10 is not addressable"));
 
                     async.flag();
                 })));
@@ -395,10 +542,10 @@ public class KafkaListenerReconcilerRoutesTest {
         @Override
         public Future<ReconciliationResult> reconcile()  {
             return services()
-                    .compose(i -> routes())
+                    .compose(i -> tlsRoutes())
                     .compose(i -> clusterIPServicesReady())
                     .compose(i -> loadBalancerServicesReady())
-                    .compose(i -> routesReady())
+                    .compose(i -> tlsRoutesReady())
                     .compose(i -> Future.succeededFuture(result));
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTest.java
@@ -26,6 +26,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.IngressOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.RouteOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.TLSRouteOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -157,6 +158,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -228,6 +230,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -314,6 +317,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -396,6 +400,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -473,6 +478,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -539,6 +545,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -599,6 +606,7 @@ public class KafkaListenerReconcilerTest {
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
+                supplier.tlsRouteOperations,
                 supplier.ingressOperations
         );
 
@@ -673,8 +681,9 @@ public class KafkaListenerReconcilerTest {
                 SecretOperator secretOperator,
                 ServiceOperator serviceOperator,
                 RouteOperator routeOperator,
+                TLSRouteOperator tlsRouteOperator,
                 IngressOperator ingressOperator) {
-            super(reconciliation, kafka, null, pfa, 300_000L, secretOperator, serviceOperator, routeOperator, ingressOperator);
+            super(reconciliation, kafka, null, pfa, 300_000L, secretOperator, serviceOperator, routeOperator, tlsRouteOperator, ingressOperator);
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/TLSRouteOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/TLSRouteOperatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.kubernetes;
+
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRoute;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRouteBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.TLSRouteList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+import static org.mockito.Mockito.when;
+
+public class TLSRouteOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, TLSRoute, TLSRouteList, Resource<TLSRoute>> {
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    @SuppressWarnings({ "rawtypes" })
+    protected Class<Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected TLSRoute resource(String name) {
+        return new TLSRouteBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(name)
+                .endMetadata()
+                .withNewSpec()
+                    .withHostnames("my-hostname")
+                .endSpec()
+                .build();
+    }
+
+    @Override
+    protected TLSRoute modifiedResource(String name) {
+        return new TLSRouteBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(name)
+                .endMetadata()
+                .withNewSpec()
+                    .withHostnames("my-other-hostname")
+                .endSpec()
+                .build();
+    }
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    protected void mocker(KubernetesClient mockClient, MixedOperation op) {
+        when(mockClient.resources(TLSRoute.class, TLSRouteList.class)).thenReturn(op);
+    }
+
+    @Override
+    protected AbstractNamespacedResourceOperator<KubernetesClient, TLSRoute, TLSRouteList, Resource<TLSRoute>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new TLSRouteOperator(vertx, mockClient);
+    }
+}

--- a/documentation/assemblies/deploying/assembly-deploy-client-access.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-client-access.adoc
@@ -21,6 +21,7 @@ include::../../modules/overview/con-configuration-points-listener-names.adoc[lev
 //access through external listeners
 include::../../modules/security/proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]
 include::../../modules/security/proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]
+include::../../modules/security/proc-accessing-kafka-using-tlsroutes.adoc[leveloffset=+1]
 //Kubernetes only
 ifdef::Section[]
 include::../../modules/security/proc-accessing-kafka-using-ingress.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -338,7 +338,7 @@ This property is used to select the preferred address type, which is checked fir
 This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
 For `loadbalancer` listeners only.
 |parentRefs
-|xref:type-ParentReference-{context}[`ParentReference`] array
+|https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#parentreference[ParentReference] array
 |Configures the resource(s) TLSRoutes created by this listener will be attached to.
 Typically this would be Gateway resource.
 For `tlsroute` listeners only.
@@ -446,35 +446,6 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 |externalIPs
 |string array
 |External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This field is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. This field can only be used with `nodeport` type listener.
-|====
-
-[id='type-ParentReference-{context}']
-= `ParentReference` schema reference
-
-Used in: xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaListenerConfiguration`]
-
-
-[cols="2,2,3a",options="header"]
-|====
-|Property |Property type |Description
-|kind
-|string
-|
-|group
-|string
-|
-|name
-|string
-|
-|namespace
-|string
-|
-|port
-|integer
-|
-|sectionName
-|string
-|
 |====
 
 [id='type-KafkaAuthorizationSimple-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -339,9 +339,9 @@ This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration
 For `loadbalancer` listeners only.
 |parentRefs
 |https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#parentreference[ParentReference] array
-|Configures the resource(s) TLSRoutes created by this listener will be attached to.
-Typically this would be Gateway resource.
-For `tlsroute` listeners only.
+|For `tlsroute` listeners only.
+Configures the Gateway API resource or resources that generated `TLSRoute` resources attach to.
+Typically, this is a `Gateway` resource.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -142,7 +142,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.a
 |integer
 |Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 |type
-|string (one of [ingress, internal, route, loadbalancer, cluster-ip, nodeport])
+|string (one of [ingress, internal, route, loadbalancer, cluster-ip, nodeport, tlsroute])
 |Type of the listener. The supported types are as follows: 
 
 * `internal` type exposes Kafka internally only within the Kubernetes cluster.
@@ -337,6 +337,11 @@ This property is used to select the preferred address type, which is checked fir
 |Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
 This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
 For `loadbalancer` listeners only.
+|parentRefs
+|xref:type-ParentReference-{context}[`ParentReference`] array
+|Configures the resource(s) TLSRoutes created by this listener will be attached to.
+Typically this would be Gateway resource.
+For `tlsroute` listeners only.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']
@@ -441,6 +446,35 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 |externalIPs
 |string array
 |External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This field is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. This field can only be used with `nodeport` type listener.
+|====
+
+[id='type-ParentReference-{context}']
+= `ParentReference` schema reference
+
+Used in: xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaListenerConfiguration`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|kind
+|string
+|
+|group
+|string
+|
+|name
+|string
+|
+|namespace
+|string
+|
+|port
+|integer
+|
+|sectionName
+|string
+|
 |====
 
 [id='type-KafkaAuthorizationSimple-{context}']

--- a/documentation/modules/overview/con-configuration-points-listener-names.adoc
+++ b/documentation/modules/overview/con-configuration-points-listener-names.adoc
@@ -15,12 +15,12 @@ From the listener configuration, the resulting listener bootstrap and per-broker
 |===
 | Listener type | Bootstrap service name | Per-Broker service name
 | `internal` | <cluster_name>-kafka-bootstrap | _Not applicable_
-| `loadbalancer`, `nodeport`, `ingress`, `route`, `cluster-ip`
+| `loadbalancer`, `nodeport`, `ingress`, `route`, `tlsroute`, `cluster-ip`
 | <cluster_name>-kafka-<listener-name>-bootstrap | <cluster_name>-kafka-<listener-name>-<idx>
 |===
 
 For example, `my-cluster-kafka-bootstrap`, `my-cluster-kafka-external1-bootstrap`, and `my-cluster-kafka-external1-0`.
-The names are assigned to the services, routes, load balancers, and ingresses created through the listener configuration.
+The names are assigned to the services, routes, load balancers, ingresses, and TLSRoutes created through the listener configuration.
 
 You can use certain backwards compatible names and port numbers to transition listeners initially configured under the retired `KafkaListeners` schema.
 The resulting external listener naming convention varies slightly. 

--- a/documentation/modules/overview/con-configuration-points-listener-names.adoc
+++ b/documentation/modules/overview/con-configuration-points-listener-names.adoc
@@ -20,7 +20,7 @@ From the listener configuration, the resulting listener bootstrap and per-broker
 |===
 
 For example, `my-cluster-kafka-bootstrap`, `my-cluster-kafka-external1-bootstrap`, and `my-cluster-kafka-external1-0`.
-The names are assigned to the services, routes, load balancers, ingresses, and TLSRoutes created through the listener configuration.
+The names are assigned to the services, routes, load balancers, ingresses, and Gateway API TLS routes generated through the listener configuration.
 
 You can use certain backwards compatible names and port numbers to transition listeners initially configured under the retired `KafkaListeners` schema.
 The resulting external listener naming convention varies slightly. 

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -30,11 +30,14 @@ External listeners:: Use external listener types to connect clients outside a Ku
 +
 * `nodeport` to use ports on Kubernetes nodes
 * `loadbalancer` to use loadbalancer services
+* `tlsroute` to use Gateway API `v1` `TLSRoute` resources
 * `ingress` to use Kubernetes `Ingress` and the {NginxIngressController} (Kubernetes only)
 * `route` to use OpenShift `Route` and the default HAProxy router (OpenShift only)
 +
 External listeners handle access to a Kafka cluster from networks that require different authentication mechanisms.
 For example, loadbalancers might not be suitable for certain infrastructure, such as bare metal, where node ports provide a better option.
+
+NOTE: The `ingress` listener type is deprecated. Consider using the `tlsroute` listener type when you have a Gateway API implementation that supports `TLSRoute` resources.
 
 IMPORTANT: Do not use the built-in `ingress` controller on OpenShift, use the `route` type instead. The Ingress NGINX Controller is only intended for use on Kubernetes. The `route` type is only supported on OpenShift.
 

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -30,14 +30,14 @@ External listeners:: Use external listener types to connect clients outside a Ku
 +
 * `nodeport` to use ports on Kubernetes nodes
 * `loadbalancer` to use loadbalancer services
-* `tlsroute` to use Gateway API `v1` `TLSRoute` resources
+* `tlsroute` to use Kubernetes Gateway API `v1` `TLSRoute` resources
 * `ingress` to use Kubernetes `Ingress` and the {NginxIngressController} (Kubernetes only)
 * `route` to use OpenShift `Route` and the default HAProxy router (OpenShift only)
 +
 External listeners handle access to a Kafka cluster from networks that require different authentication mechanisms.
 For example, loadbalancers might not be suitable for certain infrastructure, such as bare metal, where node ports provide a better option.
 
-NOTE: The `ingress` listener type is deprecated. Consider using the `tlsroute` listener type when you have a Gateway API implementation that supports `TLSRoute` resources.
+NOTE: The `ingress` listener type is deprecated. Consider using the `tlsroute` listener type if your Gateway API implementation supports `TLSRoute` resources.
 
 IMPORTANT: Do not use the built-in `ingress` controller on OpenShift, use the `route` type instead. The Ingress NGINX Controller is only intended for use on Kubernetes. The `route` type is only supported on OpenShift.
 

--- a/documentation/modules/security/proc-accessing-kafka-using-tlsroutes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-tlsroutes.adoc
@@ -5,44 +5,45 @@
 // assembly-deploy-client-access.adoc
 
 [id='proc-accessing-kafka-using-tlsroutes-{context}']
-= Accessing Kafka using Gateway API TLSRoutes
+= Accessing Kafka using Gateway API `TLSRoute` resources
 
 [role="_abstract"]
-Use Gateway API `TLSRoute` resources to access a Kafka cluster from clients outside the Kubernetes cluster.
+Use Kubernetes Gateway API `TLSRoute` resources to access a Kafka cluster from clients outside a Kubernetes cluster.
 
-To use TLSRoutes, add configuration for a `tlsroute` type listener in the `Kafka` custom resource.
+To use `TLSRoute` resources, add configuration for a `tlsroute` type listener in the `Kafka` custom resource.
 When applied, the configuration creates a dedicated `ClusterIP` service and `TLSRoute` resource for an external bootstrap and each broker in the cluster.
 Clients connect to the bootstrap hostname, which routes them through the bootstrap service to connect to a broker.
-Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific TLSRoutes and services.
+Per-broker connections are then established using DNS names that route traffic from the client to the broker through the broker-specific Gateway API TLS routes and services.
 
-Strimzi manages the `TLSRoute` resources, but it does not manage the Gateway API `Gateway` resource.
+Strimzi manages the `TLSRoute` resources, but does not manage the Gateway API `Gateway` resource.
 You must provide a Gateway API implementation and a `Gateway` that accepts the `TLSRoute` resources created by Strimzi.
 
 NOTE: Strimzi uses and supports the `gateway.networking.k8s.io/v1` API version of the `TLSRoute` resource.
 
-To connect to a broker, you specify a hostname for the TLSRoute bootstrap address.
-For access using TLSRoutes, the port used in the Kafka client is typically 443.
+To connect to a broker, specify a hostname for the `TLSRoute` bootstrap address.
+For access using `TLSRoute` resources, the port used in the Kafka client is typically 443.
 
-The procedure shows basic `tlsroute` listener configuration using TLS passthrough.
+The procedure shows a basic `tlsroute` listener configuration using TLS passthrough.
 Use the `parentRefs` configuration property to attach the generated TLSRoutes to a Gateway API resource, such as a `Gateway`.
-Use the `bootstrap.host` configuration property to specify the hostname used by the bootstrap TLSRoute.
-Use the `hostTemplate` or the `brokers[].host` fields to specify the hostname for each broker TLSRoute.
+Use the `bootstrap.host` configuration property to specify the hostname used by the bootstrap `TLSRoute`.
+Use the `hostTemplate` or the `brokers[].host` fields to specify the hostname for each broker `TLSRoute`.
 
 For more information on listener configuration, see the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference^].
 
-.TLS passthrough and termination
 
 `TLSRoute` resources use Server Name Indication (SNI) to route TLS traffic.
 The TLS mode is configured in the Gateway API `Gateway` listener, not in the Strimzi `TLSRoute` resource.
 
-With TLS passthrough, the Gateway forwards the TLS connection to the Kafka brokers.
+You can configure TLS passthrough or TLS termination.
+
+With TLS passthrough, the Gateway forwards the encrypted TLS connection to the Kafka brokers.
 The Kafka listener must have TLS encryption enabled (`tls: true`).
 The connection uses the TLS certificates from the Kafka brokers, and you can use TLS client authentication.
 To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property].
 
 With TLS termination, the Gateway terminates the TLS connection and forwards unencrypted traffic to the Kafka brokers.
 Configure the Kafka listener without TLS encryption (`tls: false`).
-The client uses the Gateway certificate, and TLS client authentication in the Strimzi listener is not available.
+The client uses the Gateway certificate, and TLS client authentication between the client and Kafka brokers is not available.
 
 .Prerequisites
 
@@ -58,7 +59,7 @@ The name of the listener is `external`.
 
 . Configure a `Kafka` resource with an external listener set to the `tlsroute` type.
 +
-Specify a bootstrap hostname, per-broker hostnames, and the Gateway API parent references for the generated TLSRoutes.
+Specify a bootstrap hostname, per-broker hostnames, and the Gateway API parent references for the generated `TLSRoute` resources.
 +
 For example:
 +
@@ -78,29 +79,33 @@ spec:
       - name: external
         port: 9094
         type: tlsroute
-        tls: true # <1>
+        tls: true
         authentication:
           type: tls
         configuration:
           parentRefs:
-            - name: kafka-gateway # <2>
-              kind: Gateway # <3>
-              group: gateway.networking.k8s.io # <4>
-              namespace: myproject # <5>
-              sectionName: kafka # <6>
+            - name: kafka-gateway
+              kind: Gateway
+              group: gateway.networking.k8s.io
+              namespace: myproject
+              sectionName: kafka
           bootstrap:
-            host: bootstrap.example.com # <7>
-          hostTemplate: broker-{nodeId}.example.com # <8>
+            host: bootstrap.example.com
+          hostTemplate: broker-{nodeId}.example.com
     # ...
 ----
-<1> Enables TLS encryption in the Kafka brokers for TLS passthrough. For TLS termination at the Gateway, set this property to `false` and do not use `tls` authentication.
-<2> Name of the Gateway API parent resource that the generated TLSRoutes attach to.
-<3> Kind of the Gateway API parent resource.
-<4> API group of the Gateway API parent resource.
-<5> Namespace of the Gateway API parent resource.
-<6> (Optional) Gateway listener name to attach the TLSRoutes to.
-<7> Hostname used by the bootstrap TLSRoute. The hostname must resolve to the Gateway address.
-<8> Template used to generate the hostnames for the per-broker TLSRoutes. The hostnames must resolve to the Gateway address.
+
+* `tls: true` enables TLS encryption in the Kafka brokers for TLS passthrough. 
+For TLS termination at the Gateway, set this property to `false` and do not configure `tls` authentication for the listener.
+* `name` under `parentRefs` specifies the name of the Gateway API parent resource that the generated `TLSRoute` resources attach to.
+* `kind` under `parentRefs` specifies the kind of the Gateway API parent resource.
+* `group` under `parentRefs` specifies the API group of the Gateway API parent resource.
+* `namespace` under `parentRefs` specifies the namespace of the Gateway API parent resource.
+* `sectionName` under `parentRefs` optionally specifies the Gateway listener name that the generated `TLSRoute` resources attach to.
+* `bootstrap.host` specifies the hostname used by the bootstrap `TLSRoute`.
+The hostname must resolve to the Gateway address.
+* `hostTemplate` specifies the template used to generate hostnames for the per-broker `TLSRoute` resources.
+The hostnames must resolve to the Gateway address.
 
 . Create or update the resource.
 +
@@ -113,9 +118,10 @@ If TLS encryption is enabled, a cluster CA certificate to verify the identity of
 +
 `ClusterIP` type services are created for each Kafka broker, as well as an external bootstrap service.
 +
-A `TLSRoute` is also created for each service, with a hostname to expose it using the Gateway API implementation.
+A `TLSRoute` resource is also created for each service, with a hostname to expose it using the Gateway API implementation.
 +
-.TLSRoutes created for the bootstrap and brokers
+TLSRoutes created for the bootstrap and brokers:
++
 [source,shell]
 ----
 NAME                                  HOSTNAMES                 AGE
@@ -125,8 +131,8 @@ my-cluster-kafka-external-2          broker-2.example.com      1m
 my-cluster-kafka-external-bootstrap  bootstrap.example.com     1m
 ----
 +
-Strimzi waits for each TLSRoute status to contain at least one parent reference.
-If a TLSRoute status is not updated with a parent reference before the Cluster Operator reconciliation timeout, the reconciliation fails.
+Strimzi waits for each `TLSRoute` status to contain at least one parent reference.
+If a `TLSRoute` status is not updated with a parent reference before the Cluster Operator reconciliation timeout, the reconciliation fails.
 
 . Retrieve the address of the bootstrap service from the status of the `Kafka` resource.
 +
@@ -144,11 +150,10 @@ bootstrap.example.com:443
 openssl s_client -connect broker-0.example.com:443 -servername broker-0.example.com -showcerts
 ----
 +
-The server name is the Server Name Indication (SNI) for passing the connection to the broker.
+The server name is used as the Server Name Indication (SNI) for passing the connection to the broker.
 +
-If the connection is successful, the certificates for the broker are returned.
+If the connection is successful, the certificates for the broker are returned:
 +
-.Certificates for the broker
 [source,shell,subs=attributes+]
 ----
 Certificate chain
@@ -171,9 +176,9 @@ If your Gateway uses a different external port, use that port in the client boot
 
 .. If you are using TLS passthrough, add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
 +
-If you enabled a client authentication mechanism, you will also need to configure it in your client.
+If you enabled a client authentication mechanism, you must also configure it in your client.
 +
-For TLS termination at the Gateway, configure the client to trust the Gateway certificate instead.
+For TLS termination at the Gateway, configure the client to trust the Gateway certificate instead of the cluster CA certificate.
 
-NOTE: If you are using your own listener certificates with TLS passthrough, check whether you need to add the CA certificate to the client's truststore configuration.
+NOTE: If you are using your own listener certificates with TLS passthrough, check whether you need to add the CA certificate to the client truststore configuration.
 If it is a public (external) CA, you usually won't need to add it.

--- a/documentation/modules/security/proc-accessing-kafka-using-tlsroutes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-tlsroutes.adoc
@@ -1,0 +1,179 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// assembly-deploy-client-access.adoc
+
+[id='proc-accessing-kafka-using-tlsroutes-{context}']
+= Accessing Kafka using Gateway API TLSRoutes
+
+[role="_abstract"]
+Use Gateway API `TLSRoute` resources to access a Kafka cluster from clients outside the Kubernetes cluster.
+
+To use TLSRoutes, add configuration for a `tlsroute` type listener in the `Kafka` custom resource.
+When applied, the configuration creates a dedicated `ClusterIP` service and `TLSRoute` resource for an external bootstrap and each broker in the cluster.
+Clients connect to the bootstrap hostname, which routes them through the bootstrap service to connect to a broker.
+Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific TLSRoutes and services.
+
+Strimzi manages the `TLSRoute` resources, but it does not manage the Gateway API `Gateway` resource.
+You must provide a Gateway API implementation and a `Gateway` that accepts the `TLSRoute` resources created by Strimzi.
+
+NOTE: Strimzi uses and supports the `gateway.networking.k8s.io/v1` API version of the `TLSRoute` resource.
+
+To connect to a broker, you specify a hostname for the TLSRoute bootstrap address.
+For access using TLSRoutes, the port used in the Kafka client is typically 443.
+
+The procedure shows basic `tlsroute` listener configuration using TLS passthrough.
+Use the `parentRefs` configuration property to attach the generated TLSRoutes to a Gateway API resource, such as a `Gateway`.
+Use the `bootstrap.host` configuration property to specify the hostname used by the bootstrap TLSRoute.
+Use the `hostTemplate` or the `brokers[].host` fields to specify the hostname for each broker TLSRoute.
+
+For more information on listener configuration, see the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference^].
+
+.TLS passthrough and termination
+
+`TLSRoute` resources use Server Name Indication (SNI) to route TLS traffic.
+The TLS mode is configured in the Gateway API `Gateway` listener, not in the Strimzi `TLSRoute` resource.
+
+With TLS passthrough, the Gateway forwards the TLS connection to the Kafka brokers.
+The Kafka listener must have TLS encryption enabled (`tls: true`).
+The connection uses the TLS certificates from the Kafka brokers, and you can use TLS client authentication.
+To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property].
+
+With TLS termination, the Gateway terminates the TLS connection and forwards unencrypted traffic to the Kafka brokers.
+Configure the Kafka listener without TLS encryption (`tls: false`).
+The client uses the Gateway certificate, and TLS client authentication in the Strimzi listener is not available.
+
+.Prerequisites
+
+* A Gateway API implementation that supports `gateway.networking.k8s.io/v1` `TLSRoute` resources is installed
+* A Gateway API `Gateway` is configured for Kafka traffic and accepts TLSRoutes from the Kafka namespace
+* DNS records for the bootstrap and per-broker hostnames resolve to the Gateway address
+* A running Cluster Operator
+
+In this procedure, the Kafka cluster name is `my-cluster`.
+The name of the listener is `external`.
+
+.Procedure
+
+. Configure a `Kafka` resource with an external listener set to the `tlsroute` type.
++
+Specify a bootstrap hostname, per-broker hostnames, and the Gateway API parent references for the generated TLSRoutes.
++
+For example:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
+spec:
+  kafka:
+    # ...
+    listeners:
+      - name: external
+        port: 9094
+        type: tlsroute
+        tls: true # <1>
+        authentication:
+          type: tls
+        configuration:
+          parentRefs:
+            - name: kafka-gateway # <2>
+              kind: Gateway # <3>
+              group: gateway.networking.k8s.io # <4>
+              namespace: myproject # <5>
+              sectionName: kafka # <6>
+          bootstrap:
+            host: bootstrap.example.com # <7>
+          hostTemplate: broker-{nodeId}.example.com # <8>
+    # ...
+----
+<1> Enables TLS encryption in the Kafka brokers for TLS passthrough. For TLS termination at the Gateway, set this property to `false` and do not use `tls` authentication.
+<2> Name of the Gateway API parent resource that the generated TLSRoutes attach to.
+<3> Kind of the Gateway API parent resource.
+<4> API group of the Gateway API parent resource.
+<5> Namespace of the Gateway API parent resource.
+<6> (Optional) Gateway listener name to attach the TLSRoutes to.
+<7> Hostname used by the bootstrap TLSRoute. The hostname must resolve to the Gateway address.
+<8> Template used to generate the hostnames for the per-broker TLSRoutes. The hostnames must resolve to the Gateway address.
+
+. Create or update the resource.
++
+[source,shell,subs=+quotes]
+----
+kubectl apply -f _<kafka_configuration_file>_
+----
++
+If TLS encryption is enabled, a cluster CA certificate to verify the identity of the Kafka brokers is created in the secret `my-cluster-cluster-ca-cert`.
++
+`ClusterIP` type services are created for each Kafka broker, as well as an external bootstrap service.
++
+A `TLSRoute` is also created for each service, with a hostname to expose it using the Gateway API implementation.
++
+.TLSRoutes created for the bootstrap and brokers
+[source,shell]
+----
+NAME                                  HOSTNAMES                 AGE
+my-cluster-kafka-external-0          broker-0.example.com      1m
+my-cluster-kafka-external-1          broker-1.example.com      1m
+my-cluster-kafka-external-2          broker-2.example.com      1m
+my-cluster-kafka-external-bootstrap  bootstrap.example.com     1m
+----
++
+Strimzi waits for each TLSRoute status to contain at least one parent reference.
+If a TLSRoute status is not updated with a parent reference before the Cluster Operator reconciliation timeout, the reconciliation fails.
+
+. Retrieve the address of the bootstrap service from the status of the `Kafka` resource.
++
+[source,shell,subs=+quotes]
+----
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
+
+bootstrap.example.com:443
+----
+
+. If you are using TLS passthrough, use a target broker to check the client-server TLS connection on port 443 using the OpenSSL `s_client`.
++
+[source,shell]
+----
+openssl s_client -connect broker-0.example.com:443 -servername broker-0.example.com -showcerts
+----
++
+The server name is the Server Name Indication (SNI) for passing the connection to the broker.
++
+If the connection is successful, the certificates for the broker are returned.
++
+.Certificates for the broker
+[source,shell,subs=attributes+]
+----
+Certificate chain
+ 0 s:O = io.strimzi, CN = my-cluster-kafka
+   i:O = io.strimzi, CN = cluster-ca v0
+----
+
+. If you are using TLS passthrough, extract the cluster CA certificate.
++
+[source,shell]
+----
+kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+
+. Configure your client to connect to the brokers.
+
+.. Specify the address for the bootstrap service and port 443 in your Kafka client as the bootstrap address to connect to the Kafka cluster.
++
+If your Gateway uses a different external port, use that port in the client bootstrap address and configure per-broker `advertisedPort` entries or the `advertisedPortTemplate` property for the per-broker advertised ports.
+
+.. If you are using TLS passthrough, add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
++
+If you enabled a client authentication mechanism, you will also need to configure it in your client.
++
+For TLS termination at the Gateway, configure the client to trust the Gateway certificate instead.
+
+NOTE: If you are using your own listener certificates with TLS passthrough, check whether you need to add the CA certificate to the client's truststore configuration.
+If it is a public (external) CA, you usually won't need to add it.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -347,9 +347,9 @@ spec:
                                     sectionName:
                                       type: string
                                 description: |-
-                                  Configures the resource(s) TLSRoutes created by this listener will be attached to.
-                                  Typically this would be Gateway resource.
                                   For `tlsroute` listeners only.
+                                  Configures the Gateway API resource or resources that generated `TLSRoute` resources attach to.
+                                  Typically, this is a `Gateway` resource.
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -89,6 +89,7 @@ spec:
                             enum:
                               - internal
                               - route
+                              - tlsroute
                               - loadbalancer
                               - nodeport
                               - ingress
@@ -328,6 +329,27 @@ spec:
                                   Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
                                   This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
                                   For `loadbalancer` listeners only.
+                              parentRefs:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    kind:
+                                      type: string
+                                    group:
+                                      type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    port:
+                                      type: integer
+                                    sectionName:
+                                      type: string
+                                description: |-
+                                  Configures the resource(s) TLSRoutes created by this listener will be attached to.
+                                  Typically this would be Gateway resource.
+                                  For `tlsroute` listeners only.
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -168,4 +168,17 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+    # The cluster operator needs to access and manage TLSRoutes to expose Strimzi components for external access
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
 {{- end -}}

--- a/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -163,3 +163,16 @@ rules:
       - delete
       - patch
       - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      # The cluster operator needs to access and manage TLSRoutes to expose Strimzi components for external access
+      - tlsroutes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -346,9 +346,9 @@ spec:
                                   sectionName:
                                     type: string
                               description: |-
-                                Configures the resource(s) TLSRoutes created by this listener will be attached to.
-                                Typically this would be Gateway resource.
                                 For `tlsroute` listeners only.
+                                Configures the Gateway API resource or resources that generated `TLSRoute` resources attach to.
+                                Typically, this is a `Gateway` resource.
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -88,6 +88,7 @@ spec:
                           enum:
                           - internal
                           - route
+                          - tlsroute
                           - loadbalancer
                           - nodeport
                           - ingress
@@ -327,6 +328,27 @@ spec:
                                 Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
                                 This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
                                 For `loadbalancer` listeners only.
+                            parentRefs:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  kind:
+                                    type: string
+                                  group:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  port:
+                                    type: integer
+                                  sectionName:
+                                    type: string
+                              description: |-
+                                Configures the resource(s) TLSRoutes created by this listener will be attached to.
+                                Typically this would be Gateway resource.
+                                For `tlsroute` listeners only.
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,11 @@
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-gatewayapi</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
                 <artifactId>openshift-model</artifactId>
                 <version>${fabric8.kubernetes-model.version}</version>
             </dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements [SEP-136 Gateway API-based `type: tlsroute` listener](https://github.com/strimzi/proposals/blob/main/136-tls-route-listener.md) and adds support for a new listener type based on Gateway API `TLSRoutes`.

This should resolve #11123.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md