### PR TITLE
Attach Mockito as an agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -949,6 +949,10 @@
                     <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
                     <useModulePath>false</useModulePath>
                     <skipTests>${skip.surefire.tests}</skipTests>
+                    <argLine>
+                        -javaagent:${org.mockito:mockito-core:jar}
+                        -Xshare:off
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -1035,6 +1039,11 @@
                         <configuration>
                             <failOnWarning>true</failOnWarning>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### Type of change

- Task

### Description

When running some tests using Mockito we get the following warning:
```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/Users/scholzj/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

This PR tries to address the warning to make sure the code continues to work even after Java 21.

_Steps to reproduce:_
* _Go to `cluster-operator`_
* _Run `mvn test -Dtest=io.strimzi.operator.cluster.operator.assembly.KafkaListenerReconcilerRoutesTest`_
* _Check the output_

### Checklist

- [ ] Make sure all tests pass