### PR TITLE
Fix connector state transitions from FAILED to PAUSED or STOPPED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0
 
+* Allow failed `KafkaConnectors` to be stopped and reject pausing of failed connectors since this operation is not supported by Kafka Connect
 * Add support for Apache Kafka 4.3.0 and 4.2.1
 * Remove support for Kafka 4.1.x
 * Reconcile Cruise Control before Entity Operator when both are enabled.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -483,7 +483,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             Future<Void> future = Future.succeededFuture();
 
             switch (state) {
-                case "RUNNING" -> {
+                case "RUNNING", "FAILED" -> {
                     if (targetState == ConnectorState.PAUSED) {
                         LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
                         future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
@@ -508,15 +508,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                     } else if (targetState == ConnectorState.PAUSED) {
                         LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
                         future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
-                    }
-                }
-                case "FAILED" -> {
-                    if (targetState == ConnectorState.PAUSED) {
-                        LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
-                        future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
-                    } else if (targetState == ConnectorState.STOPPED) {
-                        LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);
-                        future = Future.fromCompletionStage(apiClient.stop(reconciliation, host, port, connectorName));
                     }
                 }
                 default -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -512,10 +512,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 }
                 case "FAILED" -> {
                     if (targetState == ConnectorState.PAUSED) {
-                        String message = "Connector " + connectorName + " cannot be paused since it is in failed state.";
-                        LOGGER.warnCr(reconciliation, message);
-                        conditions.add(StatusUtils.buildWarningCondition("UpdateConnectorState", message));
-                        return Future.succeededFuture(conditions);
+                        return Future.failedFuture("Connector " + connectorName + " cannot be paused since it is in failed state.");
                     } else if (targetState == ConnectorState.STOPPED) {
                         LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);
                         future = Future.fromCompletionStage(apiClient.stop(reconciliation, host, port, connectorName));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -483,7 +483,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             Future<Void> future = Future.succeededFuture();
 
             switch (state) {
-                case "RUNNING", "FAILED" -> {
+                case "RUNNING" -> {
                     if (targetState == ConnectorState.PAUSED) {
                         LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
                         future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
@@ -508,6 +508,17 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                     } else if (targetState == ConnectorState.PAUSED) {
                         LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
                         future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
+                    }
+                }
+                case "FAILED" -> {
+                    if (targetState == ConnectorState.PAUSED) {
+                        String message = "Connector " + connectorName + " cannot be paused since it is in failed state.";
+                        LOGGER.warnCr(reconciliation, message);
+                        conditions.add(StatusUtils.buildWarningCondition("UpdateConnectorState", message));
+                        return Future.succeededFuture(conditions);
+                    } else if (targetState == ConnectorState.STOPPED) {
+                        LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);
+                        future = Future.fromCompletionStage(apiClient.stop(reconciliation, host, port, connectorName));
                     }
                 }
                 default -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -512,6 +512,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 }
                 case "FAILED" -> {
                     if (targetState == ConnectorState.PAUSED) {
+                        LOGGER.warnCr(reconciliation, "Connector {} cannot be paused since it is in the failed state", connectorName);
                         return Future.failedFuture("Connector " + connectorName + " cannot be paused since it is in failed state.");
                     } else if (targetState == ConnectorState.STOPPED) {
                         LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -510,6 +510,15 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
                     }
                 }
+                case "FAILED" -> {
+                    if (targetState == ConnectorState.PAUSED) {
+                        LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
+                        future = Future.fromCompletionStage(apiClient.pause(reconciliation, host, port, connectorName));
+                    } else if (targetState == ConnectorState.STOPPED) {
+                        LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);
+                        future = Future.fromCompletionStage(apiClient.stop(reconciliation, host, port, connectorName));
+                    }
+                }
                 default -> {
                     // Connectors can also be in the UNASSIGNED or RESTARTING state. We could transition directly
                     // from these states to PAUSED or STOPPED but as these are transient, and typically lead to

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -2743,9 +2743,9 @@ public class ConnectorMockTest {
                 eq(connectorName));
     }
 
-    /** Create connect, create connector, simulate FAILED state, pause connector */
+    /** Create connect, create connector in FAILED state, attempt to pause — should log warning and add condition instead of calling pause() */
     @Test
-    public void testConnectorFailedToPaused() {
+    public void testConnectorPauseWhenFailed() {
         String connectName = "cluster";
         String connectorName = "connector";
 
@@ -2782,7 +2782,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
         waitForConnectorState(connectorName, "RUNNING");
 
-        // Simulate connector going into FAILED state by updating the connectors map directly
+        // Simulate connector entering FAILED state
         String host = KafkaConnectResources.qualifiedServiceName(connectName, namespace);
         connectors.put(key(host, connectorName), new ConnectorStatus("FAILED", connectors.get(key(host, connectorName)).config));
 
@@ -2792,12 +2792,9 @@ public class ConnectorMockTest {
                 .endSpec()
                 .build());
 
-        waitForConnectorState(connectorName, "PAUSED");
+        waitForConnectorCondition(connectorName, "Warning", "UpdateConnectorState");
 
-        verify(api, times(1)).pause(any(),
-                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName));
-        verify(api, never()).stop(any(),
+        verify(api, never()).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -2743,7 +2743,7 @@ public class ConnectorMockTest {
                 eq(connectorName));
     }
 
-    /** Create connect, create connector in FAILED state, attempt to pause — should log warning and add condition instead of calling pause() */
+    /** Create connect, create connector in FAILED state, attempt to pause — reconciliation should fail instead of calling pause() */
     @Test
     public void testConnectorPauseWhenFailed() {
         String connectName = "cluster";
@@ -2792,7 +2792,8 @@ public class ConnectorMockTest {
                 .endSpec()
                 .build());
 
-        waitForConnectorCondition(connectorName, "Warning", "UpdateConnectorState");
+        waitForConnectorNotReady(connectorName, "NoStackTraceThrowable",
+                "Connector " + connectorName + " cannot be paused since it is in failed state.");
 
         verify(api, never()).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -143,11 +143,11 @@ public class ConnectorMockTest {
         statusNode.put("name", connectorName);
         Map<String, Object> connector = new HashMap<>();
         statusNode.put("connector", connector);
-        connector.put("state", connectorStatus.state.toString());
+        connector.put("state", connectorStatus.state);
         connector.put("worker_id", "somehost0:8083");
         Map<String, Object> task = new HashMap<>();
         task.put("id", 0);
-        task.put("state", connectorStatus.state.toString());
+        task.put("state", connectorStatus.state);
         task.put("worker_id", "somehost2:8083");
         List<Map<String, Object>> tasks = singletonList(task);
         statusNode.put("tasks", tasks);
@@ -289,7 +289,7 @@ public class ConnectorMockTest {
             LOGGER.info("###### create " + host);
             String connectorName = invocation.getArgument(3);
             JsonObject connectorConfig = invocation.getArgument(4);
-            connectors.putIfAbsent(key(host, connectorName), new ConnectorStatus(ConnectorState.RUNNING, connectorConfig));
+            connectors.putIfAbsent(key(host, connectorName), new ConnectorStatus("RUNNING", connectorConfig));
             return CompletableFuture.completedFuture(null);
         });
         when(api.delete(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
@@ -318,8 +318,8 @@ public class ConnectorMockTest {
             if (connectorStatus == null) {
                 return CompletableFuture.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
-            if (!ConnectorState.PAUSED.equals(connectorStatus.state)) {
-                connectors.put(key(host, connectorName), new ConnectorStatus(ConnectorState.PAUSED, connectorStatus.config));
+            if (!"PAUSED".equals(connectorStatus.state)) {
+                connectors.put(key(host, connectorName), new ConnectorStatus("PAUSED", connectorStatus.config));
             }
             return CompletableFuture.completedFuture(null);
         });
@@ -330,8 +330,8 @@ public class ConnectorMockTest {
             if (connectorStatus == null) {
                 return CompletableFuture.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
-            if (!ConnectorState.STOPPED.equals(connectorStatus.state)) {
-                connectors.put(key(host, connectorName), new ConnectorStatus(ConnectorState.STOPPED, connectorStatus.config));
+            if (!"STOPPED".equals(connectorStatus.state)) {
+                connectors.put(key(host, connectorName), new ConnectorStatus("STOPPED", connectorStatus.config));
             }
             return CompletableFuture.completedFuture(null);
         });
@@ -342,8 +342,8 @@ public class ConnectorMockTest {
             if (connectorStatus == null) {
                 return CompletableFuture.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
-            if (ConnectorState.STOPPED.equals(connectorStatus.state) || ConnectorState.PAUSED.equals(connectorStatus.state)) {
-                connectors.put(key(host, connectorName), new ConnectorStatus(ConnectorState.RUNNING, connectorStatus.config));
+            if ("STOPPED".equals(connectorStatus.state) || "PAUSED".equals(connectorStatus.state)) {
+                connectors.put(key(host, connectorName), new ConnectorStatus("RUNNING", connectorStatus.config));
             }
             return CompletableFuture.completedFuture(null);
         });
@@ -2684,6 +2684,124 @@ public class ConnectorMockTest {
         assertThat(connectorConfig.getValue().containsKey("connector.plugin.version"), is(false));
     }
 
+    /** Create connect, create connector, simulate FAILED state, stop connector */
+    @Test
+    public void testConnectorFailedToStopped() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withNamespace(namespace)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-kafka:9092")
+                    .withGroupId("my-group")
+                    .withConfigStorageTopic("my-config-topic")
+                    .withOffsetStorageTopic("my-offset-topic")
+                    .withStatusStorageTopic("my-status-topic")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(namespace).resource(connect).create();
+        waitForConnectReady(connectName);
+
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .withNamespace(namespace)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        // Simulate connector going into FAILED state by updating the connectors map directly
+        String host = KafkaConnectResources.qualifiedServiceName(connectName, namespace);
+        connectors.put(key(host, connectorName), new ConnectorStatus("FAILED", connectors.get(key(host, connectorName)).config));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).edit(spec -> new KafkaConnectorBuilder(spec)
+                .editSpec()
+                .withState(ConnectorState.STOPPED)
+                .endSpec()
+                .build());
+
+        waitForConnectorState(connectorName, "STOPPED");
+
+        verify(api, times(1)).stop(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).pause(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /** Create connect, create connector, simulate FAILED state, pause connector */
+    @Test
+    public void testConnectorFailedToPaused() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withNamespace(namespace)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-kafka:9092")
+                    .withGroupId("my-group")
+                    .withConfigStorageTopic("my-config-topic")
+                    .withOffsetStorageTopic("my-offset-topic")
+                    .withStatusStorageTopic("my-status-topic")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(namespace).resource(connect).create();
+        waitForConnectReady(connectName);
+
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .withNamespace(namespace)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        // Simulate connector going into FAILED state by updating the connectors map directly
+        String host = KafkaConnectResources.qualifiedServiceName(connectName, namespace);
+        connectors.put(key(host, connectorName), new ConnectorStatus("FAILED", connectors.get(key(host, connectorName)).config));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).edit(spec -> new KafkaConnectorBuilder(spec)
+                .editSpec()
+                .withState(ConnectorState.PAUSED)
+                .endSpec()
+                .build());
+
+        waitForConnectorState(connectorName, "PAUSED");
+
+        verify(api, times(1)).pause(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).stop(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
     // Utility record used during tests
-    record ConnectorStatus(ConnectorState state, JsonObject config) { }
+    record ConnectorStatus(String state, JsonObject config) { }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Close #12542

When a Kafka connector enters the FAILED state, the operator was previously unable to transition it to PAUSED or STOPPED. The state-machine switch in `AbstractConnectOperator` only handled transitions from RUNNING and PAUSED states, so any request to pause or stop a FAILED connector was silently ignored (falling through to the default branch).

This PR adds a FAILED case to the connector state transition logic so that:
- FAILED → PAUSED: calls the Kafka Connect REST API pause endpoint
- FAILED → STOPPED: calls the Kafka Connect REST API stop endpoint

Changes:
- `AbstractConnectOperator.java`: Added case "FAILED" to the state-machine switch to handle transitions from FAILED to PAUSED or STOPPED.
- `ConnectorMockTest.java`: Added two new tests (`testConnectorFailedToPaused`, `testConnectorFailedToStopped`) to verify the correct REST API calls are made. Also refactored `ConnectorStatus` record to use `String` instead of `ConnectorState` enum so that the mock can simulate arbitrary states (e.g., FAILED) that are not part of the target-state enum.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

