### PR TITLE
Clarify OAuth issuer checking behavior

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -124,7 +124,8 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     }
 
     @Description("Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. " +
-            "Default value is `true`.")
+            "If `validIssuerUri` is configured, issuer checking is performed even when this property is set to `false`. " +
+            "To disable issuer checking, set this property to `false` and leave `validIssuerUri` unset. Default value is `true`.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isCheckIssuer() {
         return checkIssuer;

--- a/documentation/modules/oauth/con-oauth-server-config.adoc
+++ b/documentation/modules/oauth/con-oauth-server-config.adoc
@@ -49,6 +49,9 @@ To enable OAuth 2.0 token-based authentication on a Kafka listener, configure th
 
 All OAuth 2.0 validation settings (such as JWKS or token introspection) are provided through the JAAS configuration string inside the listener configuration.
 
+If you disable issuer checking by setting `oauth.check.issuer="false"`, do not configure `oauth.valid.issuer.uri`.
+When `oauth.valid.issuer.uri` is configured, the issuer is checked against that value.
+
 === JWT validation example
 
 The following example shows a minimal listener configuration that validates JSON Web Tokens (JWTs) using a JWKS endpoint.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Clarifies that issuer checking still uses `validIssuerUri` when it is configured, even if `checkIssuer` is set to `false`.

Also adds the equivalent note for JAAS-based OAuth configuration, where `oauth.valid.issuer.uri` should be omitted when disabling issuer checking with `oauth.check.issuer="false"`.

Closes #12453

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

### Verification

- `mvn -pl api -DskipTests compile`
- `make docu_check`