### PR TITLE
Remove JUnit4 dependency

### DIFF
--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -90,11 +90,6 @@
             <groupId>com.dajudge.kindcontainer</groupId>
             <artifactId>kindcontainer</artifactId>
         </dependency>
-        <!-- JUnit dependency is needed at compile time because MockKube is instantiating the KindContainer in regular scope -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
@@ -123,8 +118,6 @@
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <!-- Needed for logging in tests using the Kubernetes Client (uses SLF4J) -->
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
-                                <!-- JUnit dependency is needed at compile time because MockKube is instantiating the KindContainer in regular scope -->
-                                <ignoredUnusedDeclaredDependency>junit:junit</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
         <kindcontainer.version>2.0.0</kindcontainer.version>
         <testcontainer.version>2.0.2</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
-        <junit4.version>4.13.2</junit4.version>
         <skodjob.kubetest4j.version>1.1.0</skodjob.kubetest4j.version>
         <skodjob-doc.version>0.6.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
@@ -753,12 +752,6 @@
                 <groupId>com.marcnuri.helm-java</groupId>
                 <artifactId>helm-java</artifactId>
                 <version>${helm-client.version}</version>
-            </dependency>
-            <!-- JUnit dependency is needed at compile time by MockKube because of how Test Containers are designed -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit4.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.skodjob</groupId>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the JUnit 4 dependency. It was required by the old Kind Test Container / Test Container dependency itself, but does not seem to be anymore since Test Containers 2.x.

### Checklist

- [x] Make sure all tests pass