### PR TITLE
Try to address FOSSA license scan findings

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -205,6 +205,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/kafka-agent/pom.xml
+++ b/kafka-agent/pom.xml
@@ -54,8 +54,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -13,6 +13,7 @@ import com.yammer.metrics.core.MetricsRegistryListener;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
@@ -30,8 +31,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.agent;
 import com.yammer.metrics.core.Gauge;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.net.URI;

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -66,6 +66,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -97,8 +97,8 @@
             <artifactId>jetty-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.common.http;
 
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.strimzi.operator.common.MetricsProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.http.HttpHeader;
@@ -16,8 +17,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.util.Callback;
-
-import javax.servlet.http.HttpServletResponse;
 
 import java.nio.charset.StandardCharsets;
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>12.0.22</jetty.version>
-        <javax-servlet.version>3.1.0</javax-servlet.version>
+        <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
         <netty.version>4.2.13.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
         <commons-codec.version>1.13</commons-codec.version>
@@ -740,9 +740,9 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax-servlet.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta-servlet.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.dajudge.kindcontainer</groupId>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -183,6 +183,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR tries to improve the FOSSA License scan findings by moving to Jakarta Servlet libraries and by making it more clear that Spotbugs Annotations are compilet time only dependency.

### Checklist

- [ ] Make sure all tests pass