### PR TITLE
Fix checkstyle command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Multi-module Maven project.
 
 - **Code style**: Enforced by checkstyle (runs in CI on all PRs)
   - Config: `.checkstyle/checkstyle.xml`
-  - Run locally: `mvn checkstyle:check`
+  - Run locally: `mvn checkstyle:check@validate`
   - CI will fail if checkstyle errors are found
 
 ## Developer Notes


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the checkstyle command in the AGENTS.md file in the docs. The old command was not using the settings from the main `pom.xml` and would ultimately always fail.