### PR TITLE
Add /v1/controller-ready endpoint to Kafka Agent for KRaft controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.1.0
 
+* Kafka Agent: add `/v1/controller-ready` endpoint that reflects KRaft controller state via the
+  `kafka.server:type=raft-metrics, current-state` JMX attribute, and use it from the controller-only
+  readiness probe. This catches the case where the CONTROLPLANE listener is bound but the controller
+  is not actually attached to the metadata quorum (e.g. a controller wedged after early DNS failures
+  during cold-boot). Falls back to the existing port-listening check when the raft-metrics MBean is
+  not registered.
 * Add support for Apache Kafka 4.3.0 and remove support for Kafka 4.1.x
 * New Cluster operator configuration option `STRIMZI_PKCS12_KEYSTORE_GENERATION` to disable generating PKCS12 stores in CA and Kafka user `Secret` resources.
 * Support for Gateway API-based `type: tlsroute` listener

--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness.sh
@@ -8,8 +8,23 @@ test -f $file
 # so, because grep would fail, the "|| true" operation allows to return empty roles result
 roles=$(grep -Po '(?<=^process.roles=).+' "$file" || true)
 if [[ "$roles" =~ "controller" ]] && [[ ! "$roles" =~ "broker" ]]; then
-  # For controller only mode, check if it is listening on port 9090 (configured in controller.listener.names).
+  # For controller only mode:
+  #   1. Listener on port 9090 (CONTROLPLANE) must be bound.
+  #   2. The local KRaft node must be attached to the metadata quorum as leader/follower —
+  #      verified via the Kafka Agent's /v1/controller-ready endpoint, which reads
+  #      'kafka.server:type=raft-metrics, current-state' via JMX. This catches cases where the
+  #      port is open but the controller never finished registering / is wedged.
+  #
+  # If the endpoint returns 404 the raft-metrics MBean isn't registered (older Kafka, or very
+  # early startup). In that case we fall back to the port-listening check alone, preserving the
+  # pre-existing behavior.
   netstat -lnt | grep -Eq 'tcp6?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9090.*LISTEN[[:space:]]*'
+
+  controller_status=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:8080/v1/controller-ready/ || echo "000")
+  case "$controller_status" in
+    204|404) ;;
+    *) exit 1 ;;
+  esac
 else
   # For combined or broker only mode, check readiness via HTTP endpoint exposed by Kafka Agent.
   # The endpoint returns 204 when broker state is 3 (RUNNING).

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -32,8 +32,14 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +49,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A very simple Java agent which polls the value of the {@code kafka.server:type=KafkaServer,name=BrokerState}
@@ -61,12 +69,22 @@ import java.util.Properties;
  *     <dt>{@code GET /v1/ready}</dt>
  *     <dd>Returns HTTP code 204 if broker state is RUNNING(3). Otherwise returns non successful HTTP code.
  *     </dd>
+ *     <dt>{@code GET /v1/controller-ready}</dt>
+ *     <dd>Returns HTTP code 204 if the KRaft controller node is attached to the metadata quorum,
+ *      i.e. the {@code current-state} attribute of the {@code kafka.server:type=raft-metrics} JMX MBean
+ *      is one of {@code leader} or {@code follower}. Returns 503 for any other state (e.g. {@code unattached},
+ *      {@code candidate}, {@code voted}, {@code resigned}, {@code observer}). Returns 404 if the raft-metrics MBean
+ *      is not registered (e.g. broker-only nodes before broker startup, or older Kafka versions without raft-metrics).
+ *      Intended to back the controller-only readiness probe — distinguishes "port 9090 is listening" from
+ *      "this controller is actually participating in the quorum."
+ *     </dd>
  * </dl>
  */
 public class KafkaAgent {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaAgent.class);
     private static final String BROKER_STATE_PATH = "/v1/broker-state";
     private static final String READINESS_ENDPOINT_PATH = "/v1/ready";
+    private static final String CONTROLLER_READINESS_ENDPOINT_PATH = "/v1/controller-ready";
     private static final int HTTPS_PORT = 8443;
     private static final int HTTP_PORT = 8080;
     private static final long GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30 * 1000;
@@ -77,6 +95,15 @@ public class KafkaAgent {
     private static final byte BROKER_RUNNING_STATE = 3;
     private static final byte BROKER_RECOVERY_STATE = 2;
     private static final byte BROKER_UNKNOWN_STATE = 127;
+
+    // KRaft raft-metrics MBean exposed by Apache Kafka. Read via the platform MBeanServer.
+    static final String RAFT_METRICS_OBJECT_NAME = "kafka.server:type=raft-metrics";
+    static final String RAFT_CURRENT_STATE_ATTRIBUTE = "current-state";
+    // Raft state values that indicate the local node is attached to the quorum and able to serve.
+    // Other values (unattached, candidate, voted, resigned, observer) mean the controller is either
+    // mid-election (transient — handled by failureThreshold) or wedged.
+    static final Set<String> RAFT_READY_STATES = Set.of("leader", "follower");
+
     static final SecureRandom RANDOM = new SecureRandom();
     private final Secret caCertSecret;
     private final Secret nodeCertSecret;
@@ -84,6 +111,9 @@ public class KafkaAgent {
     private Gauge brokerState;
     private Gauge remainingLogsToRecover;
     private Gauge remainingSegmentsToRecover;
+    // Returns the current value of the raft-metrics "current-state" attribute, or null if the MBean
+    // is not (yet) registered. Pulled at request time so it always reflects current JVM state.
+    private final Supplier<String> raftCurrentStateSupplier;
 
     /**
      * Constructor of the KafkaAgent
@@ -96,6 +126,7 @@ public class KafkaAgent {
     /* test */ KafkaAgent(KubernetesClient client, String caCertSecretName, String nodeCertSecretName, String namespace) {
         this.caCertSecret = getKubernetesSecret(client, caCertSecretName, namespace);
         this.nodeCertSecret = getKubernetesSecret(client, nodeCertSecretName, namespace);
+        this.raftCurrentStateSupplier = KafkaAgent::queryRaftCurrentStateFromJmx;
     }
 
     private Secret getKubernetesSecret(KubernetesClient client, String caCertSecretName, String namespace) {
@@ -112,11 +143,19 @@ public class KafkaAgent {
      * @param remainingSegmentsToRecover    Number of remaining segments to recover
      */
     /* test */ KafkaAgent(Secret caCertSecret, Secret nodeCertSecret, Gauge brokerState, Gauge remainingLogsToRecover, Gauge remainingSegmentsToRecover) {
+        this(caCertSecret, nodeCertSecret, brokerState, remainingLogsToRecover, remainingSegmentsToRecover, () -> null);
+    }
+
+    /**
+     * Constructor of the KafkaAgent — variant exposing the raft-current-state supplier for tests.
+     */
+    /* test */ KafkaAgent(Secret caCertSecret, Secret nodeCertSecret, Gauge brokerState, Gauge remainingLogsToRecover, Gauge remainingSegmentsToRecover, Supplier<String> raftCurrentStateSupplier) {
         this.caCertSecret = caCertSecret;
         this.nodeCertSecret = nodeCertSecret;
         this.brokerState = brokerState;
         this.remainingLogsToRecover = remainingLogsToRecover;
         this.remainingSegmentsToRecover = remainingSegmentsToRecover;
+        this.raftCurrentStateSupplier = raftCurrentStateSupplier;
     }
 
     private void run() {
@@ -221,8 +260,11 @@ public class KafkaAgent {
         ContextHandler readinessContext = new ContextHandler(READINESS_ENDPOINT_PATH);
         readinessContext.setHandler(getReadinessHandler());
 
+        ContextHandler controllerReadinessContext = new ContextHandler(CONTROLLER_READINESS_ENDPOINT_PATH);
+        controllerReadinessContext.setHandler(getControllerReadinessHandler());
+
         server.setConnectors(new Connector[] {httpsConn, httpConn});
-        server.setHandler(new ContextHandlerCollection(brokerStateContext, readinessContext));
+        server.setHandler(new ContextHandlerCollection(brokerStateContext, readinessContext, controllerReadinessContext));
 
         server.setStopTimeout(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
         server.setStopAtShutdown(true);
@@ -311,6 +353,67 @@ public class KafkaAgent {
                 return true;
             }
         };
+    }
+
+    /**
+     * Creates a Handler instance to handle incoming HTTP requests for the controller readiness check.
+     *
+     * Returns 204 if the local KRaft node is attached to the quorum as {@code leader} or {@code follower},
+     * 503 for any other raft state, and 404 if the raft-metrics MBean is not registered.
+     *
+     * @return Handler
+     */
+    /* test */ Handler getControllerReadinessHandler() {
+        return new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) {
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json; charset=UTF-8");
+
+                String state = raftCurrentStateSupplier != null ? raftCurrentStateSupplier.get() : null;
+                if (state == null) {
+                    LOGGER.trace("Raft metrics MBean not found ({} attribute {}).", RAFT_METRICS_OBJECT_NAME, RAFT_CURRENT_STATE_ATTRIBUTE);
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    response.write(true, StandardCharsets.UTF_8.encode("{\"error\":\"raft-metrics MBean not found\"}"), callback);
+                    return true;
+                }
+
+                if (RAFT_READY_STATES.contains(state)) {
+                    LOGGER.trace("Controller is ready (raft current-state={}).", state);
+                    response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+                    response.write(true, null, callback);
+                } else {
+                    LOGGER.trace("Controller is not ready (raft current-state={}).", state);
+                    response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+                    String body = String.format("{\"error\":\"controller not ready, current raft state: %s\"}", state);
+                    response.write(true, StandardCharsets.UTF_8.encode(body), callback);
+                }
+                return true;
+            }
+        };
+    }
+
+    /**
+     * Default JMX-backed implementation of {@link #raftCurrentStateSupplier}. Returns the value of the
+     * {@code current-state} attribute on {@code kafka.server:type=raft-metrics}, or {@code null} if
+     * the MBean is not registered (e.g. broker-only nodes before broker startup, or older Kafka
+     * versions without raft-metrics).
+     */
+    static String queryRaftCurrentStateFromJmx() {
+        try {
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            ObjectName name = new ObjectName(RAFT_METRICS_OBJECT_NAME);
+            Object value = server.getAttribute(name, RAFT_CURRENT_STATE_ATTRIBUTE);
+            return value == null ? null : value.toString();
+        } catch (InstanceNotFoundException e) {
+            return null;
+        } catch (MalformedObjectNameException e) {
+            // RAFT_METRICS_OBJECT_NAME is a compile-time constant — this should never happen.
+            LOGGER.warn("Malformed JMX object name {}", RAFT_METRICS_OBJECT_NAME, e);
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Could not query JMX attribute {} on {}: {}", RAFT_CURRENT_STATE_ATTRIBUTE, RAFT_METRICS_OBJECT_NAME, e.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -223,4 +223,69 @@ public class KafkaAgentTest {
 
         assertThat(HttpServletResponse.SC_SERVICE_UNAVAILABLE, is(response.statusCode()));
     }
+
+    @Test
+    public void testControllerReadinessSuccessLeader() throws Exception {
+        assertControllerReadinessStatusCode("leader", HttpServletResponse.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void testControllerReadinessSuccessFollower() throws Exception {
+        assertControllerReadinessStatusCode("follower", HttpServletResponse.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void testControllerReadinessFailUnattached() throws Exception {
+        // 'unattached' is the state observed in the cold-boot DNS-race wedge: raft heartbeats run,
+        // controller registration never completes, port 9090 is open but the node is not serving.
+        assertControllerReadinessStatusCode("unattached", HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void testControllerReadinessFailCandidate() throws Exception {
+        // 'candidate' is transient (mid-election); kubelet's failureThreshold/periodSeconds handles
+        // genuinely transient cases. We deliberately fail the probe so the pod doesn't get traffic
+        // while no leader is known.
+        assertControllerReadinessStatusCode("candidate", HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void testControllerReadinessFailResigned() throws Exception {
+        assertControllerReadinessStatusCode("resigned", HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void testControllerReadinessFailObserver() throws Exception {
+        // Observer is a non-voter; never serves as a controller for our purposes.
+        assertControllerReadinessStatusCode("observer", HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void testControllerReadinessFailProspective() throws Exception {
+        // 'prospective' is the pre-candidate state used when a follower's fetch from the leader
+        // times out. Observed during AKS testing when peer connectivity was broken and the local
+        // node could not maintain follower status. Caught by the same {leader, follower} filter.
+        assertControllerReadinessStatusCode("prospective", HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void testControllerReadinessNotFound() throws Exception {
+        // Supplier returns null = raft-metrics MBean not registered (e.g. broker-only node before
+        // broker startup, or older Kafka version). Endpoint returns 404 so the calling script can
+        // optionally fall back to a port-listening check.
+        assertControllerReadinessStatusCode(null, HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    private void assertControllerReadinessStatusCode(String raftState, int expectedStatus) throws Exception {
+        KafkaAgent agent = new KafkaAgent(caCertSecret, nodeCertSecret, null, null, null, () -> raftState);
+        context.setHandler(agent.getControllerReadinessHandler());
+        server.setHandler(context);
+        server.start();
+
+        HttpResponse<String> response = HttpClient.newBuilder()
+                .build()
+                .send(httpReq, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode(), is(expectedStatus));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Tracks #12760.

The controller-only readiness probe (`docker-images/kafka-based/kafka/scripts/kafka_readiness.sh`) only checks that port 9090 is bound — passes the instant the listener is created, well before `ControllerRegistrationManager` has finished, and without verifying the local node is part of the metadata quorum. If a controller wedges after a transient early failure (e.g. an unresolvable peer FQDN during a cold-boot CoreDNS race), it stays `1/1 Ready` forever; kubelet never restarts it; the operator reconciles indefinitely with `"An error while trying to determine the active controller"`; manual rolling is needed to recover.

This PR adds a new endpoint to the Kafka Agent that reflects raft attachment state by reading `kafka.server:type=raft-metrics, current-state` via the platform MBeanServer:

* `GET /v1/controller-ready`
  * **204 No Content** when `current-state` ∈ `{leader, follower}`
  * **503 Service Unavailable** for any other state (`unattached`, `candidate`, `prospective`, `voted`, `resigned`, `observer`), with the actual state name in the JSON response body for diagnostics
  * **404 Not Found** when the `raft-metrics` MBean is not registered (e.g. broker-only nodes before broker startup, or older Kafka versions). The calling script treats 404 the same as 204 so older Kafka / very early startup keep the existing port-listening behavior — strictly additive, no regression.

The controller-only branch of `kafka_readiness.sh` now calls this endpoint after the existing `netstat | grep :9090` check.

### Why JMX `current-state` rather than the on-disk `quorum-state` file

Considered, then rejected. The `appliedOffset` field in `__cluster_metadata-0/quorum-state` is an internal raft state-machine offset that stays at `0` on healthy nodes too (it's not a metadata-apply offset), so file-based checks can't reliably distinguish wedged from healthy. The JMX raft-metrics MBeans are stable, exposed by Apache Kafka, and already consumed by Strimzi's own KRaft Grafana dashboards (`packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kraft.json`).

### Validation

#### Unit tests (14 total, all passing)

```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

New cases mirror the existing `testReadiness*` pattern by injecting a `Supplier<String>` through a new test-only constructor. One case per raft state observed in Kafka 4.x:

| Test | Injected `current-state` | Expected HTTP |
|---|---|---|
| `testControllerReadinessSuccessLeader` | `leader` | 204 |
| `testControllerReadinessSuccessFollower` | `follower` | 204 |
| `testControllerReadinessFailUnattached` | `unattached` (wedge state from #12760) | 503 |
| `testControllerReadinessFailCandidate` | `candidate` | 503 |
| `testControllerReadinessFailResigned` | `resigned` | 503 |
| `testControllerReadinessFailObserver` | `observer` | 503 |
| `testControllerReadinessFailProspective` | `prospective` | 503 |
| `testControllerReadinessNotFound` | `null` (MBean absent) | 404 |

Six pre-existing tests (`testBrokerRunningState`, `testBrokerRecoveryState`, `testBrokerMetricNotFound`, `testReadinessSuccess`, `testReadinessFail`, `testReadinessFailWithBrokerUnknownState`) continue to pass — regression check on the broker path.

`prospective` was added to the matrix *after* it was first observed live in AKS (see below) — not from code reading.

#### Checkstyle

```
[INFO] You have 0 Checkstyle violations.
[INFO] BUILD SUCCESS
```

Run via `mvn -B validate` in the `kafka-agent` module, against `.checkstyle/checkstyle.xml`.

#### Cluster validation — kind (Strimzi 0.51.0 + Kafka 4.2.0)

Built a patched Kafka image by layering the rebuilt `kafka-agent-0.51.0.jar` + new `kafka_readiness.sh` on top of `quay.io/strimzi/kafka:0.51.0-kafka-4.2.0`, then loaded via `kind load docker-image`, with the cluster operator's `STRIMZI_KAFKA_IMAGES` env overridden to point at the local image.

**Smoke:**

```
$ kubectl -n kafka get kafka my-cluster
NAME         READY   WARNINGS   KAFKA VERSION   METADATA VERSION
my-cluster   True               4.2.0           4.2-IV1

$ kubectl -n kafka get pod -l strimzi.io/cluster=my-cluster
NAME                                          READY   STATUS    RESTARTS   AGE
my-cluster-broker-0                           1/1     Running   0          87s
my-cluster-broker-1                           1/1     Running   0          87s
my-cluster-broker-2                           1/1     Running   0          87s
my-cluster-controller-3                       1/1     Running   0          87s
my-cluster-controller-4                       1/1     Running   0          82s
my-cluster-controller-5                       1/1     Running   0          87s

# New controller endpoint — expect 204 on each
$ for p in my-cluster-controller-3 my-cluster-controller-4 my-cluster-controller-5; do
    kubectl -n kafka exec $p -- curl -sS -o /dev/null -w "$p HTTP %{http_code}\n" http://localhost:8080/v1/controller-ready/
  done
my-cluster-controller-3 HTTP 204
my-cluster-controller-4 HTTP 204
my-cluster-controller-5 HTTP 204

# Existing broker endpoint — regression check
$ for p in my-cluster-broker-0 my-cluster-broker-1 my-cluster-broker-2; do
    kubectl -n kafka exec $p -- curl -sS -o /dev/null -w "$p HTTP %{http_code}\n" http://localhost:8080/v1/ready/
  done
my-cluster-broker-0 HTTP 204
my-cluster-broker-1 HTTP 204
my-cluster-broker-2 HTTP 204
```

**Endpoint values correlate with real raft transitions:** the JVM stdout on each pod logged the expected raft transitions immediately before the smoke checks ran:

```
controller-3: "Completed transition to Leader(... epoch=14 ...)"               -> endpoint 204
controller-4: "Completed transition to FollowerState(... epoch=14, leader=3)"  -> endpoint 204
controller-5: "Completed transition to FollowerState(... epoch=14, leader=3)"  -> endpoint 204
```

On-disk `quorum-state` showed `"leaderId":3` consistently on all three controllers — confirming raft elected and the endpoint reflected actual state, not a constant.

**Re-election timing:** as an additional sanity check, deleted the leader pod (`controller-3`) and polled the survivors' `/v1/controller-ready/` at 1-second resolution for 30 s. Both controllers stayed at HTTP 204 throughout — raft re-elected to controller-4 sub-second, transient `candidate`/`prospective` window did not exceed one polling interval. Reassuring that the new probe doesn't false-fail during normal operation.

**Bug found and fixed during this validation round:** the script initially called `http://localhost:8080/v1/controller-ready` *without* trailing slash. Jetty's `ContextHandler` redirects bare context paths to the trailing-slash form with HTTP 301, which the script's case-statement treated as not-ready, breaking all controllers' readiness probes after rollout. Fixed in this PR by adding the trailing slash, matching the existing pattern on line 33 (`/v1/ready/`). Worth noting because the unit tests didn't catch it — they bypass Jetty's `ContextHandlerCollection` by hitting handlers directly. Required end-to-end testing to surface.

#### Cluster validation — AKS (Azure CNI + Kafka 4.2.0)

Repeated on a real cloud Kubernetes cluster — same smoke checks pass:

```
$ kubectl -n kafka-et5871 get kafka et5871-test
NAME          READY   WARNINGS   KAFKA VERSION   METADATA VERSION
et5871-test   True               4.2.0           4.2-IV1

$ for p in et5871-test-controller-3 et5871-test-controller-4 et5871-test-controller-5; do
    kubectl -n kafka-et5871 exec $p -- curl -sS -o /dev/null -w "$p HTTP %{http_code}\n" http://localhost:8080/v1/controller-ready/
  done
et5871-test-controller-3 HTTP 204
et5871-test-controller-4 HTTP 204
et5871-test-controller-5 HTTP 204
```

**Wedge induction via `hostAliases` DNS poisoning** — because Azure CNI without the `--network-policy` flag accepts `NetworkPolicy` objects but doesn't enforce them, I induced the wedge by patching `KafkaNodePool/controller.spec.template.pod.hostAliases` to override each controller's peer FQDNs to `127.0.0.1`:

```yaml
hostAliases:
- ip: "127.0.0.1"
  hostnames:
  - "et5871-test-controller-3.et5871-test-kafka-brokers.kafka-et5871.svc"
  - "et5871-test-controller-4.et5871-test-kafka-brokers.kafka-et5871.svc"
  - "et5871-test-controller-5.et5871-test-kafka-brokers.kafka-et5871.svc"
  # ... and the .cluster.local variants
```

When Strimzi rolled controller-4 with the new spec, raft connection attempts to peers resolved to `127.0.0.1:9090` (its own listener) and failed at TLS handshake:

```
ERROR ... [RaftManager id=4] Connection to node 3 (et5871-test-controller-3.<svc>/127.0.0.1:9090)
  failed authentication due to: SSL handshake failed
Caused by: ... No subject alternative DNS name matching et5871-test-controller-3.<svc> found.
INFO ... [RaftManager id=4] Transitioning to Prospective state due to fetch timeout
INFO ... [RaftManager id=4] Completed transition to ProspectiveState(epoch=9, ...)
```

**Captured response body during the wedge** (this is the smoking gun for "the new code reads real JMX state, not a constant"):

```
$ kubectl -n kafka-et5871 exec et5871-test-controller-4 -- \
    curl -sS http://localhost:8080/v1/controller-ready/ -w '|HTTP %{http_code}\n'
{"error":"controller not ready, current raft state: prospective"}|HTTP 503
```

A 20-poll sample at 1 s intervals against the wedged controller showed the state flapping between `prospective` and `follower` (the latter from stale on-disk state during raft fetch retries):

| State during poll | Count out of 20 | Endpoint response |
|---|---|---|
| `prospective` | 9 | HTTP 503 |
| `follower` | 11 | HTTP 204 |

**Pod readiness behavior under flap.** The wedged pod stayed `1/1 Ready` despite the endpoint correctly returning 503 ~45 % of the time. This is **expected default-probe behavior** — kubelet's readiness probe with `periodSeconds=10, failureThreshold=3` needs 3 consecutive failures (≥30 s of probing) to mark a pod NotReady, and our state was flapping back to `follower` every 1–2 s. For the original #12760 incident the wedged controllers were in a *persistent* non-ready state for 8 hours (no flap — `ControllerRegistrationManager` had given up and wasn't retrying), so in that scenario kubelet would have accumulated sustained 503s and restarted within ~45 s.

After the wedge test, `hostAliases` was removed from the `KafkaNodePool`; the cluster fully recovered to `Ready=True` with all 6 pods `1/1` and `/v1/controller-ready/` back to 204 on all three controllers.

### A caveat I want to be upfront about

This catches the broad class of "raft is not attached" failures (`current-state ∉ {leader, follower}`). It may not catch the specific #12760 wedge if raft did elect a leader and the registration-manager wedge was one layer above raft — in which case `current-state` would have been `leader` on the lead controller and `follower` on the others, and the new probe would have returned 204 throughout. The on-disk `quorum-state` we captured from the original incident showed `leaderId: 3, leaderEpoch: 1` persistent for 8 hours, suggesting raft did elect — so this is a real possibility. Happy to follow up with a second JMX check (e.g. `last-applied-record-offset` from `broker-metadata-metrics`) if maintainers want stricter coverage; that's a separate PR.

Even with this caveat, the patch is a strict improvement on the current probe: it replaces "the port is listening" with "this controller is part of the quorum", catching a broader class of failures regardless of whether it fully covers every #12760 variant.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation (Javadoc on the new handler + endpoint behavior)
- [x] Check RBAC rights for Kubernetes / OpenShift roles — no new RBAC needed (localhost-only HTTP, MBean read on the local JVM)
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally — kind + AKS, see Validation above
- [x] Reference relevant issue(s) and close them after merging — closes #12760
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards — n/a
