### PR TITLE
Improve portability of upgrade system tests when checking Kafka version from libraries

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -323,7 +323,7 @@ public class KafkaUtils {
     }
 
     public static String getVersionFromKafkaPodLibs(String namespaceName, String kafkaPodName) {
-        String command = "ls libs | grep -Po 'kafka_\\d+.\\d+-\\K(\\d+.\\d+.\\d+)(?=.*jar)' | head -1 | cut -d \"-\" -f2";
+        String command = "ls libs | sed -n 's/^kafka_[0-9]*\\.[0-9]*-\\(.*\\)\\.jar$/\\1/p' | head -1";
         return KubeResourceManager.get().kubeCmdClient()
             .inNamespace(namespaceName)
             .execInPodContainer(

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KRaftKafkaUpgradeDowngradeST.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.systemtest.TestTags.KRAFT_UPGRADE;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -217,14 +217,14 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
         LOGGER.info("Post-change Kafka version query returned: {}", controllerVersionResult);
 
         assertThat("Kafka container had version " + controllerVersionResult + " where " + newVersion.version() +
-            " was expected", controllerVersionResult, is(newVersion.version()));
+            " was expected", controllerVersionResult, containsString(newVersion.version()));
 
         // Extract the Kafka version number from the jars in the lib directory
         String brokerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(testStorage.getNamespaceName(), brokerPodName);
         LOGGER.info("Post-change Kafka version query returned: {}", brokerVersionResult);
 
         assertThat("Kafka container had version " + brokerVersionResult + " where " + newVersion.version() +
-            " was expected", brokerVersionResult, is(newVersion.version()));
+            " was expected", brokerVersionResult, containsString(newVersion.version()));
 
         if (isUpgrade && !sameMinorVersion) {
             LOGGER.info("Updating Kafka config attribute 'metadataVersion' from '{}' to '{}' version", initialVersion.metadataVersion(), newVersion.metadataVersion());


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR improves the way we compare the Kafka versions in upgrade tests:
* Instead of complicated `grep` with Perl-based regular expression, it uses `sed` command that better works across different base images (not just Red Hat UBI, but also Chainguard etc.)
* Checks whether the Kafka version is present in the string we find rather then that it is equal. This brings it on par with how we compare it in `KRaftStrimziUpgradeST`. And it also improves the compatibility accross different builds when the Kafka version uses some custom suffixes etc.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally