### PR TITLE
Fix misleading System Test log message about OpenShift projects

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/ClusterRoleBindingTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/ClusterRoleBindingTemplates.java
@@ -19,12 +19,11 @@ public class ClusterRoleBindingTemplates {
     private static final Logger LOGGER = LogManager.getLogger(ClusterRoleBindingTemplates.class);
 
     public static List<ClusterRoleBinding> clusterRoleBindingsForAllNamespaces(String namespaceName) {
-        LOGGER.info("Creating ClusterRoleBinding that grant cluster-wide access to all OpenShift projects");
         return clusterRoleBindingsForAllNamespaces(namespaceName, "strimzi-cluster-operator");
     }
 
     public static List<ClusterRoleBinding> clusterRoleBindingsForAllNamespaces(String namespaceName, String coName) {
-        LOGGER.info("Creating ClusterRoleBinding that grant cluster-wide access to all OpenShift projects");
+        LOGGER.info("Creating ClusterRoleBinding that grant cluster-wide access to all Kubernetes namespaces");
 
         return Arrays.asList(
             getClusterOperatorNamespacedCrb(namespaceName, coName),


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR improves the system test logging and fixes the misleading log message about OpenShift projects:
* Changes it to `Kubernets namespaces`
* Removes the duplicate log message when the method without specified CO name is called