### PR TITLE
Clarify OAuth issuer checking documentation

### DIFF
--- a/documentation/modules/oauth/con-oauth-server-config.adoc
+++ b/documentation/modules/oauth/con-oauth-server-config.adoc
@@ -49,6 +49,9 @@ To enable OAuth 2.0 token-based authentication on a Kafka listener, configure th
 
 All OAuth 2.0 validation settings (such as JWKS or token introspection) are provided through the JAAS configuration string inside the listener configuration.
 
+If you disable issuer checking by setting `oauth.check.issuer="false"`, do not configure `oauth.valid.issuer.uri`.
+When `oauth.valid.issuer.uri` is configured, the issuer is checked against that value.
+
 === JWT validation example
 
 The following example shows a minimal listener configuration that validates JSON Web Tokens (JWTs) using a JWKS endpoint.


### PR DESCRIPTION
### Type of change

Documentation

### Description

Clarifies the OAuth server-side configuration documentation for issuer checking.

When `oauth.check.issuer="false"` is used, `oauth.valid.issuer.uri` should not be configured. If `oauth.valid.issuer.uri` is configured, the issuer is checked against that value.

Closes #12453

### Checklist

- [ ] Write tests (N/A - documentation only)
- [x] Make sure all tests pass (`make docu_check`)
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles (N/A - documentation only)
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally (N/A - documentation only)
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md (N/A - documentation only)
- [ ] Supply screenshots for visual changes, such as Grafana dashboards (N/A - documentation only)