### PR TITLE
Remove direct commons-lang3 and commons-io dependencies - Closes #12611

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,6 @@
         <netty.version>4.2.14.Final</netty.version>
         <micrometer.version>1.14.5</micrometer.version>
         <commons-codec.version>1.13</commons-codec.version>
-        <commons-io.version>2.18.0</commons-io.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <picocli.version>4.7.7</picocli.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <javaluator.version>3.0.6</javaluator.version>
@@ -578,20 +576,6 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons-codec.version}</version>
-            </dependency>
-            <dependency>
-                <!-- transitive dep; override here to avoid version conflict between testcontainers and mockserver
-                 TODO: Remove (https://github.com/strimzi/strimzi-kafka-operator/issues/12611) -->
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
-            <dependency>
-                <!-- transitive dep; required by testcontainers 2.x to avoid NoClassDefFoundError
-                 TODO: Remove (https://github.com/strimzi/strimzi-kafka-operator/issues/12611) -->
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
### Type of change

- Task

### Description

As we moved to Kafka 4.3.0, we can now remove the direct commons-lang3 and commons-io dependnecies as described in #12611.

This should resolve #12611.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging