### PR TITLE
Fix duplicate "healthcheck" port name in entity-operator pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Major changes, deprecations, and removals
 
-* n/a
+* The entity-operator healthcheck port names have been renamed from `healthcheck` to `healthcheck-to` (topic-operator) and `healthcheck-uo` (user-operator) to avoid duplicate port name warnings in Kubernetes. If you reference these port names in custom `PodMonitor`, `ServiceMonitor`, `NetworkPolicy`, or similar resources, you will need to update them.
 
 ## 1.0.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -59,7 +59,7 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
 
     // Port configuration
     protected static final int HEALTHCHECK_PORT = 8080;
-    protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
+    protected static final String HEALTHCHECK_PORT_NAME = "healthcheck-to";
     protected static final int CRUISE_CONTROL_API_PORT = 9090;
 
     // Topic Operator configuration keys

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -49,7 +49,7 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
 
     // Port configuration
     protected static final int HEALTHCHECK_PORT = 8081;
-    protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
+    protected static final String HEALTHCHECK_PORT_NAME = "healthcheck-uo";
 
     // User Operator configuration keys
     /* test */ static final String ENV_VAR_RESOURCE_LABELS = "STRIMZI_LABELS";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -501,6 +501,19 @@ public class EntityOperatorTest {
     }
 
     @Test
+    public void testContainerPortNameUniqueness() {
+        List<Container> containers = ENTITY_OPERATOR.createContainers(null);
+
+        List<String> portNames = containers.stream()
+                .flatMap(container -> container.getPorts().stream())
+                .map(port -> port.getName())
+                .toList();
+
+        assertThat("Port names across entity-operator containers must be unique",
+                portNames.size(), is((int) portNames.stream().distinct().count()));
+    }
+
+    @Test
     public void testTopicOperatorContainerEnvVars() {
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -67,7 +67,6 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -521,9 +520,6 @@ public class EntityOperatorTest {
         assertThat(uoContainer.getPorts().get(0).getName(), is(EntityUserOperator.HEALTHCHECK_PORT_NAME));
         assertThat(uoContainer.getPorts().get(0).getContainerPort(), is(EntityUserOperator.HEALTHCHECK_PORT));
         assertThat(uoContainer.getPorts().get(0).getProtocol(), is("TCP"));
-
-        assertThat("Port names across entity-operator containers must be unique",
-                EntityTopicOperator.HEALTHCHECK_PORT_NAME, is(not(equalTo(EntityUserOperator.HEALTHCHECK_PORT_NAME))));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -67,6 +67,7 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -501,16 +502,28 @@ public class EntityOperatorTest {
     }
 
     @Test
-    public void testContainerPortNameUniqueness() {
+    public void testContainerPortNames() {
         List<Container> containers = ENTITY_OPERATOR.createContainers(null);
+        assertThat(containers.size(), is(2));
 
-        List<String> portNames = containers.stream()
-                .flatMap(container -> container.getPorts().stream())
-                .map(port -> port.getName())
-                .toList();
+        Container toContainer = containers.stream()
+                .filter(c -> EntityTopicOperator.TOPIC_OPERATOR_CONTAINER_NAME.equals(c.getName()))
+                .findFirst().orElseThrow();
+        assertThat(toContainer.getPorts().size(), is(1));
+        assertThat(toContainer.getPorts().get(0).getName(), is(EntityTopicOperator.HEALTHCHECK_PORT_NAME));
+        assertThat(toContainer.getPorts().get(0).getContainerPort(), is(EntityTopicOperator.HEALTHCHECK_PORT));
+        assertThat(toContainer.getPorts().get(0).getProtocol(), is("TCP"));
+
+        Container uoContainer = containers.stream()
+                .filter(c -> EntityUserOperator.USER_OPERATOR_CONTAINER_NAME.equals(c.getName()))
+                .findFirst().orElseThrow();
+        assertThat(uoContainer.getPorts().size(), is(1));
+        assertThat(uoContainer.getPorts().get(0).getName(), is(EntityUserOperator.HEALTHCHECK_PORT_NAME));
+        assertThat(uoContainer.getPorts().get(0).getContainerPort(), is(EntityUserOperator.HEALTHCHECK_PORT));
+        assertThat(uoContainer.getPorts().get(0).getProtocol(), is("TCP"));
 
         assertThat("Port names across entity-operator containers must be unique",
-                portNames.size(), is((int) portNames.stream().distinct().count()));
+                EntityTopicOperator.HEALTHCHECK_PORT_NAME, is(not(equalTo(EntityUserOperator.HEALTHCHECK_PORT_NAME))));
     }
 
     @Test

--- a/packaging/examples/metrics/prometheus-install/pod-monitors/entity-operator-metrics.yaml
+++ b/packaging/examples/metrics/prometheus-install/pod-monitors/entity-operator-metrics.yaml
@@ -14,4 +14,6 @@ spec:
       - myproject
   podMetricsEndpoints:
   - path: /metrics
-    port: healthcheck
+    port: healthcheck-to
+  - path: /metrics
+    port: healthcheck-uo


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The topic-operator and user-operator containers in the entity-operator pod both define a port named "healthcheck" (on containerPort 8080 and 8081 respectively). This causes duplicate port name warnings in Kubernetes, for example during kubectl rollout restart.

This PR renames the port names to be unique:

topic-operator: "healthcheck" → "healthcheck-to"
user-operator: "healthcheck" → "healthcheck-uo"

Both names are within the Kubernetes 15-character port name limit.

The PodMonitor examples for entity-operator metrics have also been updated to define two separate podMetricsEndpoints, one for each distinct port name.

No test changes were needed since existing tests reference the HEALTHCHECK_PORT_NAME constant rather than a hardcoded string.

Closes #12756

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

