### PR TITLE
Add Rubin Observatory to the list of Strimzi users

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -38,6 +38,8 @@ Please let us know by adding your company name and, if you want, a description o
 * [CERN](https://cern.ch)
 * [Banco Mercantil](https://bancomercantil.com.br/)
     * Use Strimzi to run Kafka Connect as part of the data platform for queueing, event notifications, logging, and CDC pipelines.
+* [Vera C. Rubin Observatory](https://rubinobservatory.org)
+    * Strimzi is used to deploy and manage Kafka for the Observatory Control System and the telemetry and metrics infrastructure that supports the Rubin Science Platform.
 
 ### Vendors
 


### PR DESCRIPTION
At Vera C. Rubin Observatory, Strimzi is used to deploy and manage Kafka for the Observatory Control System and the telemetry and metrics infrastructure that supports the Rubin Science Platform.