### PR TITLE
Add CRD Generator tests covering Kubernetes interactions

### DIFF
--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -67,8 +67,28 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -91,6 +111,9 @@
                                 <!-- Needed for logging using the Kubernetes Client (uses SLF4J) -->
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                <!-- Fabric8 Kubernetes Client and HttpClient are required by the integration test -->
+                                <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorIT.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorIT.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.strimzi.api.annotations.ApiVersion;
+import io.strimzi.api.annotations.KubeVersion;
+import io.strimzi.test.CrdUtils;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.interfaces.TestSeparator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Generates the CRD YAML for {@link ExampleIntegrationCrd} via {@link CrdGenerator}, installs it into a real
+ * Kubernetes API server, and verifies that the schema-level behaviours actually take effect: required fields,
+ * enum values, polymorphic discriminators, {@code minimum}, {@code minItems}, {@code oneOf}, CEL rules, and the
+ * {@code scale} subresource.
+ */
+public class CrdGeneratorIT implements TestSeparator {
+    private static final String NAMESPACE = "crd-generator-it";
+    private static final String CRD_NAME = "exampleintegrations.it.crdgenerator.strimzi.io";
+    private static final String API_VERSION = "it.crdgenerator.strimzi.io/v1";
+    private static final String KIND = "ExampleIntegration";
+
+    private static KubernetesClient client;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
+        TestUtils.createNamespace(client, NAMESPACE);
+        CrdUtils.createCrdFromYaml(client, CRD_NAME, generateCrdYaml());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        CrdUtils.deleteCrd(client, CRD_NAME);
+        TestUtils.deleteNamespace(client, NAMESPACE);
+        client.close();
+    }
+
+    @Test
+    void testValidResourceIsAccepted() {
+        CrdUtils.createDeleteCustomResource(client, """
+                apiVersion: it.crdgenerator.strimzi.io/v1
+                kind: ExampleIntegration
+                metadata:
+                  name: valid
+                spec:
+                  requiredString: hello
+                  enumProperty: FOO
+                  numericProperty: 10
+                  listProperty:
+                    - one
+                  polymorphic:
+                    type: left
+                    leftValue: a
+                  nested:
+                    requiredField: present
+                  cel:
+                    value: abcdef
+                  either: x
+                """);
+    }
+
+    static Stream<Arguments> rejectedResources() {
+        return Stream.of(
+                Arguments.of("missing required string",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: missing-required
+                        spec:
+                          either: x
+                        """,
+                        "requiredString"),
+                Arguments.of("missing required nested field",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: missing-nested
+                        spec:
+                          requiredString: hello
+                          either: x
+                          nested: {}
+                        """,
+                        "requiredField"),
+                Arguments.of("invalid enum value",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: invalid-enum
+                        spec:
+                          requiredString: hello
+                          either: x
+                          enumProperty: NOPE
+                        """,
+                        "Unsupported value"),
+                Arguments.of("invalid polymorphic discriminator",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: invalid-polymorphic
+                        spec:
+                          requiredString: hello
+                          either: x
+                          polymorphic:
+                            type: middle
+                        """,
+                        "Unsupported value"),
+                Arguments.of("numeric value below minimum",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: below-minimum
+                        spec:
+                          requiredString: hello
+                          either: x
+                          numericProperty: 1
+                        """,
+                        "should be greater than or equal to 5"),
+                Arguments.of("list below minItems",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: empty-list
+                        spec:
+                          requiredString: hello
+                          either: x
+                          listProperty: []
+                        """,
+                        "should have at least 1 items"),
+                Arguments.of("oneOf neither alternative set",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: oneof-neither
+                        spec:
+                          requiredString: hello
+                        """,
+                        "Invalid value"),
+                Arguments.of("oneOf both alternatives set",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: oneof-both
+                        spec:
+                          requiredString: hello
+                          either: x
+                          or: y
+                        """,
+                        "Invalid value"),
+                Arguments.of("CEL rule violation",
+                        """
+                        apiVersion: it.crdgenerator.strimzi.io/v1
+                        kind: ExampleIntegration
+                        metadata:
+                          name: cel-violation
+                        spec:
+                          requiredString: hello
+                          either: x
+                          cel:
+                            value: abc
+                        """,
+                        "value needs to be at least 5 characters long")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rejectedResources")
+    void testRejected(String scenario, String yaml, String expectedMessage) {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class,
+                () -> CrdUtils.createDeleteCustomResource(client, yaml));
+        assertThat(exception.getMessage(), containsStringIgnoringCase(expectedMessage));
+    }
+
+    @Test
+    void testScaleSubresource() {
+        String yaml = """
+                apiVersion: it.crdgenerator.strimzi.io/v1
+                kind: ExampleIntegration
+                metadata:
+                  name: scalable
+                spec:
+                  requiredString: hello
+                  either: x
+                  replicas: 1
+                """;
+
+        try {
+            client.resource(yaml).create();
+
+            client.genericKubernetesResources(API_VERSION, KIND).withName("scalable").scale(7);
+
+            GenericKubernetesResource updated = client.genericKubernetesResources(API_VERSION, KIND).withName("scalable").get();
+            @SuppressWarnings("unchecked")
+            Number replicas = (Number) ((java.util.Map<String, Object>) updated.get("spec")).get("replicas");
+            assertEquals(7, replicas.intValue());
+        } finally {
+            client.genericKubernetesResources(API_VERSION, KIND).withName("scalable").delete();
+        }
+    }
+
+    private static String generateCrdYaml() throws IOException {
+        CrdGenerator generator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                emptyMap(), err -> { }, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), null);
+        StringWriter writer = new StringWriter();
+        generator.generate(ExampleIntegrationCrd.class, writer);
+        return writer.toString();
+    }
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleIntegrationCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleIntegrationCrd.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.crdgenerator.annotations.CelValidation;
+import io.strimzi.crdgenerator.annotations.Crd;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.MinimumItems;
+import io.strimzi.crdgenerator.annotations.OneOf;
+
+import java.util.List;
+
+/**
+ * Synthetic CRD used solely by {@link CrdGeneratorIT} to verify, against a real Kubernetes API server, that the
+ * schema produced by {@link CrdGenerator} is actually enforced by the API server. Covers the generic schema
+ * behaviours that production CRDs rely on: required fields (top-level and nested), enum values, polymorphic
+ * discriminators, {@code @Minimum}, {@code @MinimumItems}, {@code @OneOf}, {@code @CelValidation}, and the
+ * {@code status} / {@code scale} subresources.
+ *
+ * Intentionally kept separate from {@link ExampleCrd}, which serves the YAML golden-file tests in
+ * {@link CrdGeneratorTest} and the reflection tests in {@link PropertyTest}.
+ */
+@Crd(
+    spec = @Crd.Spec(
+        group = "it.crdgenerator.strimzi.io",
+        names = @Crd.Spec.Names(
+            kind = "ExampleIntegration",
+            plural = "exampleintegrations",
+            categories = {"strimzi"}),
+        scope = "Namespaced",
+        versions = {
+            @Crd.Spec.Version(name = "v1", served = true, storage = true)
+        },
+        subresources = @Crd.Spec.Subresources(
+            status = @Crd.Spec.Subresources.Status(),
+            scale = @Crd.Spec.Subresources.Scale(
+                specReplicasPath = ".spec.replicas",
+                statusReplicasPath = ".status.replicas"
+            )
+        )
+    )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
+public class ExampleIntegrationCrd extends CustomResource<ExampleIntegrationCrd.Spec, ExampleIntegrationCrd.Status> implements Namespaced {
+    @Override
+    public Spec getSpec() {
+        return super.getSpec();
+    }
+
+    @Override
+    public Status getStatus() {
+        return super.getStatus();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"requiredString", "enumProperty", "numericProperty", "listProperty",
+        "polymorphic", "nested", "cel", "replicas", "either", "or"})
+    @OneOf({
+        @OneOf.Alternative(@OneOf.Alternative.Property("either")),
+        @OneOf.Alternative(@OneOf.Alternative.Property("or"))
+    })
+    public static class Spec {
+        private String requiredString;
+        private NormalEnum enumProperty;
+        private int numericProperty;
+        private List<String> listProperty;
+        private PolymorphicTop polymorphic;
+        private Nested nested;
+        private Cel cel;
+        private int replicas;
+        private String either;
+        private String or;
+
+        @JsonProperty(required = true)
+        public String getRequiredString() {
+            return requiredString;
+        }
+
+        public void setRequiredString(String requiredString) {
+            this.requiredString = requiredString;
+        }
+
+        public NormalEnum getEnumProperty() {
+            return enumProperty;
+        }
+
+        public void setEnumProperty(NormalEnum enumProperty) {
+            this.enumProperty = enumProperty;
+        }
+
+        @Minimum(5)
+        public int getNumericProperty() {
+            return numericProperty;
+        }
+
+        public void setNumericProperty(int numericProperty) {
+            this.numericProperty = numericProperty;
+        }
+
+        @MinimumItems(1)
+        public List<String> getListProperty() {
+            return listProperty;
+        }
+
+        public void setListProperty(List<String> listProperty) {
+            this.listProperty = listProperty;
+        }
+
+        public PolymorphicTop getPolymorphic() {
+            return polymorphic;
+        }
+
+        public void setPolymorphic(PolymorphicTop polymorphic) {
+            this.polymorphic = polymorphic;
+        }
+
+        public Nested getNested() {
+            return nested;
+        }
+
+        public void setNested(Nested nested) {
+            this.nested = nested;
+        }
+
+        public Cel getCel() {
+            return cel;
+        }
+
+        public void setCel(Cel cel) {
+            this.cel = cel;
+        }
+
+        public int getReplicas() {
+            return replicas;
+        }
+
+        public void setReplicas(int replicas) {
+            this.replicas = replicas;
+        }
+
+        public String getEither() {
+            return either;
+        }
+
+        public void setEither(String either) {
+            this.either = either;
+        }
+
+        public String getOr() {
+            return or;
+        }
+
+        public void setOr(String or) {
+            this.or = or;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"replicas"})
+    public static class Status {
+        private int replicas;
+
+        public int getReplicas() {
+            return replicas;
+        }
+
+        public void setReplicas(int replicas) {
+            this.replicas = replicas;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"requiredField"})
+    public static class Nested {
+        private String requiredField;
+
+        @JsonProperty(required = true)
+        public String getRequiredField() {
+            return requiredField;
+        }
+
+        public void setRequiredField(String requiredField) {
+            this.requiredField = requiredField;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"value"})
+    @CelValidation(rules = {
+        @CelValidation.CelValidationRule(rule = "size(self.value) >= 5", message = "value needs to be at least 5 characters long")
+    })
+    public static class Cel {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Left.class, name = "left"),
+        @JsonSubTypes.Type(value = Right.class, name = "right")
+    })
+    public abstract static class PolymorphicTop {
+        private String type;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"type", "leftValue"})
+    public static class Left extends PolymorphicTop {
+        private String leftValue;
+
+        public String getLeftValue() {
+            return leftValue;
+        }
+
+        public void setLeftValue(String leftValue) {
+            this.leftValue = leftValue;
+        }
+
+        @Override
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public String getType() {
+            return "left";
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"type", "rightValue"})
+    public static class Right extends PolymorphicTop {
+        private String rightValue;
+
+        public String getRightValue() {
+            return rightValue;
+        }
+
+        public void setRightValue(String rightValue) {
+            this.rightValue = rightValue;
+        }
+
+        @Override
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public String getType() {
+            return "right";
+        }
+    }
+}

--- a/test/src/main/java/io/strimzi/test/CrdUtils.java
+++ b/test/src/main/java/io/strimzi/test/CrdUtils.java
@@ -157,6 +157,26 @@ public final class CrdUtils {
     }
 
     /**
+     * Creates a CRD resource in the Kubernetes cluster from a YAML string; useful when the YAML is generated in
+     * memory (e.g., by the CRD generator) and there is no on-disk file to point at.
+     *
+     * @param client    Kubernetes client
+     * @param crdName   Name of the CRD
+     * @param crdYaml   CRD YAML content
+     */
+    public static void createCrdFromYaml(KubernetesClient client, String crdName, String crdYaml)   {
+        if (client.apiextensions().v1().customResourceDefinitions().withName(crdName).get() != null) {
+            deleteCrd(client, crdName);
+        }
+
+        client.resource(crdYaml).create();
+        client.apiextensions().v1()
+                .customResourceDefinitions()
+                .withName(crdName)
+                .waitUntilCondition(CrdUtils::isCrdEstablished, 10, TimeUnit.SECONDS);
+    }
+
+    /**
      * Checks if the CRD has been established
      *
      * @param crd   The CRD resource


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR follows up on #12780 and adds new integration tests to the `crd-generator` module that verify that the generated CRDs interact well with an actual Kubernetes. E.g. required fields are really required, etc. It uses a new _example_ CRD dedicated to this test. This CRD is a lot simpler than the _example_ CRD used for the non-integration tests as it has to cover less features.

This should resolve #12610.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging
- [x] AI assistance was used to create this PR