### PR TITLE
Split Strimzi Metrics Reporter defaults by Kafka node role

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -145,7 +145,7 @@ public class KafkaBrokerConfigurationBuilder {
             printSectionHeader("Strimzi Metrics Reporter configuration");
             writer.println(StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println(StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList(node));
             writer.println();
         }
         return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -117,8 +117,42 @@ import static java.util.Collections.singletonMap;
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class KafkaCluster extends AbstractModel implements SupportsMetrics, SupportsLogging, SupportsJmx {
     /**
-     * Default Strimzi Metrics Reporter allow list.
+     * Default Strimzi Metrics Reporter allow list shared by broker and controller nodes.
      * If modifying this list, make sure example dashboards are compatible with the regexes.
+     */
+    private static final List<String> DEFAULT_SHARED_METRICS_ALLOW_LIST = List.of(
+            "kafka_network_requestmetrics.*",
+            "kafka_network_socketserver_networkprocessoravgidlepercent",
+            "kafka_server_app_info.*",
+            "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent",
+            "kafka_server_kafkaserver_clusterid",
+            "kafka_server_kafkaserver_linux.*",
+            "kafka_server_request_queue_size",
+            "kafka_server_socket_server.*"
+    );
+
+    /**
+     * Default Strimzi Metrics Reporter allow list used by broker nodes.
+     */
+    private static final List<String> DEFAULT_BROKER_METRICS_ALLOW_LIST = metricsAllowList(DEFAULT_SHARED_METRICS_ALLOW_LIST, List.of(
+            "kafka_cluster_partition.*",
+            "kafka_log_log_size",
+            "kafka_server_brokertopicmetrics.*",
+            "kafka_server_kafkaserver_brokerstate",
+            "kafka_server_replicamanager.*"
+    ));
+
+    /**
+     * Default Strimzi Metrics Reporter allow list used by controller nodes.
+     */
+    private static final List<String> DEFAULT_CONTROLLER_METRICS_ALLOW_LIST = metricsAllowList(DEFAULT_SHARED_METRICS_ALLOW_LIST, List.of(
+            "kafka_controller_kafkacontroller.*",
+            "kafka_controller_controllerstats_uncleanleaderelectionspersec",
+            "kafka_server_raft.*"
+    ));
+
+    /**
+     * Default Strimzi Metrics Reporter allow list used by mixed broker/controller nodes.
      */
     private static final List<String> DEFAULT_METRICS_ALLOW_LIST = List.of(
             "kafka_cluster_partition.*",
@@ -337,7 +371,12 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         if (kafkaClusterSpec.getMetricsConfig() instanceof JmxPrometheusExporterMetrics) {
             result.metrics = new JmxPrometheusExporterModel(kafkaClusterSpec);
         } else if (kafkaClusterSpec.getMetricsConfig() instanceof StrimziMetricsReporter) {
-            result.metrics = new StrimziMetricsReporterModel(kafkaClusterSpec, DEFAULT_METRICS_ALLOW_LIST);
+            result.metrics = new StrimziMetricsReporterModel(
+                    kafkaClusterSpec,
+                    DEFAULT_METRICS_ALLOW_LIST,
+                    DEFAULT_BROKER_METRICS_ALLOW_LIST,
+                    DEFAULT_CONTROLLER_METRICS_ALLOW_LIST
+            );
         }
 
         result.logging = new LoggingModel(kafkaClusterSpec, result.getClass().getSimpleName());
@@ -495,6 +534,13 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
 
         return controllers;
+    }
+
+    private static List<String> metricsAllowList(List<String> firstAllowList, List<String> secondAllowList) {
+        Set<String> allowList = new LinkedHashSet<>();
+        allowList.addAll(firstAllowList);
+        allowList.addAll(secondAllowList);
+        return List.copyOf(allowList);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.model.metrics;
 
 import io.strimzi.api.kafka.model.common.HasConfigurableMetrics;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
+import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.model.InvalidResourceException;
 
@@ -22,19 +23,43 @@ public class StrimziMetricsReporterModel implements MetricsModel {
      * Fully qualified class name of the Strimzi Metrics Reporter.
      */
     private final List<String> allowList;
+    private final List<String> brokerAllowList;
+    private final List<String> controllerAllowList;
 
-        /**
-         * Constructs the Metrics Model for managing configurable metrics to Strimzi.
-         *
-         * @param spec Custom resource section configuring metrics.
-         * @param defaultAllowList Default allow list to be used when no value is provided.
-         */
+    /**
+     * Constructs the Metrics Model for managing configurable metrics to Strimzi.
+     *
+     * @param spec Custom resource section configuring metrics.
+     * @param defaultAllowList Default allow list to be used when no value is provided.
+     */
     public StrimziMetricsReporterModel(HasConfigurableMetrics spec, List<String> defaultAllowList) {
+        this(spec, defaultAllowList, defaultAllowList, defaultAllowList);
+    }
+
+    /**
+     * Constructs the Metrics Model for managing configurable metrics to Strimzi.
+     *
+     * @param spec Custom resource section configuring metrics.
+     * @param defaultAllowList Default allow list to be used when no value is provided.
+     * @param defaultBrokerAllowList Default allow list to be used for broker nodes when no value is provided.
+     * @param defaultControllerAllowList Default allow list to be used for controller nodes when no value is provided.
+     */
+    public StrimziMetricsReporterModel(HasConfigurableMetrics spec,
+                                       List<String> defaultAllowList,
+                                       List<String> defaultBrokerAllowList,
+                                       List<String> defaultControllerAllowList) {
         if (spec.getMetricsConfig() != null) {
             StrimziMetricsReporter config = (StrimziMetricsReporter) spec.getMetricsConfig();
             validate(config);
-            this.allowList = config.getValues() != null && config.getValues().getAllowList() != null
-                    ? config.getValues().getAllowList() : defaultAllowList;
+            if (config.getValues() != null && config.getValues().getAllowList() != null) {
+                this.allowList = config.getValues().getAllowList();
+                this.brokerAllowList = this.allowList;
+                this.controllerAllowList = this.allowList;
+            } else {
+                this.allowList = defaultAllowList;
+                this.brokerAllowList = defaultBrokerAllowList;
+                this.controllerAllowList = defaultControllerAllowList;
+            }
         } else {
             throw new InvalidConfigurationException("Unexpected empty metrics config");
         }
@@ -47,6 +72,23 @@ public class StrimziMetricsReporterModel implements MetricsModel {
      */
     public String getAllowList() {
         return String.join(",", allowList);
+    }
+
+    /**
+     * Gets the comma-separated list of allow regex expressions for a Kafka node.
+     *
+     * @param node Kafka node.
+     *
+     * @return Comma separated list of allow regex expressions.
+     */
+    public String getAllowList(NodeRef node) {
+        if (node.broker() && !node.controller()) {
+            return String.join(",", brokerAllowList);
+        } else if (!node.broker() && node.controller()) {
+            return String.join(",", controllerAllowList);
+        } else {
+            return getAllowList();
+        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -54,6 +54,7 @@ import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuild
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
@@ -1935,6 +1936,67 @@ public class KafkaClusterTest {
         // configurations for internal interfaces
         assertThat(cluster.configuration.getConfiguration(), not(CoreMatchers.containsString("listener.name.REPLICATION-9091.connections.max.reauth.ms")));
         assertThat(cluster.configuration.getConfiguration(), not(CoreMatchers.containsString("listener.name.CONTROLPLANE-9090.max.connections")));
+    }
+
+    @Test
+    public void testStrimziMetricsReporterDefaultAllowListPerNodeRole() {
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withMetricsConfig(new StrimziMetricsReporterBuilder().build())
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+
+        String controllerConfig = kafkaCluster.generatePerBrokerConfiguration(1, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
+        assertThat(controllerConfig, CoreMatchers.containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "="));
+        assertThat(controllerConfig, CoreMatchers.containsString("kafka_controller_kafkacontroller.*"));
+        assertThat(controllerConfig, CoreMatchers.containsString("kafka_server_raft.*"));
+        assertThat(controllerConfig, not(CoreMatchers.containsString("kafka_server_brokertopicmetrics.*")));
+        assertThat(controllerConfig, not(CoreMatchers.containsString("kafka_server_replicamanager.*")));
+        assertThat(controllerConfig, not(CoreMatchers.containsString("kafka_log_log_size")));
+
+        String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(6, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
+        assertThat(brokerConfig, CoreMatchers.containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "="));
+        assertThat(brokerConfig, CoreMatchers.containsString("kafka_server_brokertopicmetrics.*"));
+        assertThat(brokerConfig, CoreMatchers.containsString("kafka_server_replicamanager.*"));
+        assertThat(brokerConfig, CoreMatchers.containsString("kafka_log_log_size"));
+        assertThat(brokerConfig, not(CoreMatchers.containsString("kafka_controller_kafkacontroller.*")));
+        assertThat(brokerConfig, not(CoreMatchers.containsString("kafka_server_raft.*")));
+
+        String mixedConfig = kafkaCluster.generatePerBrokerConfiguration(3, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
+        assertThat(mixedConfig, CoreMatchers.containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "="));
+        assertThat(mixedConfig, CoreMatchers.containsString("kafka_controller_kafkacontroller.*"));
+        assertThat(mixedConfig, CoreMatchers.containsString("kafka_server_raft.*"));
+        assertThat(mixedConfig, CoreMatchers.containsString("kafka_server_brokertopicmetrics.*"));
+        assertThat(mixedConfig, CoreMatchers.containsString("kafka_server_replicamanager.*"));
+        assertThat(mixedConfig, CoreMatchers.containsString("kafka_log_log_size"));
+    }
+
+    @Test
+    public void testStrimziMetricsReporterCustomAllowListPerNodeRole() {
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withMetricsConfig(new StrimziMetricsReporterBuilder()
+                                .withNewValues()
+                                    .withAllowList(List.of("custom_metric.*"))
+                                .endValues()
+                                .build())
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+
+        String expectedAllowList = StrimziMetricsReporterConfig.ALLOW_LIST + "=custom_metric.*";
+        assertThat(kafkaCluster.generatePerBrokerConfiguration(1, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS), CoreMatchers.containsString(expectedAllowList));
+        assertThat(kafkaCluster.generatePerBrokerConfiguration(3, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS), CoreMatchers.containsString(expectedAllowList));
+        assertThat(kafkaCluster.generatePerBrokerConfiguration(6, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS), CoreMatchers.containsString(expectedAllowList));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
@@ -8,6 +8,7 @@ import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpecBuilder;
+import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +40,21 @@ public class StrimziMetricsReporterModelTest {
 
         assertThat(metrics.getAllowList().isEmpty(), is(false));
         assertThat(metrics.getAllowList(), is("kafka_log.*,kafka_network.*"));
+        assertThat(metrics.getAllowList(new NodeRef("my-cluster-kafka-0", 0, "kafka", false, true)), is("kafka_log.*,kafka_network.*"));
+        assertThat(metrics.getAllowList(new NodeRef("my-cluster-kafka-1", 1, "kafka", true, false)), is("kafka_log.*,kafka_network.*"));
+        assertThat(metrics.getAllowList(new NodeRef("my-cluster-kafka-2", 2, "kafka", true, true)), is("kafka_log.*,kafka_network.*"));
+    }
+
+    @Test
+    public void testRoleSpecificDefaultAllowLists() {
+        StrimziMetricsReporter metricsConfig = new StrimziMetricsReporterBuilder().build();
+        StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(new KafkaClusterSpecBuilder()
+                .withMetricsConfig(metricsConfig).build(), List.of("shared.*", "broker.*", "controller.*"), List.of("shared.*", "broker.*"), List.of("shared.*", "controller.*"));
+
+        assertThat(metrics.getAllowList(), is("shared.*,broker.*,controller.*"));
+        assertThat(metrics.getAllowList(new NodeRef("my-cluster-brokers-0", 0, "brokers", false, true)), is("shared.*,broker.*"));
+        assertThat(metrics.getAllowList(new NodeRef("my-cluster-controllers-1", 1, "controllers", true, false)), is("shared.*,controller.*"));
+        assertThat(metrics.getAllowList(new NodeRef("my-cluster-mixed-2", 2, "mixed", true, true)), is("shared.*,broker.*,controller.*"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #12181

This splits the default Strimzi Metrics Reporter allow list by Kafka node role:
- broker-only nodes use broker-related metrics plus shared metrics
- controller-only nodes use controller-related metrics plus shared metrics
- mixed broker/controller nodes keep the original combined defaults
- custom `values.allowList` remains unchanged for all node roles

Tests:
- `JAVA_HOME=/home/tapsell/build/jdk-21.0.11+10 PATH=/home/tapsell/build/jdk-21.0.11+10/bin:$PATH /home/tapsell/build/apache-maven-3.9.11/bin/mvn -pl cluster-operator -am -Dtest=StrimziMetricsReporterModelTest,KafkaClusterTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test`