### PR TITLE
Document that interceptor.classes must be set at the connector level when tracing is enabled

### DIFF
--- a/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
+++ b/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
@@ -36,6 +36,11 @@ For MirrorMaker 2, messages are traced from the source cluster to the target clu
 
 For Kafka Connect, only messages produced and consumed by Kafka Connect are traced. To trace messages sent between Kafka Connect and external systems, you must configure tracing in the connectors for those systems.
 
+NOTE: When tracing is enabled, Strimzi automatically sets `consumer.interceptor.classes` and `producer.interceptor.classes` on the Kafka Connect cluster to inject the OpenTelemetry interceptors.
+These properties are restricted and cannot be overridden at the `KafkaConnect` level.
+If a connector requires its own interceptor classes (for example, to enable connector-level distributed tracing with a tool such as Debezium), configure the `interceptor.classes` property in the connector configuration itself using `spec.config` in the `KafkaConnector` resource, or through the Kafka Connect REST API.
+Connector-level interceptor settings are not affected by the Connect-level restriction.
+
 .Tracing in the HTTP Bridge
 
 For the HTTP Bridge, messages produced and consumed by the HTTP Bridge are traced. Incoming HTTP requests from client applications to send and receive messages through the HTTP Bridge are also traced.


### PR DESCRIPTION
## Summary

Resolves #11390

When tracing is enabled on a `KafkaConnect` cluster, Strimzi automatically sets `consumer.interceptor.classes` and `producer.interceptor.classes` to inject the OpenTelemetry interceptors. These properties are restricted at the `KafkaConnect` level, so connectors that need their own interceptor classes (e.g. the Debezium tracing interceptor) cannot configure them through `KafkaConnect.spec.config`.

The existing documentation described that enabling tracing "updates interceptor classes in the integrated consumers and producers", but didn't explain the implication for users who need additional connector-level interceptors, nor how to work around it.

## Change

Added a `NOTE` block to the Kafka Connect tracing procedure clarifying:

1. Strimzi automatically injects OTel interceptors via `consumer.interceptor.classes` / `producer.interceptor.classes` when tracing is enabled.
2. These properties are restricted and cannot be overridden at the `KafkaConnect` level.
3. Connector-specific interceptors (e.g. Debezium) should be configured in `KafkaConnector.spec.config` or via the Kafka Connect REST API, where they are not subject to the Connect-level restriction.

## Test plan

- [ ] Build documentation: `make docu_build` and verify the NOTE renders correctly in the tracing procedure page
- [ ] Confirm the NOTE appears under the "Tracing in Kafka Connect" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)