### PR TITLE
Show N/A instead of 0 for missing data consistently across Grafana dashboards

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -231,7 +231,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -307,7 +307,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -383,7 +383,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -459,7 +459,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -771,7 +771,7 @@
             "inspect": false
           },
           "mappings": [],
-          "noValue": "0",
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka.json
@@ -447,7 +447,7 @@
                 "match": "null",
                 "result": {
                   "color": "#508642",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -526,7 +526,7 @@
                 "match": "null",
                 "result": {
                   "color": "#508642",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1438,7 +1438,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1519,7 +1519,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1600,7 +1600,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1681,7 +1681,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-operators.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-operators.json
@@ -154,7 +154,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -226,7 +226,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -298,7 +298,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -370,7 +370,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -442,7 +442,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -514,7 +514,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -586,7 +586,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -658,7 +658,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-bridge.json
@@ -231,7 +231,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -307,7 +307,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -383,7 +383,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -459,7 +459,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-connect.json
@@ -771,7 +771,7 @@
             "inspect": false
           },
           "mappings": [],
-          "noValue": "0",
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka.json
@@ -447,7 +447,7 @@
                 "match": "null",
                 "result": {
                   "color": "#508642",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -526,7 +526,7 @@
                 "match": "null",
                 "result": {
                   "color": "#508642",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1438,7 +1438,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1519,7 +1519,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1600,7 +1600,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1681,7 +1681,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-bridge.json
@@ -231,7 +231,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -307,7 +307,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -383,7 +383,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -459,7 +459,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-connect.json
@@ -771,7 +771,7 @@
             "inspect": false
           },
           "mappings": [],
-          "noValue": "0",
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka.json
@@ -447,7 +447,7 @@
                 "match": "null",
                 "result": {
                   "color": "#508642",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -526,7 +526,7 @@
                 "match": "null",
                 "result": {
                   "color": "#508642",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1438,7 +1438,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1519,7 +1519,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1600,7 +1600,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -1681,7 +1681,7 @@
                 "match": "null",
                 "result": {
                   "color": "rgba(237, 129, 40, 0.89)",
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-operators.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-operators.json
@@ -154,7 +154,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -226,7 +226,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -298,7 +298,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -370,7 +370,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -442,7 +442,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -514,7 +514,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -586,7 +586,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"
@@ -658,7 +658,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0"
+                  "text": "N/A"
                 }
               },
               "type": "special"


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description

Implements the resolution agreed in the [#12139](https://github.com/strimzi/strimzi-kafka-operator/issues/12139) triage: when a panel's query returns no data, dashboards should display `N/A` rather than `0`, since absence of data is not the same as a zero value.

Most dashboards (cruise-control, kafka-exporter, kafka-connect, mirror-maker-2) already follow the `N/A` convention. This PR updates the remaining inconsistent `null` mappings to `N/A`:

* `strimzi-operators.json` — 8 mappings
* `strimzi-kafka.json` — 6 mappings
* `strimzi-kafka-bridge.json` — 4 mappings
* `strimzi-kafka-connect.json` — 1 (`noValue` default)

Applied identically to the synced copies in `packaging/examples/metrics/`, `packaging/examples/metrics/strimzi-metrics-reporter/`, and the Helm chart under `packaging/helm-charts/`. Only mapping text values are changed —
queries, colors, and thresholds are untouched. All modified files validate as JSON and the examples/Helm copies remain identical.

Resolves [#12139](https://github.com/strimzi/strimzi-kafka-operator/issues/12139)

## Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] AI assistance was used to create this PR