### PR TITLE
Bumped Vert.x 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <fasterxml.jackson-annotations.version>2.21</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.21.2</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.21.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>5.1.1</vertx.version>
-        <vertx-junit5.version>5.1.1</vertx-junit5.version>
+        <vertx.version>5.1.2</vertx.version>
+        <vertx-junit5.version>5.1.2</vertx-junit5.version>
         <kafka.version>4.3.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps Vert.x 5.1.2. No need for Netty which stays the same.