### PR TITLE
Bumped Micrometere to fix CVE-2026-40984

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <jetty.version>12.0.35</jetty.version>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
         <netty.version>4.2.15.Final</netty.version>
-        <micrometer.version>1.14.5</micrometer.version>
+        <micrometer.version>1.16.6</micrometer.version>
         <commons-codec.version>1.13</commons-codec.version>
         <picocli.version>4.7.7</picocli.version>
         <snakeyaml.version>2.5</snakeyaml.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR aligns the Micrometer version to what is used within Vert.x Micrometer, so 1.16.6. The alignment allows to fix the [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984) as well.
