### PR TITLE
Removed unused otel alpha version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
         <log4j.version>2.25.4</log4j.version>
         <quartz.version>2.5.0</quartz.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
-        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>12.0.35</jetty.version>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
         <netty.version>4.2.15.Final</netty.version>


### PR DESCRIPTION
Trivial PR to remove the unused `opentelemetry-alpha.version` property.