### PR TITLE
Bump OpenTelemetry to fix CVE-2026-45292 and grpc

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
@@ -22,10 +22,9 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
         <kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
-        <opentelemetry.version>1.34.1</opentelemetry.version>
-        <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
+        <opentelemetry.version>1.63.0</opentelemetry.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.79.0</grpc-netty-shaded.version>
         <log4j.version>2.25.4</log4j.version>
     </properties>
 
@@ -79,7 +78,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
-            <version>${opentelemetry-alpha.version}</version>
+            <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
@@ -65,11 +65,6 @@
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-common</artifactId>
-            <version>${opentelemetry.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
             <version>${opentelemetry.instrumentation.version}</version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
@@ -56,13 +56,29 @@
         <!-- Tracing -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-common</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
             <version>${opentelemetry.instrumentation.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
@@ -69,11 +69,6 @@
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-common</artifactId>
-            <version>${opentelemetry.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
             <version>${opentelemetry.instrumentation.version}</version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
@@ -26,10 +26,9 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
         <kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
-        <opentelemetry.version>1.34.1</opentelemetry.version>
-        <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
+        <opentelemetry.version>1.63.0</opentelemetry.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.79.0</grpc-netty-shaded.version>
         <log4j.version>2.25.4</log4j.version>
     </properties>
 
@@ -83,7 +82,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
-            <version>${opentelemetry-alpha.version}</version>
+            <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
@@ -60,13 +60,29 @@
         <!-- Tracing -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-common</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
             <version>${opentelemetry.instrumentation.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
@@ -22,10 +22,9 @@
         <cruise-control.version>2.5.146</cruise-control.version>
         <kafka-quotas-plugin.version>0.4.0</kafka-quotas-plugin.version>
         <kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
-        <opentelemetry.version>1.34.1</opentelemetry.version>
-        <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
+        <opentelemetry.version>1.63.0</opentelemetry.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-        <grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
+        <grpc-netty-shaded.version>1.79.0</grpc-netty-shaded.version>
         <log4j.version>2.25.4</log4j.version>
     </properties>
 
@@ -79,7 +78,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
-            <version>${opentelemetry-alpha.version}</version>
+            <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
@@ -65,11 +65,6 @@
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-common</artifactId>
-            <version>${opentelemetry.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
             <version>${opentelemetry.instrumentation.version}</version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
@@ -56,13 +56,29 @@
         <!-- Tracing -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-common</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
             <version>${opentelemetry.instrumentation.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.4</log4j.version>
         <quartz.version>2.5.0</quartz.version>
-        <opentelemetry.version>1.34.1</opentelemetry.version>
+        <opentelemetry.version>1.63.0</opentelemetry.version>
         <jetty.version>12.0.35</jetty.version>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
         <netty.version>4.2.15.Final</netty.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps OpenTelemetry to latest 1.63.0 to address https://nvd.nist.gov/vuln/detail/CVE-2026-45292 and also grpc netty shaded to a most up to date version.

### Checklist

- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests