### PR TITLE
Don't reconcile the KafkaUser if deletionTimestamp is present

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -184,7 +184,10 @@ public class KafkaUserOperator {
      * @return  CompletionStage which completes when the reconciliation is done
      */
     public CompletionStage<KafkaUserStatus> reconcile(Reconciliation reconciliation, KafkaUser kafkaUser, Secret userSecret)  {
-        if (kafkaUser != null)  {
+        if (kafkaUser != null && kafkaUser.getMetadata().getDeletionTimestamp() != null) {
+            LOGGER.infoCr(reconciliation, "User {} in namespace {} is being deleted, skipping reconciliation", reconciliation.name(), reconciliation.namespace());
+            return CompletableFuture.completedFuture(null);
+        } else if (kafkaUser != null)  {
             // Create or update
             return createOrUpdate(reconciliation, kafkaUser, userSecret);
         } else {

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
@@ -62,6 +62,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KafkaUserOperatorMockTest {
@@ -168,6 +170,31 @@ public class KafkaUserOperatorMockTest {
             }
         });
         when(quotasOps.getAllUsers()).thenReturn(CompletableFuture.completedStage(Set.of("quotas-user-1", "quotas-user-2")));
+    }
+
+    @Test
+    public void testReconcileSkipsWhenUserIsBeingDeleted() throws ExecutionException, InterruptedException {
+        // KafkaUser pending deletion (deletionTimestamp set): must not recreate the Secret.
+        KafkaUser user = new KafkaUserBuilder(ResourceUtils.createKafkaUserTls(namespace))
+                .editMetadata()
+                    .withDeletionTimestamp("2026-06-17T12:00:00Z")
+                .endMetadata()
+                .build();
+
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(namespace), mockCertManager, secretOps, kafkaUserOps, scramOps, quotasOps, aclOps);
+        CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, namespace, ResourceUtils.NAME), user, null);
+        KafkaUserStatus status = futureResult.toCompletableFuture().get();
+
+        // No reconciliation happened => null status, so the controller loop skips the status update
+        assertThat(status, is(nullValue()));
+
+        // The Secret must NOT be created/recreated
+        assertThat(secretOps.get(namespace, ResourceUtils.NAME), is(nullValue()));
+
+        // No Kafka-side resources may be touched
+        verify(aclOps, never()).reconcile(any(), any(), any());
+        verify(scramOps, never()).reconcile(any(), any(), any());
+        verify(quotasOps, never()).reconcile(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
### Type of change

_Select the type of your PR and delete the other items_

- Enhancement / new feature

### Description

Resolves #12835

Don't trigger KafkaUser reconcile if `deletionTimestamp` field is present on the resource.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
