### PR TITLE
Bump central-publishing-maven-plugin due to Maven Central API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.checkstyle.version>3.5.0</maven.checkstyle.version>
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
         <maven.jar.version>3.1.0</maven.jar.version>
-        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
         <maven.jacoco.version>0.8.12</maven.jacoco.version>
         <maven.exec.version>3.1.0</maven.exec.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps version for central-publishing-maven-plugin after some JSON schema changes on the Maven Central API.