### PR TITLE
Align default build tag for all images

### DIFF
--- a/docker-images/kafka-based/build.sh
+++ b/docker-images/kafka-based/build.sh
@@ -59,7 +59,7 @@ function build {
             make -C "$image" "$targets" \
                 DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg KAFKA_VERSION=${kafka_version} --build-arg KAFKA_DIST_DIR=${relative_dist_dir} --build-arg THIRD_PARTY_LIBS=${lib_directory} $(alternate_base "$image")" \
                 DOCKER_TAG="${tag}-kafka-${kafka_version}" \
-                BUILD_TAG="build-kafka-${kafka_version}" \
+                BUILD_TAG="latest-kafka-${kafka_version}" \
                 KAFKA_VERSION="${kafka_version}" \
                 THIRD_PARTY_LIBS="${lib_directory}"
         done


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Currently we use `latest` as default value for `BUILD_TAG` which results that all images has `latest` during build and then we re-tag them. Only exception is Kafka where we have `build-kafka-<KAFKA_VERSION>` which eventually results into different tags.  This PR unified it. 

Eventually we can do `docker_tag` before `docker_save` but this is a simpler change.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
