### PR TITLE
Added enable flag for topic and user operators watched namespace

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -255,6 +255,11 @@ public class ClusterOperatorConfig {
     public static final ConfigParameter<Boolean> PKCS12_KEYSTORE_GENERATION = new ConfigParameter<>("STRIMZI_PKCS12_KEYSTORE_GENERATION", BOOLEAN, "true", CONFIG_VALUES);
 
     /**
+     * Set true to enable watched namespace feature for Entity Operators (Topic Operator and User Operator)
+     */
+    public static final ConfigParameter<Boolean> ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED = new ConfigParameter<>("STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED", BOOLEAN, "false", CONFIG_VALUES);
+
+    /**
      * The configured Kafka versions
      */
     private final KafkaVersion.Lookup versions;
@@ -642,6 +647,15 @@ public class ClusterOperatorConfig {
         return get(PKCS12_KEYSTORE_GENERATION);
     }
 
+    /**
+     * Checks whether Entity Operator watched namespace feature is enabled.
+     *
+     * @return  Indicates whether Entity Operator watched namespace feature is enabled.
+     */
+    public boolean isEntityOperatorWatchedNamespaceEnabled() {
+        return get(ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED);
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig{" +
@@ -665,6 +679,7 @@ public class ClusterOperatorConfig {
                 "\n\tleaderElectionConfig='" + getLeaderElectionConfig() + '\'' +
                 "\n\tpodDisruptionBudgetGeneration=" + isPodDisruptionBudgetGeneration() + '\'' +
                 "\n\tisPkcs12KeystoreGeneration='" + isPkcs12KeystoreGeneration() +
+                "\n\tisEntityOperatorWatchedNamespaceEnabled='" + isEntityOperatorWatchedNamespaceEnabled() +
                 "}";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.strimzi.api.kafka.model.common.Probe;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
@@ -56,6 +57,29 @@ public class EntityOperator extends AbstractModel {
     public static final String COMPONENT_TYPE = "entity-operator";
 
     protected static final String CO_ENV_VAR_CUSTOM_ENTITY_OPERATOR_POD_LABELS = "STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS";
+
+    /**
+     * Represents which operator permissions should be included when filtering ClusterRole rules
+     */
+    public enum Permissions {
+        /** Include only Topic Operator permissions (kafkatopics resources) */
+        TOPIC_OPERATOR,
+
+        /** Include only User Operator permissions (kafkausers and secrets resources) */
+        USER_OPERATOR,
+
+        /** Include both Topic and User Operator permissions (no filtering) */
+        BOTH
+    }
+
+    /**
+     * Map defining which resource prefixes belong to each permission type.
+     * Used for filtering ClusterRole rules to enforce least-privilege permissions.
+     */
+    private static final Map<Permissions, List<String>> OPERATOR_RESOURCE_PREFIXES = Map.of(
+        Permissions.TOPIC_OPERATOR, List.of("kafkatopics"),
+        Permissions.USER_OPERATOR, List.of("kafkausers", "secrets")
+    );
 
     /**
      * Default health check options used by the Topic and User operators
@@ -112,7 +136,7 @@ public class EntityOperator extends AbstractModel {
 
             EntityTopicOperator topicOperator = EntityTopicOperator.fromCrd(reconciliation, kafkaAssembly, sharedEnvironmentProvider, config);
             EntityUserOperator userOperator = EntityUserOperator.fromCrd(reconciliation, kafkaAssembly, sharedEnvironmentProvider, config);
-            
+
             result.topicOperator = topicOperator;
             result.cruiseControlEnabled = kafkaAssembly.getSpec().getCruiseControl() != null;
             result.userOperator = userOperator;
@@ -227,17 +251,66 @@ public class EntityOperator extends AbstractModel {
     }
 
     /**
-     * Read the entity operator ClusterRole and use the rules to create a new Role.
-     * This is done to avoid duplication of the rules set defined in source code.
-     * If the namespace of the role is different from the namespace of the parent resource (Kafka CR), we do not set
-     * the owner reference.
+     * Filters PolicyRules based on permissions to provide least-privilege access.
+     * Rules that reference both TO and UO resources are split to include only the
+     * relevant resources for the specified permissions.
      *
-     * @param ownerNamespace        The namespace of the parent resource (the Kafka CR)
-     * @param namespace             The namespace of this role will be located
-     *
-     * @return role for the entity operator
+     * @param rules        The original list of PolicyRules from the combined ClusterRole
+     * @param permissions  Which operator permissions to include
+     * @return Filtered list of PolicyRules
      */
-    public Role generateRole(String ownerNamespace, String namespace) {
+    private List<PolicyRule> filterRulesByPermissions(List<PolicyRule> rules, Permissions permissions) {
+        if (permissions == Permissions.BOTH) {
+            // No filtering needed, return all rules
+            return rules;
+        }
+
+        List<PolicyRule> filteredRules = new ArrayList<>();
+
+        for (PolicyRule rule : rules) {
+            // Filter resources that match the permissions
+            List<String> resourcesToKeep = rule.getResources().stream()
+                    .filter(resource -> matchesPermissions(resource, permissions))
+                    .toList();
+
+            // If this rule has relevant resources, create a new rule with only those resources
+            if (!resourcesToKeep.isEmpty()) {
+                PolicyRule filteredRule = new PolicyRuleBuilder(rule)
+                        .withResources(resourcesToKeep)
+                        .build();
+                filteredRules.add(filteredRule);
+            }
+        }
+
+        return filteredRules;
+    }
+
+    /**
+     * Checks if a resource matches the specified permissions based on the OPERATOR_RESOURCE_PREFIXES map.
+     * Handles both exact matches (e.g., "secrets") and subresource matches (e.g., "kafkatopics/status").
+     *
+     * @param resource     The resource name (e.g., "kafkatopics", "kafkausers/status", "secrets")
+     * @param permissions  The permissions to match against
+     * @return true if this resource belongs to the specified permissions
+     */
+    private boolean matchesPermissions(String resource, Permissions permissions) {
+        return OPERATOR_RESOURCE_PREFIXES.get(permissions).stream()
+                .anyMatch(prefix -> resource.equals(prefix) || resource.startsWith(prefix + "/"));
+    }
+
+    /**
+     * Generate a Role with filtered permissions based on which operator(s) need access.
+     * Loads the combined Entity Operator ClusterRole template and filters the rules
+     * based on the specified permissions to enforce least-privilege access.
+     *
+     * @param ownerNamespace   The namespace of the parent resource (the Kafka CR)
+     * @param namespace        The namespace where this role will be located
+     * @param roleName         The name to use for the Role resource
+     * @param permissions      Which operator permissions to include (TOPIC_OPERATOR, USER_OPERATOR, or BOTH)
+     *
+     * @return Role with appropriately filtered permissions
+     */
+    public Role generateRole(String ownerNamespace, String namespace, String roleName, Permissions permissions) {
         List<PolicyRule> rules;
 
         try (BufferedReader br = new BufferedReader(
@@ -249,13 +322,13 @@ public class EntityOperator extends AbstractModel {
             String yaml = br.lines().collect(Collectors.joining(System.lineSeparator()));
             ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
             ClusterRole cr = yamlReader.readValue(yaml, ClusterRole.class);
-            rules = cr.getRules();
+            rules = filterRulesByPermissions(cr.getRules(), permissions);
         } catch (IOException e) {
             LOGGER.errorCr(reconciliation, "Failed to read entity-operator ClusterRole.", e);
             throw new RuntimeException(e);
         }
 
-        Role role = RbacUtils.createRole(componentName, namespace, rules, labels, ownerReference, templateRole);
+        Role role = RbacUtils.createRole(roleName, namespace, rules, labels, ownerReference, templateRole);
 
         // We set OwnerReference only within the same namespace since it does not work cross-namespace
         if (!namespace.equals(ownerNamespace)) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -40,7 +40,7 @@ import java.util.Map;
  */
 public class EntityUserOperator extends AbstractModel implements SupportsLogging {
     protected static final String COMPONENT_TYPE = "entity-user-operator";
-    
+
     protected static final String USER_OPERATOR_CONTAINER_NAME = "user-operator";
     private static final String NAME_SUFFIX = "-entity-user-operator";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -25,7 +26,9 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.RoleOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceAccountOperator;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
@@ -41,6 +44,7 @@ import java.util.Map;
  * reconciliation pipeline and is also used to store the state between them.
  */
 public class EntityOperatorReconciler {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(EntityOperatorReconciler.class);
     private final Reconciliation reconciliation;
     private final long operationTimeoutMs;
     private final EntityOperator entityOperator;
@@ -52,6 +56,7 @@ public class EntityOperatorReconciler {
     private final ServiceAccountOperator serviceAccountOperator;
     private final boolean isNetworkPolicyGeneration;
     private final boolean isPodDisruptionBudgetGeneration;
+    private final boolean isEntityOperatorWatchedNamespaceEnabled;
     private final RoleOperator roleOperator;
     private final RoleBindingOperator roleBindingOperator;
     private final ConfigMapOperator configMapOperator;
@@ -87,7 +92,8 @@ public class EntityOperatorReconciler {
         this.isNetworkPolicyGeneration = config.isNetworkPolicyGeneration();
         this.isCruiseControlEnabled = kafkaAssembly.getSpec().getCruiseControl() != null;
         this.isPodDisruptionBudgetGeneration = config.isPodDisruptionBudgetGeneration();
-        
+        this.isEntityOperatorWatchedNamespaceEnabled = config.isEntityOperatorWatchedNamespaceEnabled();
+
         this.deploymentOperator = supplier.deploymentOperations;
         this.secretOperator = supplier.secretOperations;
         this.serviceAccountOperator = supplier.serviceAccountOperations;
@@ -138,7 +144,7 @@ public class EntityOperatorReconciler {
                         reconciliation,
                         reconciliation.namespace(),
                         KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
-                        entityOperator != null ? entityOperator.generateServiceAccount() : null
+                        shouldInstallEntityOperator() ? entityOperator.generateServiceAccount() : null
                 ).mapEmpty();
     }
 
@@ -155,8 +161,46 @@ public class EntityOperatorReconciler {
                         reconciliation,
                         reconciliation.namespace(),
                         KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
-                        entityOperator != null ? entityOperator.generateRole(reconciliation.namespace(), reconciliation.namespace()) : null
+                        shouldInstallEntityOperator() ? entityOperator.generateRole(reconciliation.namespace(), reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), EntityOperator.Permissions.BOTH) : null
                 ).mapEmpty();
+    }
+
+    /**
+     * Determines which operator permissions are needed for a given namespace.
+     * This implements adaptive permission selection:
+     * - Both TO and UO watch the namespace then use combined permissions (TO and UO permissions, with Secrets)
+     * - Only TO watches then use TO-only permissions (no Secrets)
+     * - Only UO watches then use UO-only permissions (with Secrets)
+     *
+     * @param namespace The namespace to determine permissions for
+     * @return The OperatorType indicating which permissions to include
+     */
+    private EntityOperator.Permissions getPermissionsForNamespace(String namespace) {
+        String toNamespace = entityOperator != null && entityOperator.topicOperator() != null
+            ? entityOperator.topicOperator().watchedNamespace()
+            : null;
+        String uoNamespace = entityOperator != null && entityOperator.userOperator() != null
+            ? entityOperator.userOperator().watchedNamespace()
+            : null;
+
+        boolean toWatches = toNamespace != null && toNamespace.equals(namespace) && topicOperatorHasValidConfig();
+        boolean uoWatches = uoNamespace != null && uoNamespace.equals(namespace) && userOperatorHasValidConfig();
+
+        if (toWatches && uoWatches) {
+            // Both watch this namespace, use combined permissions
+            return EntityOperator.Permissions.BOTH;
+        } else if (toWatches) {
+            // Only TO watches, use TO-only permissions (no Secrets)
+            return EntityOperator.Permissions.TOPIC_OPERATOR;
+        } else if (uoWatches) {
+            // Only UO watches, use UO-only permissions (with Secrets)
+            return EntityOperator.Permissions.USER_OPERATOR;
+        } else {
+            // This should never happen
+            throw new IllegalStateException("Operator type determination called for namespace "
+                    + namespace + " but neither operator watches it. " +
+                    "Topic Operator namespace: " + toNamespace + ", User Operator namespace: " + uoNamespace);
+        }
     }
 
     /**
@@ -167,22 +211,34 @@ public class EntityOperatorReconciler {
      */
     protected Future<Void> topicOperatorRole() {
         if (entityOperator != null && entityOperator.topicOperator() != null) {
-            String watchedNamespace = entityOperator.topicOperator().watchedNamespace();
+            String namespace = entityOperator.topicOperator().watchedNamespace();
+            Role role;
 
-            if (!watchedNamespace.equals(reconciliation.namespace())) {
+            if (!topicOperatorHasValidConfig()) {
+                // Deletion case: delete the Role in watched namespace
+                role = null;
+            } else if (isEntityOperatorWatchedNamespaceEnabled && !namespace.equals(reconciliation.namespace())) {
+                // Creation case: generate Role for watched namespace using adaptive permissions
+                EntityOperator.Permissions permissions = getPermissionsForNamespace(namespace);
+                role = entityOperator.generateRole(reconciliation.namespace(), namespace, KafkaResources.entityOperatorDeploymentName(reconciliation.name()), permissions);
+            } else {
+                // Feature disabled and no deletion needed (watchedNamespace = cluster namespace)
+                return Future.succeededFuture();
+            }
+
+            // Only reconcile if namespace is different from cluster namespace
+            if (namespace != null && !namespace.equals(reconciliation.namespace())) {
                 return roleOperator
                         .reconcile(
                                 reconciliation,
-                                watchedNamespace,
+                                namespace,
                                 KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
-                                entityOperator.generateRole(reconciliation.namespace(), watchedNamespace)
+                                role
                         ).mapEmpty();
-            } else {
-                return Future.succeededFuture();
             }
-        } else {
-            return Future.succeededFuture();
         }
+
+        return Future.succeededFuture();
     }
 
     /**
@@ -193,22 +249,34 @@ public class EntityOperatorReconciler {
      */
     protected Future<Void> userOperatorRole() {
         if (entityOperator != null && entityOperator.userOperator() != null) {
-            String watchedNamespace = entityOperator.userOperator().watchedNamespace();
+            String namespace = entityOperator.userOperator().watchedNamespace();
+            Role role;
 
-            if (!watchedNamespace.equals(reconciliation.namespace())) {
+            if (!userOperatorHasValidConfig()) {
+                // Deletion case: delete the Role in watched namespace
+                role = null;
+            } else if (isEntityOperatorWatchedNamespaceEnabled && !namespace.equals(reconciliation.namespace())) {
+                // Creation case: generate Role for watched namespace using adaptive permissions
+                EntityOperator.Permissions permissions = getPermissionsForNamespace(namespace);
+                role = entityOperator.generateRole(reconciliation.namespace(), namespace, KafkaResources.entityOperatorDeploymentName(reconciliation.name()), permissions);
+            } else {
+                // Feature disabled and no deletion needed (watchedNamespace = cluster namespace)
+                return Future.succeededFuture();
+            }
+
+            // Only reconcile if namespace is different from cluster namespace
+            if (namespace != null && !namespace.equals(reconciliation.namespace())) {
                 return roleOperator
                         .reconcile(
                                 reconciliation,
-                                watchedNamespace,
+                                namespace,
                                 KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
-                                entityOperator.generateRole(reconciliation.namespace(), watchedNamespace)
+                                role
                         ).mapEmpty();
-            } else {
-                return Future.succeededFuture();
             }
-        } else {
-            return Future.succeededFuture();
         }
+
+        return Future.succeededFuture();
     }
 
     /**
@@ -219,22 +287,41 @@ public class EntityOperatorReconciler {
      * @return  Future which completes when the reconciliation is done
      */
     protected Future<Void> topicOperatorRoleBindings() {
-        if (entityOperator != null && entityOperator.topicOperator() != null)   {
+        if (entityOperator != null && entityOperator.topicOperator() != null) {
             String watchedNamespace = entityOperator.topicOperator().watchedNamespace();
+            RoleBinding ownNamespaceRoleBinding;
+            RoleBinding watchedNamespaceRoleBinding;
 
+            if (!entityOperatorHasValidConfig()) {
+                // Deletion case: entire deployment being deleted, delete both RoleBindings
+                ownNamespaceRoleBinding = null;
+                watchedNamespaceRoleBinding = null;
+            } else {
+                // Creation case: generate RoleBindings
+                ownNamespaceRoleBinding = entityOperator.topicOperator().generateRoleBindingForRole(reconciliation.namespace(), reconciliation.namespace());
+                watchedNamespaceRoleBinding = isEntityOperatorWatchedNamespaceEnabled
+                        ? entityOperator.topicOperator().generateRoleBindingForRole(reconciliation.namespace(), watchedNamespace)
+                        : null;
+            }
+
+            // Always reconcile own namespace RoleBinding
+            Future<ReconcileResult<RoleBinding>> ownNamespaceFuture = roleBindingOperator
+                    .reconcile(reconciliation, reconciliation.namespace(),
+                            KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()),
+                            ownNamespaceRoleBinding);
+
+            // Reconcile watched namespace RoleBinding if different from cluster namespace
             Future<ReconcileResult<RoleBinding>> watchedNamespaceFuture;
-            if (!watchedNamespace.equals(reconciliation.namespace()))    {
-                watchedNamespaceFuture = roleBindingOperator.reconcile(reconciliation, watchedNamespace,
-                        KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()), entityOperator.topicOperator().generateRoleBindingForRole(reconciliation.namespace(), watchedNamespace));
+            if (watchedNamespace != null && !watchedNamespace.equals(reconciliation.namespace())) {
+                watchedNamespaceFuture = roleBindingOperator
+                        .reconcile(reconciliation, watchedNamespace,
+                                KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()),
+                                watchedNamespaceRoleBinding);
             } else {
                 watchedNamespaceFuture = Future.succeededFuture();
             }
 
-            Future<ReconcileResult<RoleBinding>> ownNamespaceFuture = roleBindingOperator.reconcile(reconciliation, reconciliation.namespace(),
-                    KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()), entityOperator.topicOperator().generateRoleBindingForRole(reconciliation.namespace(), reconciliation.namespace()));
-
-            return Future.join(ownNamespaceFuture, watchedNamespaceFuture)
-                    .mapEmpty();
+            return Future.join(ownNamespaceFuture, watchedNamespaceFuture).mapEmpty();
         } else {
             return roleBindingOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()), null)
@@ -250,22 +337,41 @@ public class EntityOperatorReconciler {
      * @return  Future which completes when the reconciliation is done
      */
     protected Future<Void> userOperatorRoleBindings() {
-        if (entityOperator != null && entityOperator.userOperator() != null)   {
+        if (entityOperator != null && entityOperator.userOperator() != null) {
             String watchedNamespace = entityOperator.userOperator().watchedNamespace();
+            RoleBinding ownNamespaceRoleBinding;
+            RoleBinding watchedNamespaceRoleBinding;
 
+            if (!entityOperatorHasValidConfig()) {
+                // Deletion case: entire deployment being deleted, delete both RoleBindings
+                ownNamespaceRoleBinding = null;
+                watchedNamespaceRoleBinding = null;
+            } else {
+                // Creation case: generate RoleBindings
+                ownNamespaceRoleBinding = entityOperator.userOperator().generateRoleBindingForRole(reconciliation.namespace(), reconciliation.namespace());
+                watchedNamespaceRoleBinding = isEntityOperatorWatchedNamespaceEnabled
+                        ? entityOperator.userOperator().generateRoleBindingForRole(reconciliation.namespace(), watchedNamespace)
+                        : null;
+            }
+
+            // Always reconcile own namespace RoleBinding
+            Future<ReconcileResult<RoleBinding>> ownNamespaceFuture = roleBindingOperator
+                    .reconcile(reconciliation, reconciliation.namespace(),
+                            KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()),
+                            ownNamespaceRoleBinding);
+
+            // Reconcile watched namespace RoleBinding if different from cluster namespace
             Future<ReconcileResult<RoleBinding>> watchedNamespaceFuture;
-            if (!watchedNamespace.equals(reconciliation.namespace()))    {
-                watchedNamespaceFuture = roleBindingOperator.reconcile(reconciliation, watchedNamespace,
-                        KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()), entityOperator.userOperator().generateRoleBindingForRole(reconciliation.namespace(), watchedNamespace));
+            if (watchedNamespace != null && !watchedNamespace.equals(reconciliation.namespace())) {
+                watchedNamespaceFuture = roleBindingOperator
+                        .reconcile(reconciliation, watchedNamespace,
+                                KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()),
+                                watchedNamespaceRoleBinding);
             } else {
                 watchedNamespaceFuture = Future.succeededFuture();
             }
 
-            Future<ReconcileResult<RoleBinding>> ownNamespaceFuture = roleBindingOperator.reconcile(reconciliation, reconciliation.namespace(),
-                    KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()), entityOperator.userOperator().generateRoleBindingForRole(reconciliation.namespace(), reconciliation.namespace()));
-
-            return Future.join(ownNamespaceFuture, watchedNamespaceFuture)
-                    .mapEmpty();
+            return Future.join(ownNamespaceFuture, watchedNamespaceFuture).mapEmpty();
         } else {
             return roleBindingOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()), null)
@@ -280,7 +386,7 @@ public class EntityOperatorReconciler {
      * @return  Future which completes when the reconciliation is done
      */
     protected Future<Void> topicOperatorConfigMap() {
-        if (entityOperator != null && entityOperator.topicOperator() != null) {
+        if (shouldInstallEntityOperator() && entityOperator.topicOperator() != null) {
             return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.topicOperator().logging(), null)
                     .compose(logging ->
                             configMapOperator.reconcile(
@@ -304,7 +410,7 @@ public class EntityOperatorReconciler {
      * @return  Future which completes when the reconciliation is done
      */
     protected Future<Void> userOperatorConfigMap() {
-        if (entityOperator != null && entityOperator.userOperator() != null) {
+        if (shouldInstallEntityOperator() && entityOperator.userOperator() != null) {
             return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.userOperator().logging(), null)
                     .compose(logging ->
                             configMapOperator.reconcile(
@@ -330,7 +436,7 @@ public class EntityOperatorReconciler {
      * @return      Future which completes when the reconciliation is done
      */
     protected Future<Void> topicOperatorSecret(Clock clock) {
-        if (entityOperator != null && entityOperator.topicOperator() != null) {
+        if (shouldInstallEntityOperator() && entityOperator.topicOperator() != null) {
             return secretOperator.getAsync(reconciliation.namespace(), KafkaResources.entityTopicOperatorSecretName(reconciliation.name()))
                     .compose(oldSecret -> {
                         Secret newSecret = entityOperator.topicOperator().generateCertificatesSecret(clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant()));
@@ -369,7 +475,7 @@ public class EntityOperatorReconciler {
      * @return      Future which completes when the reconciliation is done
      */
     protected Future<Void> userOperatorSecret(Clock clock) {
-        if (entityOperator != null && entityOperator.userOperator() != null) {
+        if (shouldInstallEntityOperator() && entityOperator.userOperator() != null) {
             return secretOperator.getAsync(reconciliation.namespace(), KafkaResources.entityUserOperatorSecretName(reconciliation.name()))
                     .compose(oldSecret -> {
                         Secret newSecret = entityOperator.userOperator().generateCertificatesSecret(clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant()));
@@ -400,7 +506,7 @@ public class EntityOperatorReconciler {
                             reconciliation,
                             reconciliation.namespace(),
                             KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
-                            entityOperator != null ? entityOperator.generateNetworkPolicy() : null
+                            shouldInstallEntityOperator() ? entityOperator.generateNetworkPolicy() : null
                     ).mapEmpty();
         } else {
             return Future.succeededFuture();
@@ -418,7 +524,7 @@ public class EntityOperatorReconciler {
                             reconciliation,
                             reconciliation.namespace(),
                             KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
-                            entityOperator != null ? entityOperator.generatePodDisruptionBudget() : null
+                            shouldInstallEntityOperator() ? entityOperator.generatePodDisruptionBudget() : null
                     ).mapEmpty();
         } else {
             return Future.succeededFuture();
@@ -430,7 +536,7 @@ public class EntityOperatorReconciler {
      * @return  Future which completes when the reconciliation is done
      */
     protected Future<Void> deployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
-        if (entityOperator != null) {
+        if (shouldInstallEntityOperator()) {
             Map<String, String> podAnnotations = new LinkedHashMap<>();
             podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(clusterCa.caCertGeneration()));
             podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(clusterCa.caKeyGeneration()));
@@ -442,11 +548,23 @@ public class EntityOperatorReconciler {
 
             Deployment deployment = entityOperator.generateDeployment(podAnnotations, isOpenShift, imagePullPolicy, imagePullSecrets);
 
-
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), deployment)
                     .mapEmpty();
-        } else  {
+        } else {
+            // Log warning and fail if we're deleting due to invalid configuration
+            if (entityOperator != null && !entityOperatorHasValidConfig()) {
+                String errorMessage = "Entity Operator deployment deleted because Topic Operator and/or User Operator are configured with " +
+                        "watchedNamespace set to a different namespace but the feature is disabled. " +
+                        "To enable cross-namespace watching, set STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED=true";
+
+                LOGGER.warnCr(reconciliation, errorMessage);
+
+                return deploymentOperator
+                        .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), null)
+                        .compose(v -> Future.failedFuture(new InvalidConfigurationException(errorMessage)));
+            }
+
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), null)
                     .mapEmpty();
@@ -459,11 +577,84 @@ public class EntityOperatorReconciler {
      * @return  Future which completes when the reconciliation is done
      */
     protected Future<Void> waitForDeploymentReadiness() {
-        if (entityOperator != null) {
+        if (shouldInstallEntityOperator()) {
             return deploymentOperator.waitForObserved(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), 1_000, operationTimeoutMs)
                     .compose(i -> deploymentOperator.readiness(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), 1_000, operationTimeoutMs));
         } else {
             return Future.succeededFuture();
         }
+    }
+
+    /**
+     * Determines if Topic Operator has a valid configuration.
+     * Configuration is valid when:
+     * - Feature is enabled (any watchedNamespace is allowed), OR
+     * - Feature is disabled AND watchedNamespace equals cluster namespace
+     *
+     * @return true if configuration is valid, false otherwise
+     */
+    private boolean topicOperatorHasValidConfig() {
+        if (entityOperator == null || entityOperator.topicOperator() == null) {
+            return true;
+        }
+
+        return isEntityOperatorWatchedNamespaceEnabled
+                || entityOperator.topicOperator().watchedNamespace().equals(reconciliation.namespace());
+    }
+
+    /**
+     * Determines if User Operator has a valid configuration.
+     * Configuration is valid when:
+     * - Feature is enabled (any watchedNamespace is allowed), OR
+     * - Feature is disabled AND watchedNamespace equals cluster namespace
+     *
+     * @return true if configuration is valid, false otherwise
+     */
+    private boolean userOperatorHasValidConfig() {
+        if (entityOperator == null || entityOperator.userOperator() == null) {
+            return true;
+        }
+
+        return isEntityOperatorWatchedNamespaceEnabled
+                || entityOperator.userOperator().watchedNamespace().equals(reconciliation.namespace());
+    }
+
+    /**
+     * Determines if Entity Operator has a valid configuration.
+     * Both Topic Operator and User Operator must have valid configurations.
+     *
+     * @return true if Entity Operator configuration is valid, false otherwise
+     */
+    private boolean entityOperatorHasValidConfig() {
+        return topicOperatorHasValidConfig() && userOperatorHasValidConfig();
+    }
+
+    /**
+     * Determines if the Entity Operator should be installed.
+     *
+     * @return true if Entity Operator should be installed, false otherwise
+     */
+    private boolean shouldInstallEntityOperator() {
+        return entityOperator != null && entityOperatorHasValidConfig();
+    }
+
+    /**
+     * Determines if the Topic Operator should be installed.
+     *
+     * @return true if Topic Operator should be installed, false otherwise
+     */
+    private boolean shouldInstallTopicOperator() {
+        return entityOperator != null && entityOperator.topicOperator() != null
+                && topicOperatorHasValidConfig();
+    }
+
+    /**
+     * Determines if the User Operator should be installed.
+     *
+     * @return true if User Operator should be installed, false otherwise
+     */
+    private boolean shouldInstallUserOperator() {
+        return entityOperator != null && entityOperator.userOperator() != null
+                && userOperatorHasValidConfig();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -48,6 +48,7 @@ public class ClusterOperatorConfigTest {
         ENV_VARS.put(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.key(), "my.package.CustomPodSecurityProvider");
         ENV_VARS.put(ClusterOperatorConfig.POD_DISRUPTION_BUDGET_GENERATION.key(), "false");
         ENV_VARS.put(ClusterOperatorConfig.PKCS12_KEYSTORE_GENERATION.key(), "false");
+        ENV_VARS.put(ClusterOperatorConfig.ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED.key(), "true");
     }
 
     @Test
@@ -60,6 +61,7 @@ public class ClusterOperatorConfigTest {
         envVars.remove(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.key());
         envVars.remove(ClusterOperatorConfig.POD_DISRUPTION_BUDGET_GENERATION.key());
         envVars.remove(ClusterOperatorConfig.PKCS12_KEYSTORE_GENERATION.key());
+        envVars.remove(ClusterOperatorConfig.ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED.key());
 
         ClusterOperatorConfig config = ClusterOperatorConfig.buildFromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
 
@@ -76,6 +78,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getLeaderElectionConfig(), is(nullValue()));
         assertThat(config.isPodDisruptionBudgetGeneration(), is(true));
         assertThat(config.isPkcs12KeystoreGeneration(), is(true));
+        assertThat(config.isEntityOperatorWatchedNamespaceEnabled(), is(false));
     }
 
     @Test
@@ -109,6 +112,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getPodSecurityProviderClass(), is("my.package.CustomPodSecurityProvider"));
         assertThat(config.isPodDisruptionBudgetGeneration(), is(false));
         assertThat(config.isPkcs12KeystoreGeneration(), is(false));
+        assertThat(config.isEntityOperatorWatchedNamespaceEnabled(), is(true));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -347,7 +347,7 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(1).getVolumeMounts().stream().filter(volumeMount -> "secret-volume-name".equals(volumeMount.getName())).iterator().next(), is(additionalVolumeMounts.get(0)));
 
         // Generate Role metadata
-        Role crb = entityOperator.generateRole(null, NAMESPACE);
+        Role crb = entityOperator.generateRole(null, NAMESPACE, KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), EntityOperator.Permissions.BOTH);
         assertThat(crb.getMetadata().getLabels().entrySet().containsAll(rLabels.entrySet()), is(true));
         assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(rAnnotations.entrySet()), is(true));
 
@@ -745,7 +745,7 @@ public class EntityOperatorTest {
     
     @Test
     public void testRole() {
-        Role role = ENTITY_OPERATOR.generateRole(NAMESPACE, NAMESPACE);
+        Role role = ENTITY_OPERATOR.generateRole(NAMESPACE, NAMESPACE, KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), EntityOperator.Permissions.BOTH);
 
         assertThat(role.getMetadata().getName(), is("my-cluster-entity-operator"));
         assertThat(role.getMetadata().getNamespace(), is(NAMESPACE));
@@ -781,11 +781,89 @@ public class EntityOperatorTest {
 
     @Test
     public void testRoleInDifferentNamespace() {
-        Role role = ENTITY_OPERATOR.generateRole(NAMESPACE, NAMESPACE);
+        Role role = ENTITY_OPERATOR.generateRole(NAMESPACE, NAMESPACE, KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), EntityOperator.Permissions.BOTH);
         TestUtils.checkOwnerReference(role, KAFKA);
 
-        role = ENTITY_OPERATOR.generateRole(NAMESPACE, "some-other-namespace");
+        role = ENTITY_OPERATOR.generateRole(NAMESPACE, "some-other-namespace", KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), EntityOperator.Permissions.BOTH);
         assertThat(role.getMetadata().getOwnerReferences().size(), is(0));
+    }
+
+    @Test
+    public void testRoleGenerationWithTopicOperatorOnly() {
+        Role role = ENTITY_OPERATOR.generateRole(
+            NAMESPACE,
+            "watched-namespace",
+            KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME),
+            EntityOperator.Permissions.TOPIC_OPERATOR
+        );
+
+        // Verify only kafkatopics resources are present
+        List<String> allResources = role.getRules().stream()
+            .flatMap(rule -> rule.getResources().stream())
+            .collect(Collectors.toList());
+
+        assertThat(allResources.stream().anyMatch(r -> r.startsWith("kafkatopics")), is(true));
+        assertThat(allResources.stream().anyMatch(r -> r.startsWith("kafkausers")), is(false));
+        assertThat(allResources.stream().anyMatch(r -> r.equals("secrets")), is(false));
+    }
+
+    @Test
+    public void testRoleGenerationWithUserOperatorOnly() {
+        Role role = ENTITY_OPERATOR.generateRole(
+            NAMESPACE,
+            "watched-namespace",
+            KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME),
+            EntityOperator.Permissions.USER_OPERATOR
+        );
+
+        // Verify only kafkausers and secrets resources are present
+        List<String> allResources = role.getRules().stream()
+            .flatMap(rule -> rule.getResources().stream())
+            .collect(Collectors.toList());
+
+        assertThat(allResources.stream().anyMatch(r -> r.startsWith("kafkausers")), is(true));
+        assertThat(allResources.stream().anyMatch(r -> r.equals("secrets")), is(true));
+        assertThat(allResources.stream().anyMatch(r -> r.startsWith("kafkatopics")), is(false));
+    }
+
+    @Test
+    public void testRoleGenerationWithBothOperators() {
+        Role role = ENTITY_OPERATOR.generateRole(
+            NAMESPACE,
+            "watched-namespace",
+            KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME),
+            EntityOperator.Permissions.BOTH
+        );
+
+        // Verify all resources are present
+        List<String> allResources = role.getRules().stream()
+            .flatMap(rule -> rule.getResources().stream())
+            .collect(Collectors.toList());
+
+        assertThat(allResources.stream().anyMatch(r -> r.startsWith("kafkatopics")), is(true));
+        assertThat(allResources.stream().anyMatch(r -> r.startsWith("kafkausers")), is(true));
+        assertThat(allResources.stream().anyMatch(r -> r.equals("secrets")), is(true));
+    }
+
+    @Test
+    public void testFilteringPreservesMixedRules() {
+        Role roleTO = ENTITY_OPERATOR.generateRole(
+            NAMESPACE,
+            "watched-namespace",
+            KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME),
+            EntityOperator.Permissions.TOPIC_OPERATOR
+        );
+
+        // Verify kafkatopics/status and kafkatopics/finalizers are present
+        List<String> toResources = roleTO.getRules().stream()
+            .flatMap(rule -> rule.getResources().stream())
+            .collect(Collectors.toList());
+
+        assertThat(toResources, hasItem("kafkatopics/status"));
+        assertThat(toResources, hasItem("kafkatopics/finalizers"));
+        // Verify kafkausers subresources are NOT present
+        assertThat(toResources.stream().anyMatch(r -> r.equals("kafkausers/status")), is(false));
+        assertThat(toResources.stream().anyMatch(r -> r.equals("kafkausers/finalizers")), is(false));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -258,7 +258,7 @@ public class EntityTopicOperatorTest {
         assertThat(binding.getMetadata().getAnnotations().get("anno-1"), is("value-1"));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
-        assertThat(binding.getRoleRef().getName(), is("my-cluster-entity-operator"));
+        assertThat(binding.getRoleRef().getName(), is("my-cluster-entity-operator")); // Same namespace = shared Role
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -284,7 +284,7 @@ public class EntityUserOperatorTest {
         assertThat(binding.getMetadata().getAnnotations().get("anno-1"), is("value-1"));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
-        assertThat(binding.getRoleRef().getName(), is("my-cluster-entity-operator"));
+        assertThat(binding.getRoleRef().getName(), is("my-cluster-entity-operator")); // Same namespace = shared Role
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
@@ -19,6 +19,9 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.ClusterOperatorConfig.ClusterOperatorConfigBuilder;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.ClusterCa;
@@ -32,6 +35,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.RoleOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ServiceAccountOperator;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Ca;
@@ -49,14 +53,17 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.TOPIC_OPERATOR_PASSWORD_KEY;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.TOPIC_OPERATOR_USERNAME;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.TOPIC_OPERATOR_USERNAME_KEY;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -268,9 +275,13 @@ public class EntityOperatorReconcilerTest {
                 .endSpec()
                 .build();
 
+        ClusterOperatorConfig config = new ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup())
+                .with(ClusterOperatorConfig.ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED.key(), "true")
+                .build();
+
         EntityOperatorReconciler rcnclr = new EntityOperatorReconciler(
                 Reconciliation.DUMMY_RECONCILIATION,
-                ResourceUtils.dummyClusterOperatorConfig(),
+                config,
                 supplier,
                 kafka,
                 CLUSTER_CA
@@ -298,15 +309,11 @@ public class EntityOperatorReconcilerTest {
                     assertThat(uoRoleCaptor.getValue(), is(notNullValue()));
 
                     assertThat(toRoleBindingCaptor.getAllValues().size(), is(2));
-                    assertThat(toRoleBindingCaptor.getAllValues().get(0), is(notNullValue()));
-                    assertThat(toRoleBindingCaptor.getAllValues().get(0).getMetadata().getNamespace(), is(toWatchNamespace));
-                    assertThat(toRoleBindingCaptor.getAllValues().get(1), is(notNullValue()));
-                    assertThat(toRoleBindingCaptor.getAllValues().get(1).getMetadata().getNamespace(), is(NAMESPACE));
+                    assertThat(toRoleBindingCaptor.getAllValues().stream().allMatch(Objects::nonNull), is(true));
+                    assertThat(toRoleBindingCaptor.getAllValues().stream().map(rb -> rb.getMetadata().getNamespace()).toList(), hasItems(toWatchNamespace, NAMESPACE));
                     assertThat(uoRoleBindingCaptor.getAllValues().size(), is(2));
-                    assertThat(uoRoleBindingCaptor.getAllValues().get(0), is(notNullValue()));
-                    assertThat(uoRoleBindingCaptor.getAllValues().get(0).getMetadata().getNamespace(), is(uoWatchNamespace));
-                    assertThat(uoRoleBindingCaptor.getAllValues().get(1), is(notNullValue()));
-                    assertThat(uoRoleBindingCaptor.getAllValues().get(1).getMetadata().getNamespace(), is(NAMESPACE));
+                    assertThat(uoRoleBindingCaptor.getAllValues().stream().allMatch(Objects::nonNull), is(true));
+                    assertThat(uoRoleBindingCaptor.getAllValues().stream().map(rb -> rb.getMetadata().getNamespace()).toList(), hasItems(uoWatchNamespace, NAMESPACE));
 
                     assertThat(toCmCaptor.getAllValues().size(), is(1));
                     assertThat(toCmCaptor.getValue(), is(notNullValue()));
@@ -714,6 +721,265 @@ public class EntityOperatorReconcilerTest {
                     assertThat(toRoleBindingCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(uoRoleBindingCaptor.getAllValues().size(), is(1));
                     assertThat(uoRoleBindingCaptor.getAllValues().get(0), is(nullValue()));
+
+                    assertThat(toCmCaptor.getAllValues().size(), is(1));
+                    assertThat(toCmCaptor.getValue(), is(nullValue()));
+                    assertThat(uoCmCaptor.getAllValues().size(), is(1));
+                    assertThat(uoCmCaptor.getValue(), is(nullValue()));
+
+                    assertThat(depCaptor.getAllValues().size(), is(1));
+                    assertThat(depCaptor.getValue(), is(nullValue()));
+
+                    assertThat(pdbCaptor.getAllValues().size(), is(1));
+                    assertThat(pdbCaptor.getValue(), is(nullValue()));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void reconcileWithToAndUoAndWatchNamespacesWithFeatureDisabled(VertxTestContext context) {
+        String toWatchNamespace = "to-watch-namespace";
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        ServiceAccountOperator mockSaOps = supplier.serviceAccountOperations;
+        RoleOperator mockRoleOps = supplier.roleOperations;
+        RoleBindingOperator mockRoleBindingOps = supplier.roleBindingOperations;
+        NetworkPolicyOperator mockNetPolicyOps = supplier.networkPolicyOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        PodDisruptionBudgetOperator mockPodDisruptionBudgetOps = supplier.podDisruptionBudgetOperator;
+
+        ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
+        when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)), uoSecretCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Role> operatorRoleCaptor = ArgumentCaptor.forClass(Role.class);
+        when(mockRoleOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), operatorRoleCaptor.capture())).thenReturn(Future.succeededFuture());
+        // Both TO and UO Roles in watched namespace use the same resource name, so use single captor
+        ArgumentCaptor<Role> watchedNamespaceRoleCaptor = ArgumentCaptor.forClass(Role.class);
+        when(mockRoleOps.reconcile(any(), eq(toWatchNamespace), eq(KafkaResources.entityOperatorDeploymentName(NAME)), watchedNamespaceRoleCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<RoleBinding> toRoleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorRoleBinding(NAME)), toRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockRoleBindingOps.reconcile(any(), eq(toWatchNamespace), eq(KafkaResources.entityTopicOperatorRoleBinding(NAME)), toRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<RoleBinding> uoRoleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityUserOperatorRoleBinding(NAME)), uoRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockRoleBindingOps.reconcile(any(), eq(toWatchNamespace), eq(KafkaResources.entityUserOperatorRoleBinding(NAME)), uoRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<ConfigMap> toCmCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorLoggingConfigMapName(NAME)), toCmCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<ConfigMap> uoCmCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityUserOperatorLoggingConfigMapName(NAME)), uoCmCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<NetworkPolicy> netPolicyCaptor = ArgumentCaptor.forClass(NetworkPolicy.class);
+        when(mockNetPolicyOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), netPolicyCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), depCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPodDisruptionBudgetOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Create Kafka CR with Topic Operator having watchedNamespace configured
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withNewEntityOperator()
+                        .withNewTopicOperator()
+                            .withWatchedNamespace(toWatchNamespace)
+                        .endTopicOperator()
+                        .withNewUserOperator()
+                            .withWatchedNamespace(toWatchNamespace)
+                        .endUserOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        // Create config with feature DISABLED
+        ClusterOperatorConfig config = new ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup())
+                .with(ClusterOperatorConfig.ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED.key(), "false")
+                .build();
+
+        EntityOperatorReconciler rcnclr = new EntityOperatorReconciler(
+                Reconciliation.DUMMY_RECONCILIATION,
+                config,
+                supplier,
+                kafka,
+                CLUSTER_CA
+        );
+
+        Checkpoint async = context.checkpoint();
+        rcnclr.reconcile(false, null, null, Clock.systemUTC())
+                .onComplete(context.failing(error -> context.verify(() -> {
+                    // Verify the reconciliation failed with InvalidConfigurationException
+                    assertThat(error, instanceOf(InvalidConfigurationException.class));
+                    assertThat(error.getMessage(), is("Entity Operator deployment deleted because Topic Operator and/or User Operator are configured with " +
+                            "watchedNamespace set to a different namespace but the feature is disabled. " +
+                            "To enable cross-namespace watching, set STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED=true"));
+
+                    // Verify all resources are deleted (null passed to reconcile) before failure
+                    assertThat(saCaptor.getAllValues().size(), is(1));
+                    assertThat(saCaptor.getValue(), is(nullValue()));
+
+                    assertThat(toSecretCaptor.getAllValues().size(), is(1));
+                    assertThat(toSecretCaptor.getValue(), is(nullValue()));
+                    assertThat(uoSecretCaptor.getAllValues().size(), is(1));
+                    assertThat(uoSecretCaptor.getValue(), is(nullValue()));
+
+                    assertThat(netPolicyCaptor.getAllValues().size(), is(1));
+                    assertThat(netPolicyCaptor.getValue(), is(nullValue()));
+
+                    assertThat(operatorRoleCaptor.getAllValues().size(), is(1));
+                    assertThat(operatorRoleCaptor.getValue(), is(nullValue()));
+
+                    // Both TO and UO Roles in watched namespace - should be 2 calls, both with null
+                    assertThat(watchedNamespaceRoleCaptor.getAllValues().size(), is(2));
+                    assertThat(watchedNamespaceRoleCaptor.getAllValues().stream().allMatch(r -> r == null), is(true));
+
+                    assertThat(toRoleBindingCaptor.getAllValues().size(), is(2));
+                    assertThat(toRoleBindingCaptor.getAllValues().stream().allMatch(rb -> rb == null), is(true));
+
+                    assertThat(uoRoleBindingCaptor.getAllValues().size(), is(2));
+                    assertThat(uoRoleBindingCaptor.getAllValues().stream().allMatch(rb -> rb == null), is(true));
+
+                    assertThat(toCmCaptor.getAllValues().size(), is(1));
+                    assertThat(toCmCaptor.getValue(), is(nullValue()));
+                    assertThat(uoCmCaptor.getAllValues().size(), is(1));
+                    assertThat(uoCmCaptor.getValue(), is(nullValue()));
+
+                    assertThat(depCaptor.getAllValues().size(), is(1));
+                    assertThat(depCaptor.getValue(), is(nullValue()));
+
+                    assertThat(pdbCaptor.getAllValues().size(), is(1));
+                    assertThat(pdbCaptor.getValue(), is(nullValue()));
+
+                    async.flag();
+                })));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void reconcileWithOnlyOneOperatorWatchedNamespaceAndFeatureDisabled(boolean topicOperatorWatches, VertxTestContext context) {
+        String watchNamespace = "watch-namespace";
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        ServiceAccountOperator mockSaOps = supplier.serviceAccountOperations;
+        RoleOperator mockRoleOps = supplier.roleOperations;
+        RoleBindingOperator mockRoleBindingOps = supplier.roleBindingOperations;
+        NetworkPolicyOperator mockNetPolicyOps = supplier.networkPolicyOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        PodDisruptionBudgetOperator mockPodDisruptionBudgetOps = supplier.podDisruptionBudgetOperator;
+
+        ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
+        when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)), uoSecretCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Role> operatorRoleCaptor = ArgumentCaptor.forClass(Role.class);
+        when(mockRoleOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), operatorRoleCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Role> watchRoleCaptor = ArgumentCaptor.forClass(Role.class);
+        when(mockRoleOps.reconcile(any(), eq(watchNamespace), eq(KafkaResources.entityOperatorDeploymentName(NAME)), watchRoleCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<RoleBinding> toRoleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorRoleBinding(NAME)), toRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockRoleBindingOps.reconcile(any(), eq(watchNamespace), eq(KafkaResources.entityTopicOperatorRoleBinding(NAME)), toRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<RoleBinding> uoRoleBindingCaptor = ArgumentCaptor.forClass(RoleBinding.class);
+        when(mockRoleBindingOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityUserOperatorRoleBinding(NAME)), uoRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockRoleBindingOps.reconcile(any(), eq(watchNamespace), eq(KafkaResources.entityUserOperatorRoleBinding(NAME)), uoRoleBindingCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<ConfigMap> toCmCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorLoggingConfigMapName(NAME)), toCmCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<ConfigMap> uoCmCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityUserOperatorLoggingConfigMapName(NAME)), uoCmCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<NetworkPolicy> netPolicyCaptor = ArgumentCaptor.forClass(NetworkPolicy.class);
+        when(mockNetPolicyOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), netPolicyCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), depCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPodDisruptionBudgetOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Create Kafka CR with only one operator having watchedNamespace configured
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withNewEntityOperator()
+                        .withNewTopicOperator()
+                            .withWatchedNamespace(topicOperatorWatches ? watchNamespace : null)
+                        .endTopicOperator()
+                        .withNewUserOperator()
+                            .withWatchedNamespace(topicOperatorWatches ? null : watchNamespace)
+                        .endUserOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+
+        // Create config with feature DISABLED
+        ClusterOperatorConfig config = new ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup())
+                .with(ClusterOperatorConfig.ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED.key(), "false")
+                .build();
+
+        EntityOperatorReconciler rcnclr = new EntityOperatorReconciler(
+                Reconciliation.DUMMY_RECONCILIATION,
+                config,
+                supplier,
+                kafka,
+                CLUSTER_CA
+        );
+
+        Checkpoint async = context.checkpoint();
+        rcnclr.reconcile(false, null, null, Clock.systemUTC())
+                .onComplete(context.failing(error -> context.verify(() -> {
+                    // Verify the reconciliation failed with InvalidConfigurationException
+                    assertThat(error, instanceOf(InvalidConfigurationException.class));
+
+                    // Verify ENTIRE Entity Operator deployment is deleted before failure
+                    // even though only one operator has watchedNamespace configured
+
+                    assertThat(saCaptor.getAllValues().size(), is(1));
+                    assertThat(saCaptor.getValue(), is(nullValue()));
+
+                    assertThat(toSecretCaptor.getAllValues().size(), is(1));
+                    assertThat(toSecretCaptor.getValue(), is(nullValue()));
+                    assertThat(uoSecretCaptor.getAllValues().size(), is(1));
+                    assertThat(uoSecretCaptor.getValue(), is(nullValue()));
+
+                    assertThat(netPolicyCaptor.getAllValues().size(), is(1));
+                    assertThat(netPolicyCaptor.getValue(), is(nullValue()));
+
+                    assertThat(operatorRoleCaptor.getAllValues().size(), is(1));
+                    assertThat(operatorRoleCaptor.getValue(), is(nullValue()));
+
+                    assertThat(watchRoleCaptor.getAllValues().size(), is(1));
+                    assertThat(watchRoleCaptor.getValue(), is(nullValue()));
+
+                    // RoleBindings should be deleted (both cluster namespace and watched namespace)
+                    if (topicOperatorWatches) {
+                        assertThat(toRoleBindingCaptor.getAllValues().size(), is(2));
+                        assertThat(toRoleBindingCaptor.getAllValues().stream().allMatch(rb -> rb == null), is(true));
+                        assertThat(uoRoleBindingCaptor.getAllValues().size(), is(1));
+                        assertThat(uoRoleBindingCaptor.getValue(), is(nullValue()));
+                    } else {
+                        assertThat(toRoleBindingCaptor.getAllValues().size(), is(1));
+                        assertThat(toRoleBindingCaptor.getValue(), is(nullValue()));
+                        assertThat(uoRoleBindingCaptor.getAllValues().size(), is(2));
+                        assertThat(uoRoleBindingCaptor.getAllValues().stream().allMatch(rb -> rb == null), is(true));
+                    }
 
                     assertThat(toCmCaptor.getAllValues().size(), is(1));
                     assertThat(toCmCaptor.getValue(), is(nullValue()));

--- a/documentation/assemblies/configuring/assembly-config.adoc
+++ b/documentation/assemblies/configuring/assembly-config.adoc
@@ -88,6 +88,8 @@ include::../../modules/configuring/ref-kafka-entity-operator.adoc[leveloffset=+1
 include::../../modules/configuring/con-configuring-topic-operator.adoc[leveloffset=+2]
 //user operator config
 include::../../modules/configuring/con-configuring-user-operator.adoc[leveloffset=+2]
+//watched namespace config for topic and user operators
+include::../../modules/configuring/proc-configuring-entity-operator-watched-namespace.adoc[leveloffset=+2]
 
 //cluster operator config env vars
 include::../../modules/operators/con-configuring-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-configuring-topic-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-topic-operator.adoc
@@ -15,6 +15,8 @@ The following properties are supported:
 `watchedNamespace`::
 The Kubernetes namespace in which the Topic Operator watches for `KafkaTopic` resources.
 Default is the namespace where the Kafka cluster is deployed.
+To watch a different namespace, you must enable the watched namespace feature in the Cluster Operator by setting `STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED` to `true`.
+For more information, see xref:proc-configuring-entity-operator-watched-namespace-{context}[].
 
 `reconciliationIntervalMs`::
 The interval between periodic reconciliations in milliseconds.

--- a/documentation/modules/configuring/con-configuring-user-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-user-operator.adoc
@@ -14,6 +14,8 @@ The following properties are supported:
 `watchedNamespace`::
 The Kubernetes namespace in which the User Operator watches for `KafkaUser` resources.
 Default is the namespace where the Kafka cluster is deployed.
+To watch a different namespace, you must enable the watched namespace feature in the Cluster Operator by setting `STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED` to `true`.
+For more information, see xref:proc-configuring-entity-operator-watched-namespace-{context}[].
 
 `reconciliationIntervalMs`::
 The interval between periodic reconciliations in milliseconds.

--- a/documentation/modules/configuring/proc-configuring-entity-operator-watched-namespace.adoc
+++ b/documentation/modules/configuring/proc-configuring-entity-operator-watched-namespace.adoc
@@ -1,0 +1,132 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// ref-kafka-entity-operator.adoc
+
+[id='proc-configuring-entity-operator-watched-namespace-{context}']
+= Configuring Topic and User Operators to watch a different namespace
+
+[role="_abstract"]
+By default, the Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in the same namespace where the Kafka cluster is deployed.
+You can configure them to watch a different namespace, which is useful when you want to manage Kafka topics and users in a separate namespace from the Kafka cluster itself.
+
+NOTE: This feature is disabled by default and must be explicitly enabled in the Cluster Operator configuration.
+
+WARNING: If you configure `watchedNamespace` to a different namespace while the feature is disabled, the Entity Operator deployment and all the related existing resources (ConfigMap, Secret, Role, RoleBinding and so on) will be deleted, reconciliation will fail, and a warning condition will be added to the `Kafka` resource status. Existing `KafkaTopic` and `KafkaUser` resources will stay.
+
+IMPORTANT: If you are upgrading from a previous Strimzi version where you were using `watchedNamespace` to watch a different namespace, you must enable this feature during the upgrade to avoid disruption. When upgrading the Cluster Operator, update the deployment to include the `STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED=true` environment variable at the same time. Otherwise, the Entity Operator will be deleted during the upgrade reconciliation, and your topics and users will no longer be managed until you enable the feature.
+
+.Prerequisites
+
+* The Cluster Operator is deployed and running
+* A Kafka cluster is deployed or ready to be deployed
+
+.Procedure
+
+. Enable the watched namespace feature in the Cluster Operator deployment.
++
+Edit the Cluster Operator `Deployment` to set the `STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED` environment variable to `true`:
++
+[source,yaml,options="nowrap"]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+spec:
+  # ...
+  template:
+    spec:
+      containers:
+      - name: strimzi-cluster-operator
+        # ...
+        env:
+        - name: STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED
+          value: "true"
+        # ...
+----
++
+When this environment variable is set to `false` (the default):
++
+* If `watchedNamespace` is not configured or is set to the same namespace as the Kafka cluster, the Topic and User Operators function normally.
+* If `watchedNamespace` is configured to a different namespace, the Cluster Operator deletes the Entity Operator deployment and all related resources, fails the reconciliation, and adds a warning condition to the `Kafka` resource status. Existing `KafkaTopic` and `KafkaUser` resources will stay.
+
+. Configure the `watchedNamespace` property for the Topic Operator, User Operator, or both in your `Kafka` custom resource.
++
+.Example: Topic Operator watching a different namespace
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: kafka # <1>
+spec:
+  kafka:
+    # ...
+  entityOperator:
+    topicOperator:
+      watchedNamespace: my-topics-namespace # <2>
+    userOperator:
+      watchedNamespace: my-users-namespace # <3>
+----
+<1> The Kafka cluster is deployed in the `kafka` namespace
+<2> The Topic Operator watches for `KafkaTopic` resources in the `my-topics-namespace` namespace
+<3> The User Operator watches for `KafkaUser` resources in the `my-users-namespace` namespace
++
+If the `watchedNamespace` property is not specified, both operators default to watching the namespace where the Kafka cluster is deployed.
+
+. Ensure the watched namespace exists.
++
+The Cluster Operator automatically creates a `Role` and `RoleBinding` in the watched namespace to grant the Entity Operator the necessary permissions.
+However, you must ensure the watched namespace exists before deploying the Kafka cluster.
++
+For example, if using `my-topics-namespace`:
++
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl create namespace my-topics-namespace
+----
+
+. Apply the updated `Kafka` resource:
++
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl apply -f _kafka-config.yaml_
+----
+
+.Verification
+
+. Verify that the Entity Operator pod is running:
++
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl get pods -n kafka -l strimzi.io/name=my-cluster-entity-operator
+----
+
+. Check that the required RBAC resources were created in the watched namespace:
++
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl get role,rolebinding -n my-topics-namespace
+----
++
+You should see a `Role` and `RoleBinding` created by the Cluster Operator for the Entity Operator.
+
+. Check the Topic and User Operators logs to confirm they are watching the correct namespaces:
++
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl logs -n kafka deployment/my-cluster-entity-operator -c topic-operator
+kubectl logs -n kafka deployment/my-cluster-entity-operator -c user-operator
+----
++
+The logs should indicate that the operators are watching the configured namespaces.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:topic-operator-{context}[Configuring the Topic Operator]
+* xref:user-operator-{context}[Configuring the User Operator]
+* xref:ref-operator-cluster-{context}[Configuring the Cluster Operator]

--- a/documentation/modules/configuring/ref-kafka-entity-operator.adoc
+++ b/documentation/modules/configuring/ref-kafka-entity-operator.adoc
@@ -18,7 +18,8 @@ By configuring the `Kafka` resource, the Cluster Operator can deploy the Entity 
 Once deployed, the operators are automatically configured to handle the topics and users of the Kafka cluster. 
 
 Each operator can only monitor a single namespace.
-For more information, see xref:con-operators-namespaces-str[].
+By default, they monitor the namespace where the Kafka cluster is deployed, but they can be configured to watch a different namespace.
+For more information, see xref:con-operators-namespaces-str[] and xref:proc-configuring-entity-operator-watched-namespace-{context}[].
 
 The `entityOperator` property supports several sub-properties:
 

--- a/documentation/modules/operators/con-configuring-cluster-operator.adoc
+++ b/documentation/modules/operators/con-configuring-cluster-operator.adoc
@@ -236,6 +236,12 @@ Configuration for the pluggable `PodSecurityProvider` class, which can be used t
 `STRIMZI_PKCS12_KEYSTORE_GENERATION`:: Optional. Default is `true`.
 Controls automatic creation of PKCS12 stores in the CA (Certificate Authority) and Kafka user `Secret` resources.
 
+`STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED`:: Optional. Default is `false`.
+Controls whether the Entity Operator (Topic Operator and User Operator) can watch a namespace different from the one where the Kafka cluster is deployed.
+When set to `false` (the default), the Entity Operators will only operate in the namespace where the Kafka cluster is deployed, regardless of the `watchedNamespace` configuration in the `Kafka` custom resource.
+If `watchedNamespace` is configured but differs from the cluster namespace, a warning is logged and the configuration is ignored.
+When set to `true`, the Entity Operators can watch a different namespace as specified in the `watchedNamespace` configuration.
+
 [id='ref-operator-cluster-network-policy-{context}']
 == Restricting access to the Cluster Operator using network policy
 

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -47,6 +47,7 @@ include::../../shared/snip-cluster-operator-namespace-sed.adoc[]
 +
 ** If the Cluster Operator is watching multiple namespaces, add the list of namespaces to the `STRIMZI_NAMESPACE` environment variable.
 ** If the Cluster Operator is watching all namespaces, specify `value: "*"` for the `STRIMZI_NAMESPACE` environment variable.
+** If you are using the `watchedNamespace` property in your Topic Operator or User Operator configuration to watch a different namespace than the Kafka cluster namespace, you must add the `STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED` environment variable and set it to `true`. Without this setting, the Entity Operator deployment will be deleted during the upgrade. For more information, see xref:proc-configuring-entity-operator-watched-namespace-{context}[].
 
 . If the Cluster Operator is watching more than one namespace, update the role bindings.
 +

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.watcher;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.systemtest.Environment;
@@ -14,6 +15,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+
+import java.util.List;
 
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -43,6 +46,9 @@ class AllNamespaceST extends AbstractNamespaceST {
             .getInstance()
             .withCustomConfiguration(new ClusterOperatorConfigurationBuilder()
                 .withNamespacesToWatch(TestConstants.WATCH_ALL_NAMESPACES)
+                .withExtraEnvVars(List.of(
+                    new EnvVar("STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED", "true", null)
+                ))
                 .build()
             )
             .install();

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.watcher;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.systemtest.resources.operator.ClusterOperatorConfigurationBuilder;
@@ -12,6 +13,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+
+import java.util.List;
 
 import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
@@ -42,6 +45,9 @@ class MultipleNamespaceST extends AbstractNamespaceST {
             .withCustomConfiguration(new ClusterOperatorConfigurationBuilder()
                 .withNamespaceName(CO_NAMESPACE)
                 .withNamespacesToWatch(String.join(",", CO_NAMESPACE, PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
+                .withExtraEnvVars(List.of(
+                    new EnvVar("STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED", "true", null)
+                ))
                 .build()
             )
             .install();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes [CVE-2026-55226](https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-r427-j2h7-wv3m) and [CVE-2026-55225](https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-mw9r-p8xp-wx96) on the main branch (future 1.1.0 release) as they were already addressed in the 1.0.1 patch release.
I cherry-picked the work from the `release-1.0.x` and deal with conflicts.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests