### PR TITLE
Add snyk workflow for main builds and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,3 +227,20 @@ jobs:
           helmChartName: "strimzi-kafka-operator-helm-3-chart"
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "operators"
+
+  # Run Snyk security scans on Maven dependencies and container images
+  snyk-scan:
+    name: Snyk Scan
+    needs:
+      - prepare-release-artifacts
+    if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    uses: ./.github/workflows/snyk.yml
+    with:
+      releaseVersion: ${{ inputs.releaseVersion }}
+      sourceBuildRunId: ${{ inputs.sourceBuildRunId }}
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           snykMonitor: "true"
           uploadToCodeScanning: "true"
-          projectPrefix: strimzi
+          projectPrefix: strimzi-kafka-operator
 
   # Discover container images from build artifacts for matrix scanning
   prepare-container-scan:
@@ -141,5 +141,5 @@ jobs:
           image: ${{ matrix.image }}
           snykMonitor: "true"
           uploadToCodeScanning: "true"
-          projectPrefix: strimzi
+          projectPrefix: strimzi-kafka-operator
           snykMonitorTargetReference: ${{ inputs.releaseVersion }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,145 @@
+name: Snyk Scanning
+
+on:
+  # Run after build workflow finishes in non-blocking way
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+    branches:
+      - main
+  # Allow to run it also as reusable workflow from releases
+  workflow_call:
+    inputs:
+      releaseVersion:
+        description: 'Release version for Snyk monitoring target reference'
+        required: false
+        type: string
+        default: 'latest'
+      sourceBuildRunId:
+        description: 'Build workflow run ID for artifact download'
+        required: true
+        type: string
+    secrets:
+      SNYK_TOKEN:
+        required: true
+
+# Declare default permissions as read only
+permissions:
+  contents: read
+
+# Cancel previous scans on the same branch
+concurrency:
+  group: snyk-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Scan Maven dependencies using Snyk
+  snyk-maven-scan:
+    name: Snyk Maven Scan
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Setup Java and Maven
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
+        with:
+          javaVersion: "21"
+
+      - name: Install yq
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
+        with:
+          version: "v4.6.3"
+
+      - name: Build Java code
+        run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
+
+      - name: Run Snyk Maven scan
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@main
+        with:
+          snykMonitor: "true"
+          uploadToCodeScanning: "true"
+          projectPrefix: strimzi
+
+  # Discover container images from build artifacts for matrix scanning
+  prepare-container-scan:
+    name: Prepare Container Scan
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+    outputs:
+      images: ${{ steps.list-images.outputs.images }}
+    steps:
+      - name: Download container archive
+        uses: actions/download-artifact@v7
+        with:
+          name: containers-operators-amd64.tar
+          run-id: ${{ inputs.sourceBuildRunId || github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Untar container archive
+        run: tar -xvf containers-operators-amd64.tar
+
+      - name: List container images
+        id: list-images
+        run: |
+          IMAGES=$(ls docker-images/container-archives/*.tar.gz | \
+            xargs -I{} basename {} | \
+            sed 's/\.tar\.gz$//' | \
+            jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "images=$IMAGES" >> "$GITHUB_OUTPUT"
+          echo "Found images: $IMAGES"
+
+  # Scan each container image using Snyk
+  snyk-container-scan:
+    name: Snyk Container Scan (${{ matrix.image }})
+    needs:
+      - prepare-container-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      CONTAINERS_ARCHIVE: "containers-operators-amd64.tar"
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.prepare-container-scan.outputs.images) }}
+    steps:
+      - name: Download container archive
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ env.CONTAINERS_ARCHIVE }}
+          run-id: ${{ inputs.sourceBuildRunId || github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Untar container archive
+        run: tar -xvf $CONTAINERS_ARCHIVE
+
+      - name: Install Docker
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+
+      - name: Run Snyk container scan
+        uses: strimzi/github-actions/.github/actions/security/snyk-container-scan@main
+        with:
+          imageFile: docker-images/container-archives/${{ matrix.image }}.tar.gz
+          image: ${{ matrix.image }}
+          snykMonitor: "true"
+          uploadToCodeScanning: "true"
+          projectPrefix: strimzi
+          snykMonitorTargetReference: ${{ inputs.releaseVersion }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -95,8 +95,8 @@ jobs:
       - name: List container images
         id: list-images
         run: |
-          IMAGES=$(ls docker-images/container-archives/*.tar.gz | \
-            xargs -I{} basename {} | \
+          IMAGES=$(find docker-images/container-archives -name '*.tar.gz' -print0 | \
+            xargs -0 -I{} basename {} | \
             sed 's/\.tar\.gz$//' | \
             jq -R -s -c 'split("\n") | map(select(. != ""))')
           echo "images=$IMAGES" >> "$GITHUB_OUTPUT"
@@ -129,7 +129,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Untar container archive
-        run: tar -xvf $CONTAINERS_ARCHIVE
+        run: tar -xvf "$CONTAINERS_ARCHIVE"
 
       - name: Install Docker
         uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds reusable workflow for Snyk scanning. It uses our custom actions for scanning maven artifacts and containers. By default the results are uploaded to GitHub Security and Quality page and into Snyk App. 

The scans are executed in two cases:
- push to main
- part of the release workflow

For maven it will always uses github branch as target reference in Snyk App. For containers it will use latest (main branch) or `releaseVersion` parameter value in release workflow.

In both cases it will not fail the build/release workflow.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
