### PR TITLE
Updated OpenTelemetry instrumentation Kafka clients documentation

### DIFF
--- a/documentation/modules/tracing/proc-configuring-tracers-kafka-clients.adoc
+++ b/documentation/modules/tracing/proc-configuring-tracers-kafka-clients.adoc
@@ -62,7 +62,7 @@ In each client application add the dependencies for the tracer:
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
-    <version>{OpenTelemetryAlphaVersion}</version>
+    <version>{OpenTelemetryVersion}</version>
     <scope>runtime</scope>
 </dependency>
 <dependency>

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -146,12 +146,11 @@
 // -----------------------------------------------------------------------------
 
 //distributed tracing versions and links
-:OpenTelemetryAlphaVersion: 1.34.1-alpha
-:OpenTelemetryVersion: 1.34.1
+:OpenTelemetryVersion: 1.63.0
 :OpenTelemetryInstrumentationVersion: 1.32.0-alpha
 :OpenTelemetrySemConvVersion: 1.21.0-alpha
 :OpenTelemetryKafkaClientVersion: 2.6
-:GRPCVersion: 1.75.0
+:GRPCVersion: 1.79.0
 
 :OpenTelemetry: link:https://opentelemetry.io[OpenTelemetry^]
 :OpenTelemetryDocs: link:https://opentelemetry.io/docs/[OpenTelemetry documentation^]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Given the OpenTelemetry bump via https://github.com/strimzi/strimzi-kafka-operator/pull/12834, this PR updates the Kafka clients OpenTelemetry instrumentation documentation with the same versions.
NOTE: the `OpenTelemetryAlphaVersion` attribute was removed because the only dependency using it (the `opentelemetry-exporter-sender-jdk`) was promoted to the stable version.

### Checklist

- [x] Update documentation