### PR TITLE
Split maven snyk scans to multiple runs to avoid GitHub sec page limits

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -64,12 +64,51 @@ jobs:
       - name: Build Java code
         run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
 
-      - name: Run Snyk Maven scan
+      # This step compute modules for different scans - prod modules, test modules, Kafka 3rd-party module
+      # It dynamically checks root pom file and determine prod modules by excluding test ones
+      # Test modules are defined between env vars of this step in MAVEN_TEST_MODULES
+      - name: Compute module exclude lists
+        id: compute-excludes
+        run: |
+          MAVEN_ALL_MODULES=$(grep '<module>' pom.xml \
+            | sed 's/.*<module>\(.*\)<\/module>.*/\1/' \
+            | paste -sd ',' -)
+          MAVEN_PROD_MODULES=$(grep '<module>' pom.xml \
+            | sed 's/.*<module>\(.*\)<\/module>.*/\1/' \
+            | grep -v -w -E "$(echo $MAVEN_TEST_MODULES | tr ',' '|')" \
+            | paste -sd ',' -)
+          echo "maven-all-modules=${MAVEN_ALL_MODULES}" >> "$GITHUB_OUTPUT"
+          echo "maven-prod-modules=${MAVEN_PROD_MODULES}" >> "$GITHUB_OUTPUT"
+          echo "maven-test-modules=${MAVEN_TEST_MODULES}" >> "$GITHUB_OUTPUT"
+        env:
+          MAVEN_TEST_MODULES: "systemtest,mockkube,test"
+
+      - name: Run Snyk Maven scan (prod)
         uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@main
         with:
+          scanName: operators-prod
           snykMonitor: "true"
           uploadToCodeScanning: "true"
-          projectPrefix: strimzi-kafka-operator
+          # For prod deps scan we need to exclude maven test modules and docker-images
+          exclude: "${{ steps.compute-excludes.outputs.maven-test-modules }},docker-images"
+
+      - name: Run Snyk Maven scan (test)
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@main
+        with:
+          scanName: operators-test
+          snykMonitor: "true"
+          uploadToCodeScanning: "true"
+          # For test deps scan we need to exclude maven prod modules and docker-images
+          exclude: "${{ steps.compute-excludes.outputs.maven-prod-modules }},docker-images"
+
+      - name: Run Snyk Maven scan (3rd-party)
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@main
+        with:
+          scanName: kafka-3rd-party
+          snykMonitor: "true"
+          uploadToCodeScanning: "true"
+          # For Kafka 3rd party scan we need to exclude all maven modules and scan will fallback only to 3rd party poms
+          exclude: ${{ steps.compute-excludes.outputs.maven-all-modules }}
 
   # Discover container images from build artifacts for matrix scanning
   prepare-container-scan:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -75,11 +75,13 @@ jobs:
             | paste -sd ',' -)
           MAVEN_PROD_MODULES=$(grep '<module>' pom.xml \
             | sed 's/.*<module>\(.*\)<\/module>.*/\1/' \
-            | grep -v -w -E "$(echo $MAVEN_TEST_MODULES | tr ',' '|')" \
+            | grep -v -w -E "$(echo "$MAVEN_TEST_MODULES" | tr ',' '|')" \
             | paste -sd ',' -)
-          echo "maven-all-modules=${MAVEN_ALL_MODULES}" >> "$GITHUB_OUTPUT"
-          echo "maven-prod-modules=${MAVEN_PROD_MODULES}" >> "$GITHUB_OUTPUT"
-          echo "maven-test-modules=${MAVEN_TEST_MODULES}" >> "$GITHUB_OUTPUT"
+          {
+            echo "maven-all-modules=${MAVEN_ALL_MODULES}"
+            echo "maven-prod-modules=${MAVEN_PROD_MODULES}"
+            echo "maven-test-modules=${MAVEN_TEST_MODULES}"
+          } >> "$GITHUB_OUTPUT"
         env:
           MAVEN_TEST_MODULES: "systemtest,mockkube,test"
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

With recent changes we realized that GitHub Security page has limits with 20 runs for uploads. When we run full scan we have 21 runs which will fail the workflow. This PR splits the scans into prod, test, and 3rd party parts, each will be reported separately. https://github.com/strimzi/github-actions/pull/46 is requirement for this PR.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
