### PR TITLE
Exclude base image from snyk scans

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -136,7 +136,7 @@ jobs:
       - name: List container images
         id: list-images
         run: |
-          IMAGES=$(find docker-images/container-archives -name '*.tar.gz' -print0 | \
+          IMAGES=$(find docker-images/container-archives -name '*.tar.gz' ! -name 'base-*' -print0 | \
             xargs -0 -I{} basename {} | \
             sed 's/\.tar\.gz$//' | \
             jq -R -s -c 'split("\n") | map(select(. != ""))')


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Exclude base image for containers from snyk scanning.

### Checklist

- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
