### PR TITLE
[ST] Skip collecting CertManager's Certificate in case its CRD doesn't exist

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -135,7 +135,12 @@ public interface TestConstants {
     String OPERATOR_GROUP = "OperatorGroup";
     String INSTALL_PLAN = "InstallPlan";
     String CLUSTER_SERVICE_VERSION = "ClusterServiceVersion";
+
+    /**
+     * CertManager related constants
+     */
     String CERTIFICATE = "Certificate";
+    String CERT_MANAGER_API_VERSION = "cert-manager.io/v1";
 
     /**
      * KafkaBridge JSON encoding with JSON embedded format

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
@@ -125,12 +125,26 @@ public class TestLogCollector {
      * TestLogCollector's constructor with default list of namespaced resources.
      */
     public TestLogCollector() {
+        this.logCollector = defaultLogCollectorBuilder()
+            .withNamespacedResources(resourcesToCollect().toArray(new String[0]))
+            .build();
+    }
+
+    private TestLogCollector(LogCollector logCollector) {
+        this.logCollector = logCollector;
+    }
+
+    /**
+     * Return list of resources that should be collected by LogCollector.
+     *
+     * @return  list of resources that should be collected by LogCollector.
+     */
+    private static List<String> resourcesToCollect() {
         List<String> resources = new ArrayList<>(List.of(
             TestConstants.SECRET.toLowerCase(Locale.ROOT),
             TestConstants.DEPLOYMENT.toLowerCase(Locale.ROOT),
             TestConstants.CONFIG_MAP.toLowerCase(Locale.ROOT),
             TestConstants.SERVICE.toLowerCase(Locale.ROOT),
-            TestConstants.CERTIFICATE.toLowerCase(Locale.ROOT),
             TestConstants.JOB.toLowerCase(Locale.ROOT),
             Kafka.RESOURCE_SINGULAR,
             KafkaNodePool.RESOURCE_SINGULAR,
@@ -152,13 +166,7 @@ public class TestLogCollector {
             ));
         }
 
-        this.logCollector = defaultLogCollectorBuilder()
-            .withNamespacedResources(resources.toArray(new String[0]))
-            .build();
-    }
-
-    private TestLogCollector(LogCollector logCollector) {
-        this.logCollector = logCollector;
+        return resources;
     }
 
     /**
@@ -281,16 +289,23 @@ public class TestLogCollector {
         String testClassShortName = StUtils.removePackageName(testClass);
         Path rootPathToLogsForTestCase = buildFullPathToLogs(testClass, testCase);
 
-        final LogCollector testCaseCollector = new LogCollectorBuilder(logCollector)
-            .withRootFolderPath(rootPathToLogsForTestCase.toString())
-            .build();
+        LogCollectorBuilder testCaseCollectorBuilder = new LogCollectorBuilder(logCollector)
+            .withRootFolderPath(rootPathToLogsForTestCase.toString());
+
+        // in case that we are using CertManager in the test-case, we should collect it together with other resources, otherwise it is skipped
+        if (KubeResourceManager.get().kubeClient().getClient().supports(TestConstants.CERT_MANAGER_API_VERSION, TestConstants.CERTIFICATE)) {
+            List<String> resourcesToCollect = resourcesToCollect();
+            resourcesToCollect.add(TestConstants.CERTIFICATE);
+
+            testCaseCollectorBuilder.withNamespacedResources(resourcesToCollect.toArray(new String[0]));
+        }
 
         // List Namespaces with specified test class name and test case name
         List<String> namespaces = new ArrayList<>(getListOfNamespaces(testClassShortName, testCase));
 
         namespaces = namespaces.stream().distinct().toList();
 
-        testCaseCollector.collectFromNamespaces(namespaces.toArray(new String[0]));
+        testCaseCollectorBuilder.build().collectFromNamespaces(namespaces.toArray(new String[0]));
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes issue with disrupting logs in case of logs collection in test case that doesn't use CertManager's `Certificate` - which is the most common case, as CertManager is used currently just in `OpenTelemetryST`.

I did it this way instead of picking the test class we are running the tests in, as it would maybe not work that well, the ST class name can be changed and then we can add more classes that will use CertManager, but the `Certificate` would be skipped from log collection until we would update the list. 

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests