### PR TITLE
Remove some outdted `.p12` file refernces for internal secrets

### DIFF
--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -173,12 +173,6 @@ m¦_<cluster_name>_-kafka-_<pod_id>_.key
 ¦Field
 ¦Description
 
-m¦cluster-operator.p12
-¦PKCS #12 store for storing certificates and keys.
-
-m¦cluster-operator.password
-¦Password for protecting the PKCS #12 store.
-
 m¦cluster-operator.crt
 ¦Certificate for mTLS communication between the Cluster Operator and Kafka.
 Signed by a current or former cluster CA private key in `_<cluster_name>_-cluster-ca`.
@@ -194,12 +188,6 @@ m¦cluster-operator.key
 
 ¦Field
 ¦Description
-
-m¦entity-operator.p12
-¦PKCS #12 store for storing certificates and keys.
-
-m¦entity-operator.password
-¦Password for protecting the PKCS #12 store.
 
 m¦entity-operator.crt
 ¦Certificate for mTLS communication between the Topic Operator and Kafka.
@@ -217,12 +205,6 @@ m¦entity-operator.key
 ¦Field
 ¦Description
 
-m¦entity-operator.p12
-¦PKCS #12 store for storing certificates and keys.
-
-m¦entity-operator.password
-¦Password for protecting the PKCS #12 store.
-
 m¦entity-operator.crt
 ¦Certificate for mTLS communication between the User Operator and Kafka.
 Signed by a current or former cluster CA private key in `_<cluster_name>_-cluster-ca`.
@@ -239,12 +221,6 @@ m¦entity-operator.key
 ¦Field
 ¦Description
 
-m¦cruise-control.p12
-¦PKCS #12 store for storing certificates and keys.
-
-m¦cruise-control.password
-¦Password for protecting the PKCS #12 store.
-
 m¦cruise-control.crt
 ¦Certificate for mTLS communication between Cruise Control and Kafka.
 Signed by a current or former cluster CA private key in `_<cluster_name>_-cluster-ca`.
@@ -260,12 +236,6 @@ m¦cruise-control.key
 
 ¦Field
 ¦Description
-
-m¦kafka-exporter.p12
-¦PKCS #12 store for storing certificates and keys.
-
-m¦kafka-exporter.password
-¦Password for protecting the PKCS #12 store.
 
 m¦kafka-exporter.crt
 ¦Certificate for mTLS communication between Kafka Exporter and Kafka.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The docs list details of the internal Kafka operand related Secrets with certificates. But bunch of them lists the old `p12` files we do not use and have there anymore. This Pr removes it from the docs.

### Checklist

- [x] Update documentation