### PR TITLE
Use reflection for `config-model-generator` in Kafka 4.3.0+ branch

### DIFF
--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -312,7 +312,18 @@ public class KafkaConfigModelGenerator {
         // This condition can be removed once we support only Kafka 4.3.0 and newer.
         if (classExists("org.apache.kafka.server.config.DynamicBrokerConfig")) {
             // Kafka 4.3.0+
-            return org.apache.kafka.server.config.DynamicBrokerConfig.dynamicConfigUpdateModes();
+            // Uses reflection to avoid a direct compile-time reference to DynamicBrokerConfig which does not exist
+            // in older Kafka versions. The build runs `mvn verify` for each supported Kafka version which can trigger
+            // recompilation and fail if the class is referenced directly.
+            // Once the 4.2.x branch is deleted, we can use the
+            // `return org.apache.kafka.server.config.DynamicBrokerConfig.dynamicConfigUpdateModes();` call directly
+            try {
+                Class<?> clazz = Class.forName("org.apache.kafka.server.config.DynamicBrokerConfig");
+                Method method = clazz.getDeclaredMethod("dynamicConfigUpdateModes");
+                return (Map<String, String>) method.invoke(null);
+            } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException("Failed to get dynamic config update modes", e);
+            }
         } else {
             // Kafka versions older than 4.3.0
             try {

--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -312,11 +312,6 @@ public class KafkaConfigModelGenerator {
         // This condition can be removed once we support only Kafka 4.3.0 and newer.
         if (classExists("org.apache.kafka.server.config.DynamicBrokerConfig")) {
             // Kafka 4.3.0+
-            // Uses reflection to avoid a direct compile-time reference to DynamicBrokerConfig which does not exist
-            // in older Kafka versions. The build runs `mvn verify` for each supported Kafka version which can trigger
-            // recompilation and fail if the class is referenced directly.
-            // Once the 4.2.x branch is deleted, we can use the
-            // `return org.apache.kafka.server.config.DynamicBrokerConfig.dynamicConfigUpdateModes();` call directly
             try {
                 Class<?> clazz = Class.forName("org.apache.kafka.server.config.DynamicBrokerConfig");
                 Method method = clazz.getDeclaredMethod("dynamicConfigUpdateModes");


### PR DESCRIPTION
### Type of change

- Fix

### Description

This PR changes the Kafka 4.3.0+ branch in the `KafkaConfigModelGenerator` class to use reflection as the "other" branch. The reason is that on some environments, the build of the project can fail due to missing classes:
```
[ERROR] COMPILATION ERROR :
  [INFO] -------------------------------------------------------------
  [ERROR] /tmp/tests/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java:[315,50] cannot find symbol
    symbol:   class DynamicBrokerConfig
    location: package org.apache.kafka.server.config
  [INFO] 1 error
```
the whole log from the failing part: https://gist.github.com/im-konge/ca1253f029291baba8cab2c6aaae1c71

I tried to get to the root cause of this issue, but it seems that it depends on the environment and the Maven version as well. Basically, on our CI (and locally) everything works, but there can be cases when the build fails for the first time, during generation of the Kafka 4.2.0 config-model, then second time during generation of Kafka 4.2.1 model (the 4.2.0 is generated for some reason), then finally on the third run it passes fully. But that is not great UX especially in case of CI systems.

The reason why it is failing is that the whole config-model-generator seems to be recompiled with older Kafka version (4.2.0, 4.2.1), which doesn't contain the `org.apache.kafka.server.config.DynamicBrokerConfig` class yet - which was introduced in Kafka 4.3.0 version. So the build fails. But the most common case is that the generator is compiled with the Kafka 4.3.0 version, thus the class is found and the build passes.

The reflection worked all the time during my tests. Other "solution" or "option" would be to remove `verify` goal from the `build-config-models.sh`, which will ensure that the generator will not be recompiled with different Kafka version. But, that removes various checks that are needed - analyze of the unused deps, missing deps, correct compilation of the needed deps for particular Kafka version. That's why I decided to not go this way.

Once the Kafka 4.2.x branch and versions are removed (when we start supporting Kafka 4.4.0), we can use the class call and remove the reflection fully. 

### Checklist

- [x] Make sure all tests pass
- [X] Try your changes inside a Kubernetes cluster, not just from unit tests
- [X] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
