### PR TITLE
Force using imports instead of fully qualified class names withing the code itself

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -104,6 +104,14 @@
             <property name="ignoreComments" value="true"/>
         </module>
 
+        <!-- Require imports instead of inline fully-qualified class names -->
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="NoFullyQualifiedClassNames"/>
+            <property name="format" value="^(?!\s*(?:import|package)\b).*?(?&lt;![\w.&quot;])(?:[a-z][a-zA-Z0-9_]*\.){2,}[A-Z][a-zA-Z0-9_]*"/>
+            <property name="message" value="Use an import instead of a fully qualified class name in code."/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
         <!-- code quality -->
         <module name="MethodLength"/>
         <module name="ParameterNumber">

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
@@ -66,7 +67,7 @@ import java.util.function.Predicate;
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API,
-        refs = {@BuildableReference(CustomResource.class), @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class)}
+        refs = {@BuildableReference(CustomResource.class), @BuildableReference(ObjectMeta.class)}
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "apiVersion", "kind", "metadata", "spec", "status" })

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -32,13 +32,13 @@ import java.util.Map;
 @Crd(
         spec = @Crd.Spec(
                 names = @Crd.Spec.Names(
-                        kind = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.RESOURCE_KIND,
-                        plural = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.RESOURCE_PLURAL,
+                        kind = KafkaNodePool.RESOURCE_KIND,
+                        plural = KafkaNodePool.RESOURCE_PLURAL,
                         shortNames = {"knp"},
                         categories = {Constants.STRIMZI_CATEGORY}
                 ),
-                group = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.RESOURCE_GROUP,
-                scope = io.strimzi.api.kafka.model.nodepool.KafkaNodePool.SCOPE,
+                group = KafkaNodePool.RESOURCE_GROUP,
+                scope = KafkaNodePool.SCOPE,
                 versions = {
                     @Crd.Spec.Version(name = Constants.V1, served = true, storage = true)
                 },

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
@@ -109,6 +109,7 @@ public class KafkaRebalanceSpec extends Spec {
         this.rebalanceDisk = rebalanceDisk;
     }
 
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     @Description("A regular expression where any matching topics will be excluded from the calculation of optimization proposals. " +
             "This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported format " +
             "consult the documentation for that class.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -84,6 +84,7 @@ public class EntityOperator extends AbstractModel {
     /**
      * Default health check options used by the Topic and User operators
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     protected static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new io.strimzi.api.kafka.model.common.ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(10).build();
 
     private EntityTopicOperator topicOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
@@ -199,6 +199,7 @@ public class KafkaBridgeConfigurationBuilder {
      *                      to extract the possible user-provided config provider configuration from it
      * @param prefix    prefix for the bridge Kafka client to be configured. It could be "kafka.admin", "kafka.producer" or "kafka.consumer".
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void configProvider(AbstractConfiguration userConfig, String prefix) {
         printSectionHeader("Config providers");
         String strimziConfigProviders = "strimzienv,strimzifile,strimzidir,strimzisecrets";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -541,6 +541,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param userConfig    The user configuration to extract the possible user-provided config provider configuration
      *                      from it
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void printConfigProviders(KafkaConfiguration userConfig)    {
         printSectionHeader("Config providers");
         
@@ -740,6 +741,7 @@ public class KafkaBrokerConfigurationBuilder {
      *
      * @return  Returns the builder instance
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     public KafkaBrokerConfigurationBuilder withTieredStorage(String clusterName, TieredStorage tieredStorage)  {
         if (tieredStorage == null) {
             return this;
@@ -805,6 +807,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param clusterName           Name of the cluster
      * @param quotasPluginStrimzi   Strimzi quotas plugin configuration
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void configureQuotasPluginStrimzi(String clusterName, QuotasPluginStrimzi quotasPluginStrimzi) {
         // add Kafka broker's and CruiseControl's user to the excluded principals
         List<String> excludedPrincipals = new ArrayList<>(List.of(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
@@ -233,6 +233,7 @@ public class KafkaConnectConfigurationBuilder {
      *
      * @param userConfig    the user configuration to extract the possible user-provided config provider configuration from it
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void printConfigProviders(AbstractConfiguration userConfig) {
         printSectionHeader("Config providers");
         String strimziConfigProviders = "strimzienv,strimzifile,strimzidir,strimzisecrets";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeUtils.java
@@ -20,6 +20,7 @@ public class ProbeUtils {
      * Default healthcheck options used by most of our operands with the exception of Mirror Maker (1 and 2), Connect,
      * and User / Topic operators.
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new io.strimzi.api.kafka.model.common.ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(15).build();
 
     private ProbeUtils() { }
@@ -57,6 +58,7 @@ public class ProbeUtils {
      *
      * @return  Kubernetes Probe
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public static io.fabric8.kubernetes.api.model.Probe httpProbe(Probe probeConfig, String path, String port) {
         if (path == null || path.isEmpty() || port == null || port.isEmpty()) {
             throw new IllegalArgumentException();
@@ -78,6 +80,7 @@ public class ProbeUtils {
      *
      * @return  Kubernetes Probe
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public static io.fabric8.kubernetes.api.model.Probe execProbe(Probe probeConfig, List<String> command) {
         if (command == null || command.isEmpty()) {
             throw new IllegalArgumentException();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -431,6 +431,7 @@ public class WorkloadUtils {
      *
      * @return  Created deployment strategy
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public static DeploymentStrategy deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy strategy) {
         return switch (strategy) {
             case ROLLING_UPDATE -> rollingUpdateStrategy();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheck.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 
 import java.util.HashSet;
@@ -60,7 +61,7 @@ public class BrokersInUseCheck {
 
                         for (TopicDescription td : topicDescriptions.values()) {
                             for (TopicPartitionInfo pd : td.partitions()) {
-                                for (org.apache.kafka.common.Node broker : pd.replicas()) {
+                                for (Node broker : pd.replicas()) {
                                     brokersWithPartitionReplicas.add(broker.id());
                                 }
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1040,6 +1040,7 @@ public class KafkaReconciler {
                 .onSuccess(registeredBrokerNodes -> {
 
                     // all current registered broker nodes (fenced or not)
+                    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
                     List<Integer> registeredBrokersIds = registeredBrokerNodes.stream()
                             .map(org.apache.kafka.common.Node::id)
                             .toList();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -331,6 +331,7 @@ public class KafkaRoller {
      *
      * @return A future which completes when the pod has been rolled.
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     private CompletableFuture<Void> schedule(NodeRef nodeRef, long delayMs) {
         RestartContext ctx = podToContext.computeIfAbsent(nodeRef.podName(),
             k -> new RestartContext(backoffSupplier));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -215,6 +215,7 @@ public class CruiseControlTest {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public void testGenerateDeployment() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -362,6 +363,7 @@ public class CruiseControlTest {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public void testGenerateService() {
         CruiseControl cc = createCruiseControl(KAFKA, NODES, STORAGE, Map.of());
         Service svc = cc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -140,7 +140,7 @@ public class EntityOperatorTest {
         assertThat(dep.getMetadata().getName(), is(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(dep.getSpec().getReplicas(), is(1));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(dep, KAFKA);
+        TestUtils.checkOwnerReference(dep, KAFKA);
 
         assertThat(containers.size(), is(2));
         // just check names of topic and user operators (their containers are tested in the related unit test classes)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // Fully qualified class name used due to a name conflict
 public class KafkaBridgeClusterTest {
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
 public class KafkaBridgeConfigurationBuilderTest {
 
     private static final String BRIDGE_CLUSTER = "my-bridge";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -53,7 +53,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings("checkstyle:classdataabstractioncoupling")
+@SuppressWarnings({"checkstyle:classdataabstractioncoupling", "checkstyle:NoFullyQualifiedClassNames"}) // NoFullyQualifiedClassNames is false positive, fully qualified class name used in a string
 public class KafkaBrokerConfigurationBuilderTest {
     private final static NodeRef NODE_REF = new NodeRef("my-cluster-kafka-2", 2, "kafka", false, true);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClientAuthenticationCustomConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClientAuthenticationCustomConfigurationTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KafkaClientAuthenticationCustomConfigurationTest {
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     public void testAllowAndForbiddenConfigurationOptions() {
         JsonObject config = new JsonObject()
                 .put("ssl.keystore.location", "/mnt/certs/keystore")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -794,7 +794,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -804,11 +804,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("ClusterIP"));
@@ -829,7 +829,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapRoutes.get(0).getSpec().getTo().getKind(), is("Service"));
         assertThat(bootstrapRoutes.get(0).getSpec().getTo().getName(), is(CLUSTER + "-kafka-external-bootstrap"));
         assertThat(bootstrapRoutes.get(0).getSpec().getPort().getTargetPort(), is(new IntOrString(9094)));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
 
         // Check per pod router
         List<Route> routes = kc.generateExternalRoutes();
@@ -839,11 +839,11 @@ public class KafkaClusterListenersTest {
             if (route.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(route.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(route.getSpec().getTo().getName(), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_BROKERS);
+                TestUtils.checkOwnerReference(route, POOL_BROKERS);
             } else {
                 assertThat(route.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(route.getSpec().getTo().getName(), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_MIXED);
+                TestUtils.checkOwnerReference(route, POOL_MIXED);
             }
 
             assertThat(route.getSpec().getTls().getTermination(), is("passthrough"));
@@ -1063,7 +1063,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getExternalTrafficPolicy(), is("Cluster"));
         assertThat(bootstrapServices.get(0).getSpec().getLoadBalancerSourceRanges(), is(List.of()));
         assertThat(bootstrapServices.get(0).getSpec().getAllocateLoadBalancerNodePorts(), is(nullValue()));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1073,11 +1073,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getMetadata().getFinalizers(), is(List.of()));
@@ -1479,7 +1479,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1489,11 +1489,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("NodePort"));
@@ -1666,7 +1666,7 @@ public class KafkaClusterListenersTest {
         assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(32001));
         assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ext, KAFKA);
+        TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1948,7 +1948,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -1958,11 +1958,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("ClusterIP"));
@@ -1991,7 +1991,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapIngresses.get(0).getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
         assertThat(bootstrapIngresses.get(0).getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(CLUSTER + "-kafka-external-bootstrap"));
         assertThat(bootstrapIngresses.get(0).getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapIngresses.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapIngresses.get(0), KAFKA);
 
         // Check per pod ingress
         List<Ingress> ingresses = kc.generateExternalIngresses();
@@ -2000,10 +2000,10 @@ public class KafkaClusterListenersTest {
         for (Ingress ingress : ingresses)    {
             if (ingress.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(ingress.getMetadata().getName(), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ingress, POOL_BROKERS);
+                TestUtils.checkOwnerReference(ingress, POOL_BROKERS);
             } else {
                 assertThat(ingress.getMetadata().getName(), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ingress, POOL_MIXED);
+                TestUtils.checkOwnerReference(ingress, POOL_MIXED);
             }
 
             assertThat(ingress.getSpec().getIngressClassName(), is(nullValue()));
@@ -2183,7 +2183,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-clusterip"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -2193,19 +2193,19 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().startsWith("foo-brokers-clusterip-6")) {
                 assertThat(service.getMetadata().getAnnotations().get("anno"), is("anno-value-6"));
                 assertThat(service.getMetadata().getLabels().get("label"), is("label-value-6"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else if (service.getMetadata().getName().startsWith("foo-mixed-clusterip-3")) {
                 assertThat(service.getMetadata().getAnnotations().get("anno"), is("anno-value-3"));
                 assertThat(service.getMetadata().getLabels().get("label"), is("label-value-3"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                TestUtils.checkOwnerReference(service, POOL_MIXED);
             } else {
                 assertThat(service.getMetadata().getAnnotations().get("anno"), is(nullValue()));
                 assertThat(service.getMetadata().getLabels().get("label"), is(nullValue()));
 
                 if (service.getMetadata().getName().startsWith("foo-controllers-")) {
-                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_CONTROLLERS);
+                    TestUtils.checkOwnerReference(service, POOL_CONTROLLERS);
                 } else if (service.getMetadata().getName().startsWith("foo-mixed-")) {
-                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                    TestUtils.checkOwnerReference(service, POOL_MIXED);
                 } else {
                     TestUtils.checkOwnerReference(service, POOL_BROKERS);
                 }
@@ -2427,7 +2427,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getTargetPort().getStrVal(), is("tcp-external"));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
         List<Service> services = kc.generatePerPodServices();
@@ -2437,11 +2437,11 @@ public class KafkaClusterListenersTest {
             if (service.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(service.getMetadata().getName(), startsWith("foo-brokers-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_BROKERS);
+                TestUtils.checkOwnerReference(service, POOL_BROKERS);
             } else {
                 assertThat(service.getMetadata().getName(), startsWith("foo-mixed-"));
                 assertThat(service.getSpec().getSelector().get(Labels.STRIMZI_POD_NAME_LABEL), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(service, POOL_MIXED);
+                TestUtils.checkOwnerReference(service, POOL_MIXED);
             }
 
             assertThat(service.getSpec().getType(), is("ClusterIP"));
@@ -2471,7 +2471,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getGroup(), is("gateway.networking.k8s.io"));
         assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getName(), is("envoy-gateway"));
         assertThat(bootstrapRoutes.get(0).getSpec().getParentRefs().get(0).getNamespace(), is("envoy-gateway-system"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
+        TestUtils.checkOwnerReference(bootstrapRoutes.get(0), KAFKA);
 
         // Check per pod Gateway API TLS Route
         List<TLSRoute> routes = kc.generateExternalTlsRoutes();
@@ -2480,10 +2480,10 @@ public class KafkaClusterListenersTest {
         for (TLSRoute route : routes)    {
             if (route.getMetadata().getName().contains("foo-brokers-")) {
                 assertThat(route.getMetadata().getName(), oneOf("foo-brokers-5", "foo-brokers-6", "foo-brokers-7"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_BROKERS);
+                TestUtils.checkOwnerReference(route, POOL_BROKERS);
             } else {
                 assertThat(route.getMetadata().getName(), oneOf("foo-mixed-3", "foo-mixed-4"));
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(route, POOL_MIXED);
+                TestUtils.checkOwnerReference(route, POOL_MIXED);
             }
 
             if (route.getMetadata().getName().contains("foo-brokers-5")) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -292,11 +292,11 @@ public class KafkaClusterTest {
 
         for (ConfigMap cm : cms)    {
             if (cm.getMetadata().getName().contains("controllers")) {
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, POOL_CONTROLLERS);
+                TestUtils.checkOwnerReference(cm, POOL_CONTROLLERS);
             } else if (cm.getMetadata().getName().contains("mixed")) {
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, POOL_MIXED);
+                TestUtils.checkOwnerReference(cm, POOL_MIXED);
             } else {
-                io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, POOL_BROKERS);
+                TestUtils.checkOwnerReference(cm, POOL_BROKERS);
             }
 
             assertThat(cm.getData().get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is("{\"animal\":\"wombat\"}"));
@@ -884,7 +884,7 @@ public class KafkaClusterTest {
         assertThat(clusterIp.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
         assertThat(clusterIp.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clusterIp, KAFKA);
+        TestUtils.checkOwnerReference(clusterIp, KAFKA);
     }
 
     @Test
@@ -921,7 +921,7 @@ public class KafkaClusterTest {
         assertThat(clusterIp.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
         assertThat(clusterIp.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clusterIp, KAFKA);
+        TestUtils.checkOwnerReference(clusterIp, KAFKA);
     }
 
     @Test
@@ -962,7 +962,7 @@ public class KafkaClusterTest {
 
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(headless, KAFKA);
+        TestUtils.checkOwnerReference(headless, KAFKA);
     }
 
     @Test
@@ -1167,7 +1167,7 @@ public class KafkaClusterTest {
     public void testGenerateHeadlessService() {
         Service headless = KC.generateHeadlessService();
         checkHeadlessService(headless);
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(headless, KAFKA);
+        TestUtils.checkOwnerReference(headless, KAFKA);
     }
 
     @Test
@@ -3352,7 +3352,7 @@ public class KafkaClusterTest {
         StrimziPodSet podSet = podSets.stream().filter(sps -> (CLUSTER + "-controllers").equals(sps.getMetadata().getName())).findFirst().orElse(null);
         assertThat(podSet, is(notNullValue()));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(podSet, POOL_CONTROLLERS);
+        TestUtils.checkOwnerReference(podSet, POOL_CONTROLLERS);
         assertThat(podSet.getMetadata().getName(), is(CLUSTER + "-controllers"));
         assertThat(podSet.getSpec().getSelector().getMatchLabels(), is(KC.getSelectorLabels().withStrimziPoolName("controllers").toMap()));
         assertThat(podSet.getMetadata().getLabels().entrySet().containsAll(KC.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
@@ -3409,7 +3409,7 @@ public class KafkaClusterTest {
         podSet = podSets.stream().filter(sps -> (CLUSTER + "-mixed").equals(sps.getMetadata().getName())).findFirst().orElse(null);
         assertThat(podSet, is(notNullValue()));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(podSet, POOL_MIXED);
+        TestUtils.checkOwnerReference(podSet, POOL_MIXED);
         assertThat(podSet.getMetadata().getName(), is(CLUSTER + "-mixed"));
         assertThat(podSet.getSpec().getSelector().getMatchLabels(), is(KC.getSelectorLabels().withStrimziPoolName("mixed").toMap()));
         assertThat(podSet.getMetadata().getLabels().entrySet().containsAll(KC.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -194,7 +194,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/kaniko/.docker"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(0));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(pod, kc);
+        TestUtils.checkOwnerReference(pod, kc);
     }
 
     @Test
@@ -257,7 +257,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(1));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getName(), is("REGISTRY_AUTH_FILE"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getValue(), is("/build/.docker/config.json"));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(pod, kc);
+        TestUtils.checkOwnerReference(pod, kc);
     }
 
     @Test
@@ -323,7 +323,7 @@ public class KafkaConnectBuildTest {
         assertThat(cm.getMetadata().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
         assertThat(cm.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(cm.getData().get("Dockerfile"), is(dockerfile.getDockerfile()));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(cm, RESOURCE);
+        TestUtils.checkOwnerReference(cm, RESOURCE);
     }
 
     @Test
@@ -367,7 +367,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getSpec().getStrategy().getDockerStrategy(), is(notNullValue()));
         assertThat(bc.getSpec().getResources().getLimits(), is(limit));
         assertThat(bc.getSpec().getResources().getRequests(), is(request));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(bc, kc);
+        TestUtils.checkOwnerReference(bc, kc);
     }
 
     // Test to validate that .spec.image and spec.build.output.image in Kafka Connect are not pointing to the same image

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -108,7 +108,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // Fully qualified class name used due to a name conflict
 public class KafkaConnectClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider(Map.of(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import static io.strimzi.operator.cluster.TestUtils.IsEquivalent.isEquivalent;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
 class KafkaConnectConfigurationBuilderTest {
     private static final String BOOTSTRAP_SERVERS = "my-cluster-kafka-bootstrap:9092";
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -100,7 +100,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // False positive, fully qualified class name used in a string
 public class KafkaMirrorMaker2ClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
@@ -240,7 +240,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, RESOURCE);
+        TestUtils.checkOwnerReference(svc, RESOURCE);
     }
 
     @Test
@@ -403,9 +403,9 @@ public class KafkaMirrorMaker2ClusterTest {
         StrimziPodSet podSet = kmm2.generatePodSet(3, Map.of(), Map.of(), false, null, null, null);
         PodSetUtils.podSetToPods(podSet).forEach(pod -> {
             Container cont = pod.getSpec().getContainers().get(0);
-            assertThat(io.strimzi.operator.cluster.TestUtils.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TRUSTED_CERTS),
+            assertThat(TestUtils.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TRUSTED_CERTS),
                     is(nullValue()));
-            assertThat(io.strimzi.operator.cluster.TestUtils.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_MIRRORMAKER_2_TRUSTED_CERTS_CLUSTERS),
+            assertThat(TestUtils.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_MIRRORMAKER_2_TRUSTED_CERTS_CLUSTERS),
                     is(nullValue()));
         });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeUtilsTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
 public class ProbeUtilsTest {
     private static final io.strimzi.api.kafka.model.common.Probe DEFAULT_CONFIG = new io.strimzi.api.kafka.model.common.ProbeBuilder()
             .withInitialDelaySeconds(1)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -139,6 +139,7 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testCreateDeploymentWithNullTemplateAndRecreateStrategy()  {
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         Deployment dep = WorkloadUtils.createDeployment(
                 NAME,
                 NAMESPACE,
@@ -168,6 +169,7 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testCreateDeploymentWithTemplateAndRollingUpdateStrategy()  {
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         Deployment dep = WorkloadUtils.createDeployment(
                 NAME,
                 NAMESPACE,
@@ -1031,6 +1033,7 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testDeploymentStrategyRecreate()    {
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy.RECREATE);
 
         assertThat(strategy.getType(), is("Recreate"));
@@ -1039,6 +1042,7 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testDeploymentStrategyRollingUpdate()    {
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE);
 
         assertThat(strategy.getType(), is("RollingUpdate"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingUtilsTest.java
@@ -209,6 +209,7 @@ public class LoggingUtilsTest {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     public void testVarExpansion() {
         String input = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
                 "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/securityprofiles/PodSecurityProviderFactoryTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/securityprofiles/PodSecurityProviderFactoryTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
 public class PodSecurityProviderFactoryTest {
     @Test
     public void testExistingClass() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerReconcileCasTest.java
@@ -1080,8 +1080,8 @@ public class CaReconcilerReconcileCasTest {
                     assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences(), hasSize(1));
                     assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences(), hasSize(1));
 
-                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
-                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
+                    TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
+                    TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
 
                     async.flag();
                 })));
@@ -1109,7 +1109,7 @@ public class CaReconcilerReconcileCasTest {
                     assertThat(captorSecrets.clientsCaCert().getMetadata().getOwnerReferences(), hasSize(0));
                     assertThat(captorSecrets.clientsCaKey().getMetadata().getOwnerReferences(), hasSize(0));
 
-                    io.strimzi.operator.cluster.TestUtils.checkOwnerReference(captorSecrets.clusterCaCert(), kafka);
+                    TestUtils.checkOwnerReference(captorSecrets.clusterCaCert(), kafka);
                     TestUtils.checkOwnerReference(captorSecrets.clusterCaKey(), kafka);
 
                     async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -165,6 +165,7 @@ public class CruiseControlReconcilerTest {
 
         when(mockPodDisruptionBudget.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.componentName(NAME)), any())).thenReturn(CompletableFuture.completedFuture(null));
 
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .withNewCruiseControl()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -150,6 +150,7 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
      * 8. The KafkaRebalance resource moves to the 'ProposalReady' state
      */
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     public void testKrNotReadyToProposalReadyOnSpecChange(VertxTestContext context) {
         // Set up the rebalance endpoint to get error about hard goals
         cruiseControlServer.setupCCRebalanceBadGoalsError(CruiseControlEndpoints.REBALANCE);
@@ -881,6 +882,7 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
         this.krNewWithMissingHardGoals(context, CruiseControlEndpoints.REMOVE_BROKER, kr);
     }
 
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void krNewWithMissingHardGoals(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) {
         // Set up the rebalance endpoint to get error about hard goals
         cruiseControlServer.setupCCRebalanceBadGoalsError(endpoint);
@@ -1026,6 +1028,7 @@ public class KafkaRebalanceAssemblyOperatorTest extends AbstractKafkaRebalanceAs
         this.krNewWithMissingHardGoalsAndRefresh(context, CruiseControlEndpoints.REMOVE_BROKER, kr);
     }
 
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void krNewWithMissingHardGoalsAndRefresh(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) {
         // Set up the rebalance endpoint to get error about hard goals
         cruiseControlServer.setupCCRebalanceBadGoalsError(endpoint);

--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -75,7 +75,7 @@ public class KafkaConfigModelGenerator {
         return p.getProperty("version");
     }
 
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // NoFullyQualifiedClassNames is a false positive, fully qualified class name used in a string
     private static Map<String, ConfigModel> configs(String version) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         ConfigDef def = brokerConfigs();
         Map<String, String> dynamicUpdates = brokerDynamicUpdates();
@@ -304,6 +304,7 @@ public class KafkaConfigModelGenerator {
         }
     }
 
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     static Map<String, String> brokerDynamicUpdates() {
         // From Kafka 4.3.0, this logic moved from the Scala class kafka.server.DynamicBrokerConfig to the Java class
         // org.apache.kafka.server.config.DynamicBrokerConfig. As we need to build the configuration models for both

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -882,6 +882,7 @@ class CrdGenerator {
      * @param valueType value Class
      * @return true if key-value types are equal to specified types, false otherwise.
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Type[] cannot be imported because of naming conflicts
     private boolean isMapOfTypes(PropertyType propertyType, Class<?> keyType, Class<?> valueType) {
         java.lang.reflect.Type[] types = ((ParameterizedType) propertyType.getGenericType()).getActualTypeArguments();
         return keyType.equals(types[0]) && valueType.equals(types[1]);

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorIT.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
@@ -221,7 +222,7 @@ public class CrdGeneratorIT implements TestSeparator {
 
             GenericKubernetesResource updated = client.genericKubernetesResources(API_VERSION, KIND).withName("scalable").get();
             @SuppressWarnings("unchecked")
-            Number replicas = (Number) ((java.util.Map<String, Object>) updated.get("spec")).get("replicas");
+            Number replicas = (Number) ((Map<String, Object>) updated.get("spec")).get("replicas");
             assertEquals(7, replicas.intValue());
         } finally {
             client.genericKubernetesResources(API_VERSION, KIND).withName("scalable").delete();

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -113,6 +113,7 @@ class CrdGeneratorTest {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive as the fully qualified class names are used in Strings
     void simpleTestWithErrors() throws IOException {
         CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
                 emptyMap(), crdGeneratorReporter, emptyList(), null, null,

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/ResourceSupport.java
@@ -177,7 +177,7 @@ public class ResourceSupport {
                         } else {
                             Throwable primary;
 
-                            if (Util.maybeUnwrapCompletionException(thrown) instanceof java.util.concurrent.TimeoutException) {
+                            if (Util.maybeUnwrapCompletionException(thrown) instanceof TimeoutException) {
                                 primary = new TimeoutException("\"" + watchFnDescription + "\" timed out after " + operationTimeoutMs + "ms");
                             } else {
                                 primary = thrown;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNonNamespacedResourceOperatorTest.java
@@ -14,7 +14,6 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.TimeoutException;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -151,6 +151,7 @@ class ConnectST extends AbstractST {
 
         final int connectReplicasCount = 2;
 
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
         final Map<String, Object> exceptedConfig = StUtils.loadProperties("bootstrap.servers=" + KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()) + "\n" +
                 "group.id=" + KafkaConnectResources.componentName(testStorage.getClusterName()) + "\n" +
                 "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -74,6 +74,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
@@ -765,7 +766,7 @@ public class ListenersST extends AbstractST {
                     List<String> nodeIPsBrokers = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector())
                             .stream().map(pods -> pods.getStatus().getHostIP()).distinct().sorted(Comparator.comparing(String::toString)).toList();
 
-                    List<String> nodeIPsControllers = new java.util.ArrayList<>(KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getControllerSelector())
+                    List<String> nodeIPsControllers = new ArrayList<>(KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getControllerSelector())
                             .stream().map(pods -> pods.getStatus().getHostIP()).distinct().sorted(Comparator.comparing(String::toString)).toList());
 
                     // Remove all nodes that contains broker nodes

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -98,6 +98,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
         @Label(value = TestDocsLabels.LOGGING)
     }
 )
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
 class LoggingChangeST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(LoggingChangeST.class);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -127,6 +127,7 @@ class MirrorMaker2ST extends AbstractST {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         final int mirrorMakerReplicasCount = 2;
 
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
         Map<String, Object> expectedConfig = StUtils.loadProperties("bootstrap.servers=" + KafkaResources.plainBootstrapAddress(testStorage.getTargetClusterName()) + "\n" +
                 "group.id=mirrormaker2-cluster\n" +
                 "key.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n" +

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -186,6 +186,7 @@ public class OauthPlainST extends OauthAbstractST {
         String audienceProducerName = OAUTH_CLIENT_AUDIENCE_PRODUCER + "-" + testStorage.getClusterName();
         String audienceConsumerName = OAUTH_CLIENT_AUDIENCE_CONSUMER + "-" + testStorage.getClusterName();
 
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
         String saslJaasConfig = "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=%s password=%s";
         Authentication clientAuthentication = ClientsAuthentication.configureOAuthPlain(OAUTH_CLIENT_NAME, OAUTH_CLIENT_SECRET, keycloakInstance.getOauthTokenEndpointUri());
         clientAuthentication = new AuthenticationBuilder(clientAuthentication)

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/CoreFeaturesIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/CoreFeaturesIT.java
@@ -738,7 +738,7 @@ class CoreFeaturesIT implements TestSeparator {
 
             // then
             try (var ignored = LogCaptor.logMessageMatches(BatchingTopicController.LOGGER,
-                    org.apache.logging.log4j.Level.DEBUG,
+                    Level.DEBUG,
                     "Ignoring KafkaTopic .*? not selected by selector",
                     5L,
                     TimeUnit.SECONDS)) {
@@ -763,7 +763,7 @@ class CoreFeaturesIT implements TestSeparator {
         var expectedTopicName = TopicOperatorUtil.topicName(kt);
         KafkaTopic unmanaged;
         try (var ignored = LogCaptor.logMessageMatches(BatchingTopicController.LOGGER,
-                org.apache.logging.log4j.Level.DEBUG,
+                Level.DEBUG,
                 "Ignoring KafkaTopic .*? not selected by selector",
                 5L,
                 TimeUnit.SECONDS)) {
@@ -814,7 +814,7 @@ class CoreFeaturesIT implements TestSeparator {
 
             KafkaTopic created;
             try (var ignored = LogCaptor.logMessageMatches(BatchingTopicController.LOGGER,
-                    org.apache.logging.log4j.Level.DEBUG,
+                    Level.DEBUG,
                     "Ignoring KafkaTopic .*? not selected by selector",
                     5L,
                     TimeUnit.SECONDS)) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/LogCaptor.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/LogCaptor.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
  * }
  * </pre>
  */
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified names are used due to class name conflicts
 public class LogCaptor implements AutoCloseable {
     private static final Logger LOGGER = LogManager.getLogger(LogCaptor.class);
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -20,6 +20,7 @@ import java.util.List;
  * Immutable class which represents a single ACL rule for Kafka's built-in authorizer.
  * The main reason for not using directly the classes from the api module is that we need immutable objects for use in Sets.
  */
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
 public class SimpleAclRule {
     private final AclRuleType type;
     private final SimpleAclRuleResource resource;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -95,6 +95,7 @@ public class SimpleAclRuleResource {
      *
      * @return the ResourcePattern instance
      */
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public ResourcePattern toKafkaResourcePattern() {
         org.apache.kafka.common.resource.ResourceType kafkaType;
         String kafkaName;

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
 public class SimpleAclRuleTest {
     private static final AclRuleResource ACL_RULE_TOPIC_RESOURCE;
     private static final SimpleAclRuleResource RESOURCE = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -106,6 +106,7 @@ public class SimpleAclOperatorIT extends AdminApiOperatorIT<Set<SimpleAclRule>, 
 
     private Set<SimpleAclRule> get(String username) {
         KafkaPrincipal principal = new KafkaPrincipal("User", username);
+        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         AclBindingFilter aclBindingFilter = new AclBindingFilter(ResourcePatternFilter.ANY,
                 new AccessControlEntryFilter(principal.toString(), null, org.apache.kafka.common.acl.AclOperation.ANY, AclPermissionType.ANY));
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -56,6 +56,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
 public class SimpleAclOperatorTest {
     private final static ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
 


### PR DESCRIPTION
### Type of Change

- Task

### Description

The use of fully qualified class names in the code instead of importing them was repeatedly flagged during reviews. This PR adds a check for it to the Checkstyle configuration. As there is no out-of-the-box check, it adds regular expression check for it.

There are some places where the check needs to be suppressed because duplicate class names or because the class is used within a String. But if we really want to avoid this, we should have the check built-in.

### Checklist

- [x] Try to build the project
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
