### PR TITLE
Update Jakcson and Vert.x dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,14 +76,14 @@
         <fabric8.openshift-client.version>7.7.0</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>7.7.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>7.7.0</fabric8.zjsonpatch.version>
-        <fasterxml.jackson-core.version>2.21.2</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.21.2</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.21.2</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.21</fasterxml.jackson-annotations.version>
-        <fasterxml.jackson-datatype.version>2.21.2</fasterxml.jackson-datatype.version>
-        <fasterxml.jackson-jaxrs.version>2.21.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>5.1.2</vertx.version>
-        <vertx-junit5.version>5.1.2</vertx-junit5.version>
+        <fasterxml.jackson-core.version>2.22.0</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.22.0</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.22.0</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.22</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-datatype.version>2.22.0</fasterxml.jackson-datatype.version>
+        <fasterxml.jackson-jaxrs.version>2.22.0</fasterxml.jackson-jaxrs.version>
+        <vertx.version>5.1.3</vertx.version>
+        <vertx-junit5.version>5.1.3</vertx-junit5.version>
         <kafka.version>4.3.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>
@@ -96,7 +96,6 @@
         <netty.version>4.2.15.Final</netty.version>
         <micrometer.version>1.16.6</micrometer.version>
         <commons-codec.version>1.13</commons-codec.version>
-        <picocli.version>4.7.7</picocli.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <javaluator.version>3.0.6</javaluator.version>
 


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR updates the Jackson and Vert.x dependencies. It also removes the (now unused) PicoCLI property. This replaces #12873.

### Checklist

- [x] Try your changes inside a Kubernetes cluster, not just from unit tests