### PR TITLE
Use dedicated Buildah build context directory

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -283,7 +283,7 @@ public class KafkaConnectBuild extends AbstractModel {
                 templatePod != null ? templatePod.getAffinity() : null,
                 null,
                 List.of(createContainer(imagePullPolicy, isBuildahBuild)),
-                getVolumes(isOpenShift),
+                getVolumes(isOpenShift, isBuildahBuild),
                 imagePullSecrets,
                 securityProvider.kafkaConnectBuildPodSecurityContext(podSecurityProviderContext),
                 securityProvider.kafkaConnectBuildHostUsers(podSecurityProviderContext));
@@ -292,16 +292,21 @@ public class KafkaConnectBuild extends AbstractModel {
     /**
      * Generates a list of volumes used by the builder pod
      *
-     * @param isOpenShift   Flag defining whether we are running on OpenShift
+     * @param isOpenShift       Flag defining whether we are running on OpenShift
+     * @param isBuildahBuild    Flag defining whether we should use Buildah or Kaniko (based on Feature Gate)
      *
      * @return  List of volumes
      */
-    /* test */ List<Volume> getVolumes(boolean isOpenShift) {
+    /* test */ List<Volume> getVolumes(boolean isOpenShift, boolean isBuildahBuild) {
         List<Volume> volumes = new ArrayList<>(2);
 
         volumes.add(VolumeUtils.createConfigMapVolume("dockerfile", KafkaConnectResources.dockerFileConfigMapName(cluster), Collections.singletonMap("Dockerfile", "Dockerfile")));
 
         if (build.getOutput() instanceof DockerOutput output) {
+            if (isBuildahBuild) {
+                // EmptyDir volume used for Buildah's build context (storing temporary build files etc.)
+                volumes.add(VolumeUtils.createEmptyDirVolume("build-context", null, null));
+            }
 
             if (output.getPushSecret() != null) {
                 volumes.add(VolumeUtils.createSecretVolume("docker-credentials", output.getPushSecret(), Collections.singletonMap(".dockerconfigjson", "config.json"), isOpenShift));
@@ -326,6 +331,11 @@ public class KafkaConnectBuild extends AbstractModel {
         volumeMounts.add(new VolumeMountBuilder().withName("dockerfile").withMountPath("/dockerfile").build());
 
         if (build.getOutput() instanceof DockerOutput output) {
+            if (isBuildahBuild) {
+                // /var/tmp is the default directory where Buildah stores the build context. Can be changed through TMPDIR environment variable.
+                volumeMounts.add(new VolumeMountBuilder().withName("build-context").withMountPath("/var/tmp").build());
+            }
+
             if (output.getPushSecret() != null) {
                 String pushSecretPath = isBuildahBuild ? "/build/.docker" : "/kaniko/.docker";
                 volumeMounts.add(new VolumeMountBuilder().withName("docker-credentials").withMountPath(pushSecretPath).build());
@@ -333,6 +343,7 @@ public class KafkaConnectBuild extends AbstractModel {
         } else {
             throw new RuntimeException("Kubernetes build requires output of type `docker`.");
         }
+
         TemplateUtils.addAdditionalVolumeMounts(volumeMounts, templateContainer);
 
         return volumeMounts;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -244,16 +244,20 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getPorts(), is(nullValue()));
         assertThat(pod.getSpec().getContainers().get(0).getResources().getLimits(), is(limit));
         assertThat(pod.getSpec().getContainers().get(0).getResources().getRequests(), is(request));
-        assertThat(pod.getSpec().getVolumes().size(), is(2));
+        assertThat(pod.getSpec().getVolumes().size(), is(3));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
-        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("docker-credentials"));
-        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getSecretName(), is("my-docker-credentials"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(2));
+        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("build-context"));
+        assertThat(pod.getSpec().getVolumes().get(1).getEmptyDir(), is(notNullValue()));
+        assertThat(pod.getSpec().getVolumes().get(2).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(2).getSecret().getSecretName(), is("my-docker-credentials"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(3));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/build/.docker"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("build-context"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/tmp"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/build/.docker"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(1));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getName(), is("REGISTRY_AUTH_FILE"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getValue(), is("/build/.docker/config.json"));
@@ -300,17 +304,21 @@ public class KafkaConnectBuildTest {
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
 
         Pod pod = build.generateBuilderPod(true, true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
-        String[] commands = pod.getSpec().getContainers().get(0).getArgs().get(2).split("\n");
-
-        assertThat(pod.getSpec().getVolumes().size(), is(1));
-        assertThat(commands[0], containsString(EXPECTED_DEFAULT_BUILDAH_BUILD_ARGS));
-        assertThat(commands[1], containsString(EXPECTED_DEFAULT_BUILDAH_PUSH_ARGS));
+        assertThat(pod.getSpec().getVolumes().size(), is(2));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(1));
+        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("build-context"));
+        assertThat(pod.getSpec().getVolumes().get(1).getEmptyDir(), is(notNullValue()));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(2));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("build-context"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/tmp"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(0));
+
+        String[] commands = pod.getSpec().getContainers().get(0).getArgs().get(2).split("\n");
+        assertThat(commands[0], containsString(EXPECTED_DEFAULT_BUILDAH_BUILD_ARGS));
+        assertThat(commands[1], containsString(EXPECTED_DEFAULT_BUILDAH_PUSH_ARGS));
     }
 
     @Test
@@ -708,24 +716,28 @@ public class KafkaConnectBuildTest {
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME), kc, VERSIONS, SHARED_ENV_PROVIDER, true);
 
         Pod pod = build.generateBuilderPod(true, true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
-        assertThat(pod.getSpec().getVolumes().size(), is(2));
+        assertThat(pod.getSpec().getVolumes().size(), is(3));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getName(), is(KafkaConnectResources.dockerFileConfigMapName(NAME)));
         assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().size(), is(1));
         assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().get(0).getKey(), is("Dockerfile"));
         assertThat(pod.getSpec().getVolumes().get(0).getConfigMap().getItems().get(0).getPath(), is("Dockerfile"));
-        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("docker-credentials"));
-        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getSecretName(), is("my-docker-credentials"));
-        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().size(), is(1));
-        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().get(0).getKey(), is(".dockerconfigjson"));
-        assertThat(pod.getSpec().getVolumes().get(1).getSecret().getItems().get(0).getPath(), is("config.json"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(3));
+        assertThat(pod.getSpec().getVolumes().get(1).getName(), is("build-context"));
+        assertThat(pod.getSpec().getVolumes().get(1).getEmptyDir(), is(notNullValue()));
+        assertThat(pod.getSpec().getVolumes().get(2).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(2).getSecret().getSecretName(), is("my-docker-credentials"));
+        assertThat(pod.getSpec().getVolumes().get(2).getSecret().getItems().size(), is(1));
+        assertThat(pod.getSpec().getVolumes().get(2).getSecret().getItems().get(0).getKey(), is(".dockerconfigjson"));
+        assertThat(pod.getSpec().getVolumes().get(2).getSecret().getItems().get(0).getPath(), is("config.json"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(4));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/build/.docker"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("volume"));
-        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/mnt/my/path"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("build-context"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/tmp"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("docker-credentials"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/build/.docker"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getName(), is("volume"));
+        assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getMountPath(), is("/mnt/my/path"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().size(), is(2));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getName(), is("REGISTRY_AUTH_FILE"));
         assertThat(pod.getSpec().getContainers().get(0).getEnv().get(0).getValue(), is("/build/.docker/config.json"));


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Buildah is using the `/var/tmp` directory to store its build context (e.g. temporary files that are created during the build). Currently, we do not provide any dedicated volume for this directory. That means that it just creates these files in the default overlay of its container. That might have some performance impact, but so far it seems to work. However, this will stop working in Buildah 1.44 due to some Buildah changes (such as https://github.com/podman-container-tools/buildah/commit/7c58fc17?).

As improvement to the current Buildah 1.43.1 setup and a preparation for the future Buildah 1.44 (currently not used by Strimzi, but we will move there one day), this PR adds a new `emptyDir` volume to the Buildah builder Pod and mounts it to `/vat/tmp` to use it as the build context.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
