### PR TITLE
Move TestUtil methods and remove fully qualified class names

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
@@ -17,8 +17,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -60,6 +63,44 @@ public class TestUtils {
         assertThat(or.getUid(), is(owner.getMetadata().getUid()));
         assertThat(or.getBlockOwnerDeletion(), is(true));
         assertThat(or.getController(), is(false));
+    }
+
+    /**
+     * Creates a modifiable set wit the desired elements. Use {@code Set.of()} if immutable set is sufficient.
+     *
+     * @param elements  The elements that will be added to the Set
+     *
+     * @return  Modifiable set with the elements
+     *
+     * @param <T>       Type of the elements stored in the Set
+     */
+    @SafeVarargs
+    public static <T> Set<T> modifiableSet(T... elements) {
+        return new HashSet<>(asList(elements));
+    }
+
+    /**
+     * Creates a modifiable map wit the desired elements. Use {@code Map.of()} if immutable set is sufficient.
+     *
+     * @param pairs     The key-value pairs that should be added to the Map
+     *
+     * @return  Modifiable map with the desired key-value pairs
+     *
+     * @param <T>   Type of the keys and values
+     */
+    @SafeVarargs
+    public static <T> Map<T, T> modifiableMap(T... pairs) {
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException();
+        } else {
+            Map<T, T> result = new HashMap<>(pairs.length / 2);
+
+            for (int i = 0; i < pairs.length; i += 2) {
+                result.put(pairs[i], pairs[i + 1]);
+            }
+
+            return result;
+        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -56,6 +56,7 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -63,7 +64,6 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
@@ -215,7 +215,6 @@ public class CruiseControlTest {
     }
 
     @Test
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public void testGenerateDeployment() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -234,7 +233,7 @@ public class CruiseControlTest {
         assertThat(dep.getMetadata().getName(), is(CruiseControlResources.componentName(CLUSTER_NAME)));
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(dep, kafka);
+        TestUtils.checkOwnerReference(dep, kafka);
 
         List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
         assertThat(containers.size(), is(1));
@@ -363,7 +362,6 @@ public class CruiseControlTest {
     }
 
     @Test
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     public void testGenerateService() {
         CruiseControl cc = createCruiseControl(KAFKA, NODES, STORAGE, Map.of());
         Service svc = cc.generateService();
@@ -378,7 +376,7 @@ public class CruiseControlTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, KAFKA);
+        TestUtils.checkOwnerReference(svc, KAFKA);
     }
 
     @SuppressWarnings("MethodLength")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -57,13 +57,13 @@ import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // Fully qualified class name used due to a name conflict
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // False positive, fully qualified class name used in a string
 public class KafkaBridgeClusterTest {
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
 
@@ -219,7 +219,7 @@ public class KafkaBridgeClusterTest {
 
         assertThat(svc.getMetadata().getAnnotations(), is(KBC.getDiscoveryAnnotation(KafkaBridgeCluster.DEFAULT_REST_API_PORT, false)));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, RESOURCE);
+        TestUtils.checkOwnerReference(svc, RESOURCE);
     }
 
     @Test
@@ -258,7 +258,7 @@ public class KafkaBridgeClusterTest {
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
             .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(dep, RESOURCE);
+        TestUtils.checkOwnerReference(dep, RESOURCE);
     }
 
     @Test
@@ -1119,7 +1119,7 @@ public class KafkaBridgeClusterTest {
         assertThat(svc.getMetadata().getAnnotations(), is(KBC.getDiscoveryAnnotation(1874, false)));
         assertThat(svc.getSpec().getPorts().get(1).getPort(), is(KafkaBridgeCluster.REST_API_MANAGEMENT_PORT));
         assertThat(svc.getSpec().getPorts().get(1).getName(), is(KafkaBridgeCluster.REST_API_MANAGEMENT_PORT_NAME));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -74,6 +74,7 @@ import io.strimzi.api.kafka.model.connect.MountedPluginBuilder;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
@@ -82,7 +83,6 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -108,7 +108,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // Fully qualified class name used due to a name conflict
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:NoFullyQualifiedClassNames"}) // False positive, fully qualified class name used in a string
 public class KafkaConnectClusterTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider(Map.of(
@@ -239,7 +239,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, RESOURCE);
+        TestUtils.checkOwnerReference(svc, RESOURCE);
     }
 
     @Test
@@ -272,7 +272,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaConnectCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(svc, resource);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @Test
@@ -684,7 +684,7 @@ public class KafkaConnectClusterTest {
         assertThat(ps.getMetadata().getName(), is(KafkaConnectResources.componentName(NAME)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(kc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
         assertThat(ps.getMetadata().getAnnotations(), is(Map.of("anno1", "anno-value1", "anno2", "anno-value2")));
-        io.strimzi.operator.cluster.TestUtils.checkOwnerReference(ps, resource);
+        TestUtils.checkOwnerReference(ps, resource);
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(kc.getSelectorLabels().withStrimziPodSetController(KafkaConnectResources.componentName(NAME)).toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -56,6 +56,7 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.TestUtils;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.KafkaCluster;
@@ -118,7 +119,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.model.Ca.x509Certificate;
-import static io.strimzi.test.TestUtils.modifiableSet;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -530,7 +530,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Secrets
         SecretOperator mockSecretOps = supplier.secretOperations;
-        Set<String> expectedSecrets = modifiableSet(
+        Set<String> expectedSecrets = TestUtils.modifiableSet(
                 KafkaResources.clientsCaKeySecretName(CLUSTER_NAME),
                 KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME),
                 KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME),
@@ -709,7 +709,7 @@ public class KafkaAssemblyOperatorTest {
 
                 // Check routes
                 if (openShift) {
-                    Set<String> expectedRoutes = modifiableSet(KafkaResources.bootstrapServiceName(CLUSTER_NAME));
+                    Set<String> expectedRoutes = TestUtils.modifiableSet(KafkaResources.bootstrapServiceName(CLUSTER_NAME));
                     for (NodeRef node : kafkaCluster.nodes()) {
                         if (node.broker()) {
                             expectedRoutes.add(node.podName());
@@ -910,13 +910,13 @@ public class KafkaAssemblyOperatorTest {
         when(mockCmOps.listAsync(NAMESPACE, updatedKafkaCluster.getSelectorLabels())).thenReturn(CompletableFuture.completedFuture(List.of()));
         when(mockCmOps.deleteAsync(any(), any(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(null));
 
-        Set<String> metricsCms = modifiableSet();
+        Set<String> metricsCms = TestUtils.modifiableSet();
         doAnswer(invocation -> {
             metricsCms.add(invocation.getArgument(1));
             return CompletableFuture.completedFuture(null);
         }).when(mockCmOps).reconcile(any(), eq(NAMESPACE), any(), any());
 
-        Set<String> logCms = modifiableSet();
+        Set<String> logCms = TestUtils.modifiableSet();
         doAnswer(invocation -> {
             logCms.add(invocation.getArgument(1));
             return CompletableFuture.completedFuture(null);

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -15,11 +15,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.ServerSocket;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +23,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -132,44 +127,6 @@ public final class TestUtils {
                 LOGGER.trace("{} not ready, will try again in {} ms ({}ms till timeout)", description, sleepTime, timeLeft);
             }
             LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(sleepTime));
-        }
-    }
-
-    /**
-     * Creates a modifiable set wit the desired elements. Use {@code Set.of()} if immutable set is sufficient.
-     *
-     * @param elements  The elements that will be added to the Set
-     *
-     * @return  Modifiable set with the elements
-     *
-     * @param <T>       Type of the elements stored in the Set
-     */
-    @SafeVarargs
-    public static <T> Set<T> modifiableSet(T... elements) {
-        return new HashSet<>(asList(elements));
-    }
-
-    /**
-     * Creates a modifiable map wit the desired elements. Use {@code Map.of()} if immutable set is sufficient.
-     *
-     * @param pairs     The key-value pairs that should be added to the Map
-     *
-     * @return  Modifiable map with the desired key-value pairs
-     *
-     * @param <T>   Type of the keys and values
-     */
-    @SafeVarargs
-    public static <T> Map<T, T> modifiableMap(T... pairs) {
-        if (pairs.length % 2 != 0) {
-            throw new IllegalArgumentException();
-        } else {
-            Map<T, T> result = new HashMap<>(pairs.length / 2);
-
-            for (int i = 0; i < pairs.length; i += 2) {
-                result.put(pairs[i], pairs[i + 1]);
-            }
-
-            return result;
         }
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR moves two methods that are used only in CO tests from `test` module `TestUtils` class to `cluster-operator` `TestUtil` class. That also allows us to drop some of the fully qualified class names and contributes to #12879.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Make sure all tests pass