### PR TITLE
Avoid using `maybeUnwrapCompletionException` from tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaNodeUnregistrationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaNodeUnregistrationTest.java
@@ -20,8 +20,8 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 
-import static io.strimzi.operator.common.Util.maybeUnwrapCompletionException;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -75,8 +75,8 @@ public class KafkaNodeUnregistrationTest {
                     .join();
             throw new AssertionError("Expected TimeoutException but none was thrown");
         } catch (Exception e) {
-            Throwable cause = maybeUnwrapCompletionException(e);
-            assertThat(cause, instanceOf(TimeoutException.class));
+            assertThat(e, instanceOf(CompletionException.class));
+            assertThat(e.getCause(), instanceOf(TimeoutException.class));
             assertThat(unregisteredNodeIdCaptor.getAllValues().size(), is(2));
             assertThat(unregisteredNodeIdCaptor.getAllValues(), hasItems(1874, 1919));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -29,10 +29,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.strimzi.operator.common.Util.maybeUnwrapCompletionException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -518,7 +518,10 @@ public class KafkaAvailabilityTest {
         KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac());
 
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> assertThat(maybeUnwrapCompletionException(error), instanceOf(TimeoutException.class)));
+            kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> {
+                assertThat(error, instanceOf(CompletionException.class));
+                assertThat(error.getCause(), instanceOf(TimeoutException.class));
+            });
         }
     }
 
@@ -548,7 +551,10 @@ public class KafkaAvailabilityTest {
         KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac());
 
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> assertThat(maybeUnwrapCompletionException(error), instanceOf(UnknownTopicOrPartitionException.class)));
+            kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> {
+                assertThat(error, instanceOf(CompletionException.class));
+                assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
+            });
         }
     }
 
@@ -579,8 +585,10 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             if (brokerId <= 2) {
-                kafkaAvailability.canRoll(brokerId).whenComplete((r, error) ->
-                        assertThat(maybeUnwrapCompletionException(error), instanceOf(UnknownTopicOrPartitionException.class)));
+                kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> {
+                    assertThat(error, instanceOf(CompletionException.class));
+                    assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
+                });
             }
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,7 +50,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.strimzi.operator.common.Util.maybeUnwrapCompletionException;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -835,9 +835,9 @@ public class KafkaRollerTest {
                 }).join();
             throw new AssertionError("Expected exception " + exception.getName() + " but none was thrown");
         } catch (Exception e) {
-            Throwable cause = maybeUnwrapCompletionException(e);
-            assertThat(cause.getClass() + " is not a subclass of " + exception.getName(), cause, instanceOf(exception));
-            assertThat("The exception message was not as expected", cause.getMessage(), is(message));
+            assertThat(e, instanceOf(CompletionException.class));
+            assertThat(e.getCause().getClass() + " is not a subclass of " + exception.getName(), e.getCause(), instanceOf(exception));
+            assertThat("The exception message was not as expected", e.getCause().getMessage(), is(message));
             assertThat("The restarted pods were not as expected", restarted(), is(expectedRestart));
             assertNoUnclosedAdminClient(kafkaRoller);
         }
@@ -874,11 +874,10 @@ public class KafkaRollerTest {
                 readiness.apply(podName2Number(podName)).join();
                 return true;
             } catch (Exception e) {
-                Throwable cause = maybeUnwrapCompletionException(e);
-                if (cause instanceof TimeoutException) {
+                if (e instanceof CompletionException && e.getCause() instanceof TimeoutException) {
                     return false;
                 } else {
-                    throw cause;
+                    throw e.getCause();
                 }
             }
         });

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorTest.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,15 +32,16 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -267,7 +267,8 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
 
         TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource)
             .<Void>handle((rr, error) -> {
-                assertSame(Util.maybeUnwrapCompletionException(error), ex);
+                assertThat(error, instanceOf(CompletionException.class));
+                assertThat(error.getCause(), is(ex));
                 return null;
             }));
     }
@@ -344,7 +345,8 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient, useServerSideApply);
         TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource)
             .<Void>handle((rr, error) -> {
-                assertSame(Util.maybeUnwrapCompletionException(error), ex);
+                assertThat(error, instanceOf(CompletionException.class));
+                assertThat(error.getCause(), is(ex));
                 return null;
             }));
     }
@@ -501,7 +503,8 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
 
         TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
             .<Void>handle((rr, error) -> {
-                assertThat(Util.maybeUnwrapCompletionException(error), is(ex));
+                assertThat(error, instanceOf(CompletionException.class));
+                assertThat(error.getCause(), is(ex));
                 return null;
             }));
     }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
@@ -45,6 +45,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -52,13 +53,13 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -664,8 +665,9 @@ public class KafkaUserOperatorMockTest {
 
         // Assert reconciliation failed with exception
         ExecutionException thrown = assertThrows(ExecutionException.class, futureResult.toCompletableFuture()::get);
-        Throwable rootCause = Util.maybeUnwrapCompletionException(thrown.getCause());
-        assertInstanceOf(InvalidResourceException.class, rootCause);
+        assertThat(thrown.getCause(), instanceOf(CompletionException.class));
+        assertThat(thrown.getCause().getCause(), instanceOf(InvalidResourceException.class));
+
     }
 
     @Test
@@ -1615,8 +1617,8 @@ public class KafkaUserOperatorMockTest {
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, namespace, ResourceUtils.NAME), user, null);
 
         ExecutionException thrown = assertThrows(ExecutionException.class, futureResult.toCompletableFuture()::get);
-        Throwable rootCause = Util.maybeUnwrapCompletionException(thrown.getCause());
-        assertInstanceOf(InvalidConfigurationException.class, rootCause);
-        assertThat(rootCause.getMessage(), containsString(missingSecretName));
+        assertThat(thrown.getCause(), instanceOf(CompletionException.class));
+        assertThat(thrown.getCause().getCause(), instanceOf(InvalidConfigurationException.class));
+        assertThat(thrown.getCause().getCause().getMessage(), containsString(missingSecretName));
     }
 }


### PR DESCRIPTION
### Type of change

- Task

### Description

There are currently several tests that use the `Util.maybeUnwrapCompletionException` method to possibly _unwrap_ `CompletionException` returned by async Java calls. While this method might be useful in production code in some situations, I do not think we should be using it in tests because it hides changes to the code and to returned exceptions and what is the actual returned exception. This PR updates the tests using this method to instead properly check for the right exception structure and types.

### Checklist

- [x] Make sure all tests pass