### PR TITLE
Unify IOException handling in cert generation paths

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -342,6 +342,7 @@ public class ClusterCa extends Ca {
                 certAndKey = generateSignedCert(commonName, Ca.IO_STRIMZI);
             } catch (IOException e) {
                 LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
+                throw new RuntimeException("Failed to generate signed certificate for " + commonName, e);
             }
 
             LOGGER.debugCr(reconciliation, "End generating certificates");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -340,12 +340,11 @@ public class ClusterCa extends Ca {
 
             try {
                 certAndKey = generateSignedCert(commonName, Ca.IO_STRIMZI);
+                LOGGER.debugCr(reconciliation, "End generating certificates");
             } catch (IOException e) {
                 LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
                 throw new RuntimeException("Failed to generate signed certificate for " + commonName, e);
             }
-
-            LOGGER.debugCr(reconciliation, "End generating certificates");
         } else {
             certAndKey = existingCertAndKey;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -446,7 +446,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
      * @return The generated Secret.
      */
     public Secret generateCertificatesSecret(String namespace, String clusterName, ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
-        Map<String, CertAndKey> ccCerts = new HashMap<>(4);
+        Map<String, CertAndKey> ccCerts;
         LOGGER.debugCr(reconciliation, "Generating certificates");
         try {
             CertAndKey existingCertAndKey = CertUtils.keyStoreCertAndKey(existingSecret, CruiseControl.COMPONENT_TYPE, clusterCa.caCertGenerationAnnotation());
@@ -456,6 +456,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
                     isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
+            throw new RuntimeException("Failed to prepare Cruise Control certificates", e);
         }
         LOGGER.debugCr(reconciliation, "End generating certificates");
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -446,24 +446,23 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
      * @return The generated Secret.
      */
     public Secret generateCertificatesSecret(String namespace, String clusterName, ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
-        Map<String, CertAndKey> ccCerts;
         LOGGER.debugCr(reconciliation, "Generating certificates");
         try {
             CertAndKey existingCertAndKey = CertUtils.keyStoreCertAndKey(existingSecret, CruiseControl.COMPONENT_TYPE, clusterCa.caCertGenerationAnnotation());
 
-            ccCerts = clusterCa.generateCcCerts(namespace, clusterName, existingCertAndKey,
+            Map<String, CertAndKey> ccCerts = clusterCa.generateCcCerts(namespace, clusterName, existingCertAndKey,
                     new NodeRef(CruiseControl.COMPONENT_TYPE, 0, null, false, false),
                     isMaintenanceTimeWindowsSatisfied);
+            LOGGER.debugCr(reconciliation, "End generating certificates");
+
+            return ModelUtils.createSecret(CruiseControlResources.secretName(cluster), namespace, labels, ownerReference,
+                    CertUtils.buildSecretData(ccCerts),
+                    Map.of(clusterCa.caCertGenerationAnnotation(), String.valueOf(ccCerts.get(CruiseControl.COMPONENT_TYPE).caCertGeneration())),
+                    Map.of());
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare Cruise Control certificates", e);
         }
-        LOGGER.debugCr(reconciliation, "End generating certificates");
-
-        return ModelUtils.createSecret(CruiseControlResources.secretName(cluster), namespace, labels, ownerReference,
-                CertUtils.buildSecretData(ccCerts),
-                Map.of(clusterCa.caCertGenerationAnnotation(), String.valueOf(ccCerts.get(CruiseControl.COMPONENT_TYPE).caCertGeneration())),
-                Map.of());
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -20,13 +20,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(VertxExtension.class)
 public class ClusterCaRenewalTest {
@@ -491,35 +487,6 @@ public class ClusterCaRenewalTest {
         assertThat(new String(newCert.keyStore()), is("old-keystore"));
         assertThat(newCert.storePassword(), is("old-password"));
         assertThat(newCert.caCertGeneration(), is(0));
-    }
-
-    @Test
-    public void testClientCertGenerationFailureSurfacesAsRuntimeException() {
-        // GH-12847: An IOException during signed-cert generation must abort the
-        // reconciliation (matching the KafkaCluster broker-cert path) instead
-        // of being swallowed with a warning log and a null CertAndKey, which
-        // would later NPE when the caller reads its caCertGeneration().
-        IOException injected = new IOException("disk full");
-        ClusterCa throwingCa = new MockedClusterCa() {
-            @Override
-            public CertAndKey generateSignedCert(String commonName, String organization) throws IOException {
-                throw injected;
-            }
-        };
-
-        RuntimeException thrown = assertThrows(
-                RuntimeException.class,
-                () -> throwingCa.maybeCopyOrGenerateClientCert(
-                        Reconciliation.DUMMY_RECONCILIATION,
-                        "deployment",
-                        null,
-                        true)
-        );
-
-        assertThat(thrown.getMessage(), containsString("deployment"));
-        assertThat(thrown.getCause(), notNullValue());
-        assertThat(thrown.getCause(), is(instanceOf(IOException.class)));
-        assertThat(thrown.getCause(), is(injected));
     }
 
     public static class MockedClusterCa extends ClusterCa {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -20,9 +20,13 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(VertxExtension.class)
 public class ClusterCaRenewalTest {
@@ -487,6 +491,35 @@ public class ClusterCaRenewalTest {
         assertThat(new String(newCert.keyStore()), is("old-keystore"));
         assertThat(newCert.storePassword(), is("old-password"));
         assertThat(newCert.caCertGeneration(), is(0));
+    }
+
+    @Test
+    public void testClientCertGenerationFailureSurfacesAsRuntimeException() {
+        // GH-12847: An IOException during signed-cert generation must abort the
+        // reconciliation (matching the KafkaCluster broker-cert path) instead
+        // of being swallowed with a warning log and a null CertAndKey, which
+        // would later NPE when the caller reads its caCertGeneration().
+        IOException injected = new IOException("disk full");
+        ClusterCa throwingCa = new MockedClusterCa() {
+            @Override
+            public CertAndKey generateSignedCert(String commonName, String organization) throws IOException {
+                throw injected;
+            }
+        };
+
+        RuntimeException thrown = assertThrows(
+                RuntimeException.class,
+                () -> throwingCa.maybeCopyOrGenerateClientCert(
+                        Reconciliation.DUMMY_RECONCILIATION,
+                        "deployment",
+                        null,
+                        true)
+        );
+
+        assertThat(thrown.getMessage(), containsString("deployment"));
+        assertThat(thrown.getCause(), notNullValue());
+        assertThat(thrown.getCause(), is(instanceOf(IOException.class)));
+        assertThat(thrown.getCause(), is(injected));
     }
 
     public static class MockedClusterCa extends ClusterCa {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Resolves #12847.

Bring `CruiseControl#generateCertificatesSecret` and `ClusterCa#maybeCopyOrGenerateClientCert` in line with `KafkaCluster#generatePerBrokerKafkaSecretsForPool`: catch `IOException` and rethrow as `RuntimeException` so the reconciliation fails fast instead of producing an empty secret data map / `null` `CertAndKey` that later NPEs.

The issue points out three behaviours for the same condition:

- `KafkaCluster` (line 1334): wraps the `IOException` in a `RuntimeException` → reconciliation fails, problem surfaced.
- `CruiseControl` (line 458): logs a warning and continues, producing a `Secret` with an empty `data` map and crashing on `ccCerts.get(...).caCertGeneration()` (the line right below the `catch`).
- `ClusterCa#maybeCopyOrGenerateClientCert` (line 344): logs a warning and returns `null`. Callers — `KafkaExporter` (line 311), `EntityOperator`, `EntityTopicOperator`, `EntityUserOperator`, `CaReconciler` — then dereference the `null` and NPE on `caCertGeneration()`.

The KafkaCluster pattern is the right one: a transient `IOException` while generating a cert is an operator-level failure, not something we want to silently paper over with a broken secret.

**Change:**

- `CruiseControl.java` — `throw new RuntimeException("Failed to prepare Cruise Control certificates", e);` after the existing warning log.
- `ClusterCa.java` — `throw new RuntimeException("Failed to generate signed certificate for " + commonName, e);` after the existing warning log.

The existing `warnCr` lines are kept so the `IOException` stack still appears in the operator log; the new `RuntimeException` just turns the previously-swallowed failure into a visible one.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
