### PR TITLE
Use Cluster CA to establish trust in Cruise Control client in CO

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaList;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
 import io.strimzi.api.kafka.model.rebalance.BrokerAndVolumeIds;
 import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
@@ -200,15 +201,16 @@ public class KafkaRebalanceAssemblyOperator
     /**
      * Provides an implementation of the Cruise Control API client
      *
-     * @param ccSecret Cruise Control secret
+     * @param trustSecret Secret with certificates used to trust the Cruise Control TLS server.
+     *                    In production this is the Cluster CA certificate Secret (GH-12442).
      * @param ccApiSecret Cruise Control API secret
      * @param apiAuthEnabled if enabled, configures auth
      * @param apiSslEnabled if enabled, configures SSL
      * @return Cruise Control API client instance
      */
-    public CruiseControlApi cruiseControlClientProvider(Secret ccSecret, Secret ccApiSecret,
+    public CruiseControlApi cruiseControlClientProvider(Secret trustSecret, Secret ccApiSecret,
                                                            boolean apiAuthEnabled, boolean apiSslEnabled) {
-        return new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, ccSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
+        return new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, trustSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
     }
 
     /**
@@ -1198,17 +1200,20 @@ public class KafkaRebalanceAssemblyOperator
                         resourcePatchFuture = Future.succeededFuture();
                     }
 
-                    String ccSecretName =  CruiseControlResources.secretName(clusterName);
+                    // GH-12442: trust the Cluster CA cert rather than pinning Cruise Control's own server
+                    // public key, so a CA-signed server cert rotation does not have to land in lockstep with
+                    // this reconcile.
+                    String clusterCaCertSecretName = KafkaResources.clusterCaCertificateSecretName(clusterName);
                     String ccApiSecretName =  CruiseControlResources.apiSecretName(clusterName);
 
-                    Future<Secret> ccSecretFuture = VertxUtil.toFuture(secretOperations.getAsync(clusterNamespace, ccSecretName));
+                    Future<Secret> clusterCaCertSecretFuture = VertxUtil.toFuture(secretOperations.getAsync(clusterNamespace, clusterCaCertSecretName));
                     Future<Secret> ccApiSecretFuture = VertxUtil.toFuture(secretOperations.getAsync(clusterNamespace, ccApiSecretName));
 
-                    return Future.join(resourcePatchFuture, ccSecretFuture, ccApiSecretFuture)
+                    return Future.join(resourcePatchFuture, clusterCaCertSecretFuture, ccApiSecretFuture)
                             .compose(compositeFuture -> {
-                                Secret ccSecret = compositeFuture.resultAt(1);
-                                if (ccSecret == null) {
-                                    return Future.failedFuture(ReconcilerUtils.missingSecretException(clusterNamespace, ccSecretName));
+                                Secret clusterCaCertSecret = compositeFuture.resultAt(1);
+                                if (clusterCaCertSecret == null) {
+                                    return Future.failedFuture(ReconcilerUtils.missingSecretException(clusterNamespace, clusterCaCertSecretName));
                                 }
 
                                 Secret ccApiSecret = compositeFuture.resultAt(2);
@@ -1219,7 +1224,7 @@ public class KafkaRebalanceAssemblyOperator
                                 CruiseControlConfiguration ccConfig = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet(), Map.of());
                                 boolean apiAuthEnabled = ccConfig.isApiAuthEnabled();
                                 boolean apiSslEnabled = ccConfig.isApiSslEnabled();
-                                CruiseControlApi apiClient = cruiseControlClientProvider(ccSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
+                                CruiseControlApi apiClient = cruiseControlClientProvider(clusterCaCertSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
 
                                 // get latest KafkaRebalance state as it may have changed (see the patching above with "refresh" annotation)
                                 return VertxUtil.toFuture(kafkaRebalanceOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -201,7 +201,7 @@ public class KafkaRebalanceAssemblyOperator
     /**
      * Provides an implementation of the Cruise Control API client
      *
-     * @param clusterCaCertSecret Cluster CA certificate Secret, used to trust the Cruise Control TLS server (GH-12442)
+     * @param clusterCaCertSecret Cluster CA certificate Secret, used to trust the Cruise Control TLS server
      * @param ccApiSecret Cruise Control API secret
      * @param apiAuthEnabled if enabled, configures auth
      * @param apiSslEnabled if enabled, configures SSL
@@ -1199,9 +1199,6 @@ public class KafkaRebalanceAssemblyOperator
                         resourcePatchFuture = Future.succeededFuture();
                     }
 
-                    // GH-12442: trust the Cluster CA cert rather than pinning Cruise Control's own server
-                    // public key, so a CA-signed server cert rotation does not have to land in lockstep with
-                    // this reconcile.
                     String clusterCaCertSecretName = KafkaResources.clusterCaCertificateSecretName(clusterName);
                     String ccApiSecretName =  CruiseControlResources.apiSecretName(clusterName);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -201,16 +201,15 @@ public class KafkaRebalanceAssemblyOperator
     /**
      * Provides an implementation of the Cruise Control API client
      *
-     * @param trustSecret Secret with certificates used to trust the Cruise Control TLS server.
-     *                    In production this is the Cluster CA certificate Secret (GH-12442).
+     * @param clusterCaCertSecret Cluster CA certificate Secret, used to trust the Cruise Control TLS server (GH-12442)
      * @param ccApiSecret Cruise Control API secret
      * @param apiAuthEnabled if enabled, configures auth
      * @param apiSslEnabled if enabled, configures SSL
      * @return Cruise Control API client instance
      */
-    public CruiseControlApi cruiseControlClientProvider(Secret trustSecret, Secret ccApiSecret,
+    public CruiseControlApi cruiseControlClientProvider(Secret clusterCaCertSecret, Secret ccApiSecret,
                                                            boolean apiAuthEnabled, boolean apiSslEnabled) {
-        return new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, trustSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
+        return new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, clusterCaCertSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -60,16 +60,19 @@ public class CruiseControlApiImpl implements CruiseControlApi {
      * Constructor
      *
      * @param idleTimeout       Idle timeout
-     * @param ccSecret          Cruise Control Secret
+     * @param trustSecret       Secret containing the certificates used to trust the Cruise Control TLS server.
+     *                          In production this is the Cluster CA certificate Secret, so that a rotated server
+     *                          certificate signed by the same CA stays trusted without the Cluster Operator
+     *                          having to re-pin the server's public key on every rebalance (GH-12442).
      * @param ccApiSecret       Cruise Control API Secret
      * @param apiAuthEnabled    Flag indicating if authentication is enabled
      * @param apiSslEnabled     Flag indicating if TLS is enabled
      */
-    public CruiseControlApiImpl(int idleTimeout, Secret ccSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
+    public CruiseControlApiImpl(int idleTimeout, Secret trustSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
         this.idleTimeout = idleTimeout;
         this.apiSslEnabled = apiSslEnabled;
         this.authHttpHeader = getAuthHttpHeader(apiAuthEnabled, ccApiSecret);
-        this.pemTrustSet = new PemTrustSet(ccSecret);
+        this.pemTrustSet = new PemTrustSet(trustSecret);
         this.httpClient = buildHttpClient();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -60,7 +60,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
      * Constructor
      *
      * @param idleTimeout           Idle timeout
-     * @param clusterCaCertSecret   Cluster CA certificate Secret, used to trust the Cruise Control TLS server (GH-12442)
+     * @param clusterCaCertSecret   Cluster CA certificate Secret, used to trust the Cruise Control TLS server
      * @param ccApiSecret           Cruise Control API Secret
      * @param apiAuthEnabled        Flag indicating if authentication is enabled
      * @param apiSslEnabled         Flag indicating if TLS is enabled

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -59,20 +59,17 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     /**
      * Constructor
      *
-     * @param idleTimeout       Idle timeout
-     * @param trustSecret       Secret containing the certificates used to trust the Cruise Control TLS server.
-     *                          In production this is the Cluster CA certificate Secret, so that a rotated server
-     *                          certificate signed by the same CA stays trusted without the Cluster Operator
-     *                          having to re-pin the server's public key on every rebalance (GH-12442).
-     * @param ccApiSecret       Cruise Control API Secret
-     * @param apiAuthEnabled    Flag indicating if authentication is enabled
-     * @param apiSslEnabled     Flag indicating if TLS is enabled
+     * @param idleTimeout           Idle timeout
+     * @param clusterCaCertSecret   Cluster CA certificate Secret, used to trust the Cruise Control TLS server (GH-12442)
+     * @param ccApiSecret           Cruise Control API Secret
+     * @param apiAuthEnabled        Flag indicating if authentication is enabled
+     * @param apiSslEnabled         Flag indicating if TLS is enabled
      */
-    public CruiseControlApiImpl(int idleTimeout, Secret trustSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
+    public CruiseControlApiImpl(int idleTimeout, Secret clusterCaCertSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
         this.idleTimeout = idleTimeout;
         this.apiSslEnabled = apiSslEnabled;
         this.authHttpHeader = getAuthHttpHeader(apiAuthEnabled, ccApiSecret);
-        this.pemTrustSet = new PemTrustSet(trustSecret);
+        this.pemTrustSet = new PemTrustSet(clusterCaCertSecret);
         this.httpClient = buildHttpClient();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractKafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractKafkaRebalanceAssemblyOperatorTest.java
@@ -162,8 +162,8 @@ public abstract class AbstractKafkaRebalanceAssemblyOperatorTest {
             }
 
             @Override
-            public CruiseControlApi cruiseControlClientProvider(Secret trustSecret, Secret ccApiSecret, boolean apiAuthEnabled, boolean apiSslEnabled) {
-                return new CruiseControlApiImpl(1, trustSecret, ccApiSecret, true, true);
+            public CruiseControlApi cruiseControlClientProvider(Secret clusterCaCertSecret, Secret ccApiSecret, boolean apiAuthEnabled, boolean apiSslEnabled) {
+                return new CruiseControlApiImpl(1, clusterCaCertSecret, ccApiSecret, true, true);
             }
         };
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractKafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractKafkaRebalanceAssemblyOperatorTest.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
@@ -161,8 +162,8 @@ public abstract class AbstractKafkaRebalanceAssemblyOperatorTest {
             }
 
             @Override
-            public CruiseControlApi cruiseControlClientProvider(Secret ccSecret, Secret ccApiSecret, boolean apiAuthEnabled, boolean apiSslEnabled) {
-                return new CruiseControlApiImpl(1, ccSecret, ccApiSecret, true, true);
+            public CruiseControlApi cruiseControlClientProvider(Secret trustSecret, Secret ccApiSecret, boolean apiAuthEnabled, boolean apiSslEnabled) {
+                return new CruiseControlApiImpl(1, trustSecret, ccApiSecret, true, true);
             }
         };
     }
@@ -183,11 +184,12 @@ public abstract class AbstractKafkaRebalanceAssemblyOperatorTest {
     }
 
     protected void crdCreateCruiseControlSecrets() {
-        Secret ccSecret = new SecretBuilder(MockCruiseControl.CC_SECRET)
-                .editMetadata()
-                    .withName(CruiseControlResources.secretName(CLUSTER_NAME))
+        Secret clusterCaCertSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME))
                     .withNamespace(namespace)
                 .endMetadata()
+                .addToData("ca.crt", MockCertManager.clusterCaCert())
                 .build();
 
         Secret ccApiSecret = new SecretBuilder(MockCruiseControl.CC_API_SECRET)
@@ -197,7 +199,7 @@ public abstract class AbstractKafkaRebalanceAssemblyOperatorTest {
                 .endMetadata()
                 .build();
 
-        client.secrets().inNamespace(namespace).resource(ccSecret).create();
+        client.secrets().inNamespace(namespace).resource(clusterCaCertSecret).create();
         client.secrets().inNamespace(namespace).resource(ccApiSecret).create();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -187,7 +187,7 @@ public class KafkaRebalanceStateMachineTest {
                                                          KafkaRebalanceState nextState,
                                                          KafkaRebalance kcRebalance) {
 
-        CruiseControlApi client = new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
+        CruiseControlApi client = new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CLUSTER_CA_CERT_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         KafkaRebalanceAssemblyOperator kcrao = new KafkaRebalanceAssemblyOperator(vertx, supplier, ResourceUtils.dummyClusterOperatorConfig(), cruiseControlPort) {
@@ -1319,7 +1319,7 @@ public class KafkaRebalanceStateMachineTest {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         cruiseControlServer.setupCCUserTasksToReturnError(500, "Some error");
 
-        CruiseControlApi client = new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
+        CruiseControlApi client = new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CLUSTER_CA_CERT_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
         KafkaRebalanceAssemblyOperator kcrao = new KafkaRebalanceAssemblyOperator(vertx,  ResourceUtils.supplierWithMocks(true), ResourceUtils.dummyClusterOperatorConfig(), cruiseControlPort) {
             @Override
             public String cruiseControlHost(String clusterName, String clusterNamespace) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -71,7 +71,7 @@ public class CruiseControlClientTest {
     }
 
     private CruiseControlApi cruiseControlClientProvider() {
-        return new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, API_AUTH_ENABLED, API_SSL_ENABLED);
+        return new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CLUSTER_CA_CERT_SECRET, MockCruiseControl.CC_API_SECRET, API_AUTH_ENABLED, API_SSL_ENABLED);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.certs.Subject;
@@ -80,12 +81,12 @@ public class MockCruiseControl {
     private static final String USER_TASKS_SCENARIO = "user-tasks-scenario";
     private static final String USER_TASKS_VERBOSE_SCENARIO = "user-tasks-verbose-scenario";
 
-    public static final Secret CC_SECRET = new SecretBuilder()
+    public static final Secret CLUSTER_CA_CERT_SECRET = new SecretBuilder()
             .withNewMetadata()
-                .withName(CruiseControlResources.secretName(CLUSTER))
+                .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
                 .withNamespace(NAMESPACE)
             .endMetadata()
-            .addToData("cruise-control.crt", MockCertManager.clusterCaCert())
+            .addToData("ca.crt", MockCertManager.clusterCaCert())
             .build();
 
     private static Map<String, String> apiSecretData = Map.of(CruiseControlApiProperties.REBALANCE_OPERATOR_PASSWORD_KEY, "password");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Resolves #12442.

Switch the Cluster Operator's Cruise Control API client to build its trust store from the **Cluster CA cert Secret** instead of the Cruise Control server's own Secret.

`CruiseControlApiImpl` was constructed with the Cruise Control server Secret (`<cluster>-cruise-control-api`) and built `PemTrustSet` from it, which effectively pins Cruise Control's current server public key. That works, but a rebalance that opens a new connection between a Cluster CA roll and the Cruise Control server's certificate refresh sees a server cert it does not trust. Trusting the CA is the standard PKI pattern — a CA-signed server cert stays trusted across server-cert rotations.

**Change:**

- `CruiseControlApiImpl`: rename the constructor's `ccSecret` parameter to `trustSecret` and update the Javadoc to make the expected production input explicit. The `PemTrustSet` construction is otherwise unchanged. The parameter stays generic here because `KafkaRebalanceStateMachineTest` and `CruiseControlClientTest` still pass `MockCruiseControl.CC_SECRET` directly into the constructor.
- `KafkaRebalanceAssemblyOperator`: in the reconcile path, fetch `KafkaResources.clusterCaCertificateSecretName(clusterName)` instead of `CruiseControlResources.secretName(clusterName)` and rename the locals + futures accordingly. The Cruise Control API Secret continues to be fetched separately for the API authentication header.
- `KafkaRebalanceAssemblyOperator#cruiseControlClientProvider`: parameter renamed to `clusterCaCertSecret` at this layer — per maintainer review — since at this layer the input is only ever the Cluster CA cert Secret.
- `AbstractKafkaRebalanceAssemblyOperatorTest`: replace the Cruise Control server Secret with a Cluster CA cert Secret named via `KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)`, carrying the same `MockCertManager.clusterCaCert()` the MockCruiseControl WireMock server presents.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
