### PR TITLE
Update Fabric8 Kubernetes Client to 7.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,14 @@
         <!-- Build tools -->
         <checkstyle.version>10.18.1</checkstyle.version>
         <spotbugs.version>4.7.3</spotbugs.version>
-        <sundrio.version>0.230.1</sundrio.version>
+        <sundrio.version>0.230.2</sundrio.version>
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.7.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.7.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.7.0</fabric8.kubernetes-model.version>
-        <fabric8.zjsonpatch.version>7.7.0</fabric8.zjsonpatch.version>
+        <fabric8.kubernetes-client.version>7.8.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.8.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.8.0</fabric8.kubernetes-model.version>
+        <fabric8.zjsonpatch.version>7.8.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.22.0</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.22.0</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.22.0</fasterxml.jackson-dataformat.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR udpates Fabric8 Kubernetes Client to 7.8.0. It also bumps Sundrio to keep it in sync with what Fabric8 uses.

### Checklist

- [x] Try your changes inside a Kubernetes cluster, not just from unit tests