### PR TITLE
Fix MM2 Grafana dashboards for Strimzi Metrics Reporter

### DIFF
--- a/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-mirror-maker-2.json
@@ -693,7 +693,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": false,
-          "expr": "sum(kafka_consumer_consumer_fetch_manager_metrics_records_lag{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\",clientid=~\".*replication-consumer\\\"\"}) by (topic, partition)",
+          "expr": "sum(kafka_consumer_consumer_fetch_manager_metrics_records_lag{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\",client_id=~\".*replication-consumer\"}) by (topic, partition)",
           "interval": "",
           "legendFormat": "{{topic}} (partition: {{partition}})",
           "refId": "A"
@@ -757,7 +757,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": false,
-          "expr": "topk(20, sum(kafka_consumer_consumer_fetch_manager_metrics_records_lag{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\",clientid=~\".*replication-consumer\\\"\"}) by (partition, topic))",
+          "expr": "topk(20, sum(kafka_consumer_consumer_fetch_manager_metrics_records_lag{strimzi_io_kind=~\"KafkaMirrorMaker2\",strimzi_io_cluster=\"$strimzi_mirror_maker_cluster_name\",client_id=~\".*replication-consumer\"}) by (partition, topic))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1427,7 +1427,7 @@
           "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(kafka_producer_producer_metrics_buffer_available_bytes) by (client_id)",
           "interval": "",
-          "legendFormat": "{{clientid}}",
+          "legendFormat": "{{client_id}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
 ### Type of change
  - Bugfix

  ### Description
  Closes #12870.

  The replication-consumer lag panels in the MM2 SMR dashboard filtered on the JMX label name `clientid` (no
  underscore) and required a trailing escaped quote in the matched value — a JMX exporter artifact. Strimzi Metrics
  Reporter emits the label as `client_id` (underscore, value unquoted), so the regex matched nothing and the panels
  rendered empty.

  Other working queries in the same file already use the SMR convention (e.g. `client_id="mirrormaker2-cluster-offsets"` at line 733), confirming the naming convention.

  `packaging/examples/metrics/strimzi-metrics-reporter/grafana-dashboards/strimzi-kafka-mirror-maker-2.json` — 3
  spots:
  - line 696 (records_lag panel): `clientid=~".*replication-consumer\""` → `client_id=~".*replication-consumer"`
  - line 760 (top-20 table): same
  - line 1430 (producer buffer legend): `{{clientid}}` → `{{client_id}}`

  ### Checklist

  - [ ] Update documentation
  - [ ] Update CHANGELOG.md (if present)
  - [x] Reference relevant issue(s) and close them after merging
  - [ ] Write tests
  - [ ] Make sure all tests pass
  - [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
  - [x] AI assistance was used to create this PR (see the [Strimzi AI
  policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))