### PR TITLE
Removed usage of Vert.x instance within KafkaClusterCreator and BrokersInUseCheck

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheck.java
@@ -6,13 +6,10 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.cluster.model.KafkaCluster;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -23,6 +20,8 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Class which contains several utility function which check if broker scale down or role change can be done or not.
@@ -42,21 +41,20 @@ public class BrokersInUseCheck {
      * Checks if broker contains any partition replicas when scaling down
      *
      * @param reconciliation        Reconciliation marker
-     * @param vertx                 Vert.x instance
      * @param coTlsPemIdentity      Trust set and identity for TLS client authentication for connecting to the Kafka cluster
      * @param adminClientProvider   Used to create the Admin client instance
      *
-     * @return returns future set of node ids containing partition replicas based on the outcome of the check
+     * @return returns CompletionStage with set of node ids containing partition replicas based on the outcome of the check
      */
-    public Future<Set<Integer>> brokersInUse(Reconciliation reconciliation, Vertx vertx, TlsPemIdentity coTlsPemIdentity, AdminClientProvider adminClientProvider) {
+    public CompletionStage<Set<Integer>> brokersInUse(Reconciliation reconciliation, TlsPemIdentity coTlsPemIdentity, AdminClientProvider adminClientProvider) {
         try {
             String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
             LOGGER.debugCr(reconciliation, "Creating AdminClient for Kafka cluster in namespace {}", reconciliation.namespace());
             Admin kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
 
-            return topicNames(reconciliation, vertx, kafkaAdmin)
-                    .compose(names -> describeTopics(reconciliation, vertx, kafkaAdmin, names))
-                    .compose(topicDescriptions -> {
+            return topicNames(kafkaAdmin)
+                    .thenCompose(names -> describeTopics(kafkaAdmin, names))
+                    .thenApply(topicDescriptions -> {
                         Set<Integer> brokersWithPartitionReplicas = new HashSet<>();
 
                         for (TopicDescription td : topicDescriptions.values()) {
@@ -67,41 +65,37 @@ public class BrokersInUseCheck {
                             }
                         }
 
+                        return brokersWithPartitionReplicas;
+                    }).whenComplete((result, error) -> {
+                        if (error != null) {
+                            LOGGER.warnCr(reconciliation, "Failed to get list of brokers in use", error);
+                        }
                         kafkaAdmin.close();
-                        return Future.succeededFuture(brokersWithPartitionReplicas);
-                    }).recover(error -> {
-                        LOGGER.warnCr(reconciliation, "Failed to get list of brokers in use", error);
-                        kafkaAdmin.close();
-                        return Future.failedFuture(error);
                     });
         } catch (KafkaException e) {
             LOGGER.warnCr(reconciliation, "Failed to check if broker contains any partition replicas", e);
-            return Future.failedFuture(e);
+            return CompletableFuture.failedFuture(e);
         }
     }
 
     /**
      * This method gets the topic names after interacting with the Admin client
      *
-     * @param reconciliation      Reconciliation marker
-     * @param vertx               Vert.x instance
      * @param kafkaAdmin          Instance of Kafka Admin
-     * @return  a Future with set of topic names
+     * @return  a CompletionStage with set of topic names
      */
-    /* test */ Future<Set<String>> topicNames(Reconciliation reconciliation, Vertx vertx, Admin kafkaAdmin) {
-        return VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.listTopics(new ListTopicsOptions().listInternal(true)).names());
+    /* test */ CompletionStage<Set<String>> topicNames(Admin kafkaAdmin) {
+        return kafkaAdmin.listTopics(new ListTopicsOptions().listInternal(true)).names().toCompletionStage();
     }
 
     /**
      * Returns a collection of topic descriptions
      *
-     * @param reconciliation Reconciliation marker
-     * @param vertx          Vert.x instance
      * @param kafkaAdmin     Instance of Admin client
      * @param names          Set of topic names
-     * @return a Future with map containing the topic name and description
+     * @return a CompletionStage with map containing the topic name and description
      */
-    /* test */ Future<Map<String, TopicDescription>> describeTopics(Reconciliation reconciliation, Vertx vertx, Admin kafkaAdmin, Set<String> names) {
-        return VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.describeTopics(names).allTopicNames());
+    /* test */ CompletionStage<Map<String, TopicDescription>> describeTopics(Admin kafkaAdmin, Set<String> names) {
+        return kafkaAdmin.describeTopics(names).allTopicNames().toCompletionStage();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -516,8 +516,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                         KafkaClusterCreator kafkaClusterCreator =
                                 new KafkaClusterCreator(reconciliation, config, supplier);
-                        return kafkaClusterCreator
-                                .prepareKafkaCluster(kafkaAssembly, nodePools, oldStorage, versionChange, kafkaStatus, true)
+                        return VertxUtil.toFuture(kafkaClusterCreator
+                                .prepareKafkaCluster(kafkaAssembly, nodePools, oldStorage, versionChange, kafkaStatus, true))
                                 .compose(kafkaCluster -> {
                                     // We store this for use with Cruise Control later. As these configurations might
                                     // not be exactly the same as in the original custom resource (for example because

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -515,7 +515,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         }
 
                         KafkaClusterCreator kafkaClusterCreator =
-                                new KafkaClusterCreator(vertx, reconciliation, config, supplier);
+                                new KafkaClusterCreator(reconciliation, config, supplier);
                         return kafkaClusterCreator
                                 .prepareKafkaCluster(kafkaAssembly, nodePools, oldStorage, versionChange, kafkaStatus, true)
                                 .compose(kafkaCluster -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreator.java
@@ -18,7 +18,6 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
 import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.common.AdminClientProvider;
@@ -27,13 +26,14 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.StatusUtils;
-import io.vertx.core.Future;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 /**
@@ -102,7 +102,7 @@ public class KafkaClusterCreator {
      *
      * @return  New Kafka Cluster instance
      */
-    public Future<KafkaCluster> prepareKafkaCluster(
+    public CompletionStage<KafkaCluster> prepareKafkaCluster(
             Kafka kafkaCr,
             List<KafkaNodePool> nodePools,
             Map<String, Storage> oldStorage,
@@ -110,16 +110,16 @@ public class KafkaClusterCreator {
             KafkaStatus kafkaStatus,
             boolean tryToFixProblems)   {
         return createKafkaCluster(kafkaCr, nodePools, oldStorage, versionChange)
-                .compose(kafka -> brokerRemovalCheck(kafkaCr, kafka))
-                .compose(kafka -> {
+                .thenCompose(kafka -> brokerRemovalCheck(kafkaCr, kafka))
+                .thenCompose(kafka -> {
                     if (checkFailed() && tryToFixProblems)   {
                         // saving scaling down blocked nodes, before they are reverted back
                         this.scalingDownBlockedNodes.addAll(kafka.removedNodes());
                         // We have a failure, and should try to fix issues
                         // Once we fix it, we call this method again, but this time with tryToFixProblems set to false
                         return revertScaleDown(nodePools)
-                                .compose(revertedNodePools -> revertRoleChange(revertedNodePools))
-                                .compose(revertedNodePools -> prepareKafkaCluster(kafkaCr, revertedNodePools, oldStorage, versionChange, kafkaStatus, false));
+                                .thenCompose(revertedNodePools -> revertRoleChange(revertedNodePools))
+                                .thenCompose(revertedNodePools -> prepareKafkaCluster(kafkaCr, revertedNodePools, oldStorage, versionChange, kafkaStatus, false));
                     } else if (checkFailed()) {
                         // We have a failure, but we should not try to fix it
                         List<String> errors = new ArrayList<>();
@@ -132,7 +132,7 @@ public class KafkaClusterCreator {
                             errors.add("Cannot remove the broker role from nodes " + kafka.usedToBeBrokerNodes() + " because they have assigned partition-replicas.");
                         }
 
-                        return Future.failedFuture(new InvalidResourceException("Following errors were found when processing the Kafka custom resource: " + errors));
+                        return CompletableFuture.failedFuture(new InvalidResourceException("Following errors were found when processing the Kafka custom resource: " + errors));
                     } else {
                         // If everything succeeded, we return the KafkaCluster object
                         // If any warning conditions exist from the reverted changes, we add them to the status
@@ -140,7 +140,7 @@ public class KafkaClusterCreator {
                             kafkaStatus.addConditions(warningConditions);
                         }
 
-                        return Future.succeededFuture(kafka);
+                        return CompletableFuture.completedFuture(kafka);
                     }
                 });
     }
@@ -153,15 +153,15 @@ public class KafkaClusterCreator {
      * @param oldStorage        Old storage configuration
      * @param versionChange     Version change descriptor containing any upgrade / downgrade changes
      *
-     * @return  Future with the new KafkaCluster object
+     * @return  CompletionStage with the new KafkaCluster object
      */
-    private Future<KafkaCluster> createKafkaCluster(
+    private CompletionStage<KafkaCluster> createKafkaCluster(
             Kafka kafkaCr,
             List<KafkaNodePool> nodePoolCrs,
             Map<String, Storage> oldStorage,
             KafkaVersionChange versionChange
     )   {
-        return Future.succeededFuture(createKafkaCluster(reconciliation, kafkaCr, nodePoolCrs, oldStorage, versionChange, versions, sharedEnvironmentProvider));
+        return CompletableFuture.completedFuture(createKafkaCluster(reconciliation, kafkaCr, nodePoolCrs, oldStorage, versionChange, versions, sharedEnvironmentProvider));
     }
 
     /**
@@ -171,18 +171,19 @@ public class KafkaClusterCreator {
      * @param kafkaCr   Kafka custom resource
      * @param kafka     Kafka cluster model
      *
-     * @return  Future with the Kafka cluster model
+     * @return  CompletionStage with the Kafka cluster model
      */
-    private Future<KafkaCluster> brokerRemovalCheck(Kafka kafkaCr, KafkaCluster kafka) {
+    private CompletionStage<KafkaCluster> brokerRemovalCheck(Kafka kafkaCr, KafkaCluster kafka) {
         if (skipBrokerScaleDownCheck(kafkaCr) // The check was disabled by the user
                 || (kafka.removedNodes().isEmpty() && kafka.usedToBeBrokerNodes().isEmpty())) { // There is no scale-down or role change, so there is nothing to check
             scaleDownCheckFailed = false;
             usedToBeBrokersCheckFailed = false;
-            return Future.succeededFuture(kafka);
+            return CompletableFuture.completedFuture(kafka);
         } else {
             return ReconcilerUtils.coTlsPemIdentity(reconciliation, secretOperator)
-                    .compose(coTlsPemIdentity -> VertxUtil.toFuture(brokerScaleDownOperations.brokersInUse(reconciliation, coTlsPemIdentity, adminClientProvider)))
-                    .compose(brokersInUse -> {
+                    .toCompletionStage()
+                    .thenCompose(coTlsPemIdentity -> brokerScaleDownOperations.brokersInUse(reconciliation, coTlsPemIdentity, adminClientProvider))
+                    .thenApply(brokersInUse -> {
                         // Check nodes that are being scaled down
                         Set<Integer> scaledDownBrokersInUse = kafka.removedNodes().stream().filter(brokersInUse::contains).collect(Collectors.toSet());
                         if (!scaledDownBrokersInUse.isEmpty()) {
@@ -201,7 +202,7 @@ public class KafkaClusterCreator {
                             usedToBeBrokersCheckFailed = false;
                         }
 
-                        return Future.succeededFuture(kafka);
+                        return kafka;
                     });
         }
     }
@@ -211,9 +212,9 @@ public class KafkaClusterCreator {
      *
      * @param nodePoolCrs   List with KafkaNodePool custom resources
      *
-     * @return  Future with KafkaAndNodePools record containing the fixed Kafka and KafkaNodePool CRs
+     * @return  CompletionStage with KafkaAndNodePools record containing the fixed Kafka and KafkaNodePool CRs
      */
-    private Future<List<KafkaNodePool>> revertScaleDown(List<KafkaNodePool> nodePoolCrs)   {
+    private CompletionStage<List<KafkaNodePool>> revertScaleDown(List<KafkaNodePool> nodePoolCrs)   {
         if (scaleDownCheckFailed) {
             // Node pools are used -> we have to fix scale down in the KafkaNodePools
             List<KafkaNodePool> newNodePools = new ArrayList<>();
@@ -237,10 +238,10 @@ public class KafkaClusterCreator {
                 }
             }
 
-            return Future.succeededFuture(newNodePools);
+            return CompletableFuture.completedFuture(newNodePools);
         } else {
             // The scale-down check did not fail => return the original resources
-            return Future.succeededFuture(nodePoolCrs);
+            return CompletableFuture.completedFuture(nodePoolCrs);
         }
     }
 
@@ -249,9 +250,9 @@ public class KafkaClusterCreator {
      *
      * @param nodePoolCrs   List with KafkaNodePool custom resources
      *
-     * @return  Future with KafkaAndNodePools record containing the fixed Kafka and KafkaNodePool CRs
+     * @return  CompletionStage with KafkaAndNodePools record containing the fixed Kafka and KafkaNodePool CRs
      */
-    private Future<List<KafkaNodePool>> revertRoleChange(List<KafkaNodePool> nodePoolCrs)   {
+    private CompletionStage<List<KafkaNodePool>> revertRoleChange(List<KafkaNodePool> nodePoolCrs)   {
         if (usedToBeBrokersCheckFailed) {
             List<KafkaNodePool> newNodePools = new ArrayList<>();
 
@@ -272,10 +273,10 @@ public class KafkaClusterCreator {
                 }
             }
 
-            return Future.succeededFuture(newNodePools);
+            return CompletableFuture.completedFuture(newNodePools);
         } else {
             // The used-to-be-brokers check did not fail => return the original resources
-            return Future.succeededFuture(nodePoolCrs);
+            return CompletableFuture.completedFuture(nodePoolCrs);
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreator.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
 import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
+import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.common.AdminClientProvider;
@@ -27,7 +28,6 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.StatusUtils;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -47,7 +47,6 @@ public class KafkaClusterCreator {
     private final KafkaVersion.Lookup versions;
 
     // Operators and other tools
-    private final Vertx vertx;
     private final AdminClientProvider adminClientProvider;
     private final SecretOperator secretOperator;
     private final SharedEnvironmentProvider sharedEnvironmentProvider;
@@ -61,13 +60,11 @@ public class KafkaClusterCreator {
     /**
      * Constructor
      *
-     * @param vertx             Vert.x instance
      * @param reconciliation    Reconciliation marker
      * @param config            Cluster Operator configuration
      * @param supplier          Resource Operators supplier
      */
     public KafkaClusterCreator(
-            Vertx vertx,
             Reconciliation reconciliation,
             ClusterOperatorConfig config,
             ResourceOperatorSupplier supplier
@@ -75,7 +72,6 @@ public class KafkaClusterCreator {
         this.reconciliation = reconciliation;
         this.versions = config.versions();
 
-        this.vertx = vertx;
         this.adminClientProvider = supplier.adminClientProvider;
         this.secretOperator = supplier.secretOperations;
         this.sharedEnvironmentProvider = supplier.sharedEnvironmentProvider;
@@ -185,7 +181,7 @@ public class KafkaClusterCreator {
             return Future.succeededFuture(kafka);
         } else {
             return ReconcilerUtils.coTlsPemIdentity(reconciliation, secretOperator)
-                    .compose(coTlsPemIdentity -> brokerScaleDownOperations.brokersInUse(reconciliation, vertx, coTlsPemIdentity, adminClientProvider))
+                    .compose(coTlsPemIdentity -> VertxUtil.toFuture(brokerScaleDownOperations.brokersInUse(reconciliation, coTlsPemIdentity, adminClientProvider)))
                     .compose(brokersInUse -> {
                         // Check nodes that are being scaled down
                         Set<Integer> scaledDownBrokersInUse = kafka.removedNodes().stream().filter(brokersInUse::contains).collect(Collectors.toSet());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
@@ -5,13 +5,8 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.api.kafka.model.kafka.Kafka;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
-import io.vertx.core.Vertx;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
@@ -20,10 +15,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collection;
@@ -37,33 +29,21 @@ import static io.strimzi.operator.common.auth.TlsPemIdentity.DUMMY_IDENTITY;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(VertxExtension.class)
 public class BrokersInUseCheckTest {
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-cluster";
     private static final Reconciliation RECONCILIATION = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME);
     private static final Function<Integer, Node> NODE = id -> new Node(id, Node.noNode().host(), Node.noNode().port());
 
-    private static Vertx vertx;
-
-    @BeforeAll
-    public static void before() {
-        vertx = Vertx.vertx();
-    }
-
-    @AfterAll
-    public static void after() {
-        vertx.close();
-    }
-
     @Test
-    public void testBrokersInUse(VertxTestContext context) {
+    public void testBrokersInUse() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
@@ -85,23 +65,21 @@ public class BrokersInUseCheckTest {
         when(admin.listTopics(any())).thenReturn(ltr);
 
         // Get brokers in use
-        Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
-                .onComplete(context.succeeding(brokersInUse -> {
-                    Collection<String> topicList = topicListCaptor.getValue();
-                    assertThat(topicList.size(), is(3));
-                    assertThat(topicList, hasItems("my-topic", "my-topic2", "my-topic3"));
+        Set<Integer> brokersInUse = operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock)
+                .toCompletableFuture()
+                .join();
 
-                    assertThat(brokersInUse.size(), is(3));
-                    assertThat(brokersInUse, is(Set.of(0, 1, 2)));
+        Collection<String> topicList = topicListCaptor.getValue();
+        assertThat(topicList.size(), is(3));
+        assertThat(topicList, hasItems("my-topic", "my-topic2", "my-topic3"));
 
-                    checkpoint.flag();
-                }));
+        assertThat(brokersInUse.size(), is(3));
+        assertThat(brokersInUse, is(Set.of(0, 1, 2)));
     }
 
     @Test
-    public void testBrokersInUseWithSingleTopicAndMultiplePartitions(VertxTestContext context) {
+    public void testBrokersInUseWithSingleTopicAndMultiplePartitions() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
@@ -118,29 +96,27 @@ public class BrokersInUseCheckTest {
         ArgumentCaptor<Collection<String>> topicListCaptor = ArgumentCaptor.forClass(Collection.class);
         when(admin.describeTopics(topicListCaptor.capture())).thenReturn(dtr);
 
-        // Mock ls foist topics
+        // Mock list topics
         ListTopicsResult ltr = mock(ListTopicsResult.class);
         when(ltr.names()).thenReturn(KafkaFuture.completedFuture(Set.of("my-topic")));
         when(admin.listTopics(any())).thenReturn(ltr);
 
         // Get brokers in use
-        Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
-                .onComplete(context.succeeding(brokersInUse -> {
-                    Collection<String> topicList = topicListCaptor.getValue();
-                    assertThat(topicList.size(), is(1));
-                    assertThat(topicList, hasItems("my-topic"));
+        Set<Integer> brokersInUse = operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock)
+                .toCompletableFuture()
+                .join();
 
-                    assertThat(brokersInUse.size(), is(3));
-                    assertThat(brokersInUse, is(Set.of(0, 1, 4)));
+        Collection<String> topicList = topicListCaptor.getValue();
+        assertThat(topicList.size(), is(1));
+        assertThat(topicList, hasItems("my-topic"));
 
-                    checkpoint.flag();
-                }));
+        assertThat(brokersInUse.size(), is(3));
+        assertThat(brokersInUse, is(Set.of(0, 1, 4)));
     }
 
     @Test
-    public void testTopicDescriptionFailure(VertxTestContext context) {
+    public void testTopicDescriptionFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
@@ -159,19 +135,17 @@ public class BrokersInUseCheckTest {
         when(admin.listTopics(any())).thenReturn(ltr);
 
         // Get brokers in use
-        Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
-                .onComplete(context.failing(e -> {
-                    // CompletionStage wraps exceptions in CompletionException, so check the cause
-                    assertThat(e.getCause().getMessage(), is("Test error ..."));
+        Exception e = assertThrows(Exception.class, () ->
+                operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock)
+                        .toCompletableFuture()
+                        .join());
 
-                    checkpoint.flag();
-                }));
+        assertThat(e.getCause().getMessage(), is("Test error ..."));
     }
 
     @Test
-    public void testListTopicsFailure(VertxTestContext context) {
+    public void testListTopicsFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
@@ -185,19 +159,17 @@ public class BrokersInUseCheckTest {
         when(admin.listTopics(any())).thenReturn(ltr);
 
         // Get brokers in use
-        Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
-                .onComplete(context.failing(e -> {
-                    // CompletionStage wraps exceptions in CompletionException, so check the cause
-                    assertThat(e.getCause().getMessage(), is("Test error ..."));
+        Exception e = assertThrows(Exception.class, () ->
+                operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock)
+                        .toCompletableFuture()
+                        .join());
 
-                    checkpoint.flag();
-                }));
+        assertThat(e.getCause().getMessage(), is("Test error ..."));
     }
 
     @Test
-    public void testKafkaClientFailure(VertxTestContext context) {
+    public void testKafkaClientFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
@@ -206,15 +178,12 @@ public class BrokersInUseCheckTest {
         when(admin.listTopics(any())).thenThrow(new KafkaException("Test error ..."));
 
         // Get brokers in use
-        Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
-                .onComplete(context.failing(e -> {
-                    // This exception is thrown in the try-catch block and returned via CompletableFuture.failedFuture()
-                    // which doesn't wrap it in CompletionException, so we check the message directly
-                    assertThat(e.getMessage(), is("Test error ..."));
+        Exception e = assertThrows(Exception.class, () ->
+                operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock)
+                        .toCompletableFuture()
+                        .join());
 
-                    checkpoint.flag();
-                }));
+        assertThat(e.getCause().getMessage(), is("Test error ..."));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.vertx.core.Vertx;
@@ -29,6 +30,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static io.strimzi.operator.common.auth.TlsPemIdentity.DUMMY_IDENTITY;
@@ -85,7 +87,7 @@ public class BrokersInUseCheckTest {
         // Get brokers in use
         Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        operations.brokersInUse(RECONCILIATION, vertx, DUMMY_IDENTITY, mock)
+        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
                 .onComplete(context.succeeding(brokersInUse -> {
                     Collection<String> topicList = topicListCaptor.getValue();
                     assertThat(topicList.size(), is(3));
@@ -116,7 +118,7 @@ public class BrokersInUseCheckTest {
         ArgumentCaptor<Collection<String>> topicListCaptor = ArgumentCaptor.forClass(Collection.class);
         when(admin.describeTopics(topicListCaptor.capture())).thenReturn(dtr);
 
-        // Mock list topics
+        // Mock ls foist topics
         ListTopicsResult ltr = mock(ListTopicsResult.class);
         when(ltr.names()).thenReturn(KafkaFuture.completedFuture(Set.of("my-topic")));
         when(admin.listTopics(any())).thenReturn(ltr);
@@ -124,7 +126,7 @@ public class BrokersInUseCheckTest {
         // Get brokers in use
         Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        operations.brokersInUse(RECONCILIATION, vertx, DUMMY_IDENTITY, mock)
+        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
                 .onComplete(context.succeeding(brokersInUse -> {
                     Collection<String> topicList = topicListCaptor.getValue();
                     assertThat(topicList.size(), is(1));
@@ -146,11 +148,7 @@ public class BrokersInUseCheckTest {
         // Mock topic description
         @SuppressWarnings(value = "unchecked")
         KafkaFuture<Map<String, TopicDescription>> kf = mock(KafkaFuture.class);
-        when(kf.whenComplete(any())).thenAnswer(i -> {
-            KafkaFuture.BiConsumer<Void, Throwable> action = i.getArgument(0);
-            action.accept(null, new Throwable("Test error ..."));
-            return null;
-        });
+        when(kf.toCompletionStage()).thenReturn(CompletableFuture.failedFuture(new Throwable("Test error ...")));
         DescribeTopicsResult dtr = mock(DescribeTopicsResult.class);
         when(dtr.allTopicNames()).thenReturn(kf);
         when(admin.describeTopics(anyCollection())).thenReturn(dtr);
@@ -163,9 +161,10 @@ public class BrokersInUseCheckTest {
         // Get brokers in use
         Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        operations.brokersInUse(RECONCILIATION, vertx, DUMMY_IDENTITY, mock)
+        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
                 .onComplete(context.failing(e -> {
-                    assertThat(e.getMessage(), is("Test error ..."));
+                    // CompletionStage wraps exceptions in CompletionException, so check the cause
+                    assertThat(e.getCause().getMessage(), is("Test error ..."));
 
                     checkpoint.flag();
                 }));
@@ -180,11 +179,7 @@ public class BrokersInUseCheckTest {
         // Mock list topics
         @SuppressWarnings(value = "unchecked")
         KafkaFuture<Set<String>> kf = mock(KafkaFuture.class);
-        when(kf.whenComplete(any())).thenAnswer(i -> {
-            KafkaFuture.BiConsumer<Void, Throwable> action = i.getArgument(0);
-            action.accept(null, new Throwable("Test error ..."));
-            return null;
-        });
+        when(kf.toCompletionStage()).thenReturn(CompletableFuture.failedFuture(new Throwable("Test error ...")));
         ListTopicsResult ltr = mock(ListTopicsResult.class);
         when(ltr.names()).thenReturn(kf);
         when(admin.listTopics(any())).thenReturn(ltr);
@@ -192,9 +187,10 @@ public class BrokersInUseCheckTest {
         // Get brokers in use
         Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        operations.brokersInUse(RECONCILIATION, vertx, DUMMY_IDENTITY, mock)
+        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
                 .onComplete(context.failing(e -> {
-                    assertThat(e.getMessage(), is("Test error ..."));
+                    // CompletionStage wraps exceptions in CompletionException, so check the cause
+                    assertThat(e.getCause().getMessage(), is("Test error ..."));
 
                     checkpoint.flag();
                 }));
@@ -212,8 +208,10 @@ public class BrokersInUseCheckTest {
         // Get brokers in use
         Checkpoint checkpoint = context.checkpoint();
         BrokersInUseCheck operations = new BrokersInUseCheck();
-        operations.brokersInUse(RECONCILIATION, vertx, DUMMY_IDENTITY, mock)
+        VertxUtil.toFuture(operations.brokersInUse(RECONCILIATION, DUMMY_IDENTITY, mock))
                 .onComplete(context.failing(e -> {
+                    // This exception is thrown in the try-catch block and returned via CompletableFuture.failedFuture()
+                    // which doesn't wrap it in CompletionException, so we check the message directly
                     assertThat(e.getMessage(), is("Test error ..."));
 
                     checkpoint.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class BrokersInUseCheckTest {
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-cluster";
@@ -45,7 +46,6 @@ public class BrokersInUseCheckTest {
     private static final Function<Integer, Node> NODE = id -> new Node(id, Node.noNode().host(), Node.noNode().port());
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testBrokersInUse() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -82,7 +82,6 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testBrokersInUseWithSingleTopicAndMultiplePartitions() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -120,7 +119,6 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testTopicDescriptionFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -150,7 +148,6 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testListTopicsFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -175,7 +172,6 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testKafkaClientFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheckTest.java
@@ -16,6 +16,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collection;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static io.strimzi.operator.common.auth.TlsPemIdentity.DUMMY_IDENTITY;
@@ -43,6 +45,7 @@ public class BrokersInUseCheckTest {
     private static final Function<Integer, Node> NODE = id -> new Node(id, Node.noNode().host(), Node.noNode().port());
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testBrokersInUse() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -79,6 +82,7 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testBrokersInUseWithSingleTopicAndMultiplePartitions() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -116,6 +120,7 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testTopicDescriptionFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -145,6 +150,7 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testListTopicsFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);
@@ -169,6 +175,7 @@ public class BrokersInUseCheckTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testKafkaClientFailure() {
         Admin admin = mock(Admin.class);
         AdminClientProvider mock = mock(AdminClientProvider.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -89,7 +89,6 @@ import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.concurrent.CrdOperator;
 import io.strimzi.platform.KubernetesVersion;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.junit5.Checkpoint;
@@ -1082,7 +1081,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock broker scale down operation
         BrokersInUseCheck operations = supplier.brokersInUseCheck;
-        when(operations.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of()));
+        when(operations.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of()));
 
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 CERT_MANAGER,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
@@ -23,11 +23,13 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -180,6 +182,7 @@ public class KafkaClusterCreatorTest {
     //////////////////////////////////////////////////
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testNewClusterWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -204,6 +207,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testNewClusterWithMixedNodesKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -228,6 +232,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testExistingClusterWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -252,6 +257,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testExistingClusterWithMixedNodesKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -276,6 +282,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertScaleDownWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -312,6 +319,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertScaleDownWithKRaftMixedNodes() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -344,6 +352,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testCorrectScaleDownWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -372,6 +381,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testThrowsRevertScaleDownFailsWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -400,6 +410,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testSkipScaleDownCheckWithKRaft() throws Exception {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()
@@ -430,6 +441,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertRoleChangeWithKRaftMixedNodes() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -465,6 +477,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertRoleChangeWithKRaftDedicatedNodes() throws Exception {
         KafkaNodePool poolBFromBrokerToControllerOnly = new KafkaNodePoolBuilder(POOL_B_WITH_STATUS)
                 .editSpec()
@@ -506,6 +519,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testCorrectRoleChangeWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -535,6 +549,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testThrowsRevertBrokerChangeFailsWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -563,6 +578,7 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testSkipRoleChangeCheckWithKRaft() throws Exception {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
@@ -21,7 +21,6 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.junit5.Checkpoint;
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -205,7 +205,7 @@ public class KafkaClusterCreatorTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS, POOL_A, POOL_B), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -220,7 +220,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -231,7 +231,7 @@ public class KafkaClusterCreatorTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -246,7 +246,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -257,7 +257,7 @@ public class KafkaClusterCreatorTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -272,7 +272,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -283,7 +283,7 @@ public class KafkaClusterCreatorTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -298,7 +298,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -310,10 +310,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 1003, 2004)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(1000, 1001, 1002, 1003, 2004)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -336,7 +336,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions().get(1).getMessage(), is("Reverting scale-down of KafkaNodePool pool-b by changing number of replicas to 5"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(2)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(2)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -348,10 +348,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(3000, 3001, 3002, 3003)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(3000, 3001, 3002, 3003)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -370,7 +370,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-mixed by changing number of replicas to 5"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -382,10 +382,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -400,7 +400,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down reverted => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -412,10 +412,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1003, 1004, 2003, 2004)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(1003, 1004, 2003, 2004)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
@@ -428,7 +428,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down failed => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -445,7 +445,7 @@ public class KafkaClusterCreatorTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(kafka, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
@@ -460,7 +460,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down check skipped => should be never called
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -472,10 +472,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -497,7 +497,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-mixed (setting roles to [CONTROLLER, BROKER])"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -515,10 +515,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS, POOL_A_WITH_STATUS, poolBFromBrokerToControllerOnly), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -540,7 +540,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-b (setting roles to [BROKER])"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -552,10 +552,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 20022)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(1000, 1001, 1002, 2000, 2001, 20022)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
@@ -571,7 +571,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down reverted => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -583,10 +583,10 @@ public class KafkaClusterCreatorTest {
 
         // Mock brokers-in-use check
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
-        when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(3000, 3002)));
+        when(brokersInUseOps.brokersInUse(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(Set.of(3000, 3002)));
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
@@ -599,7 +599,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down failed => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));
@@ -616,7 +616,7 @@ public class KafkaClusterCreatorTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
-        KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
+        KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
         creator.prepareKafkaCluster(kafka, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
@@ -632,7 +632,7 @@ public class KafkaClusterCreatorTest {
                     assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down check skipped => should be never called
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
+                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class KafkaClusterCreatorTest {
     private final static String NAMESPACE = "my-ns";
     private final static String CLUSTER_NAME = "my-cluster";
@@ -182,7 +183,6 @@ public class KafkaClusterCreatorTest {
     //////////////////////////////////////////////////
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testNewClusterWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -207,7 +207,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testNewClusterWithMixedNodesKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -232,7 +231,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testExistingClusterWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -257,7 +255,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testExistingClusterWithMixedNodesKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -282,7 +279,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertScaleDownWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -319,7 +315,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertScaleDownWithKRaftMixedNodes() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -352,7 +347,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testCorrectScaleDownWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -381,7 +375,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testThrowsRevertScaleDownFailsWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -410,7 +403,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testSkipScaleDownCheckWithKRaft() throws Exception {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()
@@ -441,7 +433,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertRoleChangeWithKRaftMixedNodes() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -477,7 +468,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testRevertRoleChangeWithKRaftDedicatedNodes() throws Exception {
         KafkaNodePool poolBFromBrokerToControllerOnly = new KafkaNodePoolBuilder(POOL_B_WITH_STATUS)
                 .editSpec()
@@ -519,7 +509,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testCorrectRoleChangeWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -549,7 +538,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testThrowsRevertBrokerChangeFailsWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -578,7 +566,6 @@ public class KafkaClusterCreatorTest {
     }
 
     @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testSkipRoleChangeCheckWithKRaft() throws Exception {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
@@ -16,20 +16,13 @@ import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
-import io.vertx.core.Vertx;
-import io.vertx.core.WorkerExecutor;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Map;
@@ -42,13 +35,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(VertxExtension.class)
 public class KafkaClusterCreatorTest {
     private final static String NAMESPACE = "my-ns";
     private final static String CLUSTER_NAME = "my-cluster";
@@ -181,131 +174,109 @@ public class KafkaClusterCreatorTest {
             .endStatus()
             .build();
 
-    private static Vertx vertx;
-    private static WorkerExecutor sharedWorkerExecutor;
-
-    @BeforeAll
-    public static void beforeAll()  {
-        vertx = Vertx.vertx();
-        sharedWorkerExecutor = vertx.createSharedWorkerExecutor("kubernetes-ops-pool");
-    }
-
-    @AfterAll
-    public static void afterAll()    {
-        sharedWorkerExecutor.close();
-        vertx.close();
-    }
 
     //////////////////////////////////////////////////
     // KRaft tests
     //////////////////////////////////////////////////
 
     @Test
-    public void testNewClusterWithKRaft(VertxTestContext context) {
+    public void testNewClusterWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS, POOL_A, POOL_B), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2, 3, 4, 5, 6, 7, 8)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS, POOL_A, POOL_B), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2, 3, 4, 5, 6, 7, 8)));
+        assertThat(kc.removedNodes(), is(Set.of()));
 
-                    // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // No scale-down => scale-down check is not done
+        verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testNewClusterWithMixedNodesKRaft(VertxTestContext context) {
+    public void testNewClusterWithMixedNodesKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(3));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(3));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2)));
+        assertThat(kc.removedNodes(), is(Set.of()));
 
-                    // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // No scale-down => scale-down check is not done
+        verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testExistingClusterWithKRaft(VertxTestContext context) {
+    public void testExistingClusterWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of()));
 
-                    // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // No scale-down => scale-down check is not done
+        verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testExistingClusterWithMixedNodesKRaft(VertxTestContext context) {
+    public void testExistingClusterWithMixedNodesKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(3));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(3));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of()));
 
-                    // No scale-down => scale-down check is not done
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // No scale-down => scale-down check is not done
+        verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testRevertScaleDownWithKRaft(VertxTestContext context) {
+    public void testRevertScaleDownWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -315,35 +286,33 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(13));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 1003, 1004, 2000, 2001, 2002, 2003, 2004, 3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of(3003, 3004))); // Controllers are not affected
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions().size(), is(2));
-                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
-                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
-                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
-                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-a by changing number of replicas to 5"));
-                    assertThat(kafkaStatus.getConditions().get(1).getStatus(), is("True"));
-                    assertThat(kafkaStatus.getConditions().get(1).getType(), is("Warning"));
-                    assertThat(kafkaStatus.getConditions().get(1).getReason(), is("ScaleDownPreventionCheck"));
-                    assertThat(kafkaStatus.getConditions().get(1).getMessage(), is("Reverting scale-down of KafkaNodePool pool-b by changing number of replicas to 5"));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(13));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 1003, 1004, 2000, 2001, 2002, 2003, 2004, 3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of(3003, 3004))); // Controllers are not affected
 
-                    // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(2)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions().size(), is(2));
+        assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+        assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+        assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+        assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-a by changing number of replicas to 5"));
+        assertThat(kafkaStatus.getConditions().get(1).getStatus(), is("True"));
+        assertThat(kafkaStatus.getConditions().get(1).getType(), is("Warning"));
+        assertThat(kafkaStatus.getConditions().get(1).getReason(), is("ScaleDownPreventionCheck"));
+        assertThat(kafkaStatus.getConditions().get(1).getMessage(), is("Reverting scale-down of KafkaNodePool pool-b by changing number of replicas to 5"));
 
-                    async.flag();
-                })));
+        // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
+        verify(supplier.brokersInUseCheck, times(2)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testRevertScaleDownWithKRaftMixedNodes(VertxTestContext context) {
+    public void testRevertScaleDownWithKRaftMixedNodes() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -353,31 +322,29 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(5));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002, 3003, 3004)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions().size(), is(1));
-                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
-                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
-                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
-                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-mixed by changing number of replicas to 5"));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(5));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002, 3003, 3004)));
+        assertThat(kc.removedNodes(), is(Set.of()));
 
-                    // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions().size(), is(1));
+        assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+        assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+        assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+        assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-mixed by changing number of replicas to 5"));
 
-                    async.flag();
-                })));
+        // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testCorrectScaleDownWithKRaft(VertxTestContext context) {
+    public void testCorrectScaleDownWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -387,27 +354,25 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004, 3003, 3004)));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004, 3003, 3004)));
 
-                    // Scale-down reverted => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // Scale-down reverted => should be called once
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testThrowsRevertScaleDownFailsWithKRaft(VertxTestContext context) {
+    public void testThrowsRevertScaleDownFailsWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -417,25 +382,25 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
-                .onComplete(context.failing(ex -> context.verify(() -> {
-                    // Check exception
-                    assertThat(ex, instanceOf(InvalidResourceException.class));
-                    assertThat(ex.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot scale-down Kafka brokers [3003, 3004, 1003, 1004, 2003, 2004] because they have assigned partition-replicas.]"));
+        Exception e = assertThrows(Exception.class, () ->
+                creator.prepareKafkaCluster(KAFKA, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
+                        .toCompletableFuture()
+                        .join());
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // CompletionStage wraps exceptions in CompletionException
+        Throwable cause = e.getCause();
+        assertThat(cause, instanceOf(InvalidResourceException.class));
+        assertThat(cause.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot scale-down Kafka brokers [3003, 3004, 1003, 1004, 2003, 2004] because they have assigned partition-replicas.]"));
 
-                    // Scale-down failed => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // Scale-down failed => should be called once
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testSkipScaleDownCheckWithKRaft(VertxTestContext context) {
+    public void testSkipScaleDownCheckWithKRaft() throws Exception {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_SKIP_BROKER_SCALEDOWN_CHECK, "true")
@@ -447,27 +412,25 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(kafka, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004, 3003, 3004)));
+        KafkaCluster kc = creator.prepareKafkaCluster(kafka, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004, 3003, 3004)));
 
-                    // Scale-down check skipped => should be never called
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // Scale-down check skipped => should be never called
+        verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testRevertRoleChangeWithKRaftMixedNodes(VertxTestContext context) {
+    public void testRevertRoleChangeWithKRaftMixedNodes() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -477,34 +440,32 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.brokerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.controllerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
-                    assertThat(kc.usedToBeBrokerNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions().size(), is(1));
-                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
-                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
-                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
-                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-mixed (setting roles to [CONTROLLER, BROKER])"));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.brokerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.controllerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of()));
+        assertThat(kc.usedToBeBrokerNodes(), is(Set.of()));
 
-                    // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions().size(), is(1));
+        assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+        assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+        assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+        assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-mixed (setting roles to [CONTROLLER, BROKER])"));
 
-                    async.flag();
-                })));
+        // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testRevertRoleChangeWithKRaftDedicatedNodes(VertxTestContext context) {
+    public void testRevertRoleChangeWithKRaftDedicatedNodes() throws Exception {
         KafkaNodePool poolBFromBrokerToControllerOnly = new KafkaNodePoolBuilder(POOL_B_WITH_STATUS)
                 .editSpec()
                     .withRoles(ProcessRoles.CONTROLLER)
@@ -520,34 +481,32 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS, POOL_A_WITH_STATUS, poolBFromBrokerToControllerOnly), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.brokerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.controllerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
-                    assertThat(kc.usedToBeBrokerNodes(), is(Set.of()));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_WITH_STATUS, POOL_A_WITH_STATUS, poolBFromBrokerToControllerOnly), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions().size(), is(1));
-                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
-                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
-                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
-                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-b (setting roles to [BROKER])"));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.brokerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.controllerNodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of()));
+        assertThat(kc.usedToBeBrokerNodes(), is(Set.of()));
 
-                    // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions().size(), is(1));
+        assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+        assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+        assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+        assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-b (setting roles to [BROKER])"));
 
-                    async.flag();
-                })));
+        // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testCorrectRoleChangeWithKRaft(VertxTestContext context) {
+    public void testCorrectRoleChangeWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -557,28 +516,26 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
-                    assertThat(kc.usedToBeBrokerNodes(), is(Set.of(3000, 3001, 3002)));
+        KafkaCluster kc = creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, true)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of()));
+        assertThat(kc.usedToBeBrokerNodes(), is(Set.of(3000, 3001, 3002)));
 
-                    // Scale-down reverted => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // Scale-down reverted => should be called once
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testThrowsRevertBrokerChangeFailsWithKRaft(VertxTestContext context) {
+    public void testThrowsRevertBrokerChangeFailsWithKRaft() throws Exception {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         // Mock brokers-in-use check
@@ -588,25 +545,25 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
-                .onComplete(context.failing(ex -> context.verify(() -> {
-                    // Check exception
-                    assertThat(ex, instanceOf(InvalidResourceException.class));
-                    assertThat(ex.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot remove the broker role from nodes [3000, 3001, 3002] because they have assigned partition-replicas.]"));
+        Exception e = assertThrows(Exception.class, () ->
+                creator.prepareKafkaCluster(KAFKA, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
+                        .toCompletableFuture()
+                        .join());
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // CompletionStage wraps exceptions in CompletionException
+        Throwable cause = e.getCause();
+        assertThat(cause, instanceOf(InvalidResourceException.class));
+        assertThat(cause.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot remove the broker role from nodes [3000, 3001, 3002] because they have assigned partition-replicas.]"));
 
-                    // Scale-down failed => should be called once
-                    verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // Scale-down failed => should be called once
+        verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any());
     }
 
     @Test
-    public void testSkipRoleChangeCheckWithKRaft(VertxTestContext context) {
+    public void testSkipRoleChangeCheckWithKRaft() throws Exception {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_SKIP_BROKER_SCALEDOWN_CHECK, "true")
@@ -618,23 +575,21 @@ public class KafkaClusterCreatorTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(RECONCILIATION, CO_CONFIG, supplier);
 
-        Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(kafka, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
-                .onComplete(context.succeeding(kc -> context.verify(() -> {
-                    // Kafka cluster is created
-                    assertThat(kc, is(notNullValue()));
-                    assertThat(kc.nodes().size(), is(9));
-                    assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
-                    assertThat(kc.removedNodes(), is(Set.of()));
-                    assertThat(kc.usedToBeBrokerNodes(), is(Set.of(3000, 3001, 3002)));
+        KafkaCluster kc = creator.prepareKafkaCluster(kafka, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, kafkaStatus, false)
+                .toCompletableFuture()
+                .join();
 
-                    // Check the status conditions
-                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
+        // Kafka cluster is created
+        assertThat(kc, is(notNullValue()));
+        assertThat(kc.nodes().size(), is(9));
+        assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
+        assertThat(kc.removedNodes(), is(Set.of()));
+        assertThat(kc.usedToBeBrokerNodes(), is(Set.of(3000, 3001, 3002)));
 
-                    // Scale-down check skipped => should be never called
-                    verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
+        // Check the status conditions
+        assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
-                    async.flag();
-                })));
+        // Scale-down check skipped => should be never called
+        verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any());
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the need for having the `KafkaClusterCreator` passing a Vert.x instance to the `BrokersInUseCheck` and moves to the usage of CompletionStage and CompletableFuture.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
