### PR TITLE
Making the KRaftMetadataManager class being Vert.x free

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -7,21 +7,19 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.operator.cluster.model.KafkaCluster;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.StatusUtils;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.FeatureUpdate;
 import org.apache.kafka.clients.admin.UpdateFeaturesOptions;
 import org.apache.kafka.server.common.MetadataVersion;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Utility class for managing the KRaft metadata version. It encapsulates the methods for getting the current metadata
@@ -54,17 +52,15 @@ public class KRaftMetadataManager {
      * manually.
      *
      * @param reconciliation            Reconciliation marker
-     * @param vertx                     Vert.x instance
      * @param coTlsPemIdentity          Trust set and identity for TLS client authentication for connecting to the Kafka cluster
      * @param adminClientProvider       Kafka Admin client provider
      * @param desiredMetadataVersion    Desired metadata version
      * @param status                    Kafka status
      *
-     * @return  Future that completes when the metadata update is finished (or was not needed) and the status is updated
+     * @return  CompletionStage that completes when the metadata update is finished (or was not needed) and the status is updated
      */
-    public static Future<Void> maybeUpdateMetadataVersion(
+    public static CompletionStage<Void> maybeUpdateMetadataVersion(
             Reconciliation reconciliation,
-            Vertx vertx,
             TlsPemIdentity coTlsPemIdentity,
             AdminClientProvider adminClientProvider,
             String desiredMetadataVersion,
@@ -74,29 +70,24 @@ public class KRaftMetadataManager {
         LOGGER.debugCr(reconciliation, "Creating AdminClient for Kafka cluster in namespace {}", reconciliation.namespace());
         Admin kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
 
-        Promise<Void> updatePromise = Promise.promise();
-        maybeUpdateMetadataVersion(reconciliation, vertx, kafkaAdmin, desiredMetadataVersion, status)
-                .onComplete(res -> {
+        return maybeUpdateMetadataVersion(reconciliation, kafkaAdmin, desiredMetadataVersion, status)
+                .whenComplete((result, error) -> {
                     // Close the Admin client and return the original result
                     LOGGER.debugCr(reconciliation, "Closing the Kafka Admin API connection");
                     kafkaAdmin.close();
-                    updatePromise.handle(res);
                 });
-
-        return updatePromise.future();
     }
 
-    private static Future<Void> maybeUpdateMetadataVersion(
+    private static CompletionStage<Void> maybeUpdateMetadataVersion(
             Reconciliation reconciliation,
-            Vertx vertx,
             Admin kafkaAdmin,
             String desiredMetadataVersion,
             KafkaStatus status
     )    {
         short desiredMetadataLevel = MetadataVersion.fromVersionString(desiredMetadataVersion, false).featureLevel();
 
-        return currentVersion(reconciliation, vertx, kafkaAdmin)
-                .compose(currentMetadataLevel -> {
+        return currentVersion(reconciliation, kafkaAdmin)
+                .thenCompose(currentMetadataLevel -> {
                     if (currentMetadataLevel.equals(desiredMetadataLevel))  {
                         // No metadata version change as the current and desired versions are equal
                         // We convert the metadata level to the version for the use in the status instead of using the
@@ -104,58 +95,56 @@ public class KRaftMetadataManager {
                         String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString();
                         LOGGER.debugCr(reconciliation, "Metadata version is already set to the desired version {}", metadataVersion);
                         status.setKafkaMetadataVersion(MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString());
-                        return Future.succeededFuture();
+                        return CompletableFuture.completedFuture(null);
                     } else {
-                        Promise<Void> promise = Promise.promise();
-
-                        updateVersion(reconciliation, vertx, kafkaAdmin, currentMetadataLevel, desiredMetadataLevel)
-                                .onComplete(res -> {
-                                    if (res.succeeded())    {
+                        CompletableFuture<Void> result = new CompletableFuture<>();
+                        updateVersion(reconciliation, kafkaAdmin, currentMetadataLevel, desiredMetadataLevel)
+                                .whenComplete((voidResult, error) -> {
+                                    if (error == null) {
                                         // We convert the metadata level to the version for the use in the status instead of using the
                                         // desired version directly in order to get the full version including the subversion
                                         String metadataVersion = MetadataVersion.fromFeatureLevel(desiredMetadataLevel).toString();
                                         LOGGER.infoCr(reconciliation, "Successfully updated metadata version to {}", metadataVersion);
                                         status.setKafkaMetadataVersion(metadataVersion);
-                                        promise.complete();
+                                        result.complete(null);
                                     } else {
                                         // We failed to update the metadata version, but we do not want to break the
                                         // reconciliation. We log the error and update the metadata version status.
-                                        currentVersion(reconciliation, vertx, kafkaAdmin)
-                                                .compose(currentMetadataLevelAfterFailure -> {
-                                                    String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevelAfterFailure).toString();
-                                                    LOGGER.warnCr(reconciliation, "Failed to update metadata version to {} (the current version is {})", desiredMetadataVersion, metadataVersion, res.cause());
-                                                    status.addCondition(StatusUtils.buildWarningCondition("MetadataUpdateFailed", "Failed to update metadata version to " + desiredMetadataVersion));
-                                                    status.setKafkaMetadataVersion(metadataVersion);
-
-                                                    promise.complete();
-                                                    return Future.succeededFuture();
+                                        currentVersion(reconciliation, kafkaAdmin)
+                                                .whenComplete((currentMetadataLevelAfterFailure, e) -> {
+                                                    if (e == null) {
+                                                        String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevelAfterFailure).toString();
+                                                        LOGGER.warnCr(reconciliation, "Failed to update metadata version to {} (the current version is {})", desiredMetadataVersion, metadataVersion, error);
+                                                        status.addCondition(StatusUtils.buildWarningCondition("MetadataUpdateFailed", "Failed to update metadata version to " + desiredMetadataVersion));
+                                                        status.setKafkaMetadataVersion(metadataVersion);
+                                                        result.complete(null);
+                                                    } else {
+                                                        result.completeExceptionally(e);
+                                                    }
                                                 });
                                     }
                                 });
-
-                        return promise.future();
+                        return result;
                     }
                 });
     }
 
-    private static Future<Short> currentVersion(
+    private static CompletionStage<Short> currentVersion(
             Reconciliation reconciliation,
-            Vertx vertx,
             Admin kafkaAdmin
     )  {
-        return VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.describeFeatures().featureMetadata())
-                .compose(featureMetadata -> {
+        return kafkaAdmin.describeFeatures().featureMetadata().toCompletionStage()
+                .thenCompose(featureMetadata -> {
                     if (featureMetadata.finalizedFeatures().get(METADATA_VERSION_KEY) != null)  {
-                        return Future.succeededFuture(featureMetadata.finalizedFeatures().get(METADATA_VERSION_KEY).maxVersionLevel());
+                        return CompletableFuture.completedFuture(featureMetadata.finalizedFeatures().get(METADATA_VERSION_KEY).maxVersionLevel());
                     } else {
-                        return Future.failedFuture("Failed to describe " + METADATA_VERSION_KEY + " feature");
+                        return CompletableFuture.failedFuture(new RuntimeException("Failed to describe " + METADATA_VERSION_KEY + " feature"));
                     }
                 });
     }
 
-    private static Future<Void> updateVersion(
+    private static CompletionStage<Void> updateVersion(
             Reconciliation reconciliation,
-            Vertx vertx,
             Admin kafkaAdmin,
             short currentMetadataLevel,
             short desiredMetadataLevel
@@ -166,8 +155,6 @@ public class KRaftMetadataManager {
 
         LOGGER.infoCr(reconciliation, "Updating metadata version from {} to {}", MetadataVersion.fromFeatureLevel(currentMetadataLevel), MetadataVersion.fromFeatureLevel(desiredMetadataLevel));
 
-        return VertxUtil
-                .kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.updateFeatures(Map.of(METADATA_VERSION_KEY, featureUpdate), options).values().get(METADATA_VERSION_KEY))
-                .mapEmpty();
+        return kafkaAdmin.updateFeatures(Map.of(METADATA_VERSION_KEY, featureUpdate), options).values().get(METADATA_VERSION_KEY).toCompletionStage();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -97,34 +97,27 @@ public class KRaftMetadataManager {
                         status.setKafkaMetadataVersion(MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString());
                         return CompletableFuture.completedFuture(null);
                     } else {
-                        CompletableFuture<Void> result = new CompletableFuture<>();
-                        updateVersion(reconciliation, kafkaAdmin, currentMetadataLevel, desiredMetadataLevel)
-                                .whenComplete((voidResult, error) -> {
-                                    if (error == null) {
-                                        // We convert the metadata level to the version for the use in the status instead of using the
-                                        // desired version directly in order to get the full version including the subversion
-                                        String metadataVersion = MetadataVersion.fromFeatureLevel(desiredMetadataLevel).toString();
-                                        LOGGER.infoCr(reconciliation, "Successfully updated metadata version to {}", metadataVersion);
-                                        status.setKafkaMetadataVersion(metadataVersion);
-                                        result.complete(null);
-                                    } else {
-                                        // We failed to update the metadata version, but we do not want to break the
-                                        // reconciliation. We log the error and update the metadata version status.
-                                        currentVersion(reconciliation, kafkaAdmin)
-                                                .whenComplete((currentMetadataLevelAfterFailure, e) -> {
-                                                    if (e == null) {
-                                                        String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevelAfterFailure).toString();
-                                                        LOGGER.warnCr(reconciliation, "Failed to update metadata version to {} (the current version is {})", desiredMetadataVersion, metadataVersion, error);
-                                                        status.addCondition(StatusUtils.buildWarningCondition("MetadataUpdateFailed", "Failed to update metadata version to " + desiredMetadataVersion));
-                                                        status.setKafkaMetadataVersion(metadataVersion);
-                                                        result.complete(null);
-                                                    } else {
-                                                        result.completeExceptionally(e);
-                                                    }
-                                                });
-                                    }
+                        return updateVersion(reconciliation, kafkaAdmin, currentMetadataLevel, desiredMetadataLevel)
+                                .thenCompose(voidResult -> {
+                                    // We convert the metadata level to the version for the use in the status instead of using the
+                                    // desired version directly in order to get the full version including the subversion
+                                    String metadataVersion = MetadataVersion.fromFeatureLevel(desiredMetadataLevel).toString();
+                                    LOGGER.infoCr(reconciliation, "Successfully updated metadata version to {}", metadataVersion);
+                                    status.setKafkaMetadataVersion(metadataVersion);
+                                    return CompletableFuture.<Void>completedFuture(null);
+                                })
+                                .exceptionallyCompose(error -> {
+                                    // We failed to update the metadata version, but we do not want to break the
+                                    // reconciliation. We log the error and update the metadata version status.
+                                    return currentVersion(reconciliation, kafkaAdmin)
+                                            .thenCompose(currentMetadataLevelAfterFailure -> {
+                                                String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevelAfterFailure).toString();
+                                                LOGGER.warnCr(reconciliation, "Failed to update metadata version to {} (the current version is {})", desiredMetadataVersion, metadataVersion, error);
+                                                status.addCondition(StatusUtils.buildWarningCondition("MetadataUpdateFailed", "Failed to update metadata version to " + desiredMetadataVersion));
+                                                status.setKafkaMetadataVersion(metadataVersion);
+                                                return CompletableFuture.completedFuture(null);
+                                            });
                                 });
-                        return result;
                     }
                 });
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1088,7 +1088,7 @@ public class KafkaReconciler {
      * @return  Future which completes when the KRaft metadata version is set to the current version or updated.
      */
     protected Future<Void> metadataVersion(KafkaStatus kafkaStatus) {
-        return KRaftMetadataManager.maybeUpdateMetadataVersion(reconciliation, vertx, this.coTlsPemIdentity, adminClientProvider, kafka.getMetadataVersion(), kafkaStatus);
+        return VertxUtil.toFuture(KRaftMetadataManager.maybeUpdateMetadataVersion(reconciliation, this.coTlsPemIdentity, adminClientProvider, kafka.getMetadataVersion(), kafkaStatus));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManagerTest.java
@@ -7,10 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
-import io.vertx.core.Vertx;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeFeaturesResult;
 import org.apache.kafka.clients.admin.FeatureMetadata;
@@ -19,19 +15,20 @@ import org.apache.kafka.clients.admin.FinalizedVersionRange;
 import org.apache.kafka.clients.admin.UpdateFeaturesResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.errors.InvalidUpdateVersionException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.operator.common.auth.TlsPemIdentity.DUMMY_IDENTITY;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -40,19 +37,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(VertxExtension.class)
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class KRaftMetadataManagerTest {
-    private static Vertx vertx;
-
-    @BeforeAll
-    public static void before() {
-        vertx = Vertx.vertx();
-    }
-
-    @AfterAll
-    public static void after() {
-        vertx.close();
-    }
 
     private AdminClientProvider mockAdminClientProvider(Admin adminClient)  {
         AdminClientProvider mockAdminClientProvider = mock(AdminClientProvider.class);
@@ -75,7 +61,7 @@ public class KRaftMetadataManagerTest {
     }
 
     @Test
-    public void testNoMetadataVersionChange(VertxTestContext context)   {
+    public void testNoMetadataVersionChange()   {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -88,57 +74,18 @@ public class KRaftMetadataManagerTest {
         // Dummy KafkaStatus to check the values from
         KafkaStatus status = new KafkaStatus();
 
-        Checkpoint checkpoint = context.checkpoint();
-        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, DUMMY_IDENTITY, mockAdminClientProvider, "3.6-IV1", status)
-                .onComplete(context.succeeding(s -> {
-                    assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.6-IV1", status)
+                .toCompletableFuture()
+                .join();
 
-                    verify(mockAdminClient, never()).updateFeatures(any(), any());
-                    verify(mockAdminClient, times(1)).describeFeatures();
+        assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
 
-                    checkpoint.flag();
-                }));
+        verify(mockAdminClient, never()).updateFeatures(any(), any());
+        verify(mockAdminClient, times(1)).describeFeatures();
     }
 
     @Test
-    public void testSuccessfulMetadataVersionUpgrade(VertxTestContext context)   {
-        // Mock the Admin client
-        Admin mockAdminClient = mock(Admin.class);
-
-        // Mock describing the current metadata version
-        mockDescribeVersion(mockAdminClient);
-
-        // Mock updating metadata version
-        UpdateFeaturesResult ufr = mock(UpdateFeaturesResult.class);
-        when(ufr.values()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, KafkaFuture.completedFuture(null)));
-        @SuppressWarnings(value = "unchecked")
-        ArgumentCaptor<Map<String, FeatureUpdate>> updateCaptor = ArgumentCaptor.forClass(Map.class);
-        when(mockAdminClient.updateFeatures(updateCaptor.capture(), any())).thenReturn(ufr);
-
-        // Mock the Admin client provider
-        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
-
-        // Dummy KafkaStatus to check the values from
-        KafkaStatus status = new KafkaStatus();
-
-        Checkpoint checkpoint = context.checkpoint();
-        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, DUMMY_IDENTITY, mockAdminClientProvider, "3.6", status)
-                .onComplete(context.succeeding(s -> {
-                    assertThat(status.getKafkaMetadataVersion(), is("3.6-IV2"));
-
-                    verify(mockAdminClient, times(1)).updateFeatures(any(), any());
-                    verify(mockAdminClient, times(1)).describeFeatures();
-
-                    assertThat(updateCaptor.getAllValues().size(), is(1));
-                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).upgradeType(), is(FeatureUpdate.UpgradeType.UPGRADE));
-                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).maxVersionLevel(), is((short) 14));
-
-                    checkpoint.flag();
-                }));
-    }
-
-    @Test
-    public void testSuccessfulMetadataVersionDowngrade(VertxTestContext context)   {
+    public void testSuccessfulMetadataVersionUpgrade()   {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -158,24 +105,57 @@ public class KRaftMetadataManagerTest {
         // Dummy KafkaStatus to check the values from
         KafkaStatus status = new KafkaStatus();
 
-        Checkpoint checkpoint = context.checkpoint();
-        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, DUMMY_IDENTITY, mockAdminClientProvider, "3.5", status)
-                .onComplete(context.succeeding(s -> {
-                    assertThat(status.getKafkaMetadataVersion(), is("3.5-IV2"));
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.6", status)
+                .toCompletableFuture()
+                .join();
 
-                    verify(mockAdminClient, times(1)).updateFeatures(any(), any());
-                    verify(mockAdminClient, times(1)).describeFeatures();
+        assertThat(status.getKafkaMetadataVersion(), is("3.6-IV2"));
 
-                    assertThat(updateCaptor.getAllValues().size(), is(1));
-                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).upgradeType(), is(FeatureUpdate.UpgradeType.SAFE_DOWNGRADE));
-                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).maxVersionLevel(), is((short) 11));
+        verify(mockAdminClient, times(1)).updateFeatures(any(), any());
+        verify(mockAdminClient, times(1)).describeFeatures();
 
-                    checkpoint.flag();
-                }));
+        assertThat(updateCaptor.getAllValues().size(), is(1));
+        assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).upgradeType(), is(FeatureUpdate.UpgradeType.UPGRADE));
+        assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).maxVersionLevel(), is((short) 14));
     }
 
     @Test
-    public void testUnsuccessfulMetadataVersionChange(VertxTestContext context)   {
+    public void testSuccessfulMetadataVersionDowngrade()   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeVersion(mockAdminClient);
+
+        // Mock updating metadata version
+        UpdateFeaturesResult ufr = mock(UpdateFeaturesResult.class);
+        when(ufr.values()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, KafkaFuture.completedFuture(null)));
+        @SuppressWarnings(value = "unchecked")
+        ArgumentCaptor<Map<String, FeatureUpdate>> updateCaptor = ArgumentCaptor.forClass(Map.class);
+        when(mockAdminClient.updateFeatures(updateCaptor.capture(), any())).thenReturn(ufr);
+
+        // Mock the Admin client provider
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.5", status)
+                .toCompletableFuture()
+                .join();
+
+        assertThat(status.getKafkaMetadataVersion(), is("3.5-IV2"));
+
+        verify(mockAdminClient, times(1)).updateFeatures(any(), any());
+        verify(mockAdminClient, times(1)).describeFeatures();
+
+        assertThat(updateCaptor.getAllValues().size(), is(1));
+        assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).upgradeType(), is(FeatureUpdate.UpgradeType.SAFE_DOWNGRADE));
+        assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).maxVersionLevel(), is((short) 11));
+    }
+
+    @Test
+    public void testUnsuccessfulMetadataVersionChange()   {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -185,11 +165,7 @@ public class KRaftMetadataManagerTest {
         // Mock updating metadata version
         @SuppressWarnings(value = "unchecked")
         KafkaFuture<Void> kf = mock(KafkaFuture.class);
-        when(kf.whenComplete(any())).thenAnswer(i -> {
-            KafkaFuture.BiConsumer<Void, Throwable> action = i.getArgument(0);
-            action.accept(null, new InvalidUpdateVersionException("Test error ..."));
-            return null;
-        });
+        when(kf.toCompletionStage()).thenReturn(CompletableFuture.failedFuture(new InvalidUpdateVersionException("Test error ...")));
         UpdateFeaturesResult ufr = mock(UpdateFeaturesResult.class);
         when(ufr.values()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, kf));
         when(mockAdminClient.updateFeatures(any(), any())).thenReturn(ufr);
@@ -200,35 +176,29 @@ public class KRaftMetadataManagerTest {
         // Dummy KafkaStatus to check the values from
         KafkaStatus status = new KafkaStatus();
 
-        Checkpoint checkpoint = context.checkpoint();
-        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, DUMMY_IDENTITY, mockAdminClientProvider, "3.6", status)
-                .onComplete(context.succeeding(s -> {
-                    assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
-                    assertThat(status.getConditions().size(), is(1));
-                    assertThat(status.getConditions().get(0).getType(), is("Warning"));
-                    assertThat(status.getConditions().get(0).getReason(), is("MetadataUpdateFailed"));
-                    assertThat(status.getConditions().get(0).getMessage(), is("Failed to update metadata version to 3.6"));
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.6", status)
+                .toCompletableFuture()
+                .join();
 
-                    verify(mockAdminClient, times(1)).updateFeatures(any(), any());
-                    verify(mockAdminClient, times(2)).describeFeatures();
+        assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
+        assertThat(status.getConditions().size(), is(1));
+        assertThat(status.getConditions().get(0).getType(), is("Warning"));
+        assertThat(status.getConditions().get(0).getReason(), is("MetadataUpdateFailed"));
+        assertThat(status.getConditions().get(0).getMessage(), is("Failed to update metadata version to 3.6"));
 
-                    checkpoint.flag();
-                }));
+        verify(mockAdminClient, times(1)).updateFeatures(any(), any());
+        verify(mockAdminClient, times(2)).describeFeatures();
     }
 
     @Test
-    public void testUnexpectedError(VertxTestContext context)   {
+    public void testUnexpectedError()   {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
         // Mock describing the current metadata version
         @SuppressWarnings(value = "unchecked")
         KafkaFuture<FeatureMetadata> kf = mock(KafkaFuture.class);
-        when(kf.whenComplete(any())).thenAnswer(i -> {
-            KafkaFuture.BiConsumer<FeatureMetadata, Throwable> action = i.getArgument(0);
-            action.accept(null, new RuntimeException("Test error ..."));
-            return null;
-        });
+        when(kf.toCompletionStage()).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Test error ...")));
         DescribeFeaturesResult dfr = mock(DescribeFeaturesResult.class);
         when(dfr.featureMetadata()).thenReturn(kf);
         when(mockAdminClient.describeFeatures()).thenReturn(dfr);
@@ -239,19 +209,18 @@ public class KRaftMetadataManagerTest {
         // Dummy KafkaStatus to check the values from
         KafkaStatus status = new KafkaStatus();
 
-        Checkpoint checkpoint = context.checkpoint();
-        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, DUMMY_IDENTITY, mockAdminClientProvider, "3.5", status)
-                .onComplete(context.failing(s -> {
-                    assertThat(s, instanceOf(RuntimeException.class));
-                    assertThat(s.getMessage(), is("Test error ..."));
+        Exception e = assertThrows(Exception.class, () ->
+                KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.5", status)
+                        .toCompletableFuture()
+                        .join());
 
-                    assertThat(status.getKafkaMetadataVersion(), is(nullValue()));
+        assertThat(e.getCause(), instanceOf(RuntimeException.class));
+        assertThat(e.getCause().getMessage(), is("Test error ..."));
 
-                    verify(mockAdminClient, never()).updateFeatures(any(), any());
-                    verify(mockAdminClient, times(1)).describeFeatures();
+        assertThat(status.getKafkaMetadataVersion(), is(nullValue()));
 
-                    checkpoint.flag();
-                }));
+        verify(mockAdminClient, never()).updateFeatures(any(), any());
+        verify(mockAdminClient, times(1)).describeFeatures();
     }
 }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the usage of Vert.x from the `KRaftMetadataManager` class and corresponding tests.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
