### PR TITLE
Make ClusterCaRenewalTest test with real existing certificates

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -411,17 +411,18 @@ public class ClusterCa extends Ca {
      * @return  List of certificate Subject Alternate Names
      */
     private List<String> getSubjectAltNames(byte[] certificate) {
-        List<String> subjectAltNames = null;
+        List<String> subjectAltNames = new ArrayList<>();
 
         try {
             X509Certificate cert = x509Certificate(certificate);
             Collection<List<?>> altNames = cert.getSubjectAlternativeNames();
-            subjectAltNames = altNames.stream()
-                    .filter(name -> name.get(1) instanceof String)
-                    .map(item -> (String) item.get(1))
-                    .collect(Collectors.toList());
+            if (altNames != null) {
+                subjectAltNames = altNames.stream()
+                        .filter(name -> name.get(1) instanceof String)
+                        .map(item -> (String) item.get(1))
+                        .collect(Collectors.toList());
+            }
         } catch (CertificateException | RuntimeException e) {
-            // TODO: We should mock the certificates properly so that this doesn't fail in tests (not now => long term :-o)
             LOGGER.debugCr(reconciliation, "Failed to parse existing certificate", e);
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -28,6 +29,56 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ClusterCaRenewalTest {
     private static final Function<NodeRef, Subject> SUBJECT_FN = node -> new Subject.Builder().build();
     private static final Set<NodeRef> NODES = new LinkedHashSet<>();
+
+    // This certificate is used for testing purposes only. It is valid until 2119, so it should not cause any issues with the tests.
+    private final static String DUMMY_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDLDCCAhSgAwIBAgIUAw8AFcPvJkD5ijYTuT5KBt6sUX8wDQYJKoZIhvcNAQEL\n" +
+            "BQAwLTETMBEGA1UECgwKaW8uc3RyaW16aTEWMBQGA1UEAwwNY2x1c3Rlci1jYSB2\n" +
+            "MDAgFw0yNjA2MzAxMjU0MTNaGA8yMTE5MDYwODEyNTQxM1owFTETMBEGA1UEAwwK\n" +
+            "dmFsaWQtdXNlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJvaDeKe\n" +
+            "8XQgS8bwp8XTjnaO07+sVufu9vg/2HuDExn5oG2OFYSIZzS6Sl03xrsoQXBw8LLy\n" +
+            "XExmem+iZM1r5zVAvqrmD4GIdc+SRalpGdA1STm3PUUUiAVAaM2wlrXMQm8xSIjL\n" +
+            "tMUcLSsg8zzbCjwiTQ4F8svvFGBSEkLfuxYzonQlp6pfRhS66Hl1GAY7lOBlXmwy\n" +
+            "5rZbJkJMy+vVt/6uQe4gJonRmOPqofeGEVPmfyPCNgl1cIETMxv1JJS74hFM3pSf\n" +
+            "w1zl4WEAuVNA04tIMrFCQC8vMmxs0/spMzNt9adVnHDWE0/FwExYWKPNFYXPt3nW\n" +
+            "O3nljkEYNlFcUhcCAwEAAaNaMFgwCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwHQYD\n" +
+            "VR0OBBYEFPhOVigIhxQpcTlsrM68V9M7k2IaMB8GA1UdIwQYMBaAFJXl3KBqS4/x\n" +
+            "rjOAskayMxAzPjWQMA0GCSqGSIb3DQEBCwUAA4IBAQAZqNkA/cl0AWKhbYLPiOVM\n" +
+            "cVbjO5cKeaiKOswLyUlRDUElBPv0+zV2Q7x1JckxP/5nKo1CIQMHaWuYnrdnEBZc\n" +
+            "6xmS/DCtgD7+FWUpbMdD4cL+iFYkH5DsnG0D5AYo73/wbg/+e+38YPdYUYz94rG/\n" +
+            "1YfY/7+U2lXpncPkqIMwDiJBBKvCVCEyY/KOqbq4urEYUVHXNlZ1YcSOTqHYyY2C\n" +
+            "WpP//JDkel5JYikIMqp5BE9HKWBkZVkSS9kisHJkskbcKcCW1jCWwHE2hRqWE0WZ\n" +
+            "91mD7YKS3VB3cQ/mBqYpf2bCf1zQZtqOB7dfbRevHMYlfKyH+qX7rlfujF8nOP/g\n" +
+            "-----END CERTIFICATE-----\n";
+
+
+    // Certificate used for expiration tests where actual expiration is needed. This certificate expires on 27th March 2023.
+    // But with correct configuration or renewal days before expiration, it can be used to trigger expiration,
+    private final static String EXPIRED_DUMMY_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIECTCCAfGgAwIBAgIUAw8AFcPvJkD5ijYTuT5KBt6sUX4wDQYJKoZIhvcNAQEN\n" +
+            "BQAwLTETMBEGA1UECgwKaW8uc3RyaW16aTEWMBQGA1UEAwwNY2xpZW50cy1jYSB2\n" +
+            "MDAeFw0yMjAzMjcxNTQyNTBaFw0yMzAzMjcxNTQyNTBaMA8xDTALBgNVBAMMBHVz\n" +
+            "ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8cpNdaHYyZuPJ2p1I\n" +
+            "2LpEN5nwrE6Bys79ITbfwj+C12O5wyLp+n0VNr/7DPZUQP71vwWDdSmrP2gW6OSV\n" +
+            "EOb40mjLvRSRRDrcowNXL6NlV+tzd7QuNgBilWssBfpvBGYHsux7dA7Qf+DGv/Wp\n" +
+            "Wqw31ybPk5NqQXzRjJ+6xVLjERlLuIGy0s4XsO4Grfuwa1Le40KVoHNR+BRft+H6\n" +
+            "wajKnUP/j0hJHOgYmYNeuB6Aw8T49HctKJzay/b/0Jud1Vre3/cS4l5EyKpq1H3l\n" +
+            "DWPShSY0CdcvmVkSoqRJeRbqeRrUrAdzWtOIXVBuI9SonAov5RHBtaX+rZldALZD\n" +
+            "o3FrAgMBAAGjPzA9MB0GA1UdDgQWBBTO8o3wkH+x7WSJNO9Gi316f5SBADAMBgNV\n" +
+            "HRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIFoDANBgkqhkiG9w0BAQ0FAAOCAgEAjGBr\n" +
+            "wBlL2Bxcqo8BbRsLtQyRjiOtG+K0gniMAJaX5T6zUxPouzw4fkz+FMlyU+/SGYHt\n" +
+            "wDKhe6pNqls5If884i2R/Vkl4PpX1WMi1BewzdENIGkQFKzjRQd/yCKqlW2+QaNM\n" +
+            "H+u+K5l6yxyZ0FWH5pf7XVMpgs8MI/0Hq1349Lh56Ekcna8MZNxg1wBjMQzSrv9U\n" +
+            "QUV7ITOCt4ghYsUx3gaoehLt9lXnnNWCW7o/7VcZEfxV1Cr6pm+cgfvqS+sTeb8E\n" +
+            "xxlIVuwhVuT6kxzepjEceXrletj66aITAZlg3xPQwzw3jYX354HXkmpDox2KvcLK\n" +
+            "xKhBfbqbEZbI/kVKZF6XQEWmflnz/kiy1hTfHBNRuOTu/pHb4LHXW0b4qUcljxRR\n" +
+            "412HUn/OTulvqtU9pQi442+KzxFX+bm6mQwO95eZbte8omK5EzWZkvop6CjT4V9a\n" +
+            "Rnb2PLgqNCSBkp4XhR77bdWI8y569y+lcMckj6xK2ct1OGNpudClkd0oeUb/MZnT\n" +
+            "4ebFTZY24EM5LNmWXaR6RVmbg0Xc1kSR8DqUzTaNA2s8lbtQId4yvzxOP5Lkcq/G\n" +
+            "dJl3QtzbWBWFW2bU8MHZ2bUQsmw0RtmTg9tDMCHLAH+9Mw7yMWsEg5iX0H7hnwJA\n" +
+            "T/DiI+A2t2dGukf5qfzqgiXkq4XqM6+p0zY1Cv0=\n" +
+            "-----END CERTIFICATE-----\n";
+
     // LinkedHashSet is used to maintain ordering and have predictable test results
     static {
         NODES.add(new NodeRef("pod0", 0, null, false, true));
@@ -39,14 +90,12 @@ public class ClusterCaRenewalTest {
     public void renewalOfCertificatesWithNullCertificates() throws IOException {
         ClusterCa mockedCa = new MockedClusterCa();
 
-        boolean isMaintenanceTimeWindowsSatisfied = true;
-
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
                 NODES,
                 SUBJECT_FN,
                 null,
-                isMaintenanceTimeWindowsSatisfied,
+                true,
                 false
         );
 
@@ -72,18 +121,16 @@ public class ClusterCaRenewalTest {
         mockedCa.setCaCertGeneration(1);
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-
-        boolean isMaintenanceTimeWindowsSatisfied = true;
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
+                true,
                 false
         );
 
@@ -109,21 +156,18 @@ public class ClusterCaRenewalTest {
     @Test
     public void renewalOfCertificatesDelayedRenewalInWindow() throws IOException {
         MockedClusterCa mockedCa = new MockedClusterCa();
-        mockedCa.setCertExpiring(true);
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-
-        boolean isMaintenanceTimeWindowsSatisfied = true;
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
+                true,
                 false
         );
 
@@ -152,35 +196,33 @@ public class ClusterCaRenewalTest {
     @Test
     public void renewalOfCertificatesDelayedRenewalOutsideWindow() throws IOException {
         MockedClusterCa mockedCa = new MockedClusterCa();
-        mockedCa.setCertExpiring(true);
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
         
-        boolean isMaintenanceTimeWindowsSatisfied = false;
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
+                false,
                 false
         );
 
-        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod0").cert()), is(EXPIRED_DUMMY_CERT));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
         assertThat(newCerts.get("pod0").caCertGeneration(), is(0));
 
 
-        assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod1").cert()), is(EXPIRED_DUMMY_CERT));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
         assertThat(newCerts.get("pod1").caCertGeneration(), is(0));
 
 
-        assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod2").cert()), is(EXPIRED_DUMMY_CERT));
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
         assertThat(newCerts.get("pod1").caCertGeneration(), is(0));
 
@@ -189,27 +231,24 @@ public class ClusterCaRenewalTest {
     @Test
     public void renewalOfCertificatesWithNewNodesOutsideWindow() throws IOException {
         MockedClusterCa mockedCa = new MockedClusterCa();
-        mockedCa.setCertExpiring(true);
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-
-        boolean isMaintenanceTimeWindowsSatisfied = false;
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
+                false,
                 false
         );
 
-        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod0").cert()), is(EXPIRED_DUMMY_CERT));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
 
-        assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod1").cert()), is(EXPIRED_DUMMY_CERT));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("new-cert0"));
@@ -221,9 +260,9 @@ public class ClusterCaRenewalTest {
         MockedClusterCa mockedCa = new MockedClusterCa();
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -234,13 +273,13 @@ public class ClusterCaRenewalTest {
                 false
         );
 
-        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod0").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
 
-        assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod1").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
 
-        assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod2").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
     }
 
@@ -249,7 +288,7 @@ public class ClusterCaRenewalTest {
         MockedClusterCa mockedCa = new MockedClusterCa();
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -260,7 +299,7 @@ public class ClusterCaRenewalTest {
                 false
         );
 
-        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod0").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("new-cert0"));
@@ -275,8 +314,8 @@ public class ClusterCaRenewalTest {
         MockedClusterCa mockedCa = new MockedClusterCa();
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -287,13 +326,13 @@ public class ClusterCaRenewalTest {
                 false
         );
 
-        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod0").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod1").key()), is("new-key0"));
 
-        assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod2").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
     }
 
@@ -302,9 +341,9 @@ public class ClusterCaRenewalTest {
         MockedClusterCa mockedCa = new MockedClusterCa();
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -317,7 +356,7 @@ public class ClusterCaRenewalTest {
 
         assertThat(newCerts.get("pod0"), is(nullValue()));
 
-        assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod1").cert()), is(DUMMY_CERT));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
 
         assertThat(newCerts.get("pod2"), is(nullValue()));
@@ -326,21 +365,18 @@ public class ClusterCaRenewalTest {
     @Test
     public void changedSubjectOfCertificates() throws IOException {
         MockedClusterCa mockedCa = new MockedClusterCa();
-        mockedCa.setCertExpiring(true);
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-
-        boolean isMaintenanceTimeWindowsSatisfied = true;
+        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
                 NODES,
-                node -> new Subject.Builder().withCommonName(node.podName()).build(),
+                node -> new Subject.Builder().addDnsName(node.podName() + ".test.com").build(),
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
+                true,
                 false
         );
 
@@ -378,9 +414,9 @@ public class ClusterCaRenewalTest {
         MockedClusterCa mockedCa = new MockedClusterCa();
 
         Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("new-key0".getBytes(), "new-cert0".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("new-key1".getBytes(), "new-cert1".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("new-key2".getBytes(), "new-cert2".getBytes()));
+        initialCerts.put("pod0", new CertAndKey("new-key0".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod1", new CertAndKey("new-key1".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
+        initialCerts.put("pod2", new CertAndKey("new-key2".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8)));
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateServerCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -417,7 +453,7 @@ public class ClusterCaRenewalTest {
         MockedClusterCa mockedCa = new MockedClusterCa();
         mockedCa.setCaCertGeneration(1);
 
-        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), "old-cert".getBytes());
+        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8));
 
         CertAndKey newCert = mockedCa.maybeCopyOrGenerateClientCert(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -434,9 +470,8 @@ public class ClusterCaRenewalTest {
     @Test
     public void testRenewalOfDeploymentCertificateDelayedRenewal() {
         MockedClusterCa mockedCa = new MockedClusterCa();
-        mockedCa.setCertExpiring(true);
 
-        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), "old-cert".getBytes());
+        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8));
 
         CertAndKey newCert = mockedCa.maybeCopyOrGenerateClientCert(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -451,11 +486,10 @@ public class ClusterCaRenewalTest {
     }
 
     @Test
-    public void testRenewalOfDeploymentCertificateDelayedRenewalOutsideOfMaintenanceWindow() throws IOException {
+    public void testRenewalOfDeploymentCertificateDelayedRenewalOutsideOfMaintenanceWindow() {
         MockedClusterCa mockedCa = new MockedClusterCa();
-        mockedCa.setCertExpiring(true);
 
-        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), "old-cert".getBytes());
+        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), EXPIRED_DUMMY_CERT.getBytes(StandardCharsets.UTF_8));
 
         CertAndKey newCert = mockedCa.maybeCopyOrGenerateClientCert(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -464,17 +498,17 @@ public class ClusterCaRenewalTest {
                 false
         );
 
-        assertThat(new String(newCert.cert()), is("old-cert"));
+        assertThat(new String(newCert.cert()), is(EXPIRED_DUMMY_CERT));
         assertThat(new String(newCert.key()), is("old-key"));
         assertThat(newCert.caCertGeneration(), is(0));
     }
 
     @Test
-    public void testHandlingOldSecretWithPKCS12Files() throws IOException {
+    public void testHandlingOldSecretWithPKCS12Files() {
         MockedClusterCa mockedCa = new MockedClusterCa();
 
-        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), "old-cert".getBytes(), null, "old-keystore".getBytes(), "old-password");
-
+        CertAndKey initialCert = new CertAndKey("old-key".getBytes(), DUMMY_CERT.getBytes(StandardCharsets.UTF_8),
+                null, "old-keystore".getBytes(), "old-password");
         CertAndKey newCert = mockedCa.maybeCopyOrGenerateClientCert(
                 Reconciliation.DUMMY_RECONCILIATION,
                 "deployment",
@@ -482,7 +516,7 @@ public class ClusterCaRenewalTest {
                 true
         );
 
-        assertThat(new String(newCert.cert()), is("old-cert"));
+        assertThat(new String(newCert.cert()), is(DUMMY_CERT));
         assertThat(new String(newCert.key()), is("old-key"));
         assertThat(new String(newCert.keyStore()), is("old-keystore"));
         assertThat(newCert.storePassword(), is("old-password"));
@@ -492,7 +526,6 @@ public class ClusterCaRenewalTest {
     public static class MockedClusterCa extends ClusterCa {
         private final AtomicInteger invocationCount = new AtomicInteger(0);
         private int caCertGeneration;
-        private boolean isCertExpiring;
 
         public MockedClusterCa() {
             super(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null);
@@ -501,17 +534,6 @@ public class ClusterCaRenewalTest {
         @Override
         public byte[] currentCaCertBytes() {
             return "CA-CERT".getBytes();
-        }
-
-        @Override
-        public boolean isExpiring(byte[] certificate)  {
-            return isCertExpiring;
-        }
-
-        @Override
-        protected boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
-            // When differs from the default we use, we indicate change
-            return !new Subject.Builder().build().equals(desiredSubject);
         }
 
         @Override
@@ -538,24 +560,8 @@ public class ClusterCaRenewalTest {
         }
 
         @Override
-        public CertAndKey addKeyAndCertToKeyStore(String alias, byte[] key, byte[] cert) {
-            int index = invocationCount.getAndIncrement();
-
-            return new CertAndKey(
-                    key,
-                    cert,
-                    ("new-truststore" + index).getBytes(),
-                    ("new-keystore" + index).getBytes(),
-                    "new-password" + index);
-        }
-
-        @Override
         public int caCertGeneration() {
             return caCertGeneration;
-        }
-
-        public void setCertExpiring(boolean certExpiring) {
-            isCertExpiring = certExpiring;
         }
 
         public void setCaCertGeneration(int value) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -27,56 +27,58 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(VertxExtension.class)
 public class ClusterCaRenewalTest {
-    private static final Function<NodeRef, Subject> SUBJECT_FN = node -> new Subject.Builder().build();
+    private static final Function<NodeRef, Subject> SUBJECT_FN = node -> {
+        Subject.Builder subject = new Subject.Builder();
+        subject.addDnsName("example.local");
+        subject.addIpAddress("127.0.0.1");
+        return subject.build();
+    };
     private static final Set<NodeRef> NODES = new LinkedHashSet<>();
 
-    // This certificate is used for testing purposes only. It is valid until 2119, so it should not cause any issues with the tests.
+    // This certificate is used for testing purposes only. It is valid until 2126 and includes SANs (DNS: example.local; IP: 127.0.0.1).
     private final static String DUMMY_CERT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIDLDCCAhSgAwIBAgIUAw8AFcPvJkD5ijYTuT5KBt6sUX8wDQYJKoZIhvcNAQEL\n" +
+            "MIIDTDCCAjSgAwIBAgIUWAVui97Rf8gVcC/s5QL+L4OL04cwDQYJKoZIhvcNAQEL\n" +
             "BQAwLTETMBEGA1UECgwKaW8uc3RyaW16aTEWMBQGA1UEAwwNY2x1c3Rlci1jYSB2\n" +
-            "MDAgFw0yNjA2MzAxMjU0MTNaGA8yMTE5MDYwODEyNTQxM1owFTETMBEGA1UEAwwK\n" +
-            "dmFsaWQtdXNlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJvaDeKe\n" +
-            "8XQgS8bwp8XTjnaO07+sVufu9vg/2HuDExn5oG2OFYSIZzS6Sl03xrsoQXBw8LLy\n" +
-            "XExmem+iZM1r5zVAvqrmD4GIdc+SRalpGdA1STm3PUUUiAVAaM2wlrXMQm8xSIjL\n" +
-            "tMUcLSsg8zzbCjwiTQ4F8svvFGBSEkLfuxYzonQlp6pfRhS66Hl1GAY7lOBlXmwy\n" +
-            "5rZbJkJMy+vVt/6uQe4gJonRmOPqofeGEVPmfyPCNgl1cIETMxv1JJS74hFM3pSf\n" +
-            "w1zl4WEAuVNA04tIMrFCQC8vMmxs0/spMzNt9adVnHDWE0/FwExYWKPNFYXPt3nW\n" +
-            "O3nljkEYNlFcUhcCAwEAAaNaMFgwCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwHQYD\n" +
-            "VR0OBBYEFPhOVigIhxQpcTlsrM68V9M7k2IaMB8GA1UdIwQYMBaAFJXl3KBqS4/x\n" +
-            "rjOAskayMxAzPjWQMA0GCSqGSIb3DQEBCwUAA4IBAQAZqNkA/cl0AWKhbYLPiOVM\n" +
-            "cVbjO5cKeaiKOswLyUlRDUElBPv0+zV2Q7x1JckxP/5nKo1CIQMHaWuYnrdnEBZc\n" +
-            "6xmS/DCtgD7+FWUpbMdD4cL+iFYkH5DsnG0D5AYo73/wbg/+e+38YPdYUYz94rG/\n" +
-            "1YfY/7+U2lXpncPkqIMwDiJBBKvCVCEyY/KOqbq4urEYUVHXNlZ1YcSOTqHYyY2C\n" +
-            "WpP//JDkel5JYikIMqp5BE9HKWBkZVkSS9kisHJkskbcKcCW1jCWwHE2hRqWE0WZ\n" +
-            "91mD7YKS3VB3cQ/mBqYpf2bCf1zQZtqOB7dfbRevHMYlfKyH+qX7rlfujF8nOP/g\n" +
+            "MDAgFw0yNjA3MDYwOTAyMzBaGA8yMTI2MDYxMjA5MDIzMFowFTETMBEGA1UEAwwK\n" +
+            "dmFsaWQtdXNlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAO5t4wYz\n" +
+            "10K39pRlxNy3LXa6nFsnRi7g+C2h5X1Hbu/9Lv2mSVy0MmLWNw/Nx8qbdprdgBlt\n" +
+            "GnmEz2e435g6tg354qlyb/pMSEE6v1tXpY68+p882tDFY/+2y1YEcseQUXd70H7T\n" +
+            "pT+Go/Bqj5e4YpsZPUtPw0NSDJAp0DYwcJFeVtrltv11CWX6A8p0LaqaTT/gewKP\n" +
+            "D19Z6tQ/LOQpMHRXwcKpk8Xwuoj6iV5SuhYa/Tvmz6h/vedDftcUEVbmyQLXLyUf\n" +
+            "o+4QLGyTtQqJ11B5ssKhAsB4DSd7WIfuZSUo8sykGeoVJ2bNF+RmQtvRBt0xYWgq\n" +
+            "CoTrTgs2q7zsAU8CAwEAAaN6MHgwCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwHgYD\n" +
+            "VR0RBBcwFYINZXhhbXBsZS5sb2NhbIcEfwAAATAdBgNVHQ4EFgQUcWpAdlVDH5RL\n" +
+            "TAntb4q2Bqkt3YowHwYDVR0jBBgwFoAURtdYM1go6ehB9x21eBjupnzy1pAwDQYJ\n" +
+            "KoZIhvcNAQELBQADggEBAEBQ0ptk3cMCLQNG8IT5kkSruvoxov+mDDh4YLLTp9qQ\n" +
+            "+nfCwFDyaDrGeQ8aKds5VF53lLdZV/s6L2oxjVdysrI6FMd2asUubbME0BitPsrS\n" +
+            "qwWdasACBpQUM8JwZURVQHA0fCfdAB6v3kds5kz4QZ22FQI0I6HQ9ZGqsYIpHrA7\n" +
+            "ZoGmkRZHnDhqw7VGDkyRaCjxSu8hMaYgorFhMFnoRflbCh44lJcv16hudyvt+v4l\n" +
+            "Mmat3ZFEVzjyiKA/bSQKveGfS9D+LQedVRitZq15qh4heoc78pdxDZV664nttAgp\n" +
+            "dl8yPaW/n+jon4ZQ1CEW6NVh3YHDFGcs5KHgdSNuL80=\n" +
             "-----END CERTIFICATE-----\n";
 
 
-    // Certificate used for expiration tests where actual expiration is needed. This certificate expires on 27th March 2023.
+    // Certificate used for expiration tests where actual expiration is needed. This certificate expires on 27th March 2023 and includes SANs (DNS: example.local; IP: 127.0.0.1).
     // But with correct configuration or renewal days before expiration, it can be used to trigger expiration,
     private final static String EXPIRED_DUMMY_CERT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIECTCCAfGgAwIBAgIUAw8AFcPvJkD5ijYTuT5KBt6sUX4wDQYJKoZIhvcNAQEN\n" +
+            "MIIDRDCCAiygAwIBAgIUAw8AFcPvJkD5ijYTuT5KBt6sUX4wDQYJKoZIhvcNAQEL\n" +
             "BQAwLTETMBEGA1UECgwKaW8uc3RyaW16aTEWMBQGA1UEAwwNY2xpZW50cy1jYSB2\n" +
             "MDAeFw0yMjAzMjcxNTQyNTBaFw0yMzAzMjcxNTQyNTBaMA8xDTALBgNVBAMMBHVz\n" +
-            "ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8cpNdaHYyZuPJ2p1I\n" +
-            "2LpEN5nwrE6Bys79ITbfwj+C12O5wyLp+n0VNr/7DPZUQP71vwWDdSmrP2gW6OSV\n" +
-            "EOb40mjLvRSRRDrcowNXL6NlV+tzd7QuNgBilWssBfpvBGYHsux7dA7Qf+DGv/Wp\n" +
-            "Wqw31ybPk5NqQXzRjJ+6xVLjERlLuIGy0s4XsO4Grfuwa1Le40KVoHNR+BRft+H6\n" +
-            "wajKnUP/j0hJHOgYmYNeuB6Aw8T49HctKJzay/b/0Jud1Vre3/cS4l5EyKpq1H3l\n" +
-            "DWPShSY0CdcvmVkSoqRJeRbqeRrUrAdzWtOIXVBuI9SonAov5RHBtaX+rZldALZD\n" +
-            "o3FrAgMBAAGjPzA9MB0GA1UdDgQWBBTO8o3wkH+x7WSJNO9Gi316f5SBADAMBgNV\n" +
-            "HRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIFoDANBgkqhkiG9w0BAQ0FAAOCAgEAjGBr\n" +
-            "wBlL2Bxcqo8BbRsLtQyRjiOtG+K0gniMAJaX5T6zUxPouzw4fkz+FMlyU+/SGYHt\n" +
-            "wDKhe6pNqls5If884i2R/Vkl4PpX1WMi1BewzdENIGkQFKzjRQd/yCKqlW2+QaNM\n" +
-            "H+u+K5l6yxyZ0FWH5pf7XVMpgs8MI/0Hq1349Lh56Ekcna8MZNxg1wBjMQzSrv9U\n" +
-            "QUV7ITOCt4ghYsUx3gaoehLt9lXnnNWCW7o/7VcZEfxV1Cr6pm+cgfvqS+sTeb8E\n" +
-            "xxlIVuwhVuT6kxzepjEceXrletj66aITAZlg3xPQwzw3jYX354HXkmpDox2KvcLK\n" +
-            "xKhBfbqbEZbI/kVKZF6XQEWmflnz/kiy1hTfHBNRuOTu/pHb4LHXW0b4qUcljxRR\n" +
-            "412HUn/OTulvqtU9pQi442+KzxFX+bm6mQwO95eZbte8omK5EzWZkvop6CjT4V9a\n" +
-            "Rnb2PLgqNCSBkp4XhR77bdWI8y569y+lcMckj6xK2ct1OGNpudClkd0oeUb/MZnT\n" +
-            "4ebFTZY24EM5LNmWXaR6RVmbg0Xc1kSR8DqUzTaNA2s8lbtQId4yvzxOP5Lkcq/G\n" +
-            "dJl3QtzbWBWFW2bU8MHZ2bUQsmw0RtmTg9tDMCHLAH+9Mw7yMWsEg5iX0H7hnwJA\n" +
-            "T/DiI+A2t2dGukf5qfzqgiXkq4XqM6+p0zY1Cv0=\n" +
+            "ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDG+c0r8BqSSttN3glQ\n" +
+            "u1rhodlB3+Q4XTLMmpX1kvzaeMHGLS/D6gmu2X1Ox7QJkb5Sv9pq7ufUuSFXzWPV\n" +
+            "Kyi4BrrrQH5ysKoaeEY8oZFZZjsD0FmAsh7NTzXCy4rXzj+p3zCZvJ/W3njsBhuW\n" +
+            "ed/Cpbx/fJEfD8IzK3qpjDBFYgkhxOMuObiEar49rbFVs4lsP9wu+NwXIOKufCAj\n" +
+            "EdQxTkcqR4Qt88g/DfJN0tP4bro2gdvbF6tlbFidFV0hXwQoN1oEflWU3Wc8gry7\n" +
+            "cRSA0myTJKORgtQrBsv4+i42RbcqOFyYgAdYqkh4s/BQQHCHsU8uCewPA4Cc/xkV\n" +
+            "kTFnAgMBAAGjejB4MAkGA1UdEwQCMAAwCwYDVR0PBAQDAgWgMB4GA1UdEQQXMBWC\n" +
+            "DWV4YW1wbGUubG9jYWyHBH8AAAEwHQYDVR0OBBYEFCEHtiyjUqOmlZjAEOdNhpoU\n" +
+            "QAb+MB8GA1UdIwQYMBaAFPEx+LWO3ZmV78yRt+1BMu/LB9LmMA0GCSqGSIb3DQEB\n" +
+            "CwUAA4IBAQAK3NIyn7jBDniyTVkNvC0RMO4SqIAU7pzwFo575YrUizweYc7xdV2V\n" +
+            "23zR9M4gIfom1Cjccws8ZgvHUsNR1UidewyEt4pihsiNB2ad6W6Ft+4CKbHTFd0g\n" +
+            "Geu1S58duUJhIPHzRHkSYKGHqt0N6WYwYAgsWH4rJlL59Rkpv9IokW2C6ST2102H\n" +
+            "0q7axKbD8nWiXpTfID8ei723u1imNKEg/2z60CgJPfDg8DscbhaoRpgND0XlcB3J\n" +
+            "xxKC9M18nAM4kikCp0Cx4UvQbwdzNwjmDfQpmTwLCOfC88ZYYgEju0+rjna5caOb\n" +
+            "2CTLAx8SYKOGBTzflSuvKzib0gSoXZUW\n" +
             "-----END CERTIFICATE-----\n";
 
     // LinkedHashSet is used to maintain ordering and have predictable test results


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors ClusterCaRenewalTest to test with real existing certificates so that checks for expiration and subject change are tested instead of mocking them to trigger certifcate generation. 

getSubjectAltNames method of ClusterCa is updated with null check for alternate subject names as that could cause NPE which then gets ignored.  It is also updated to return empty list instead of null, as it causes tests to fail because of regenerating certificates unnecessarily due to null != [] being treated as "subjects changed" in certSubjectChanged method:
```
2026-07-01 16:59:19 INFO  Ca:400 - Reconciliation #0(test) kind(namespace/name): Current alternate subjects: null
2026-07-01 16:59:19 INFO  Ca:401 - Reconciliation #0(test) kind(namespace/name): Desired alternate subjects: []
``` 

changedSubjectOfCertificates test is updated so that DNS name is changed instead of the common name, as that's the expected behaviour in the ClusterCa. 

Mock override for addKeyAndCertToKeyStore() is removed, as this is only used by ClientsCa (KafkaUserModel) so it's not necessary for this test class. 

Mocked generateSignedCert method is left to create not real certificates, as we just care that this method is called and new certificates don't need to be real. 
  
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
