### PR TITLE
Add flag for setting enableServiceLinks on operator deployment

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -120,6 +120,7 @@ the documentation for more details.
 | `deploymentStrategy`                             | Adjust the Kubernetes rollout strategy of the Cluster Operator Deployment       | `nil`                        |
 | `priorityClassName`                              | Cluster Operator pod's priority class name                                      | `nil`                        |
 | `hostUsers`                                      | Set hostUsers value on the Cluster Operator container                           | `nil`                       |
+| `enableServiceLinks`                             | Set enableServiceLinks value on the Cluster Operator pod                         | `nil`                        |
 | `securityContext`                                | Cluster Operator container's security context                                   | `nil`                        |
 | `rbac.create`                                    | Whether to create RBAC related resources                                        | `yes`                        |
 | `serviceAccountCreate`                           | Whether to create a service account                                             | `yes`                        |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -57,6 +57,9 @@ spec:
       {{- if kindIs "bool" .Values.hostUsers }}
       hostUsers: {{ .Values.hostUsers }}
       {{- end }}
+      {{- if kindIs "bool" .Values.enableServiceLinks }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
@@ -67,6 +67,23 @@ tests:
           path: spec.template.spec.hostUsers
           value: true
 
+  - it: should not set enableServiceLinks by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.enableServiceLinks
+
+  - it: should allow override of enableServiceLinks to false
+    set:
+      enableServiceLinks: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: false
+
   - it: should have custom image if details are provided
     set:
       image:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -47,6 +47,7 @@ deploymentStrategy: {}
 priorityClassName: ""
 
 hostUsers: NULL
+enableServiceLinks: NULL
 podSecurityContext: {}
 securityContext: {}
 rbac:


### PR DESCRIPTION
Kubernetes injects one set of `*_SERVICE_HOST` / `*_SERVICE_PORT` environment variables per Service in the operator's namespace when `enableServiceLinks` is true (the default). In clusters with a large number of Services in that namespace, this can exceed the kernel argument limit and the Cluster Operator container fails to start with `exec ...: argument list too long`.

This exposes `enableServiceLinks` as a Helm value on the Cluster Operator Deployment so it can be set to `false` to avoid this, mirroring the existing `hostUsers` flag. The value is only rendered when explicitly set to a boolean, so the default behaviour is unchanged.

Includes helm-unittest coverage for both the unset (default) and `false` cases.