### PR TITLE
Remove unused methods from `Crds` class

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apiextensions</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -4,13 +4,6 @@
  */
 package io.strimzi.api.kafka;
 
-import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
-import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
-import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion;
-import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersionBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceSubresourceStatus;
-import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -35,282 +28,48 @@ import io.strimzi.api.kafka.model.topic.KafkaTopicList;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserList;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.singletonList;
-
 /**
  * "Static" information about the CRDs defined in this package
  */
 public class Crds {
-    @SuppressWarnings("unchecked")
-    private static final Class<? extends CustomResource>[] CRDS = new Class[] {
-        Kafka.class,
-        KafkaConnect.class,
-        KafkaTopic.class,
-        KafkaUser.class,
-        KafkaBridge.class,
-        KafkaConnector.class,
-        KafkaMirrorMaker2.class,
-        KafkaRebalance.class,
-        StrimziPodSet.class,
-        KafkaNodePool.class
-    };
-
     private Crds() { }
-
-    @SuppressWarnings({"checkstyle:JavaNCSS"})
-    private static CustomResourceDefinition crd(Class<? extends CustomResource> cls) {
-        String scope, plural, singular, group, kind, listKind;
-        List<String> versions;
-        CustomResourceSubresourceStatus status = null;
-
-        if (cls.equals(Kafka.class)) {
-            scope = Kafka.SCOPE;
-            plural = Kafka.RESOURCE_PLURAL;
-            singular = Kafka.RESOURCE_SINGULAR;
-            group = Kafka.RESOURCE_GROUP;
-            kind = Kafka.RESOURCE_KIND;
-            listKind = Kafka.RESOURCE_LIST_KIND;
-            versions = Kafka.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaConnect.class)) {
-            scope = KafkaConnect.SCOPE;
-            plural = KafkaConnect.RESOURCE_PLURAL;
-            singular = KafkaConnect.RESOURCE_SINGULAR;
-            group = KafkaConnect.RESOURCE_GROUP;
-            kind = KafkaConnect.RESOURCE_KIND;
-            listKind = KafkaConnect.RESOURCE_LIST_KIND;
-            versions = KafkaConnect.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaTopic.class)) {
-            scope = KafkaTopic.SCOPE;
-            plural = KafkaTopic.RESOURCE_PLURAL;
-            singular = KafkaTopic.RESOURCE_SINGULAR;
-            group = KafkaTopic.RESOURCE_GROUP;
-            kind = KafkaTopic.RESOURCE_KIND;
-            listKind = KafkaTopic.RESOURCE_LIST_KIND;
-            versions = KafkaTopic.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaUser.class)) {
-            scope = KafkaUser.SCOPE;
-            plural = KafkaUser.RESOURCE_PLURAL;
-            singular = KafkaUser.RESOURCE_SINGULAR;
-            group = KafkaUser.RESOURCE_GROUP;
-            kind = KafkaUser.RESOURCE_KIND;
-            listKind = KafkaUser.RESOURCE_LIST_KIND;
-            versions = KafkaUser.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaBridge.class)) {
-            scope = KafkaBridge.SCOPE;
-            plural = KafkaBridge.RESOURCE_PLURAL;
-            singular = KafkaBridge.RESOURCE_SINGULAR;
-            group = KafkaBridge.RESOURCE_GROUP;
-            kind = KafkaBridge.RESOURCE_KIND;
-            listKind = KafkaBridge.RESOURCE_LIST_KIND;
-            versions = KafkaBridge.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaConnector.class)) {
-            scope = KafkaConnector.SCOPE;
-            plural = KafkaConnector.RESOURCE_PLURAL;
-            singular = KafkaConnector.RESOURCE_SINGULAR;
-            group = KafkaConnector.RESOURCE_GROUP;
-            kind = KafkaConnector.RESOURCE_KIND;
-            listKind = KafkaConnector.RESOURCE_LIST_KIND;
-            versions = KafkaConnector.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaMirrorMaker2.class)) {
-            scope = KafkaMirrorMaker2.SCOPE;
-            plural = KafkaMirrorMaker2.RESOURCE_PLURAL;
-            singular = KafkaMirrorMaker2.RESOURCE_SINGULAR;
-            group = KafkaMirrorMaker2.RESOURCE_GROUP;
-            kind = KafkaMirrorMaker2.RESOURCE_KIND;
-            listKind = KafkaMirrorMaker2.RESOURCE_LIST_KIND;
-            versions = KafkaMirrorMaker2.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaRebalance.class)) {
-            scope = KafkaRebalance.SCOPE;
-            plural = KafkaRebalance.RESOURCE_PLURAL;
-            singular = KafkaRebalance.RESOURCE_SINGULAR;
-            group = KafkaRebalance.RESOURCE_GROUP;
-            kind = KafkaRebalance.RESOURCE_KIND;
-            listKind = KafkaRebalance.RESOURCE_LIST_KIND;
-            versions = KafkaRebalance.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(StrimziPodSet.class)) {
-            scope = StrimziPodSet.SCOPE;
-            plural = StrimziPodSet.RESOURCE_PLURAL;
-            singular = StrimziPodSet.RESOURCE_SINGULAR;
-            group = StrimziPodSet.RESOURCE_GROUP;
-            kind = StrimziPodSet.RESOURCE_KIND;
-            listKind = StrimziPodSet.RESOURCE_LIST_KIND;
-            versions = StrimziPodSet.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else if (cls.equals(KafkaNodePool.class)) {
-            scope = KafkaNodePool.SCOPE;
-            plural = KafkaNodePool.RESOURCE_PLURAL;
-            singular = KafkaNodePool.RESOURCE_SINGULAR;
-            group = KafkaNodePool.RESOURCE_GROUP;
-            kind = KafkaNodePool.RESOURCE_KIND;
-            listKind = KafkaNodePool.RESOURCE_LIST_KIND;
-            versions = KafkaNodePool.VERSIONS;
-            status = new CustomResourceSubresourceStatus();
-        } else {
-            throw new RuntimeException();
-        }
-
-        List<CustomResourceDefinitionVersion> crVersions = new ArrayList<>(versions.size());
-        for (String apiVersion : versions)  {
-            crVersions.add(new CustomResourceDefinitionVersionBuilder()
-                    .withName(apiVersion)
-                    .withNewSubresources()
-                        .withStatus(status)
-                    .endSubresources()
-                    .withNewSchema()
-                        .withNewOpenAPIV3Schema()
-                            .withType("object")
-                            .withXKubernetesPreserveUnknownFields(true)
-                        .endOpenAPIV3Schema()
-                    .endSchema()
-                    .withStorage("v1beta2".equals(apiVersion))
-                    .withServed(true)
-                    .build());
-        }
-
-        return new CustomResourceDefinitionBuilder()
-                .withNewMetadata()
-                    .withName(plural + "." + group)
-                .endMetadata()
-                .withNewSpec()
-                    .withScope(scope)
-                    .withGroup(group)
-                    .withVersions(crVersions)
-                    .withNewNames()
-                        .withSingular(singular)
-                        .withPlural(plural)
-                        .withKind(kind)
-                        .withListKind(listKind)
-                    .endNames()
-                .endSpec()
-                .build();
-    }
-
-    public static CustomResourceDefinition kafka() {
-        return crd(Kafka.class);
-    }
 
     public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOperation(KubernetesClient client) {
         return client.resources(Kafka.class, KafkaList.class);
-    }
-
-    public static CustomResourceDefinition kafkaConnect() {
-        return crd(KafkaConnect.class);
     }
 
     public static MixedOperation<KafkaConnect, KafkaConnectList, Resource<KafkaConnect>> kafkaConnectOperation(KubernetesClient client) {
         return client.resources(KafkaConnect.class, KafkaConnectList.class);
     }
 
-    public static CustomResourceDefinition kafkaConnector() {
-        return crd(KafkaConnector.class);
-    }
-
     public static MixedOperation<KafkaConnector, KafkaConnectorList, Resource<KafkaConnector>> kafkaConnectorOperation(KubernetesClient client) {
         return client.resources(KafkaConnector.class, KafkaConnectorList.class);
-    }
-
-    public static CustomResourceDefinition kafkaTopic() {
-        return crd(KafkaTopic.class);
     }
 
     public static MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> topicOperation(KubernetesClient client) {
         return client.resources(KafkaTopic.class, KafkaTopicList.class);
     }
 
-    public static CustomResourceDefinition kafkaUser() {
-        return crd(KafkaUser.class);
-    }
-
     public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserOperation(KubernetesClient client) {
         return client.resources(KafkaUser.class, KafkaUserList.class);
-    }
-
-    public static CustomResourceDefinition kafkaBridge() {
-        return crd(KafkaBridge.class);
     }
 
     public static MixedOperation<KafkaBridge, KafkaBridgeList, Resource<KafkaBridge>> kafkaBridgeOperation(KubernetesClient client) {
         return client.resources(KafkaBridge.class, KafkaBridgeList.class);
     }
 
-    public static CustomResourceDefinition kafkaMirrorMaker2() {
-        return crd(KafkaMirrorMaker2.class);
-    }
-
     public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>> kafkaMirrorMaker2Operation(KubernetesClient client) {
         return client.resources(KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
-    }
-
-    public static CustomResourceDefinition kafkaRebalance() {
-        return crd(KafkaRebalance.class);
     }
 
     public static MixedOperation<KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>> kafkaRebalanceOperation(KubernetesClient client) {
         return client.resources(KafkaRebalance.class, KafkaRebalanceList.class);
     }
-
-    public static CustomResourceDefinition strimziPodSet() {
-        return crd(StrimziPodSet.class);
-    }
-
     public static MixedOperation<StrimziPodSet, StrimziPodSetList, Resource<StrimziPodSet>> strimziPodSetOperation(KubernetesClient client) {
         return client.resources(StrimziPodSet.class, StrimziPodSetList.class);
     }
 
-    public static CustomResourceDefinition kafkaNodePool() {
-        return crd(KafkaNodePool.class);
-    }
-
     public static MixedOperation<KafkaNodePool, KafkaNodePoolList, Resource<KafkaNodePool>> kafkaNodePoolOperation(KubernetesClient client) {
         return client.resources(KafkaNodePool.class, KafkaNodePoolList.class);
-    }
-
-    public static <T extends CustomResource, L extends DefaultKubernetesResourceList<T>> MixedOperation<T, L, Resource<T>>
-            operation(KubernetesClient client,
-                      Class<T> cls,
-                      Class<L> listCls) {
-        return client.resources(cls, listCls);
-    }
-
-    public static <T extends CustomResource> String kind(Class<T> cls) {
-        try {
-            return cls.getDeclaredConstructor().newInstance().getKind();
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <T extends CustomResource> List<String> apiVersions(Class<T> cls) {
-        try {
-            String group = (String) cls.getField("RESOURCE_GROUP").get(null);
-
-            List<String> versions;
-            try {
-                versions = singletonList(group + "/" + cls.getField("VERSION").get(null));
-            } catch (NoSuchFieldException e) {
-                versions = ((List<String>) cls.getField("VERSIONS").get(null)).stream().map(v ->
-                        group + "/" + v).collect(Collectors.toList());
-            }
-            return versions;
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static int getNumCrds() {
-        return CRDS.length;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorOffsetsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorOffsetsTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.api.ResourceAnnotations;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
@@ -292,7 +291,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                     List<OwnerReference> ownerReferenceList = configMap.getMetadata().getOwnerReferences();
                     assertThat(ownerReferenceList, hasSize(1));
                     assertThat(ownerReferenceList.get(0).getName(), is(CONNECTOR_NAME));
-                    assertThat(ownerReferenceList.get(0).getKind(), is(Crds.kind(KafkaConnector.class)));
+                    assertThat(ownerReferenceList.get(0).getKind(), is(KafkaConnector.RESOURCE_KIND));
                     Map<String, String> configMapData = configMap.getData();
                     assertThat(configMapData, hasEntry("offsets.json", OFFSETS_JSON));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.api.ResourceAnnotations;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.connector.AlterOffsets;
 import io.strimzi.api.kafka.model.connector.AlterOffsetsBuilder;
@@ -454,7 +453,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                     List<OwnerReference> ownerReferenceList = configMap.getMetadata().getOwnerReferences();
                     assertThat(ownerReferenceList, hasSize(1));
                     assertThat(ownerReferenceList.get(0).getName(), is(MM2_NAME));
-                    assertThat(ownerReferenceList.get(0).getKind(), is(Crds.kind(KafkaMirrorMaker2.class)));
+                    assertThat(ownerReferenceList.get(0).getKind(), is(KafkaMirrorMaker2.RESOURCE_KIND));
                     Map<String, String> configMapData = configMap.getData();
                     assertThat(configMapData, hasEntry(getConfigmapEntryName(connector), OFFSETS_JSON));
 
@@ -530,7 +529,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                     assertThat(ownerReferenceList.get(0).getName(), is(ResourceUtils.DUMMY_OWNER_REFERENCE.getName()));
                     assertThat(ownerReferenceList.get(0).getKind(), is(ResourceUtils.DUMMY_OWNER_REFERENCE.getKind()));
                     assertThat(ownerReferenceList.get(1).getName(), is(MM2_NAME));
-                    assertThat(ownerReferenceList.get(1).getKind(), is(Crds.kind(KafkaMirrorMaker2.class)));
+                    assertThat(ownerReferenceList.get(1).getKind(), is(KafkaMirrorMaker2.RESOURCE_KIND));
 
                     Map<String, String> configMapData = configMap.getData();
                     assertThat(configMapData, hasEntry(getConfigmapEntryName(connector), OFFSETS_JSON));


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes some unused methods from the `Crds` class in the `api` module. These methods are not used anymore after various changes and refactorings.

For example, the `crd(...)` method used to provide a fake CRD that was used to create the Fabric8 operator objects, but is not needed after it accepts the classes directly. Apart from not being used in Strimzi, this method is also misleading for the `api` module users (see https://github.com/orgs/strimzi/discussions/12897) making them thing that they can use this to create the CRD in an actual Kubernetes API. But this was never the intended use-case and likely never worked properly. (And if we want the `api` module to provide this functionality, we would need to make sure it does so for the proper CRD YAMLs and not faked CRD classes without proper structures).

### Checklist

- [ ] Make sure all tests pass