### PR TITLE
Make KafkaAgent broker-state metric fields volatile

### DIFF
--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -76,10 +76,12 @@ public class KafkaAgent {
     static final SecureRandom RANDOM = new SecureRandom();
     private final Secret caCertSecret;
     private final Secret nodeCertSecret;
-    private MetricName brokerStateName;
-    private Gauge brokerState;
-    private Gauge remainingLogsToRecover;
-    private Gauge remainingSegmentsToRecover;
+    // These metric references are written by the Yammer metrics-registry listener thread and read by the
+    // Jetty request-handling threads, so they are volatile to guarantee visibility of the published values.
+    private volatile MetricName brokerStateName;
+    private volatile Gauge brokerState;
+    private volatile Gauge remainingLogsToRecover;
+    private volatile Gauge remainingSegmentsToRecover;
 
     /**
      * Constructor of the KafkaAgent
@@ -132,18 +134,31 @@ public class KafkaAgent {
             }
 
             @Override
-            public synchronized void onMetricAdded(MetricName metricName, Metric metric) {
-                LOGGER.debug("Metric added {}", metricName);
-                if (isBrokerState(metricName) && metric instanceof Gauge) {
-                    brokerStateName = metricName;
-                    brokerState = (Gauge) metric;
-                } else if (isRemainingLogsToRecover(metricName) && metric instanceof Gauge) {
-                    remainingLogsToRecover = (Gauge) metric;
-                } else if (isRemainingSegmentsToRecover(metricName) && metric instanceof Gauge) {
-                    remainingSegmentsToRecover = (Gauge) metric;
-                }
+            public void onMetricAdded(MetricName metricName, Metric metric) {
+                handleMetricAdded(metricName, metric);
             }
         });
+    }
+
+    /**
+     * Records the broker-state metrics published by the Kafka metrics registry so that they can be served by the
+     * broker-state and readiness endpoints. This is invoked from the metrics-registry listener thread while the Jetty
+     * request-handling threads read the same fields, so the fields it writes are {@code volatile} to make the published
+     * references visible to those reader threads.
+     *
+     * @param metricName    Name of the metric that was added to the registry
+     * @param metric        The metric that was added to the registry
+     */
+    /* test */ synchronized void handleMetricAdded(MetricName metricName, Metric metric) {
+        LOGGER.debug("Metric added {}", metricName);
+        if (isBrokerState(metricName) && metric instanceof Gauge) {
+            brokerStateName = metricName;
+            brokerState = (Gauge) metric;
+        } else if (isRemainingLogsToRecover(metricName) && metric instanceof Gauge) {
+            remainingLogsToRecover = (Gauge) metric;
+        } else if (isRemainingSegmentsToRecover(metricName) && metric instanceof Gauge) {
+            remainingSegmentsToRecover = (Gauge) metric;
+        }
     }
 
     /**

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.kafka.agent;
 
 import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import jakarta.servlet.http.HttpServletResponse;
@@ -222,5 +223,28 @@ public class KafkaAgentTest {
                 .send(httpReq, HttpResponse.BodyHandlers.ofString());
 
         assertThat(HttpServletResponse.SC_SERVICE_UNAVAILABLE, is(response.statusCode()));
+    }
+
+    @Test
+    public void testReadinessReflectsBrokerStatePublishedByMetricsListener() throws Exception {
+        @SuppressWarnings({ "rawtypes" })
+        final Gauge brokerState = mock(Gauge.class);
+        when(brokerState.value()).thenReturn((byte) 3);
+
+        // The HTTP server starts serving requests before the BrokerState metric is registered, so the metric is
+        // published to the agent later, from the metrics-registry listener thread. Simulate that registration and
+        // check the readiness endpoint then observes the running broker and reports it as ready.
+        KafkaAgent agent = new KafkaAgent(caCertSecret, nodeCertSecret, null, null, null);
+        agent.handleMetricAdded(new MetricName("kafka.server", "KafkaServer", "BrokerState"), brokerState);
+
+        context.setHandler(agent.getReadinessHandler());
+        server.setHandler(context);
+        server.start();
+
+        HttpResponse<String> response = HttpClient.newBuilder()
+                .build()
+                .send(httpReq, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode(), is(HttpServletResponse.SC_NO_CONTENT));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`KafkaAgent` serves the Kafka broker's state on the `/v1/broker-state` and
`/v1/ready` HTTP endpoints, and `/v1/ready` is what gates the broker Pod's
readiness in Kubernetes. Both endpoints read four instance fields that hold the
broker-state metrics: `brokerStateName`, `brokerState`, `remainingLogsToRecover`
and `remainingSegmentsToRecover`.

These fields are written on one thread and read on another with nothing that
makes the writes visible to the reader:

- They are **written** by the Yammer metrics-registry listener callback
  `onMetricAdded`, which runs on the Kafka thread that registers the broker's
  `BrokerState` metric.
- They are **read** without synchronization by the Jetty request handlers
  `getBrokerStateHandler()` and `getReadinessHandler()`, which run on Jetty
  request-handling threads.

`run()` starts the HTTP server *before* it registers the listener, so the reader
threads are already serving requests when these writes happen (so this is not a
safe publish-before-start). The `synchronized` on `onMetricAdded` only locks the
listener instance, which the readers never lock, so it creates no happens-before
relationship with them. Under the Java Memory Model a reader is therefore not
guaranteed to observe the published references, so `/v1/ready` can keep returning
`404 Broker state metric not found` (still seeing `brokerState` as `null`) after
the broker has actually registered its state.

**Fix:** mark the four fields `volatile`. Each field holds a single published
reference and is read as a whole, so `volatile` gives the reader threads the
visibility guarantee that is missing, without needing a heavier lock.

To make this testable, the body of the listener callback is extracted into a
package-private `handleMetricAdded` method. The new test publishes a running
`BrokerState` through that method (the same path the metrics registry uses) and
asserts the readiness endpoint then reports the broker as ready, exercising the
metric-publication-to-endpoint path that was previously untested. A
memory-visibility race cannot be reproduced deterministically in a unit test, so
the test covers the behaviour rather than the race itself.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
