### PR TITLE
Report non-integer Cruise Control metrics topic config as InvalidResourceException

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
@@ -44,29 +44,11 @@ public record CruiseControlMetricsReporter(String topicName, Integer numPartitio
                 topicName = kafka.getSpec().getCruiseControl().getConfig().get(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue()).toString();
             }
 
-            int numPartitions;
-            if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue()) == null) {
-                numPartitions = Integer.parseInt(configuration.getConfigOption(KAFKA_NUM_PARTITIONS_CONFIG_FIELD, "1"));
-            } else {
-                numPartitions = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue()));
-                configuration.removeConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue());
-            }
-
-            int replicationFactor;
-            if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()) == null) {
-                replicationFactor = Integer.parseInt(configuration.getConfigOption(KAFKA_REPLICATION_FACTOR_CONFIG_FIELD, "1"));
-            } else {
-                replicationFactor = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()));
-                configuration.removeConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue());
-            }
-
-            int minInSyncReplicas;
-            if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()) == null) {
-                minInSyncReplicas = 1;
-            } else {
-                minInSyncReplicas = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()));
-                configuration.removeConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue());
-            }
+            int numPartitions = intConfigOption(configuration, CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue(),
+                    Integer.parseInt(configuration.getConfigOption(KAFKA_NUM_PARTITIONS_CONFIG_FIELD, "1")));
+            int replicationFactor = intConfigOption(configuration, CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue(),
+                    Integer.parseInt(configuration.getConfigOption(KAFKA_REPLICATION_FACTOR_CONFIG_FIELD, "1")));
+            int minInSyncReplicas = intConfigOption(configuration, CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue(), 1);
 
             validateCruiseControl(kafka, numberOfBrokers, replicationFactor, minInSyncReplicas);
 
@@ -74,6 +56,35 @@ public record CruiseControlMetricsReporter(String topicName, Integer numPartitio
         } else {
             // Cruise Control is not enabled
             return null;
+        }
+    }
+
+    /**
+     * Resolves an integer configuration option from the user-provided configuration. When the option is set, its value
+     * is parsed as an integer and the option is removed from the configuration so that it is not passed on as a Kafka
+     * broker property. When the option is not set, the supplied default value is used. A non-integer value is reported
+     * as an {@link InvalidResourceException} instead of letting the raw {@link NumberFormatException} propagate, so that
+     * a typo in the Kafka custom resource is reported as a clear configuration error.
+     *
+     * @param configuration     The user-provided configuration of the Kafka cluster
+     * @param configOption      The name of the configuration option
+     * @param defaultValue      The value used when the configuration option is not set
+     *
+     * @return  The integer value of the configuration option, or the default value when the option is not set
+     */
+    private static int intConfigOption(KafkaConfiguration configuration, String configOption, int defaultValue) {
+        String value = configuration.getConfigOption(configOption);
+
+        if (value == null) {
+            return defaultValue;
+        }
+
+        configuration.removeConfigOption(configOption);
+
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new InvalidResourceException("Cruise Control configuration option '" + configOption + "' should be an integer but was set to '" + value + "'.", e);
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
@@ -151,4 +151,14 @@ public class CruiseControlMetricsReporterTest {
 
         assertThat(e.getMessage(), is("The Cruise Control metric topic minISR was set to a value (4) which is higher than the number of replicas for that topic (3). Please ensure that the Cruise Control metrics topic minISR is <= to the topic's replication factor."));
     }
+
+    @Test
+    public void testNonIntegerCruiseControlMetricsTopicConfig() {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("cruise.control.metrics.topic.num.partitions", "not-a-number");
+
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 3));
+
+        assertThat(e.getMessage(), is("Cruise Control configuration option 'cruise.control.metrics.topic.num.partitions' should be an integer but was set to 'not-a-number'."));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`CruiseControlMetricsReporter.fromCrd` reads the metrics topic settings
`cruise.control.metrics.topic.num.partitions`,
`cruise.control.metrics.topic.replication.factor` and
`cruise.control.metrics.topic.min.insync.replicas` from the user's free-form
`spec.cruiseControl.config` and parsed each with a bare `Integer.parseInt`.

These Cruise Control keys have no `@Pattern` and are not Kafka broker properties,
so they are not covered by the Kafka config-model validation. A typo such as:

```yaml
spec:
  cruiseControl:
    config:
      cruise.control.metrics.topic.num.partitions: "abc"
```

reached `Integer.parseInt` unvalidated and threw an uncaught
`NumberFormatException`, surfacing as an opaque operator error instead of a clear
configuration problem. The surrounding `validateCruiseControl` already reports
its numeric checks as `InvalidResourceException`, so this was an inconsistency in
how the same block handles bad numeric input.

Following review, the whole resolution of each metrics topic setting now lives in
a single `metricsTopicConfig` helper that reads the option, applies the default
when it is unset, removes the option once consumed, and parses the value. A
non-integer value is rethrown as an `InvalidResourceException` naming the
offending option and value:

```
Cruise Control configuration option 'cruise.control.metrics.topic.num.partitions' should be an integer but was set to 'abc'.
```

This mirrors the existing `validateIntConfigProperty` handling in `KafkaCluster`.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
