### PR TITLE
Assert on completion in KafkaQuorumCheckTest and KafkaAvailabilityTest

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -290,7 +291,7 @@ public class KafkaAvailabilityTest {
                     assertFalse(canRoll,
                             "broker " + brokerId + " should not be rollable, being minisr = 2 and it's only replicated on two brokers");
                 }
-            });
+            }).join();
         }
     }
 
@@ -327,7 +328,7 @@ public class KafkaAvailabilityTest {
                     assertTrue(canRoll,
                             "broker " + brokerId + " should be rollable, because although rolling it will impact availability minisr=|replicas|");
                 }
-            });
+            }).join();
         }
     }
 
@@ -357,7 +358,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                    "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr"));
+                    "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr")).join();
         }
     }
 
@@ -379,7 +380,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas"));
+                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas")).join();
         }
     }
 
@@ -401,7 +402,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas"));
+                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas")).join();
         }
     }
 
@@ -422,7 +423,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 2, but only 1 replicas"));
+                        "broker " + brokerId + " should be rollable, being minisr = 2, but only 1 replicas")).join();
         }
     }
 
@@ -459,7 +460,7 @@ public class KafkaAvailabilityTest {
                     assertTrue(canRoll,
                             "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr");
                 }
-            });
+            }).join();
         }
     }
 
@@ -487,7 +488,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr"));
+                        "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr")).join();
         }
     }
 
@@ -518,10 +519,8 @@ public class KafkaAvailabilityTest {
         KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac());
 
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> {
-                assertThat(error, instanceOf(CompletionException.class));
-                assertThat(error.getCause(), instanceOf(TimeoutException.class));
-            });
+            Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).join());
+            assertThat(error.getCause(), instanceOf(TimeoutException.class));
         }
     }
 
@@ -551,10 +550,8 @@ public class KafkaAvailabilityTest {
         KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac());
 
         for (Integer brokerId : ksb.brokers.keySet()) {
-            kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> {
-                assertThat(error, instanceOf(CompletionException.class));
-                assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
-            });
+            Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).join());
+            assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
         }
     }
 
@@ -585,10 +582,8 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             if (brokerId <= 2) {
-                kafkaAvailability.canRoll(brokerId).whenComplete((r, error) -> {
-                    assertThat(error, instanceOf(CompletionException.class));
-                    assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
-                });
+                Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).join());
+                assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
             }
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheckTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheckTest.java
@@ -16,9 +16,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -52,7 +55,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(9700L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
     }
 
     @Test
@@ -64,7 +67,7 @@ class KafkaQuorumCheckTest {
         controllers.put(4, OptionalLong.of(9600L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
     }
 
     @Test
@@ -75,7 +78,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(8200L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -87,7 +90,7 @@ class KafkaQuorumCheckTest {
         controllers.put(4, OptionalLong.of(9000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -98,7 +101,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(10000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(2).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(2).whenComplete((result, err) -> assertTrue(result)).join();
     }
 
     @Test
@@ -109,7 +112,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(10000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(3).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(3).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -120,7 +123,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(-1));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(3).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(3).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -133,7 +136,8 @@ class KafkaQuorumCheckTest {
         kafkaFuture.completeExceptionally(new Exception(expectedError));
         when(qrmResult.quorumInfo()).thenReturn(kafkaFuture);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((r, error) -> assertThat(error.getMessage(), is(expectedError)));
+        CompletionException exception = assertThrows(CompletionException.class, () -> quorumCheck.canRollController(1).join());
+        assertThat(exception.getCause().getMessage(), is(expectedError));
     }
 
     @Test
@@ -142,7 +146,7 @@ class KafkaQuorumCheckTest {
         controllers.put(1, OptionalLong.of(10000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
     }
 
     @Test
@@ -152,7 +156,7 @@ class KafkaQuorumCheckTest {
         controllers.put(2, OptionalLong.of(9500L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
     }
 
     @Test
@@ -162,7 +166,7 @@ class KafkaQuorumCheckTest {
         controllers.put(2, OptionalLong.of(7000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -173,7 +177,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(9500L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -188,7 +192,7 @@ class KafkaQuorumCheckTest {
         Admin admin = setUpMocks(-1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
 
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
     }
 
     @Test
@@ -199,6 +203,6 @@ class KafkaQuorumCheckTest {
         Admin admin = setUpMocks(1, controllers);
         long dynamicTimeout = 100L; // Dynamic timeout value
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, dynamicTimeout);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result));
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
     }
 }


### PR DESCRIPTION

### Type of change

- Bugfix


Since Vert.x was removed from these classes (#12356), the async assertions in
`KafkaQuorumCheckTest` and `KafkaAvailabilityTest` were attached inside
`CompletableFuture.whenComplete(...)` on a future that was then discarded. The
mocked `Admin` returns already-completed futures, so the callbacks do run, but
any `AssertionError` they throw is captured into the unobserved returned future
and never rethrown. Every test therefore passes regardless of what it asserts.

The masking hid two problems:

- In `KafkaQuorumCheckTest`, seven negative cases had their expectation flipped
  from `assertFalse` to `assertTrue` during the Vert.x conversion. They assert
  the opposite of the intended behaviour and only stay green because the
  `AssertionError` is swallowed. These are the "cannot roll" cases: a follower
  behind (odd and even sized quorum), another follower behind, an invalid
  timestamp, incomplete quorum data, no leader, and the two-node follower-behind
  quorum. Each is wrong against `KafkaQuorumCheck.isQuorumHealthyWithoutNode`,
  which returns `false` for all of them.
- The error-path tests never verified the exception, because the future they
  attached the check to was discarded.

This PR chains `.join()` onto the returned future in the value tests so the
assertions run on the test thread and failures surface, restores the correct
`assertFalse` expectations for the seven cases above, and rewrites the
error-path tests to block with `assertThrows(CompletionException.class, ...)`
and assert on the completion exception cause.

Note: #12883 recently reworked the three `KafkaAvailabilityTest` error-path
tests to assert on `error.getCause()` instead of `maybeUnwrapCompletionException`,
but it kept them inside `whenComplete(...)` without joining, so those assertions
still do not execute on `main`. This change keeps that PR's exception-shape
decision and adds the missing `.join()` via `assertThrows` so they actually run.

No production code changes.

### Checklist

- [ ] Update documentation (not applicable, test-only change)
- [ ] Update CHANGELOG.md (not applicable, no user-facing change)
- [ ] Reference relevant issue(s) and close them after merging (no filed issue)
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests (not applicable, unit-test-only change)
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
