### PR TITLE
Make the `diff(...)` method in `AbstractResourceOperator` private

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/PvcOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/PvcOperatorTest.java
@@ -11,8 +11,11 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.kubernetes.AbstractNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.kubernetes.AbstractNamespacedResourceOperatorTest;
 import org.junit.jupiter.api.Test;
@@ -20,8 +23,11 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -140,11 +146,30 @@ public class PvcOperatorTest extends AbstractNamespacedResourceOperatorTest<Kube
                 .endMetadata()
                 .build();
 
-        PvcOperator op = createResourceOperations(mock(KubernetesClient.class), false);
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+        PvcOperator op = createResourceOperations(mockClient, false);
 
-        assertThat(op.diff(Reconciliation.DUMMY_RECONCILIATION, "my-pvc", pvcWithDefaultAnnos, pvcWithDefaultAnnos).isEmpty(), is(true));
-        assertThat(op.diff(Reconciliation.DUMMY_RECONCILIATION, "my-pvc", pvcWithDefaultAnnos, pvcWithIgnoredAnnos).isEmpty(), is(true));
-        assertThat(op.diff(Reconciliation.DUMMY_RECONCILIATION, "my-pvc", pvcWithDefaultAnnos, pvcWithOtherAnnos).isEmpty(), is(false));
+        // This tests check that the AbstractResourceoperator.diff(...) method to verify that IGNORABLE_PATHS is respected.
+        // But because it is not accessible directly, it checks it through the internalUpdate method that is accessible.
+        @SuppressWarnings("unchecked")
+        MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> pvcOp = mock(MixedOperation.class);
+        @SuppressWarnings("unchecked")
+        NonNamespaceOperation<PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> nsOp = mock(NonNamespaceOperation.class);
+        @SuppressWarnings("unchecked")
+        Resource<PersistentVolumeClaim> resourceOp = mock(Resource.class);
+        when(mockClient.persistentVolumeClaims()).thenReturn(pvcOp);
+        when(nsOp.withName(anyString())).thenReturn(resourceOp);
+        when(pvcOp.inNamespace(anyString())).thenReturn(nsOp);
+        when(resourceOp.patch(any(PatchContext.class), any(PersistentVolumeClaim.class))).thenAnswer(i -> new PersistentVolumeClaimBuilder((PersistentVolumeClaim) i.getArgument(1))
+                .editMetadata()
+                    .withResourceVersion("new-version")
+                .endMetadata()
+                .build());
+
+        assertThat(op.internalUpdate(Reconciliation.DUMMY_RECONCILIATION, "my-namespace", "my-pvc", pvcWithDefaultAnnos, pvcWithDefaultAnnos).toCompletableFuture().join(), is(ReconcileResult.noop(pvcWithDefaultAnnos)));
+        assertThat(op.internalUpdate(Reconciliation.DUMMY_RECONCILIATION, "my-namespace", "my-pvc", pvcWithDefaultAnnos, pvcWithIgnoredAnnos).toCompletableFuture().join(), is(ReconcileResult.noop(pvcWithDefaultAnnos)));
+        assertThat(op.internalUpdate(Reconciliation.DUMMY_RECONCILIATION, "my-namespace", "my-pvc", pvcWithDefaultAnnos, pvcWithOtherAnnos).toCompletableFuture().join(), is(instanceOf(ReconcileResult.Patched.class)));
+        assertThat(op.internalUpdate(Reconciliation.DUMMY_RECONCILIATION, "my-namespace", "my-pvc", pvcWithDefaultAnnos, pvcWithOtherAnnos).toCompletableFuture().join().resource().getMetadata().getAnnotations().get("some.annotation.io/key"), is("value"));
     }
 
     @Test

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/kubernetes/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/kubernetes/AbstractResourceOperator.java
@@ -89,7 +89,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      *
      * @return              The ResourceDiff instance
      */
-    public ResourceDiff<T> diff(Reconciliation reconciliation, String resourceName, T current, T desired)  {
+    private ResourceDiff<T> diff(Reconciliation reconciliation, String resourceName, T current, T desired)  {
         return new ResourceDiff<>(reconciliation, resourceKind, resourceName, current, desired, ignorablePaths());
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

When removing Vert.x from the Cluster Operator Kubernetes Resource Operators, I had to make the `diff(...)` method in `AbstractResourceOperator` public because it was used by the `PvcOperatorTest` which is in different package. This PR refactors the test and instead of testing the `diff(...)` method directly, it now tests it through another method. That allows us to make the `diff(...)` method private.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass