### PR TITLE
Validate persistent-claim storage size format in the CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0
 
 * Add support for Apache Kafka 4.3.1
+* Validate the format of the `size` field in persistent-claim storage in the CRD, so malformed values (for example `100XYZ`) are rejected on admission instead of failing later during reconciliation. This matches the existing validation on the ephemeral storage `sizeLimit` field.
 
 ### Major changes, deprecations, and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -54,6 +55,7 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
         super.setId(id);
     }
 
+    @Pattern(Constants.MEMORY_REGEX)
     @Description("When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. " +
             "Mandatory when `type=persistent-claim`.")
     public String getSize() {

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -87,6 +87,7 @@ spec:
                       description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                     size:
                       type: string
+                      pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
                       description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
                     sizeLimit:
                       type: string
@@ -129,6 +130,7 @@ spec:
                             description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                           size:
                             type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
                             description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
                           sizeLimit:
                             type: string

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -86,6 +86,7 @@ spec:
                     description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                   size:
                     type: string
+                    pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
                     description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
                   sizeLimit:
                     type: string
@@ -128,6 +129,7 @@ spec:
                           description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                         size:
                           type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
                           description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
                         sizeLimit:
                           type: string


### PR DESCRIPTION

Validate the format of the `size` field of persistent-claim storage in the CRD.

### Problem

The `size` field of persistent-claim storage (`PersistentClaimStorage.getSize()`)
carries no format validation. Its CRD schema is generated as a plain
`type: string` with no `pattern`, so the Kubernetes API server accepts any
value at admission, including malformed ones such as `100XYZ`, `10gi`, or `abc`.

The value is only parsed later, during reconciliation, in
`StorageUtils.convertToMillibytes`. A malformed size then throws an uncaught
`IllegalArgumentException` (unknown memory suffix) or `NumberFormatException`
(empty numeric part, for example `Gi`). So an invalid size is not reported back
to the user as an admission error on the resource; it surfaces later as an
operator-side reconciliation failure.

This is inconsistent with the analogous ephemeral storage field: `sizeLimit`
(`EphemeralStorage.getSizeLimit()`) already carries
`@Pattern(Constants.MEMORY_REGEX)`, which the CRD generator compiles into an
OpenAPI `pattern`, so malformed ephemeral sizes are rejected up front at
admission.

### Change

Add `@Pattern(Constants.MEMORY_REGEX)` to `PersistentClaimStorage.getSize()`,
mirroring the existing ephemeral `sizeLimit` field exactly (same regex, same
annotation placement), and regenerate the affected CRDs. Malformed persistent
storage sizes are now rejected by the Kubernetes API server at admission,
matching the ephemeral field, instead of failing later during reconciliation.

`Constants.MEMORY_REGEX` is `^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`, the same
pattern already used for `sizeLimit`. It accepts the standard Kubernetes
quantity forms already used across the tests and docs (for example `100Gi`,
`500M`, `1Ti`, `2.1e6`) and rejects the malformed values above, so this is not a
backward-compatibility break for any valid size.

### Files

- `api/.../kafka/model/kafka/PersistentClaimStorage.java` - add the `@Pattern`
  annotation and its import.
- `packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml` and
  `packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml`
  - regenerated CRDs (`mvn -pl api ... process-classes` + `make crd_install`);
  the `pattern` is added to both `size` occurrences (top-level storage and JBOD
  volume).
- `CHANGELOG.md` - one entry under the unreleased section.

### Precedent

This follows PR #5609, which introduced `MEMORY_REGEX` and added the same
`@Pattern` to the ephemeral `sizeLimit` field. That PR shipped the annotation,
the regenerated CRDs, and a CHANGELOG entry, with no dedicated schema-assertion
unit test (the generated CRD YAML, diffed in CI, is the regression artifact).
This change mirrors that shape.

### Testing

- `mvn -pl api checkstyle:check@validate` - passes.
- `mvn -pl api -am test -DskipITs` - 53 tests pass (includes `ExamplesTest`,
  `CrdTest`, and the crd-generator tests, which validate the generated CRD
  schema against the example resources).
- `mvn -pl cluster-operator -am test -Dtest=StorageUtilsTest -DskipITs` - 5
  tests pass; the reactor builds successfully.
- The integration tests that need a live cluster (`StructuralCrdIT`, `CrdIT`,
  `CelValidationIT`) were not run locally; they will run in CI. Adding a
  `pattern` to an existing `string` field is structurally identical to the
  already-present `sizeLimit`, so no structural regression is expected.

I did not add a dedicated unit test, matching the precedent in #5609; the
regenerated CRD YAML is the regression artifact for the schema change.
