### PR TITLE
Add Drain Cleaner 1.6.1 to the operators repo

### DIFF
--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -33,7 +33,7 @@
 :BridgeVersion: 1.0.0
 
 // Drain Cleaner Version
-:DrainCleanerVersion: 1.6.0
+:DrainCleanerVersion: 1.6.1
 
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub releases page^]

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.6.1-rc1
+          image: quay.io/strimzi/drain-cleaner:1.6.1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.6.0
+          image: quay.io/strimzi/drain-cleaner:1.6.1-rc1
           ports:
             - containerPort: 8080
               name: http
@@ -66,4 +66,5 @@ spec:
           secret:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: "5Mi"

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.6.1-rc1
+          image: quay.io/strimzi/drain-cleaner:1.6.1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.6.0
+          image: quay.io/strimzi/drain-cleaner:1.6.1-rc1
           ports:
             - containerPort: 8080
               name: http
@@ -66,4 +66,5 @@ spec:
           secret:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: "5Mi"

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.6.1-rc1
+          image: quay.io/strimzi/drain-cleaner:1.6.1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.6.0
+          image: quay.io/strimzi/drain-cleaner:1.6.1-rc1
           ports:
             - containerPort: 8080
               name: http
@@ -66,4 +66,5 @@ spec:
           secret:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: "5Mi"


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds Drain Cleaner 1.6.1 to the packaging directory and updates the Drain Cleaner version in docs.

### Checklist

- [x] Update documentation