### PR TITLE
Rename `TimeoutException` and `DeplomentStrategy`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
@@ -31,7 +31,7 @@ import java.util.Map;
 @ToString
 public class DeploymentTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
     private MetadataTemplate metadata;
-    private DeploymentStrategy deploymentStrategy;
+    private StrimziDeploymentStrategy deploymentStrategy;
     private Map<String, Object> additionalProperties;
 
     @Description("Metadata applied to the resource.")
@@ -48,11 +48,11 @@ public class DeploymentTemplate implements HasMetadataTemplate, UnknownPropertyP
             "Valid values are `RollingUpdate` and `Recreate`. " +
             "Defaults to `RollingUpdate`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public DeploymentStrategy getDeploymentStrategy() {
+    public StrimziDeploymentStrategy getDeploymentStrategy() {
         return deploymentStrategy;
     }
 
-    public void setDeploymentStrategy(DeploymentStrategy deploymentStrategy) {
+    public void setDeploymentStrategy(StrimziDeploymentStrategy deploymentStrategy) {
         this.deploymentStrategy = deploymentStrategy;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/StrimziDeploymentStrategy.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/StrimziDeploymentStrategy.java
@@ -9,12 +9,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Locale;
 
-public enum DeploymentStrategy {
+public enum StrimziDeploymentStrategy {
     ROLLING_UPDATE,
     RECREATE;
 
     @JsonCreator
-    public static DeploymentStrategy forValue(String value) {
+    public static StrimziDeploymentStrategy forValue(String value) {
         switch (value.toLowerCase(Locale.ENGLISH)) {
             case "rollingupdate":
                 return ROLLING_UPDATE;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -28,6 +28,7 @@ import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -65,7 +66,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE;
 import static io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS;
 import static io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration.CRUISE_CONTROL_GOALS;
 import static java.lang.String.format;
@@ -374,7 +374,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
                 templateDeployment,
                 1,
                 null,
-                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
+                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, StrimziDeploymentStrategy.ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,
                         labels,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityOperatorSpec;
@@ -44,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.strimzi.api.kafka.model.common.template.DeploymentStrategy.RECREATE;
 import static io.strimzi.operator.cluster.model.TemplateUtils.addAdditionalVolumes;
 
 /**
@@ -205,7 +205,7 @@ public class EntityOperator extends AbstractModel {
                 templateDeployment,
                 1,
                 null,
-                WorkloadUtils.deploymentStrategy(RECREATE), // we intentionally ignore the template here as EO doesn't support RU strategy
+                WorkloadUtils.deploymentStrategy(StrimziDeploymentStrategy.RECREATE), // we intentionally ignore the template here as EO doesn't support RU strategy
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,
                         labels,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -41,12 +41,12 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
-import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
@@ -395,7 +395,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
                 templateDeployment,
                 replicas,
                 null,
-                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, DeploymentStrategy.ROLLING_UPDATE)),
+                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, StrimziDeploymentStrategy.ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,
                         labels,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -21,6 +21,7 @@ import io.strimzi.api.kafka.model.common.ProbeBuilder;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -40,8 +41,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE;
 
 /**
  * Kafka Exporter model
@@ -192,7 +191,7 @@ public class KafkaExporter extends AbstractModel {
                 templateDeployment,
                 1,
                 null,
-                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
+                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, StrimziDeploymentStrategy.ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,
                         labels,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -10,10 +10,10 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
-import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.HasMetadataTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.operator.common.model.InvalidResourceException;
 
 import java.util.List;
@@ -169,7 +169,7 @@ public class TemplateUtils {
      *
      * @return  Custom deployment strategy or default value if not defined
      */
-    public static DeploymentStrategy deploymentStrategy(DeploymentTemplate template, DeploymentStrategy defaultValue) {
+    public static StrimziDeploymentStrategy deploymentStrategy(DeploymentTemplate template, StrimziDeploymentStrategy defaultValue) {
         return template != null && template.getDeploymentStrategy() != null ? template.getDeploymentStrategy() : defaultValue;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.operator.common.Reconciliation;
@@ -431,8 +432,7 @@ public class WorkloadUtils {
      *
      * @return  Created deployment strategy
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-    public static DeploymentStrategy deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy strategy) {
+    public static DeploymentStrategy deploymentStrategy(StrimziDeploymentStrategy strategy) {
         return switch (strategy) {
             case ROLLING_UPDATE -> rollingUpdateStrategy();
             case RECREATE -> recreateStrategy();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.cluster.operator;
 
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.TimeoutException;
+import io.strimzi.operator.common.StrimziTimeoutException;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -156,7 +156,7 @@ public final class VertxUtil {
                                     if (timeLeft <= 0) {
                                         String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
                                         LOGGER.errorCr(reconciliation, exceptionMessage);
-                                        promise.fail(new TimeoutException(exceptionMessage));
+                                        promise.fail(new StrimziTimeoutException(exceptionMessage));
                                     } else {
                                         // Schedule ourselves to run again
                                         vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -20,7 +20,7 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.TimeoutException;
+import io.strimzi.operator.common.StrimziTimeoutException;
 import io.strimzi.operator.common.metrics.MetricsHolder;
 import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
 import io.strimzi.operator.common.model.InvalidConfigParameterException;
@@ -371,7 +371,7 @@ public abstract class AbstractOperator<
      * The exception by which Futures returned by {@link #withLock(Reconciliation, long, Callable)} are failed when
      * the lock cannot be acquired within the timeout.
      */
-    static class UnableToAcquireLockException extends TimeoutException {
+    static class UnableToAcquireLockException extends StrimziTimeoutException {
         UnableToAcquireLockException() { }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -23,6 +23,7 @@ import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.StrimziTimeoutException;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
@@ -331,7 +332,6 @@ public class KafkaRoller {
      *
      * @return A future which completes when the pod has been rolled.
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     private CompletableFuture<Void> schedule(NodeRef nodeRef, long delayMs) {
         RestartContext ctx = podToContext.computeIfAbsent(nodeRef.podName(),
             k -> new RestartContext(backoffSupplier));
@@ -354,7 +354,7 @@ public class KafkaRoller {
                     LOGGER.infoCr(reconciliation, "Could not verify pod {} is up-to-date, giving up after {} attempts. Total delay between attempts {}ms",
                             nodeRef, ctx.backOff.maxAttempts(), ctx.backOff.totalDelayMs(), e);
                     ctx.completableFuture.completeExceptionally(e instanceof TimeoutException ?
-                            new io.strimzi.operator.common.TimeoutException() :
+                            new StrimziTimeoutException() :
                             e);
                 } else {
                     long delay1Ms = ctx.backOff.delayMs();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -14,7 +14,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.operator.common.CruiseControlUtil;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.TimeoutException;
+import io.strimzi.operator.common.StrimziTimeoutException;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.auth.PemTrustSet;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties;
@@ -487,7 +487,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
     private RuntimeException httpExceptionHandler(Throwable ex, String requestMethod, long timeout) {
         if (ex.getCause() instanceof HttpTimeoutException) {
-            return new TimeoutException("The timeout period of " + timeout * 1000 + "ms has been exceeded while executing " + requestMethod);
+            return new StrimziTimeoutException("The timeout period of " + timeout * 1000 + "ms has been exceeded while executing " + requestMethod);
         } else if (ex.getCause() instanceof NoRouteToHostException || ex.getCause() instanceof ConnectException) {
             return new CruiseControlRetriableConnectionException(ex.getCause());
         } else {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -52,9 +52,9 @@ import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
-import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.TestUtils;
@@ -536,7 +536,7 @@ public class KafkaBridgeClusterTest {
                                 .withLabels(depLabels)
                                 .withAnnotations(depAnots)
                             .endMetadata()
-                            .withDeploymentStrategy(DeploymentStrategy.RECREATE)
+                            .withDeploymentStrategy(StrimziDeploymentStrategy.RECREATE)
                         .endDeployment()
                         .withNewPod()
                             .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -30,7 +30,7 @@ import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
-import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -448,7 +448,7 @@ public class KafkaExporterTest {
                     .withNewKafkaExporter()
                         .withNewTemplate()
                             .withNewDeployment()
-                                .withDeploymentStrategy(DeploymentStrategy.RECREATE)
+                                .withDeploymentStrategy(StrimziDeploymentStrategy.RECREATE)
                             .endDeployment()
                         .endTemplate()
                     .endKafkaExporter()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -35,6 +35,7 @@ import io.strimzi.api.kafka.model.common.template.DnsPolicy;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplateBuilder;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
@@ -139,7 +140,6 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testCreateDeploymentWithNullTemplateAndRecreateStrategy()  {
-        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         Deployment dep = WorkloadUtils.createDeployment(
                 NAME,
                 NAMESPACE,
@@ -148,7 +148,7 @@ public class WorkloadUtilsTest {
                 null,
                 REPLICAS,
                 Map.of("extra", "annotations"),
-                WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy.RECREATE),
+                WorkloadUtils.deploymentStrategy(StrimziDeploymentStrategy.RECREATE),
                 DUMMY_POD_TEMPLATE_SPEC
         );
 
@@ -183,7 +183,7 @@ public class WorkloadUtilsTest {
                         .build(),
                 REPLICAS,
                 Map.of("extra", "annotations"),
-                WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE),
+                WorkloadUtils.deploymentStrategy(StrimziDeploymentStrategy.ROLLING_UPDATE),
                 DUMMY_POD_TEMPLATE_SPEC
         );
 
@@ -1033,8 +1033,7 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testDeploymentStrategyRecreate()    {
-        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-        DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy.RECREATE);
+        DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(StrimziDeploymentStrategy.RECREATE);
 
         assertThat(strategy.getType(), is("Recreate"));
         assertThat(strategy.getRollingUpdate(), is(nullValue()));
@@ -1042,8 +1041,7 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testDeploymentStrategyRollingUpdate()    {
-        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-        DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.common.template.DeploymentStrategy.ROLLING_UPDATE);
+        DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(StrimziDeploymentStrategy.ROLLING_UPDATE);
 
         assertThat(strategy.getType(), is("RollingUpdate"));
         assertThat(strategy.getRollingUpdate().getMaxSurge(), is(new IntOrString(1)));

--- a/operator-common/src/main/java/io/strimzi/operator/common/StrimziTimeoutException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/StrimziTimeoutException.java
@@ -7,11 +7,11 @@ package io.strimzi.operator.common;
 /**
  * Thrown to indicate that timeout has been exceeded.
  */
-public class TimeoutException extends RuntimeException {
+public class StrimziTimeoutException extends RuntimeException {
     /**
      * Constructs the TimeoutException
      */
-    public TimeoutException() {
+    public StrimziTimeoutException() {
         super();
     }
 
@@ -20,7 +20,7 @@ public class TimeoutException extends RuntimeException {
      *
      * @param message   Error message
      */
-    public TimeoutException(String message) {
+    public StrimziTimeoutException(String message) {
         super(message);
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/kubernetes/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/kubernetes/ResourceSupport.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.client.dsl.Listable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.TimeoutException;
+import io.strimzi.operator.common.StrimziTimeoutException;
 import io.strimzi.operator.common.Util;
 
 import java.io.Closeable;
@@ -177,8 +177,8 @@ public class ResourceSupport {
                         } else {
                             Throwable primary;
 
-                            if (Util.maybeUnwrapCompletionException(thrown) instanceof TimeoutException) {
-                                primary = new TimeoutException("\"" + watchFnDescription + "\" timed out after " + operationTimeoutMs + "ms");
+                            if (Util.maybeUnwrapCompletionException(thrown) instanceof StrimziTimeoutException) {
+                                primary = new StrimziTimeoutException("\"" + watchFnDescription + "\" timed out after " + operationTimeoutMs + "ms");
                             } else {
                                 primary = thrown;
                             }
@@ -327,7 +327,7 @@ public class ResourceSupport {
                                 "Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext,
                                 logState);
                         LOGGER.errorCr(reconciliation, exceptionMessage);
-                        promise.completeExceptionally(new TimeoutException(exceptionMessage));
+                        promise.completeExceptionally(new StrimziTimeoutException(exceptionMessage));
                     } else {
                         // Schedule ourselves to run again
                         CompletableFuture.delayedExecutor(

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/kubernetes/AbstractReadyResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/kubernetes/AbstractReadyResourceOperatorTest.java
@@ -11,7 +11,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.TimeoutException;
+import io.strimzi.operator.common.StrimziTimeoutException;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +56,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         TestUtils.await(op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
             .<Void>handle((v, error) -> {
                 assertThat(error, is(notNullValue()));
-                assertThat(error, is(instanceOf(TimeoutException.class)));
+                assertThat(error, is(instanceOf(StrimziTimeoutException.class)));
 
                 verify(mockResource, atLeastOnce()).get();
                 verify(mockResource, never()).isReady();
@@ -86,7 +86,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         TestUtils.await(op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
             .<Void>handle((v, error) -> {
                 assertThat(error, is(notNullValue()));
-                assertThat(error, is(instanceOf(TimeoutException.class)));
+                assertThat(error, is(instanceOf(StrimziTimeoutException.class)));
 
                 verify(mockResource, never()).isReady();
                 return null;
@@ -165,7 +165,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         TestUtils.await(op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
             .<Void>handle((v, error) -> {
                 assertThat(error, is(notNullValue()));
-                assertThat(error, is(instanceOf(TimeoutException.class)));
+                assertThat(error, is(instanceOf(StrimziTimeoutException.class)));
 
                 verify(mockResource, atLeastOnce()).get();
                 verify(mockResource, atLeastOnce()).isReady();
@@ -197,7 +197,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         TestUtils.await(op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
             .<Void>handle((v, error) -> {
                 assertThat(error, is(notNullValue()));
-                assertThat(error, is(instanceOf(TimeoutException.class)));
+                assertThat(error, is(instanceOf(StrimziTimeoutException.class)));
 
                 return null;
             }));

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -65,7 +65,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
     }
 
     enum LogIgnoreList {
-        CO_TIMEOUT_EXCEPTION("io.strimzi.operator.common.TimeoutException"),
+        CO_TIMEOUT_EXCEPTION("io.strimzi.operator.common.StrimziTimeoutException"),
         // "NO_ERROR" is necessary because DnsNameResolver prints debug information `QUERY(0), NoError(0), RD RA` after `received` operation
         NO_ERROR("NoError\\(0\\)"),
         // This is necessary for OCP 3.10 or less because of having exception handling during the patching of NetworkPolicy

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -16,7 +16,7 @@ import io.skodjob.kubetest4j.resources.KubeResourceManager;
 import io.strimzi.api.kafka.model.bridge.KafkaBridge;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
-import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
+import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -412,7 +412,7 @@ class HttpBridgeST extends AbstractST {
             .editSpec()
                 .editOrNewTemplate()
                     .editOrNewDeployment()
-                        .withDeploymentStrategy(DeploymentStrategy.RECREATE)
+                        .withDeploymentStrategy(StrimziDeploymentStrategy.RECREATE)
                     .endDeployment()
                 .endTemplate()
             .endSpec()
@@ -430,11 +430,11 @@ class HttpBridgeST extends AbstractST {
         LOGGER.info("Checking that observed gen. is still on 1 (recreation) and new label is present");
         assertThat(kafkaBridge.getStatus().getObservedGeneration(), is(1L));
         assertThat(kafkaBridge.getMetadata().getLabels().toString(), containsString("some=label"));
-        assertThat(kafkaBridge.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(DeploymentStrategy.RECREATE));
+        assertThat(kafkaBridge.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(StrimziDeploymentStrategy.RECREATE));
 
-        LOGGER.info("Changing Deployment strategy to {}", DeploymentStrategy.ROLLING_UPDATE);
+        LOGGER.info("Changing Deployment strategy to {}", StrimziDeploymentStrategy.ROLLING_UPDATE);
         KafkaBridgeUtils.replace(Environment.TEST_SUITE_NAMESPACE, bridgeName,
-            kb -> kb.getSpec().getTemplate().getDeployment().setDeploymentStrategy(DeploymentStrategy.ROLLING_UPDATE));
+            kb -> kb.getSpec().getTemplate().getDeployment().setDeploymentStrategy(StrimziDeploymentStrategy.ROLLING_UPDATE));
         KafkaBridgeUtils.waitForKafkaBridgeReady(Environment.TEST_SUITE_NAMESPACE, bridgeName);
 
         LOGGER.info("Adding another label to KafkaBridge resource, Pods should be rolled");
@@ -448,7 +448,7 @@ class HttpBridgeST extends AbstractST {
 
             return kB.getStatus().getObservedGeneration() == 2L &&
                 kB.getMetadata().getLabels().toString().contains("another=label") &&
-                kB.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
+                kB.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(StrimziDeploymentStrategy.ROLLING_UPDATE);
         });
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

As discussed in https://github.com/strimzi/strimzi-kafka-operator/issues/12879, this PR renames the `TimeoutException` and `DeplomentStrategy` classes to `StrimziTimeoutException` and `StrimziDeplomentStrategy`.

This contributes to #12879.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [ ] Make sure all tests pass