### PR TITLE
Replace CompletableFuture with CompletionStage in API return types

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -40,7 +40,7 @@ class KafkaAvailability {
 
     private final Reconciliation reconciliation;
 
-    private final CompletableFuture<Collection<TopicDescription>> descriptions;
+    private final CompletionStage<Collection<TopicDescription>> descriptions;
 
     KafkaAvailability(Reconciliation reconciliation, Admin ac) {
         this.ac = ac;
@@ -52,7 +52,7 @@ class KafkaAvailability {
             LOGGER.debugCr(reconciliation, "Got {} topic names", names.size());
             LOGGER.traceCr(reconciliation, "Topic names {}", names);
             return describeTopics(names);
-        }).toCompletableFuture();
+        });
     }
 
     /**
@@ -64,8 +64,8 @@ class KafkaAvailability {
         return canRollBroker(descriptions, podId);
     }
 
-    private CompletableFuture<Boolean> canRollBroker(CompletableFuture<Collection<TopicDescription>> descriptions, int podId) {
-        CompletableFuture<Set<TopicDescription>> topicsOnGivenBroker = descriptions
+    private CompletionStage<Boolean> canRollBroker(CompletionStage<Collection<TopicDescription>> descriptions, int podId) {
+        CompletionStage<Set<TopicDescription>> topicsOnGivenBroker = descriptions
                 .whenComplete((r, error) -> {
                     if (error != null) {
                         Throwable cause = maybeUnwrapCompletionException(error);
@@ -77,7 +77,7 @@ class KafkaAvailability {
                 });
 
         // 4. Get topic configs (for those on $broker)
-        CompletableFuture<Map<String, Config>> topicConfigsOnGivenBroker = topicsOnGivenBroker
+        CompletionStage<Map<String, Config>> topicConfigsOnGivenBroker = topicsOnGivenBroker
                 .thenCompose(td -> topicConfigs(td.stream().map(t -> t.name()).collect(Collectors.toSet())));
 
         // 5. join
@@ -161,7 +161,7 @@ class KafkaAvailability {
         return isr.stream().anyMatch(node -> node.id() == broker);
     }
 
-    private CompletableFuture<Map<String, Config>> topicConfigs(Collection<String> topicNames) {
+    private CompletionStage<Map<String, Config>> topicConfigs(Collection<String> topicNames) {
         LOGGER.debugCr(reconciliation, "Getting topic configs for {} topics", topicNames.size());
         List<ConfigResource> configs = topicNames.stream()
                 .map((String topicName) -> new ConfigResource(ConfigResource.Type.TOPIC, topicName))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.Util.maybeUnwrapCompletionException;
@@ -45,20 +46,20 @@ class KafkaAvailability {
         this.ac = ac;
         this.reconciliation = reconciliation;
         // 1. Get all topic names
-        CompletableFuture<Set<String>> topicNames = topicNames();
+        CompletionStage<Set<String>> topicNames = topicNames();
         // 2. Get topic descriptions
         descriptions = topicNames.thenCompose(names -> {
             LOGGER.debugCr(reconciliation, "Got {} topic names", names.size());
             LOGGER.traceCr(reconciliation, "Topic names {}", names);
             return describeTopics(names);
-        });
+        }).toCompletableFuture();
     }
 
     /**
      * Determine whether the given broker can be rolled without affecting
      * producers with acks=all publishing to topics with a {@code min.in.sync.replicas}.
      */
-    CompletableFuture<Boolean> canRoll(int podId) {
+    CompletionStage<Boolean> canRoll(int podId) {
         LOGGER.debugCr(reconciliation, "Determining whether broker {} can be rolled", podId);
         return canRollBroker(descriptions, podId);
     }
@@ -195,7 +196,7 @@ class KafkaAvailability {
         return topicPartitionInfos;
     }
 
-    protected CompletableFuture<Collection<TopicDescription>> describeTopics(Set<String> names) {
+    protected CompletionStage<Collection<TopicDescription>> describeTopics(Set<String> names) {
         CompletableFuture<Collection<TopicDescription>> descFuture = new CompletableFuture<>();
         ac.describeTopics(names).allTopicNames()
                 .whenComplete((tds, error) -> {
@@ -209,7 +210,7 @@ class KafkaAvailability {
         return descFuture;
     }
 
-    protected CompletableFuture<Set<String>> topicNames() {
+    protected CompletionStage<Set<String>> topicNames() {
         CompletableFuture<Set<String>> namesFuture = new CompletableFuture<>();
         ac.listTopics(new ListTopicsOptions().listInternal(true)).names()
                 .whenComplete((names, error) -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
@@ -12,6 +12,7 @@ import org.apache.kafka.clients.admin.QuorumInfo;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.Util.maybeUnwrapCompletionException;
@@ -40,7 +41,7 @@ class KafkaQuorumCheck {
      * healthy if the majority of controllers, excluding the given node, have caught up with the quorum leader within the
      * controller.quorum.fetch.timeout.ms.
      */
-    CompletableFuture<Boolean> canRollController(int nodeId) {
+    CompletionStage<Boolean> canRollController(int nodeId) {
         LOGGER.debugCr(reconciliation, "Determining whether controller pod {} can be rolled", nodeId);
         return describeMetadataQuorum().whenComplete((qrmInfo, error) -> {
             if (error != null) {
@@ -62,7 +63,7 @@ class KafkaQuorumCheck {
     /**
      * Returns id of the active controller/quorum leader.
      **/
-    CompletableFuture<Integer> quorumLeaderId() {
+    CompletionStage<Integer> quorumLeaderId() {
         LOGGER.debugCr(reconciliation, "Determining the active controller");
         return describeMetadataQuorum()
                 .whenComplete((qrmInfo, error) -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
@@ -139,7 +139,7 @@ class KafkaQuorumCheck {
         }
     }
 
-    private CompletableFuture<QuorumInfo> describeMetadataQuorum() {
-        return admin.describeMetadataQuorum().quorumInfo().toCompletionStage().toCompletableFuture();
+    private CompletionStage<QuorumInfo> describeMetadataQuorum() {
+        return admin.describeMetadataQuorum().quorumInfo().toCompletionStage();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheck.java
@@ -10,7 +10,6 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.QuorumInfo;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -217,9 +217,9 @@ public class KafkaRoller {
      * Which pods get rolled is determined by {@code podNeedsRestart}.
      * The pods may not be rolled in id order, due to the {@linkplain KafkaRoller rolling algorithm}.
      * @param podNeedsRestart Predicate for determining whether a pod should be rolled.
-     * @return A CompletableFuture completed when rolling is complete.
+     * @return A CompletionStage completed when rolling is complete.
      */
-    public CompletableFuture<Void> rollingRestart(Function<Pod, RestartReasons> podNeedsRestart) {
+    public CompletionStage<Void> rollingRestart(Function<Pod, RestartReasons> podNeedsRestart) {
         this.podNeedsRestart = podNeedsRestart;
         CompletableFuture<Void> result = new CompletableFuture<>();
         singleExecutor.submit(() -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -332,7 +332,6 @@ public class KafkaRoller {
      *
      * @return A future which completes when the pod has been rolled.
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
     private CompletionStage<Void> schedule(NodeRef nodeRef, long delayMs) {
         RestartContext ctx = podToContext.computeIfAbsent(nodeRef.podName(),
             k -> new RestartContext(backoffSupplier));
@@ -652,7 +651,7 @@ public class KafkaRoller {
         if (isPureController) {
             KafkaFuture<Config> configFuture = controllerAdminClient.describeConfigs(singletonList(resource)).values().get(resource);
             if (configFuture != null) {
-                return await(configFuture.toCompletionStage().toCompletableFuture(),
+                return await(configFuture.toCompletionStage(),
                         30_000,
                         error -> new ForceableProblem("Error getting controller config: " + error, error)
                 );
@@ -661,7 +660,7 @@ public class KafkaRoller {
         } else {
             KafkaFuture<Config> configFuture = brokerAdminClient.describeConfigs(singletonList(resource)).values().get(resource);
             if (configFuture != null) {
-                return await(configFuture.toCompletionStage().toCompletableFuture(),
+                return await(configFuture.toCompletionStage(),
                         30_000,
                         error -> new ForceableProblem("Error getting broker config: " + error, error)
                 );
@@ -687,7 +686,7 @@ public class KafkaRoller {
             KafkaFuture<Void> brokerConfigFuture = alterBrokerConfigResult.values().get(getBrokersConfig(nodeRef.nodeId()));
 
             if (brokerConfigFuture != null) {
-                await(brokerConfigFuture.toCompletionStage().toCompletableFuture(), 30_000, error -> {
+                await(brokerConfigFuture.toCompletionStage(), 30_000, error -> {
                     LOGGER.errorCr(reconciliation, "Error updating Kafka configuration for pod {}", nodeRef, error);
                     return new ForceableProblem("Error updating Kafka configuration for pod " + nodeRef, error);
                 });
@@ -709,7 +708,7 @@ public class KafkaRoller {
             KafkaFuture<Void> clusterConfigFuture = alterClusterConfigResult.values().get(getClusterWideConfig());
 
             if (clusterConfigFuture != null) {
-                await(clusterConfigFuture.toCompletionStage().toCompletableFuture(), 30_000, error -> {
+                await(clusterConfigFuture.toCompletionStage(), 30_000, error -> {
                     LOGGER.errorCr(reconciliation, "Error updating cluster-wide configuration", error);
                     return new ForceableProblem("Error updating cluster-wide configuration", error);
                 });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -243,18 +243,18 @@ public class KafkaRoller {
 
                 LOGGER.debugCr(reconciliation, "Initial order for updating pods (rolling restart or dynamic update) is controller pods={}, broker pods={}", controllerPods, brokerPods);
 
-                List<CompletableFuture<Void>> controllerFutures = new ArrayList<>(controllerPods.size());
+                List<CompletionStage<Void>> controllerFutures = new ArrayList<>(controllerPods.size());
                 for (NodeRef node : controllerPods) {
                     controllerFutures.add(schedule(node, 0));
                 }
 
-                CompletableFuture.allOf(controllerFutures.toArray(new CompletableFuture[0]))
+                CompletableFuture.allOf(controllerFutures.stream().map(CompletionStage::toCompletableFuture).toArray(CompletableFuture[]::new))
                         .thenCompose(i -> {
-                            List<CompletableFuture<Void>> brokerFutures = new ArrayList<>(nodes.size());
+                            List<CompletionStage<Void>> brokerFutures = new ArrayList<>(nodes.size());
                             for (NodeRef node : brokerPods) {
                                 brokerFutures.add(schedule(node, 0));
                             }
-                            return CompletableFuture.allOf(brokerFutures.toArray(new CompletableFuture[0]));
+                            return CompletableFuture.allOf(brokerFutures.stream().map(CompletionStage::toCompletableFuture).toArray(CompletableFuture[]::new));
                         }).whenComplete((i, error) -> {
                             singleExecutor.shutdown();
                             publishEventExecutor.shutdown();
@@ -332,7 +332,7 @@ public class KafkaRoller {
      * @return A future which completes when the pod has been rolled.
      */
     @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-    private CompletableFuture<Void> schedule(NodeRef nodeRef, long delayMs) {
+    private CompletionStage<Void> schedule(NodeRef nodeRef, long delayMs) {
         RestartContext ctx = podToContext.computeIfAbsent(nodeRef.podName(),
             k -> new RestartContext(backoffSupplier));
         singleExecutor.schedule(() -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -291,7 +291,7 @@ public class KafkaAvailabilityTest {
                     assertFalse(canRoll,
                             "broker " + brokerId + " should not be rollable, being minisr = 2 and it's only replicated on two brokers");
                 }
-            }).join();
+            }).toCompletableFuture().join();
         }
     }
 
@@ -328,7 +328,7 @@ public class KafkaAvailabilityTest {
                     assertTrue(canRoll,
                             "broker " + brokerId + " should be rollable, because although rolling it will impact availability minisr=|replicas|");
                 }
-            }).join();
+            }).toCompletableFuture().join();
         }
     }
 
@@ -358,7 +358,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                    "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr")).join();
+                    "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr")).toCompletableFuture().join();
         }
     }
 
@@ -380,7 +380,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas")).join();
+                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas")).toCompletableFuture().join();
         }
     }
 
@@ -402,7 +402,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas")).join();
+                        "broker " + brokerId + " should be rollable, being minisr = 3, but only 3 replicas")).toCompletableFuture().join();
         }
     }
 
@@ -423,7 +423,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 2, but only 1 replicas")).join();
+                        "broker " + brokerId + " should be rollable, being minisr = 2, but only 1 replicas")).toCompletableFuture().join();
         }
     }
 
@@ -460,7 +460,7 @@ public class KafkaAvailabilityTest {
                     assertTrue(canRoll,
                             "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr");
                 }
-            }).join();
+            }).toCompletableFuture().join();
         }
     }
 
@@ -488,7 +488,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) -> assertTrue(canRoll,
-                        "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr")).join();
+                        "broker " + brokerId + " should be rollable, being minisr = 1 and having two brokers in its isr")).toCompletableFuture().join();
         }
     }
 
@@ -519,7 +519,7 @@ public class KafkaAvailabilityTest {
         KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac());
 
         for (Integer brokerId : ksb.brokers.keySet()) {
-            Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).join());
+            Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).toCompletableFuture().join());
             assertThat(error.getCause(), instanceOf(TimeoutException.class));
         }
     }
@@ -550,7 +550,7 @@ public class KafkaAvailabilityTest {
         KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac());
 
         for (Integer brokerId : ksb.brokers.keySet()) {
-            Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).join());
+            Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).toCompletableFuture().join());
             assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
         }
     }
@@ -582,7 +582,7 @@ public class KafkaAvailabilityTest {
 
         for (Integer brokerId : ksb.brokers.keySet()) {
             if (brokerId <= 2) {
-                Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).join());
+                Throwable error = assertThrows(CompletionException.class, () -> kafkaAvailability.canRoll(brokerId).toCompletableFuture().join());
                 assertThat(error.getCause(), instanceOf(UnknownTopicOrPartitionException.class));
             }
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheckTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaQuorumCheckTest.java
@@ -55,7 +55,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(9700L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -67,7 +67,7 @@ class KafkaQuorumCheckTest {
         controllers.put(4, OptionalLong.of(9600L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -78,7 +78,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(8200L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -90,7 +90,7 @@ class KafkaQuorumCheckTest {
         controllers.put(4, OptionalLong.of(9000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -101,7 +101,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(10000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(2).whenComplete((result, err) -> assertTrue(result)).join();
+        quorumCheck.canRollController(2).whenComplete((result, err) -> assertTrue(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -112,7 +112,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(10000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(3).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(3).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -123,7 +123,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(-1));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(3).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(3).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -136,7 +136,7 @@ class KafkaQuorumCheckTest {
         kafkaFuture.completeExceptionally(new Exception(expectedError));
         when(qrmResult.quorumInfo()).thenReturn(kafkaFuture);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        CompletionException exception = assertThrows(CompletionException.class, () -> quorumCheck.canRollController(1).join());
+        CompletionException exception = assertThrows(CompletionException.class, () -> quorumCheck.canRollController(1).toCompletableFuture().join());
         assertThat(exception.getCause().getMessage(), is(expectedError));
     }
 
@@ -146,7 +146,7 @@ class KafkaQuorumCheckTest {
         controllers.put(1, OptionalLong.of(10000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -156,7 +156,7 @@ class KafkaQuorumCheckTest {
         controllers.put(2, OptionalLong.of(9500L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -166,7 +166,7 @@ class KafkaQuorumCheckTest {
         controllers.put(2, OptionalLong.of(7000L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -177,7 +177,7 @@ class KafkaQuorumCheckTest {
         controllers.put(3, OptionalLong.of(9500L));
         Admin admin = setUpMocks(1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -192,7 +192,7 @@ class KafkaQuorumCheckTest {
         Admin admin = setUpMocks(-1, controllers);
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS);
 
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertFalse(result)).toCompletableFuture().join();
     }
 
     @Test
@@ -203,6 +203,6 @@ class KafkaQuorumCheckTest {
         Admin admin = setUpMocks(1, controllers);
         long dynamicTimeout = 100L; // Dynamic timeout value
         KafkaQuorumCheck quorumCheck = new KafkaQuorumCheck(Reconciliation.DUMMY_RECONCILIATION, admin, dynamicTimeout);
-        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).join();
+        quorumCheck.canRollController(1).whenComplete((result, err) -> assertTrue(result)).toCompletableFuture().join();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -776,7 +776,7 @@ public class KafkaRollerTest {
             .whenComplete((v, err) -> {
                 assertThat(restarted(), is(asList(0, 1, 2, 3, 4)));
                 assertNoUnclosedAdminClient(kafkaRoller);
-            }).join();
+            }).toCompletableFuture().join();
     }
 
     private TestingKafkaRoller rollerWithActiveController(PodOperator podOps, Set<NodeRef> nodes, int activeController) {
@@ -792,7 +792,7 @@ public class KafkaRollerTest {
                 .whenComplete((v, error) -> {
                     assertThat(restarted(), is(expected));
                     assertNoUnclosedAdminClient(kafkaRoller);
-                }).join();
+                }).toCompletableFuture().join();
     }
 
     private void doSuccessfulRollingRestart(TestingKafkaRoller kafkaRoller,
@@ -809,7 +809,7 @@ public class KafkaRollerTest {
                 .whenComplete((v, err) -> {
                     assertThat(restarted(), is(expected));
                     assertNoUnclosedAdminClient(kafkaRoller);
-                }).join();
+                }).toCompletableFuture().join();
     }
 
     private void assertNoUnclosedAdminClient(TestingKafkaRoller kafkaRoller) {
@@ -832,7 +832,7 @@ public class KafkaRollerTest {
                     } else {
                         return RestartReasons.empty();
                     }
-                }).join();
+                }).toCompletableFuture().join();
             throw new AssertionError("Expected exception " + exception.getName() + " but none was thrown");
         } catch (Exception e) {
             assertThat(e, instanceOf(CompletionException.class));


### PR DESCRIPTION
### Description

Replaces CompletableFuture with CompletionStage in the public/protected/package-private API method return types of three classes, as requested in #12918.

### Changes

**KafkaRoller.java:**
- `rollingRestart()` return type changed from `CompletableFuture<Void>` to `CompletionStage<Void>`

**KafkaQuorumCheck.java:**
- `canRollController()` return type changed from `CompletableFuture<Boolean>` to `CompletionStage<Boolean>`
- `quorumLeaderId()` return type changed from `CompletableFuture<Integer>` to `CompletionStage<Integer>`

**KafkaAvailability.java:**
- `canRoll()` return type changed from `CompletableFuture<Boolean>` to `CompletionStage<Boolean>`
- `describeTopics()` return type changed from `CompletableFuture<Collection<TopicDescription>>` to `CompletionStage<Collection<TopicDescription>>`
- `topicNames()` return type changed from `CompletableFuture<Set<String>>` to `CompletionStage<Set<String>>`

### Design decisions

- **Private methods and fields** retain CompletableFuture (internal implementation details are unchanged)
- **Constructor bridge**: KafkaAvailability constructor uses `.toCompletableFuture()` to bridge from CompletionStage back to the private CompletableFuture field
- **All callers** already accept CompletionStage:
  - KafkaRoller.await() takes CompletionStage<T>
  - CaReconciler uses Future.fromCompletionStage()
  - KafkaReconciler chains through .toCompletionStage()
- **Test overrides** with CompletableFuture remain valid (covariant return type: CompletableFuture implements CompletionStage)

### Checklist

- [x] The changes are scoped to the three source files identified in #12918
- [x] All type transitions are covariant-safe
- [x] DCO sign-off included on the commit

Closes #12918