### PR TITLE
Removed null check on metadata version

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -310,10 +310,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         result.kafkaVersion = versions.supportedVersion(kafkaClusterSpec.getVersion());
 
         // Validates and sets the metadata version used in KRaft
-        if (versionChange.metadataVersion() != null) {
-            validateMetadataVersion(versionChange.metadataVersion());
-            result.metadataVersion = versionChange.metadataVersion();
-        }
+        validateMetadataVersion(versionChange.metadataVersion());
+        result.metadataVersion = versionChange.metadataVersion();
 
         // Number of broker nodes => used later in various validation methods
         long numberOfBrokers = result.brokerNodes().size();


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the null check on the metadata version (returned by the `KafkaVersionChange` class) within the `KafkaCluster` model creation because following the code it's always valued, by what the user set into the spec or what's the default from the Kafka versions YAML file.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests