### PR TITLE
Rename `Probe` to `StrimziProbe`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
@@ -16,9 +16,9 @@ import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Logging;
-import io.strimzi.api.kafka.model.common.Probe;
 import io.strimzi.api.kafka.model.common.Rack;
 import io.strimzi.api.kafka.model.common.Spec;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
@@ -66,8 +66,8 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     private JvmOptions jvmOptions;
     private Logging logging;
     private MetricsConfig metricsConfig;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     private KafkaBridgeTemplate template;
     private Tracing tracing;
     private String clientRackInitImage;
@@ -227,21 +227,21 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/HasLivenessProbe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/HasLivenessProbe.java
@@ -13,12 +13,12 @@ public interface HasLivenessProbe {
      *
      * @return  Liveness probe configuration
      */
-    Probe getLivenessProbe();
+    StrimziProbe getLivenessProbe();
 
     /**
      * Sets the liveness probe configuration
      *
      * @param livenessProbe     Liveness probe configuration
      */
-    void setLivenessProbe(Probe livenessProbe);
+    void setLivenessProbe(StrimziProbe livenessProbe);
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/HasReadinessProbe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/HasReadinessProbe.java
@@ -13,12 +13,12 @@ public interface HasReadinessProbe {
      *
      * @return  Readiness probe configuration
      */
-    Probe getReadinessProbe();
+    StrimziProbe getReadinessProbe();
 
     /**
      * Sets the readiness probe configuration
      *
      * @param readinessProbe    Readiness probe configuration
      */
-    void setReadinessProbe(Probe readinessProbe);
+    void setReadinessProbe(StrimziProbe readinessProbe);
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/HasStartupProbe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/HasStartupProbe.java
@@ -13,12 +13,12 @@ public interface HasStartupProbe {
      *
      * @return  Startup probe configuration
      */
-    Probe getStartupProbe();
+    StrimziProbe getStartupProbe();
 
     /**
      * Sets the startup probe configuration
      *
      * @param startupProbe    Startup probe configuration
      */
-    void setStartupProbe(Probe startupProbe);
+    void setStartupProbe(StrimziProbe startupProbe);
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/StrimziProbe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/StrimziProbe.java
@@ -27,7 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"initialDelaySeconds", "timeoutSeconds", "periodSeconds", "successThreshold", "failureThreshold"})
 @EqualsAndHashCode
 @ToString
-public class Probe implements UnknownPropertyPreserving {
+public class StrimziProbe implements UnknownPropertyPreserving {
     private int initialDelaySeconds = 15;
     private int timeoutSeconds = 5;
     private Integer periodSeconds;
@@ -35,9 +35,9 @@ public class Probe implements UnknownPropertyPreserving {
     private Integer failureThreshold;
     private Map<String, Object> additionalProperties;
 
-    public Probe() { }
+    public StrimziProbe() { }
 
-    public Probe(int initialDelaySeconds, int timeoutSeconds) {
+    public StrimziProbe(int initialDelaySeconds, int timeoutSeconds) {
         this.initialDelaySeconds = initialDelaySeconds;
         this.timeoutSeconds = timeoutSeconds;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -15,9 +15,9 @@ import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Logging;
-import io.strimzi.api.kafka.model.common.Probe;
 import io.strimzi.api.kafka.model.common.Rack;
 import io.strimzi.api.kafka.model.common.Spec;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.jmx.HasJmxOptions;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
@@ -44,8 +44,8 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     private String version;
     private String image;
     private ResourceRequirements resources;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     private KafkaJmxOptions jmxOptions;
     private JvmOptions jvmOptions;
     private MetricsConfig metricsConfig;
@@ -112,21 +112,21 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -14,8 +14,8 @@ import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Logging;
-import io.strimzi.api.kafka.model.common.Probe;
 import io.strimzi.api.kafka.model.common.Rack;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.api.kafka.model.common.jmx.HasJmxOptions;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions;
@@ -81,8 +81,8 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     private Rack rack;
     private Logging logging;
     private String image;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     private JvmOptions jvmOptions;
     private KafkaJmxOptions jmxOptions;
     private MetricsConfig metricsConfig;
@@ -173,21 +173,21 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Logging;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.crdgenerator.annotations.CelValidation;
@@ -51,8 +51,8 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
 
     private String image;
     private ResourceRequirements resources;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     private JvmOptions jvmOptions;
     private Logging logging;
     private CruiseControlTemplate template;
@@ -165,21 +165,21 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness checking for the Cruise Control container")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Description("Pod readiness checking for the Cruise Control container.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.HasStartupProbe;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Logging;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
@@ -46,9 +46,9 @@ public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLiven
     protected String watchedNamespace;
     protected String image;
     private Long reconciliationIntervalMs;
-    private Probe startupProbe;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe startupProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     protected ResourceRequirements resources;
     protected Logging logging;
     private JvmOptions jvmOptions;
@@ -95,31 +95,31 @@ public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLiven
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod startup checking.")
-    public Probe getStartupProbe() {
+    public StrimziProbe getStartupProbe() {
         return startupProbe;
     }
 
-    public void setStartupProbe(Probe startupProbe) {
+    public void setStartupProbe(StrimziProbe startupProbe) {
         this.startupProbe = startupProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
@@ -13,7 +13,7 @@ import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Logging;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
@@ -47,8 +47,8 @@ public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivene
     private String image;
     private String secretPrefix;
     private Long reconciliationIntervalMs;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     private ResourceRequirements resources;
     private Logging logging;
     private JvmOptions jvmOptions;
@@ -95,21 +95,21 @@ public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivene
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
@@ -44,8 +44,8 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
     private String groupExcludeRegex;
 
     private ResourceRequirements resources;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
+    private StrimziProbe livenessProbe;
+    private StrimziProbe readinessProbe;
     private String logging = "info";
     private boolean enableSaramaLogging;
     private boolean showAllOffsets = true;
@@ -152,21 +152,21 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod liveness check.")
-    public Probe getLivenessProbe() {
+    public StrimziProbe getLivenessProbe() {
         return livenessProbe;
     }
 
-    public void setLivenessProbe(Probe livenessProbe) {
+    public void setLivenessProbe(StrimziProbe livenessProbe) {
         this.livenessProbe = livenessProbe;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("Pod readiness check.")
-    public Probe getReadinessProbe() {
+    public StrimziProbe getReadinessProbe() {
         return readinessProbe;
     }
 
-    public void setReadinessProbe(Probe readinessProbe) {
+    public void setReadinessProbe(StrimziProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -66,8 +66,8 @@ public abstract class AbstractModel {
      * Container configuration
      */
     protected ResourceRequirements resources;
-    protected Probe readinessProbeOptions;
-    protected Probe livenessProbeOptions;
+    protected StrimziProbe readinessProbeOptions;
+    protected StrimziProbe livenessProbeOptions;
 
     /**
      * PodSecurityProvider

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -18,7 +18,8 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
@@ -84,8 +85,7 @@ public class EntityOperator extends AbstractModel {
     /**
      * Default health check options used by the Topic and User operators
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-    protected static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new io.strimzi.api.kafka.model.common.ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(10).build();
+    protected static final StrimziProbe DEFAULT_HEALTHCHECK_OPTIONS = new StrimziProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(10).build();
 
     private EntityTopicOperator topicOperator;
     private EntityUserOperator userOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -17,8 +17,8 @@ import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.Probe;
-import io.strimzi.api.kafka.model.common.ProbeBuilder;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -99,7 +99,7 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
 
     private LoggingModel logging;
 
-    private Probe startupProbeOptions;
+    private StrimziProbe startupProbeOptions;
 
     /**
      * Constructs a new EntityTopicOperator.
@@ -150,7 +150,7 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
             result.resources = topicOperatorSpec.getResources();
             result.readinessProbeOptions = ProbeUtils.extractReadinessProbeOptionsOrDefault(topicOperatorSpec, EntityOperator.DEFAULT_HEALTHCHECK_OPTIONS);
             result.livenessProbeOptions = ProbeUtils.extractLivenessProbeOptionsOrDefault(topicOperatorSpec, EntityOperator.DEFAULT_HEALTHCHECK_OPTIONS);
-            result.startupProbeOptions = ProbeUtils.extractStartupProbeOptionsOrDefault(topicOperatorSpec, new ProbeBuilder().withPeriodSeconds(10).withFailureThreshold(12).build());
+            result.startupProbeOptions = ProbeUtils.extractStartupProbeOptionsOrDefault(topicOperatorSpec, new StrimziProbeBuilder().withPeriodSeconds(10).withFailureThreshold(12).build());
 
             if (kafkaAssembly.getSpec().getEntityOperator().getTemplate() != null)  {
                 result.templateRoleBinding = kafkaAssembly.getSpec().getEntityOperator().getTemplate().getTopicOperatorRoleBinding();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -29,9 +29,9 @@ import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.strimzi.api.kafka.model.common.ClientTls;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.Probe;
-import io.strimzi.api.kafka.model.common.ProbeBuilder;
 import io.strimzi.api.kafka.model.common.Rack;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.common.TopologyLabelRack;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
@@ -120,7 +120,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected static final String KAFKA_CONNECT_CONFIG_VOLUME_MOUNT = "/opt/kafka/custom-config/";
 
     // Configuration defaults
-    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(60).build();
+    private static final StrimziProbe DEFAULT_HEALTHCHECK_OPTIONS = new StrimziProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(60).build();
 
     /**
      * Key under which the Connect configuration is stored in ConfigMap

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -16,8 +16,8 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
-import io.strimzi.api.kafka.model.common.Probe;
-import io.strimzi.api.kafka.model.common.ProbeBuilder;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
@@ -61,7 +61,7 @@ public class KafkaExporter extends AbstractModel {
     /*test*/ static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     /*test*/ static final int DEFAULT_HEALTHCHECK_TIMEOUT = 15;
     /*test*/ static final int DEFAULT_HEALTHCHECK_PERIOD = 30;
-    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT).withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).withPeriodSeconds(DEFAULT_HEALTHCHECK_PERIOD).build();
+    private static final StrimziProbe DEFAULT_HEALTHCHECK_OPTIONS = new StrimziProbeBuilder().withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT).withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).withPeriodSeconds(DEFAULT_HEALTHCHECK_PERIOD).build();
 
     protected static final String ENV_VAR_KAFKA_EXPORTER_LOGGING = "KAFKA_EXPORTER_LOGGING";
     protected static final String ENV_VAR_KAFKA_EXPORTER_KAFKA_VERSION = "KAFKA_EXPORTER_KAFKA_VERSION";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeUtils.java
@@ -4,11 +4,13 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
 import io.strimzi.api.kafka.model.common.HasStartupProbe;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 
 import java.util.List;
 
@@ -20,8 +22,7 @@ public class ProbeUtils {
      * Default healthcheck options used by most of our operands with the exception of Mirror Maker (1 and 2), Connect,
      * and User / Topic operators.
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-    public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new io.strimzi.api.kafka.model.common.ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(15).build();
+    public static final StrimziProbe DEFAULT_HEALTHCHECK_OPTIONS = new StrimziProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(15).build();
 
     private ProbeUtils() { }
 
@@ -31,7 +32,7 @@ public class ProbeUtils {
      * @param probeConfig the initial config for the ProbeBuilder
      * @return ProbeBuilder
      */
-    public static ProbeBuilder defaultBuilder(Probe probeConfig) {
+    public static ProbeBuilder defaultBuilder(StrimziProbe probeConfig) {
         if (probeConfig == null) {
             throw new IllegalArgumentException();
         }
@@ -58,8 +59,7 @@ public class ProbeUtils {
      *
      * @return  Kubernetes Probe
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-    public static io.fabric8.kubernetes.api.model.Probe httpProbe(Probe probeConfig, String path, String port) {
+    public static Probe httpProbe(StrimziProbe probeConfig, String path, String port) {
         if (path == null || path.isEmpty() || port == null || port.isEmpty()) {
             throw new IllegalArgumentException();
         }
@@ -80,8 +80,7 @@ public class ProbeUtils {
      *
      * @return  Kubernetes Probe
      */
-    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
-    public static io.fabric8.kubernetes.api.model.Probe execProbe(Probe probeConfig, List<String> command) {
+    public static Probe execProbe(StrimziProbe probeConfig, List<String> command) {
         if (command == null || command.isEmpty()) {
             throw new IllegalArgumentException();
         }
@@ -102,7 +101,7 @@ public class ProbeUtils {
      *
      * @return  Probe options configured by the user or the defaults
      */
-    public static Probe extractLivenessProbeOptionsOrDefault(HasLivenessProbe spec, Probe defaultOptions)    {
+    public static StrimziProbe extractLivenessProbeOptionsOrDefault(HasLivenessProbe spec, StrimziProbe defaultOptions)    {
         if (spec.getLivenessProbe() != null)    {
             return spec.getLivenessProbe();
         } else {
@@ -119,7 +118,7 @@ public class ProbeUtils {
      *
      * @return  Probe options configured by the user or the defaults
      */
-    public static Probe extractReadinessProbeOptionsOrDefault(HasReadinessProbe spec, Probe defaultOptions)    {
+    public static StrimziProbe extractReadinessProbeOptionsOrDefault(HasReadinessProbe spec, StrimziProbe defaultOptions)    {
         if (spec.getReadinessProbe() != null)    {
             return spec.getReadinessProbe();
         } else {
@@ -136,7 +135,7 @@ public class ProbeUtils {
      *
      * @return  Probe options configured by the user or the defaults
      */
-    public static Probe extractStartupProbeOptionsOrDefault(HasStartupProbe spec, Probe defaultOptions)    {
+    public static StrimziProbe extractStartupProbeOptionsOrDefault(HasStartupProbe spec, StrimziProbe defaultOptions)    {
         if (spec.getStartupProbe() != null)    {
             return spec.getStartupProbe();
         } else {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ContainerUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ContainerUtilsTest.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVarBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplateBuilder;
@@ -40,8 +40,8 @@ public class ContainerUtilsTest {
                 List.of(ContainerUtils.createEnvVar("VAR_1", "value1")),
                 List.of(ContainerUtils.createContainerPort("my-port", 8443)),
                 List.of(VolumeUtils.createVolumeMount("my-volume", "/my-volume")),
-                ProbeUtils.execProbe(new Probe(), List.of("/liveness.sh")),
-                ProbeUtils.execProbe(new Probe(), List.of("/readiness.sh")),
+                ProbeUtils.execProbe(new StrimziProbe(), List.of("/liveness.sh")),
+                ProbeUtils.execProbe(new StrimziProbe(), List.of("/readiness.sh")),
                 null
         );
 
@@ -81,9 +81,9 @@ public class ContainerUtilsTest {
                 List.of(ContainerUtils.createEnvVar("VAR_1", "value1")),
                 List.of(ContainerUtils.createContainerPort("my-port", 8443)),
                 List.of(VolumeUtils.createVolumeMount("my-volume", "/my-volume")),
-                ProbeUtils.execProbe(new Probe(), List.of("/liveness.sh")),
-                ProbeUtils.execProbe(new Probe(), List.of("/readiness.sh")),
-                ProbeUtils.execProbe(new Probe(), List.of("/startup.sh")),
+                ProbeUtils.execProbe(new StrimziProbe(), List.of("/liveness.sh")),
+                ProbeUtils.execProbe(new StrimziProbe(), List.of("/readiness.sh")),
+                ProbeUtils.execProbe(new StrimziProbe(), List.of("/startup.sh")),
                 ImagePullPolicy.NEVER,
                 new LifecycleBuilder().withNewPreStop().withNewExec().withCommand("/pre-stop.sh").endExec().endPreStop().build()
         );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -47,8 +47,8 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.Probe;
-import io.strimzi.api.kafka.model.common.ProbeBuilder;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.common.SystemPropertyBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
@@ -485,14 +485,14 @@ public class KafkaClusterTest {
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withLivenessProbe(new ProbeBuilder()
+                        .withLivenessProbe(new StrimziProbeBuilder()
                                 .withInitialDelaySeconds(1)
                                 .withPeriodSeconds(2)
                                 .withTimeoutSeconds(3)
                                 .withSuccessThreshold(4)
                                 .withFailureThreshold(5)
                                 .build())
-                        .withReadinessProbe(new ProbeBuilder()
+                        .withReadinessProbe(new StrimziProbeBuilder()
                                 .withInitialDelaySeconds(6)
                                 .withPeriodSeconds(7)
                                 .withTimeoutSeconds(8)
@@ -3608,14 +3608,14 @@ public class KafkaClusterTest {
 
         String image = "my-custom-image:latest";
 
-        Probe livenessProbe = new Probe();
+        StrimziProbe livenessProbe = new StrimziProbe();
         livenessProbe.setInitialDelaySeconds(1);
         livenessProbe.setTimeoutSeconds(2);
         livenessProbe.setSuccessThreshold(3);
         livenessProbe.setFailureThreshold(4);
         livenessProbe.setPeriodSeconds(5);
 
-        Probe readinessProbe = new Probe();
+        StrimziProbe readinessProbe = new StrimziProbe();
         readinessProbe.setInitialDelaySeconds(6);
         readinessProbe.setTimeoutSeconds(7);
         readinessProbe.setSuccessThreshold(8);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -48,7 +48,7 @@ import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
@@ -208,8 +208,8 @@ public class KafkaConnectClusterTest {
         KafkaConnect resource = new KafkaConnectBuilder(RESOURCE)
             .editSpec()
                 .withImage("my-image:latest")
-                .withReadinessProbe(new Probe(200, 20))
-                .withLivenessProbe(new Probe(100, 10))
+                .withReadinessProbe(new StrimziProbe(200, 20))
+                .withLivenessProbe(new StrimziProbe(100, 10))
             .endSpec()
             .build();
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS, SHARED_ENV_PROVIDER);
@@ -659,8 +659,8 @@ public class KafkaConnectClusterTest {
         KafkaConnect resource = new KafkaConnectBuilder(RESOURCE)
                 .editSpec()
                     .withImage("my-image:latest")
-                    .withReadinessProbe(new Probe(200, 20))
-                    .withLivenessProbe(new Probe(100, 10))
+                    .withReadinessProbe(new StrimziProbe(200, 20))
+                    .withLivenessProbe(new StrimziProbe(100, 10))
                     .withNewJmxPrometheusExporterMetricsConfig()
                         .withNewValueFrom()
                             .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("metrics-cm").withKey("metrics-config.yml").withOptional(true).build())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -43,7 +43,7 @@ import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.Probe;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
@@ -248,8 +248,8 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(RESOURCE)
                 .editSpec()
                     .withImage("my-image:latest")
-                    .withReadinessProbe(new Probe(123, 456))
-                    .withLivenessProbe(new Probe(321, 654))
+                    .withReadinessProbe(new StrimziProbe(123, 456))
+                    .withLivenessProbe(new StrimziProbe(321, 654))
                     .withNewJmxPrometheusExporterMetricsConfig()
                         .withNewValueFrom()
                         .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ProbeUtilsTest.java
@@ -6,6 +6,8 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import io.strimzi.api.kafka.model.common.StrimziProbe;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpecBuilder;
 import org.junit.jupiter.api.Test;
@@ -18,9 +20,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
 public class ProbeUtilsTest {
-    private static final io.strimzi.api.kafka.model.common.Probe DEFAULT_CONFIG = new io.strimzi.api.kafka.model.common.ProbeBuilder()
+    private static final StrimziProbe DEFAULT_CONFIG = new StrimziProbeBuilder()
             .withInitialDelaySeconds(1)
             .withTimeoutSeconds(2)
             .withPeriodSeconds(3)
@@ -48,10 +49,10 @@ public class ProbeUtilsTest {
 
     }
 
-    // Inherits defaults from the io.strimzi.api.kafka.model.common.Probe class
+    // Inherits defaults from the StrimziProbe class
     @Test
     public void testDefaultBuilderNoValues() {
-        Probe probe = ProbeUtils.defaultBuilder(new io.strimzi.api.kafka.model.common.ProbeBuilder().build())
+        Probe probe = ProbeUtils.defaultBuilder(new StrimziProbeBuilder().build())
                 .build();
         assertThat(probe, is(new ProbeBuilder()
                 .withInitialDelaySeconds(15)
@@ -113,7 +114,7 @@ public class ProbeUtilsTest {
 
     @Test
     public void testZeroInitialDelayIsSetToNull() {
-        io.strimzi.api.kafka.model.common.Probe probeConfig = new io.strimzi.api.kafka.model.common.ProbeBuilder()
+        StrimziProbe probeConfig = new StrimziProbeBuilder()
                 .withInitialDelaySeconds(0)
                 .build();
 
@@ -149,7 +150,7 @@ public class ProbeUtilsTest {
                 .endStartupProbe()
                 .build();
 
-        io.strimzi.api.kafka.model.common.Probe probe = ProbeUtils.extractLivenessProbeOptionsOrDefault(spec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
+        StrimziProbe probe = ProbeUtils.extractLivenessProbeOptionsOrDefault(spec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
         assertThat(probe.getInitialDelaySeconds(), is(11));
         assertThat(probe.getTimeoutSeconds(), is(12));
         assertThat(probe.getPeriodSeconds(), is(13));
@@ -175,7 +176,7 @@ public class ProbeUtilsTest {
     public void testExtractProbeOptionNotSet()  {
         EntityTopicOperatorSpec spec = new EntityTopicOperatorSpecBuilder().build();
 
-        io.strimzi.api.kafka.model.common.Probe probe = ProbeUtils.extractLivenessProbeOptionsOrDefault(spec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
+        StrimziProbe probe = ProbeUtils.extractLivenessProbeOptionsOrDefault(spec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
         assertThat(probe.getInitialDelaySeconds(), is(15));
         assertThat(probe.getTimeoutSeconds(), is(5));
         assertThat(probe.getPeriodSeconds(), is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -169,7 +169,6 @@ public class WorkloadUtilsTest {
 
     @Test
     public void testCreateDeploymentWithTemplateAndRollingUpdateStrategy()  {
-        @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // Fully qualified class name used due to a name conflict
         Deployment dep = WorkloadUtils.createDeployment(
                 NAME,
                 NAMESPACE,

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -91,10 +91,10 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |string
 |The image of the init container used for initializing the `broker.rack`.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking.
 |jvmOptions
 |xref:type-JvmOptions-{context}[`JvmOptions`]
@@ -558,8 +558,8 @@ It must have the value `environment-variable` for the type `EnvironmentVariableR
 |The name of the environment variable that defines the rack ID. Its value sets the `broker.rack` configuration for Kafka brokers and the `client.rack` configuration for Kafka Connect or MirrorMaker 2.
 |====
 
-[id='type-Probe-{context}']
-= `Probe` schema reference
+[id='type-StrimziProbe-{context}']
+= `StrimziProbe` schema reference
 
 Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaExporterSpec-{context}[`KafkaExporterSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 
@@ -1245,13 +1245,13 @@ include::../api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOpera
 |integer
 |Interval between periodic reconciliations in milliseconds.
 |startupProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod startup checking.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking.
 |resources
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core[ResourceRequirements]
@@ -1293,10 +1293,10 @@ include::../api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityUserOperat
 |string
 |The prefix that will be added to the KafkaUser name to be used as the Secret name.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking.
 |resources
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core[ResourceRequirements]
@@ -1421,10 +1421,10 @@ include::../api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core[ResourceRequirements]
 |CPU and memory resources to reserve for the Cruise Control container.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking for the Cruise Control container.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking for the Cruise Control container.
 |jvmOptions
 |xref:type-JvmOptions-{context}[`JvmOptions`]
@@ -1623,10 +1623,10 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness check.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness check.
 |enableSaramaLogging
 |boolean
@@ -1901,10 +1901,10 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core[ResourceRequirements]
 |The maximum limits for CPU and memory resources and the requested initial resources.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking.
 |jvmOptions
 |xref:type-JvmOptions-{context}[`JvmOptions`]
@@ -3028,10 +3028,10 @@ include::../api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc[leveloffs
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking.
 |template
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
@@ -3425,10 +3425,10 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core[ResourceRequirements]
 |The maximum limits for CPU and memory resources and the requested initial resources.
 |livenessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod liveness checking.
 |readinessProbe
-|xref:type-Probe-{context}[`Probe`]
+|xref:type-StrimziProbe-{context}[`StrimziProbe`]
 |Pod readiness checking.
 |jvmOptions
 |xref:type-JvmOptions-{context}[`JvmOptions`]

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetST.java
@@ -11,7 +11,7 @@ import io.skodjob.annotations.Step;
 import io.skodjob.annotations.SuiteDoc;
 import io.skodjob.annotations.TestDoc;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
-import io.strimzi.api.kafka.model.common.ProbeBuilder;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -126,7 +126,7 @@ public class PodSetST extends AbstractST {
         LOGGER.info("Changing Kafka resource configuration, the Pods should not be rolled");
 
         KafkaUtils.replace(testStorage.getNamespaceName(), testStorage.getClusterName(), kafka -> {
-            kafka.getSpec().getKafka().setReadinessProbe(new ProbeBuilder().withTimeoutSeconds(probeTimeoutSeconds).build());
+            kafka.getSpec().getKafka().setReadinessProbe(new StrimziProbeBuilder().withTimeoutSeconds(probeTimeoutSeconds).build());
         });
 
         RollingUpdateUtils.waitForNoKafkaRollingUpdate(testStorage.getNamespaceName(), testStorage.getClusterName(), brokerPods);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -17,7 +17,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.skodjob.kubetest4j.MetricsCollector;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
-import io.strimzi.api.kafka.model.common.ProbeBuilder;
+import io.strimzi.api.kafka.model.common.StrimziProbeBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -323,7 +323,7 @@ class RollingUpdateST extends AbstractST {
 
         // Changes to readiness probe should trigger a rolling update
         KafkaUtils.replace(Environment.TEST_SUITE_NAMESPACE, testStorage.getClusterName(), kafka -> {
-            kafka.getSpec().getKafka().setReadinessProbe(new ProbeBuilder().withTimeoutSeconds(6).build());
+            kafka.getSpec().getKafka().setReadinessProbe(new StrimziProbeBuilder().withTimeoutSeconds(6).build());
         });
 
         TestUtils.waitFor("rolling update starts", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT,


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR contributes another part to https://github.com/strimzi/strimzi-kafka-operator/issues/12879 and renames the `Probe` class to `StrimziProbe` to avoid class name conflicts with Fabric8's `Probe`.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests