### PR TITLE
Run integration tests against multiple kubernetes versions

### DIFF
--- a/.github/actions/build/integration-test-strimzi/action.yml
+++ b/.github/actions/build/integration-test-strimzi/action.yml
@@ -48,7 +48,6 @@ runs:
       shell: bash
       run: |
         mvn -e -V -B -Dmaven.javadoc.skip=true \
-          -DskipTests \
           -Dfailsafe.rerunFailingTestsCount=2 \
           verify
       env:

--- a/.github/actions/build/integration-test-strimzi/action.yml
+++ b/.github/actions/build/integration-test-strimzi/action.yml
@@ -1,0 +1,74 @@
+name: "Integration Test Strimzi"
+description: "Runs Strimzi integration tests with Maven (Failsafe only) against a Kind cluster"
+
+inputs:
+  kindNodeImage:
+    description: "Kubernetes node image for Kind cluster (e.g., kindest/node:v1.30.13@sha256:...)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Java and Maven
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+      with:
+        javaVersion: "21"
+
+    - name: Install Docker
+      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+
+    - name: Install yq
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+      with:
+        version: "v4.6.3"
+
+    - name: Install Helm
+      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+      with:
+        helmVersion: "v3.16.0"
+
+    - name: Restore Maven cache
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.m2/repository
+        key: maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          maven-
+
+    - name: Setup Kind cluster
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@v2
+      with:
+        controlNodes: 1
+        workerNodes: 3
+        kindVersion: 0.31.0
+      env:
+        KIND_NODE_IMAGE: ${{ inputs.kindNodeImage }}
+
+    - name: Run integration tests
+      shell: bash
+      run: |
+        mvn -e -V -B -Dmaven.javadoc.skip=true \
+          -DskipTests \
+          -Dfailsafe.rerunFailingTestsCount=2 \
+          verify
+      env:
+        TESTCONTAINERS_RYUK_DISABLED: true
+        TESTCONTAINERS_CHECKS_DISABLE: true
+        STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: false
+
+    - name: Publish test results
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: 'Integration Tests (${{ inputs.kindNodeImage }})'
+        path: '**/TEST-*.xml'
+        reporter: java-junit
+        fail-on-error: false
+
+    - name: Upload test coverage to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        files: ./**/target/site/jacoco/jacoco.xml
+        flags: integrationtests
+        name: codecov-integration
+        fail_ci_if_error: false

--- a/.github/actions/build/integration-test-strimzi/action.yml
+++ b/.github/actions/build/integration-test-strimzi/action.yml
@@ -48,6 +48,7 @@ runs:
       shell: bash
       run: |
         mvn -e -V -B -Dmaven.javadoc.skip=true \
+          -Dskip.surefire.tests \
           -Dfailsafe.rerunFailingTestsCount=2 \
           verify
       env:

--- a/.github/actions/build/unit-test-strimzi/action.yml
+++ b/.github/actions/build/unit-test-strimzi/action.yml
@@ -1,5 +1,5 @@
-name: "Test Strimzi"
-description: "Runs Strimzi unit and integration tests with Maven"
+name: "Unit Test Strimzi"
+description: "Runs Strimzi unit tests with Maven (Surefire only, no Kind cluster needed)"
 
 runs:
   using: "composite"
@@ -30,38 +30,27 @@ runs:
         restore-keys: |
           maven-
 
-    - name: Setup Kind cluster
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@v2
-      with:
-        controlNodes: 1
-        workerNodes: 3
-        kindVersion: 0.31.0
-      env:
-        KIND_NODE_IMAGE: "oldest"
-        
-    - name: Run unit and integration tests
+    - name: Run unit tests
       shell: bash
       run: |
         mvn -e -V -B -Dmaven.javadoc.skip=true \
+          -DskipITs \
           -Dsurefire.rerunFailingTestsCount=5 \
-          -Dfailsafe.rerunFailingTestsCount=2 \
-          install
+          verify
       env:
-        # Test container optimization and eliminate pulling RYUK image from DockerHub to prevent limits
         TESTCONTAINERS_RYUK_DISABLED: true
         TESTCONTAINERS_CHECKS_DISABLE: true
-        # Disable container logging for cleaner test output
         STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: false
-        
+
     - name: Publish test results
       uses: dorny/test-reporter@v3
       if: always()
       with:
-        name: 'Unit & Integration Tests'
+        name: 'Unit Tests'
         path: '**/TEST-*.xml'
         reporter: java-junit
         fail-on-error: false
-        
+
     - name: Upload test coverage to Codecov
       uses: codecov/codecov-action@v6
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,16 +89,37 @@ jobs:
           path: docker-images/artifacts/binaries/kafka/archives
           key: kafka-binaries-${{ hashFiles('kafka-versions.yaml') }}
 
-  # Runs Strimzi unit and integration tests
-  test-strimzi:
-    name: Strimzi Unit & IT tests
+  # Runs Strimzi unit tests (Surefire only, no Kind cluster needed)
+  unit-test-strimzi:
+    name: Unit Tests
     needs:
       - build-strimzi
     runs-on: ubuntu-latest
-    timeout-minutes: 80
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/build/test-strimzi
+      - uses: ./.github/actions/build/unit-test-strimzi
+
+  # Runs Strimzi integration tests (Failsafe only) against multiple Kubernetes versions
+  integration-test-strimzi:
+    name: Integration Tests (${{ matrix.kindNodeImage }})
+    needs:
+      - build-strimzi
+    strategy:
+      fail-fast: false
+      matrix:
+        kindNodeImage:
+          # Oldest Kube version we support
+          - "kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648"
+          # Latest Kube version we support
+          - "kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/build/integration-test-strimzi
+        with:
+          kindNodeImage: ${{ matrix.kindNodeImage }}
 
   # Builds Strimzi docs
   build-docs:
@@ -165,7 +186,8 @@ jobs:
     name: Push Containers
     needs:
       - build-strimzi
-      - test-strimzi
+      - unit-test-strimzi
+      - integration-test-strimzi
       - build-containers
       - build-docs
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -207,7 +229,8 @@ jobs:
     name: Publish Docs
     needs:
       - build-strimzi
-      - test-strimzi
+      - unit-test-strimzi
+      - integration-test-strimzi
       - build-containers
       - build-docs
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -225,7 +248,8 @@ jobs:
     name: Deploy Java artifacts
     needs:
       - build-strimzi
-      - test-strimzi
+      - unit-test-strimzi
+      - integration-test-strimzi
       - build-containers
       - build-docs
     if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR split unit and integration tests into separeted jobs. Integration tests are executed in matrix for multipl ekubernetes versions. This will allow us to get rid of build pipeline from azure.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
