### PR TITLE
Remove duplicate test for `Util.parseMap(...)`

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -58,23 +58,6 @@ public class ModelUtilsTest {
     }
 
     @Test
-    public void testAnnotationsOrLabelsImageMap() {
-        Map<String, String> m = parseMap(" discovery.3scale.net=true");
-        assertThat(m.size(), is(1));
-        assertThat(m.get("discovery.3scale.net"), is("true"));
-
-        m = parseMap(" discovery.3scale.net/scheme=http\n" +
-                "        discovery.3scale.net/port=8080\n" +
-                "        discovery.3scale.net/path=path/\n" +
-                "        discovery.3scale.net/description-path=oapi/");
-        assertThat(m.size(), is(4));
-        assertThat(m.get("discovery.3scale.net/scheme"), is("http"));
-        assertThat(m.get("discovery.3scale.net/port"), is("8080"));
-        assertThat(m.get("discovery.3scale.net/path"), is("path/"));
-        assertThat(m.get("discovery.3scale.net/description-path"), is("oapi/"));
-    }
-
-    @Test
     public void testStorageSerializationAndDeserialization()    {
         Storage jbod = new JbodStorageBuilder().withVolumes(
                 new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -23,13 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class UtilTest {
     @Test
     public void testParseMap() {
-        String stringMap = "key1=value1\n" +
-                "key2=value2";
+        String stringMap = """
+                key1=value1
+                    key2=value2
+                key3=value3""";
 
         Map<String, String> m = parseMap(stringMap);
-        assertThat(m, aMapWithSize(2));
+        assertThat(m, aMapWithSize(3));
         assertThat(m, hasEntry("key1", "value1"));
         assertThat(m, hasEntry("key2", "value2"));
+        assertThat(m, hasEntry("key3", "value3"));
     }
 
     @Test


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR removes duplicate and slightly misleading test. The test `ModelUtilsTest.testAnnotationsOrLabelsImageMap` is a bit strange, as it:
* Tests a method from a different class and module
* Does not really test any specific labels, annotations, or images logic

The method that it tests - `Util.parseMap(...)` has already pretty good coverage in its own test class `UtilTest`. I added the only thing that seemed missing which was whitespace handling. And the test it self can be now removed.

### Checklist

- [x] Make sure all tests pass