### PR TITLE
Replace CompletableFuture with CompletionStage in KafkaConnectApi

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -13,7 +13,7 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * A Java client for the Kafka Connect REST API.
@@ -29,7 +29,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns information about the connector, including its name, config and tasks.
      */
-    CompletableFuture<Map<String, Object>> createOrUpdatePutRequest(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson);
+    CompletionStage<Map<String, Object>> createOrUpdatePutRequest(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.
@@ -40,7 +40,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's config.
      */
-    CompletableFuture<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.
@@ -53,7 +53,7 @@ public interface KafkaConnectApi {
      *
      * @return A Future which completes with the result of the request. If the request was successful, this returns the connector's config.
      */
-    CompletableFuture<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
+    CompletionStage<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}}.
@@ -64,7 +64,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns information about the connector, including its name, config and tasks.
      */
-    CompletableFuture<Map<String, Object>> getConnector(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Map<String, Object>> getConnector(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code DELETE} request to {@code /connectors/${connectorName}}.
@@ -74,7 +74,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to delete.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}.
@@ -85,7 +85,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's status.
      */
-    CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}.
@@ -97,7 +97,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's status.
      */
-    CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes);
+    CompletionStage<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}, retrying according to {@code backoff}.
@@ -109,7 +109,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's status.
      */
-    CompletableFuture<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
+    CompletionStage<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/pause}.
@@ -119,7 +119,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to pause.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/stop}.
@@ -129,7 +129,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to pause.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/resume}.
@@ -139,7 +139,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to resume.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> resume(Reconciliation reconciliation,  String host, int port, String connectorName);
+    CompletionStage<Void> resume(Reconciliation reconciliation,  String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors}
@@ -149,7 +149,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connectors.
      */
-    CompletableFuture<List<String>> list(Reconciliation reconciliation, String host, int port);
+    CompletionStage<List<String>> list(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code GET} request to {@code /connector-plugins}.
@@ -159,7 +159,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connector plugins.
      */
-    CompletableFuture<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port);
+    CompletionStage<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code GET} request to {@code /admin/loggers}.
@@ -169,7 +169,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connect loggers.
      */
-    CompletableFuture<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port);
+    CompletionStage<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/restart}.
@@ -181,7 +181,7 @@ public interface KafkaConnectApi {
      * @param onlyFailed    Specifies whether to restart just the instances with a FAILED status or all instances.
      * @return A Future which completes with the result of the request and the new status of the connector
      */
-    CompletableFuture<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
+    CompletionStage<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/tasks/${taskID}/restart}.
@@ -191,7 +191,7 @@ public interface KafkaConnectApi {
      * @param taskID The ID of the connector task to restart.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> restartTask(String host, int port, String connectorName, int taskID);
+    CompletionStage<Void> restartTask(String host, int port, String connectorName, int taskID);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/topics}.
@@ -202,7 +202,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's topics.
      */
-    CompletableFuture<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/offsets}.
@@ -213,7 +213,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's offsets.
      */
-    CompletableFuture<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PATCH} request to {@code /connectors/${connectorName}/offsets}.
@@ -224,7 +224,7 @@ public interface KafkaConnectApi {
      * @param newOffsets The new offsets for the connector.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets);
+    CompletionStage<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets);
 
     /**
      * Make a {@code DELETE} request to {@code /connectors/${connectorName}/offsets}.
@@ -234,7 +234,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to reset the offsets of.
      * @return A Future which completes with the result of the request.
      */
-    CompletableFuture<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletionStage<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
 }
 
 class ConnectRestException extends RuntimeException {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -55,7 +56,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, Object>> createOrUpdatePutRequest(
+    public CompletionStage<Map<String, Object>> createOrUpdatePutRequest(
             Reconciliation reconciliation,
             String host, int port,
             String connectorName, JsonObject configJson) {
@@ -89,7 +90,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, Object>> getConnector(
+    public CompletionStage<Map<String, Object>> getConnector(
             Reconciliation reconciliation,
             String host, int port,
             String connectorName) {
@@ -114,7 +115,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
 
-    private <T> CompletableFuture<T> doGet(Reconciliation reconciliation, String host, int port, String path, Set<Integer> okStatusCodes, TypeReference<T> type) {
+    private <T> CompletionStage<T> doGet(Reconciliation reconciliation, String host, int port, String path, Set<Integer> okStatusCodes, TypeReference<T> type) {
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
 
         HttpRequest request = HttpRequest.newBuilder()
@@ -146,7 +147,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> getConnectorConfig(
+    public CompletionStage<Map<String, String>> getConnectorConfig(
             Reconciliation reconciliation,
             String host, int port,
             String connectorName) {
@@ -156,13 +157,13 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
+    public CompletionStage<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
         return withBackoff(reconciliation, backOff, connectorName, Collections.singleton(409),
             () -> getConnectorConfig(reconciliation, host, port, connectorName), "config");
     }
 
     @Override
-    public CompletableFuture<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = "/connectors/" + connectorName;
         LOGGER.debugCr(reconciliation, "Making DELETE request to {}", path);
 
@@ -191,15 +192,15 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
+    public CompletionStage<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
         return withBackoff(reconciliation, backOff, connectorName, Collections.singleton(404),
             () -> status(reconciliation, host, port, connectorName), "status");
     }
 
-    private <T> CompletableFuture<T> withBackoff(Reconciliation reconciliation,
+    private <T> CompletionStage<T> withBackoff(Reconciliation reconciliation,
                                                  BackOff backOff, String connectorName,
                                                  Set<Integer> retriableStatusCodes,
-                                                 Supplier<CompletableFuture<T>> supplier,
+                                                 Supplier<? extends CompletionStage<T>> supplier,
                                                  String attribute) {
         CompletableFuture<T> statusFuture = new CompletableFuture<>();
         ScheduledExecutorService singleExecutor = Executors.newSingleThreadScheduledExecutor(
@@ -215,7 +216,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                                  Set<Integer> retriableStatusCodes,
                                                  ScheduledExecutorService singleExecutor,
                                                  CompletableFuture<T> statusFuture,
-                                                 Supplier<CompletableFuture<T>> supplier,
+                                                 Supplier<? extends CompletionStage<T>> supplier,
                                                  String attribute, long delay) {
         singleExecutor.schedule(() -> {
             supplier.get().whenComplete((result, error) -> {
@@ -246,32 +247,32 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
         return status(reconciliation, host, port, connectorName, Collections.singleton(200));
     }
 
     @Override
-    public CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes) {
+    public CompletionStage<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes) {
         String path = "/connectors/" + connectorName + "/status";
         return doGet(reconciliation, host, port, path, okStatusCodes, TREE_TYPE);
     }
 
     @Override
-    public CompletableFuture<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
         return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/pause", 202);
     }
 
     @Override
-    public CompletableFuture<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName) {
         return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/stop", 204);
     }
 
     @Override
-    public CompletableFuture<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
         return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/resume", 202);
     }
 
-    private CompletableFuture<Void> updateState(Reconciliation reconciliation, String host, int port, String path, int expectedStatusCode) {
+    private CompletionStage<Void> updateState(Reconciliation reconciliation, String host, int port, String path, int expectedStatusCode) {
         LOGGER.debugCr(reconciliation, "Making PUT request to {} ", path);
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(String.format("http://%s:%d%s", host, port, encodeURLString(path))))
@@ -290,7 +291,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<List<String>> list(Reconciliation reconciliation, String host, int port) {
+    public CompletionStage<List<String>> list(Reconciliation reconciliation, String host, int port) {
         String path = "/connectors";
         LOGGER.debugCr(reconciliation, "Making GET request to {} ", path);
         HttpRequest request = HttpRequest.newBuilder()
@@ -325,7 +326,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port) {
+    public CompletionStage<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port) {
         String path = "/connector-plugins";
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
 
@@ -352,7 +353,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 });
     }
 
-    private CompletableFuture<Void> updateConnectorLogger(Reconciliation reconciliation, String host, int port, String logger, String level) {
+    private CompletionStage<Void> updateConnectorLogger(Reconciliation reconciliation, String host, int port, String logger, String level) {
         String path = "/admin/loggers/" + logger + "?scope=cluster";
 
         ObjectNode levelJO = OBJECT_MAPPER.createObjectNode();
@@ -386,7 +387,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port) {
+    public CompletionStage<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port) {
         String path = "/admin/loggers/";
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
         HttpRequest request = HttpRequest.newBuilder()
@@ -435,17 +436,17 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
+    public CompletionStage<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
         return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/restart?includeTasks=" + includeTasks + "&onlyFailed=" + onlyFailed);
     }
 
     @Override
-    public CompletableFuture<Void> restartTask(String host, int port, String connectorName, int taskID) {
+    public CompletionStage<Void> restartTask(String host, int port, String connectorName, int taskID) {
         return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/tasks/" + taskID + "/restart")
             .thenCompose(result -> CompletableFuture.completedFuture(null));
     }
 
-    private CompletableFuture<Map<String, Object>> restartConnectorOrTask(String host, int port, String path) {
+    private CompletionStage<Map<String, Object>> restartConnectorOrTask(String host, int port, String path) {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(String.format("http://%s:%d%s", host, port, encodeURLString(path))))
                 .POST(HttpRequest.BodyPublishers.noBody())
@@ -469,7 +470,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/topics", connectorName);
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
 
@@ -498,7 +499,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/offsets", connectorName);
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
 
@@ -529,7 +530,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets) {
+    public CompletionStage<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets) {
         String path = String.format("/connectors/%s/offsets", connectorName);
         LOGGER.debugCr(reconciliation, "Making PATCH request to {}", path);
 
@@ -560,7 +561,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public CompletableFuture<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletionStage<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/offsets", connectorName);
         LOGGER.debugCr(reconciliation, "Making DELETE request to {}", path);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +81,7 @@ public class KafkaConnectApiIT {
         cluster.stop();
     }
 
-    private void checkStatusWithDelay(Supplier<CompletableFuture<Map<String, Object>>> statusSupplier,
+    private void checkStatusWithDelay(Supplier<? extends CompletionStage<Map<String, Object>>> statusSupplier,
                                       ScheduledExecutorService singleExecutor,
                                       CompletableFuture<Map<String, Object>> completableFuture,
                                       long delay) {
@@ -241,6 +242,6 @@ public class KafkaConnectApiIT {
                         }
                         return null;
                     }))
-            .join();
+            .toCompletableFuture().join();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
@@ -73,7 +73,7 @@ public class KafkaConnectApiImplTest {
         KafkaConnectApi api = new KafkaConnectApiImpl();
 
         assertThrows(Exception.class, api.createOrUpdatePutRequest(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(), "my-connector", new JsonObject())
-                .whenComplete((res, ex) -> assertThat(ex.getMessage(), containsString("Unknown error message")))::join);
+                .whenComplete((res, ex) -> assertThat(ex.getMessage(), containsString("Unknown error message"))).toCompletableFuture()::join);
     }
 
     @Test
@@ -86,7 +86,7 @@ public class KafkaConnectApiImplTest {
         KafkaConnectApi api = new KafkaConnectApiImpl();
 
         assertThrows(Exception.class, api.createOrUpdatePutRequest(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(), "my-connector", new JsonObject())
-                .whenComplete((res, ex) -> assertThat(ex.getMessage(), containsString("This is the error")))::join);
+                .whenComplete((res, ex) -> assertThat(ex.getMessage(), containsString("This is the error"))).toCompletableFuture()::join);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class KafkaConnectApiImplTest {
                 () -> api.status(
                         Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(),
                         "my-connector", Collections.singleton(404))
-                        .get());
+                        .toCompletableFuture().get());
         assertThat(ex.getCause(), instanceOf(ConnectRestException.class));
         assertThat(ex.getCause().getMessage(), containsString("Unexpected HTTP status code 200"));
     }
@@ -123,7 +123,7 @@ public class KafkaConnectApiImplTest {
                 () -> api.status(
                         Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(),
                         "c", Collections.singleton(200))
-                        .get());
+                        .toCompletableFuture().get());
         assertThat(ex.getCause(), instanceOf(ConnectRestException.class));
         assertThat(ex.getCause().getMessage(), containsString("Connect cluster error"));
     }
@@ -148,7 +148,7 @@ public class KafkaConnectApiImplTest {
                 .whenComplete((res, ex) -> assertThat(res, allOf(
                         aMapWithSize(1),
                         hasEntry("org.apache.kafka.connect", "INFO")
-                ))).join();
+                ))).toCompletableFuture().join();
     }
 
     @Test
@@ -172,6 +172,6 @@ public class KafkaConnectApiImplTest {
                 .whenComplete((res, ex) -> assertThat(res, allOf(
                         aMapWithSize(1),
                         hasEntry("org.apache.kafka.connect", "WARN")))
-                ).join();
+                ).toCompletableFuture().join();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -14,6 +14,7 @@ import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -31,7 +32,7 @@ public class KafkaConnectApiMockTest {
 
         KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
         api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-                .whenComplete((r, e) -> assertThat(e, nullValue())).join();
+                .whenComplete((r, e) -> assertThat(e, nullValue())).toCompletableFuture().join();
     }
 
     @Test
@@ -44,7 +45,7 @@ public class KafkaConnectApiMockTest {
         KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
 
         api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-                .whenComplete((r, e) -> assertThat(e, nullValue())).join();
+                .whenComplete((r, e) -> assertThat(e, nullValue())).toCompletableFuture().join();
     }
 
     @Test
@@ -60,7 +61,7 @@ public class KafkaConnectApiMockTest {
                 .whenComplete((r, e) -> {
                     assertThat(e.getMessage(), containsString("404"));
                     assertThat(statusResults.size(), is(0));
-                })::join);
+                }).toCompletableFuture()::join);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class KafkaConnectApiMockTest {
         KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
 
         assertThrows(Exception.class, api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-                .whenComplete((r, e) -> assertThat(e.getMessage(), containsString("500")))::join);
+                .whenComplete((r, e) -> assertThat(e.getMessage(), containsString("500"))).toCompletableFuture()::join);
     }
 
     static class MockKafkaConnectApi extends KafkaConnectApiImpl   {
@@ -83,7 +84,7 @@ public class KafkaConnectApiMockTest {
         }
 
         @Override
-        public CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
+        public CompletionStage<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
             return statusResults.remove();
         }
     }


### PR DESCRIPTION
### Type of change

- Task

### Description

Replaces `CompletableFuture` with `CompletionStage` in the interfaces and APIs of `KafkaConnectApi`, as requested in #12916 (subtask of #12878).

`KafkaConnectApi`interface:

-  All 20 method return types changed from `CompletableFuture<T>` to `CompletionStage<T>`

`KafkaConnectApiImpl` implementation:

- All `@Override` method return types updated to` CompletionStage<T>`
- Private methods (`doGet`, `updateState`, `withBackoff`, `restartConnectorOrTask`, `updateConnectorLogger`) also updated to return `CompletionStage<T>`
- `Supplier` parameters in `withBackoff/executeBackOffInternal` widened to `Supplier<? `extends `CompletionStage<T>>`
- `CompletableFuture` retained only where a new instance is created (`new CompletableFuture<>()`, `completedFuture()`, `failedFuture()`) or where `complete()/completeExceptionally()` is called

Tests:

- `KafkaConnectApiImplTest`: Added `toCompletableFuture()` before `join()`/`get()` calls
- `KafkaConnectApiMockTest`: Updated `MockKafkaConnectApi.status()` return type and added `toCompletableFuture()` before `join()` calls
- `KafkaConnectApiIT`: Widened `checkStatusWithDelay` supplier type to `Supplier<?` extends `CompletionStage<...>>` and added `toCompletableFuture()` before terminal `join()`

No production caller changes needed — all callers already use `Future.fromCompletionStage()` which accepts `CompletionStage`.

Closes #12916

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
