### PR TITLE
Implement Gatekeeper plugin interfaces

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -46,6 +46,8 @@ ignore:
   - "test"
   # The API model is just getters and setters that are not tested. Measuring coverage for them adds only a little value.
   - "api/src/main/java/io/strimzi/api/kafka/model"
+  # The plugin package of the `api` module contains interfaces that are not tested.  Measuring coverage for them adds only a little value.
+  - "api/src/main/java/io/strimzi/plugin"
   # Test infrastructure, not production code
   - "mockkube"
   # Generated Log4j wrapper — testing it verifies Log4j works, not Strimzi logic

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeDeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeDeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the KafkaBridge plugins. It is invoked when a KafkaBridge is being deleted.
+ */
+public interface GatekeeperKafkaBridgeDeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeEntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeEntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the KafkaBridge plugins (both mutating and validating). It is invoked at the start of
+ * a KafkaBridge reconciliation.
+ */
+public interface GatekeeperKafkaBridgeEntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the KafkaBridge plugins (both mutating and validating). It is invoked after a KafkaBridge
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaBridgeExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeMutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeMutatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link KafkaBridge} operand. The entry method is invoked at the start of a KafkaBridge
+ * reconciliation and can mutate the {@code KafkaBridge} resource. The exit method is invoked after the reconciliation
+ * completes and can mutate the status section of the {@code KafkaBridge} resource.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaBridgeMutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaBridge reconciliation. The default implementation returns the resource unchanged.
+     *
+     * @param context   Context for the entry phase of the mutating KafkaBridge plugin
+     * @param kafkaBridge   The KafkaBridge custom resource being reconciled
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaBridge resource
+     */
+    default CompletionStage<KafkaBridge> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+        return CompletableFuture.completedFuture(kafkaBridge);
+    }
+
+    /**
+     * Invoked after a KafkaBridge reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context           Context for the exit phase of the mutating KafkaBridge plugin
+     * @param kafkaBridge           The KafkaBridge custom resource being reconciled
+     * @param newKafkaBridgeStatus   The new status computed for the KafkaBridge resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaBridge status
+     */
+    default CompletionStage<KafkaBridgeStatus> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus newKafkaBridgeStatus) {
+        return CompletableFuture.completedFuture(newKafkaBridgeStatus);
+    }
+
+    /**
+     * Invoked when a {@link KafkaBridge} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaBridge plugin
+     * @param namespace The namespace of the KafkaBridge being deleted
+     * @param name      The name of the KafkaBridge being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaBridgeValidatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link KafkaBridge} operand. The entry method is invoked at the start of a KafkaBridge
+ * reconciliation and the exit method after it completes. Validating plugins do not mutate the resource; they can reject
+ * the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaBridgeValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaBridge reconciliation. The default implementation does nothing.
+     *
+     * @param context   Context for the entry phase of the validating KafkaBridge plugin
+     * @param kafkaBridge   The KafkaBridge custom resource being reconciled
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a KafkaBridge reconciliation completes. The default implementation does nothing.
+     *
+     * @param context           Context for the exit phase of the validating KafkaBridge plugin
+     * @param kafkaBridge           The KafkaBridge custom resource being reconciled
+     * @param newKafkaBridgeStatus   The new status computed for the KafkaBridge resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus newKafkaBridgeStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link KafkaBridge} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaBridge plugin
+     * @param namespace The namespace of the KafkaBridge being deleted
+     * @param name      The name of the KafkaBridge being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectDeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectDeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the KafkaConnect plugins. It is invoked when a KafkaConnect is being deleted.
+ */
+public interface GatekeeperKafkaConnectDeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectEntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectEntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the KafkaConnect plugins (both mutating and validating). It is invoked at the start of
+ * a KafkaConnect reconciliation.
+ */
+public interface GatekeeperKafkaConnectEntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the KafkaConnect plugins (both mutating and validating). It is invoked after a KafkaConnect
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaConnectExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectMutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectMutatingPlugin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link KafkaConnect} operand and its {@link KafkaConnector} resources. The entry
+ * method is invoked at the start of a Kafka Connect reconciliation and can mutate the {@code KafkaConnect} resource and
+ * its connectors. The exit methods are invoked after the reconciliation completes and can mutate the status sections of
+ * the {@code KafkaConnect} resource and its connectors.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaConnectMutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a Kafka Connect reconciliation. The default implementation returns the resources unchanged.
+     *
+     * @param context           Context for the entry phase of the mutating Kafka Connect plugin
+     * @param kafkaConnect      The KafkaConnect custom resource being reconciled
+     * @param kafkaConnectors   The list of KafkaConnector resources belonging to the Kafka Connect cluster
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaConnect resource and its connectors
+     */
+    default CompletionStage<KafkaConnectAndKafkaConnectors> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+        return CompletableFuture.completedFuture(new KafkaConnectAndKafkaConnectors(kafkaConnect, kafkaConnectors));
+    }
+
+    /**
+     * Invoked after a Kafka Connect reconciliation completes, once for each KafkaConnector. The default implementation
+     * returns the status unchanged.
+     *
+     * @param context                   Context for the exit phase of the mutating Kafka Connect plugin
+     * @param kafkaConnect              The KafkaConnect custom resource being reconciled
+     * @param kafkaConnector            The KafkaConnector resource whose status is being updated
+     * @param newKafkaConnectorStatus   The new status computed for the KafkaConnector resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaConnector status
+     */
+    default CompletionStage<KafkaConnectorStatus> kafkaConnectorExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, KafkaConnector kafkaConnector, KafkaConnectorStatus newKafkaConnectorStatus) {
+        return CompletableFuture.completedFuture(newKafkaConnectorStatus);
+    }
+
+    /**
+     * Invoked after a Kafka Connect reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context               Context for the exit phase of the mutating Kafka Connect plugin
+     * @param kafkaConnect          The KafkaConnect custom resource being reconciled
+     * @param kafkaConnectors       The list of KafkaConnector resources belonging to the Kafka Connect cluster
+     * @param newKafkaConnectStatus The new status computed for the KafkaConnect resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaConnect status
+     */
+    default CompletionStage<KafkaConnectStatus> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus newKafkaConnectStatus) {
+        return CompletableFuture.completedFuture(newKafkaConnectStatus);
+    }
+
+    /**
+     * Invoked when a {@link KafkaConnect} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaConnect plugin
+     * @param namespace The namespace of the KafkaConnect being deleted
+     * @param name      The name of the KafkaConnect being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaConnectValidatingPlugin.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link KafkaConnect} operand and its {@link KafkaConnector} resources. The entry
+ * method is invoked at the start of a Kafka Connect reconciliation and the exit methods after it completes. Validating
+ * plugins do not mutate the resources; they can reject the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaConnectValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a Kafka Connect reconciliation. The default implementation does nothing.
+     *
+     * @param context           Context for the entry phase of the validating Kafka Connect plugin
+     * @param kafkaConnect      The KafkaConnect custom resource being reconciled
+     * @param kafkaConnectors   The list of KafkaConnector resources belonging to the Kafka Connect cluster
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a Kafka Connect reconciliation completes, once for each KafkaConnector. The default implementation
+     * does nothing.
+     *
+     * @param context                   Context for the exit phase of the validating Kafka Connect plugin
+     * @param kafkaConnect              The KafkaConnect custom resource being reconciled
+     * @param kafkaConnector            The KafkaConnector resource whose status is being validated
+     * @param newKafkaConnectorStatus   The new status computed for the KafkaConnector resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaConnectorExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, KafkaConnector kafkaConnector, KafkaConnectorStatus newKafkaConnectorStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a Kafka Connect reconciliation completes. The default implementation does nothing.
+     *
+     * @param context               Context for the exit phase of the validating Kafka Connect plugin
+     * @param kafkaConnect          The KafkaConnect custom resource being reconciled
+     * @param kafkaConnectors       The list of KafkaConnector resources belonging to the Kafka Connect cluster
+     * @param newKafkaConnectStatus The new status computed for the KafkaConnect resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus newKafkaConnectStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link KafkaConnect} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaConnect plugin
+     * @param namespace The namespace of the KafkaConnect being deleted
+     * @param name      The name of the KafkaConnect being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaDeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaDeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the Kafka plugins. It is invoked when a Kafka is being deleted.
+ */
+public interface GatekeeperKafkaDeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaEntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaEntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the Kafka plugins (both mutating and validating). It is invoked at the start of
+ * a Kafka reconciliation.
+ */
+public interface GatekeeperKafkaEntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the Kafka plugins (both mutating and validating). It is invoked after a Kafka
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2DeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2DeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the KafkaMirrorMaker2 plugins. It is invoked when a KafkaMirrorMaker2 is being deleted.
+ */
+public interface GatekeeperKafkaMirrorMaker2DeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2EntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2EntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the KafkaMirrorMaker2 plugins (both mutating and validating). It is invoked at the start of
+ * a KafkaMirrorMaker2 reconciliation.
+ */
+public interface GatekeeperKafkaMirrorMaker2EntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2ExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2ExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the KafkaMirrorMaker2 plugins (both mutating and validating). It is invoked after a KafkaMirrorMaker2
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaMirrorMaker2ExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2MutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2MutatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link KafkaMirrorMaker2} operand. The entry method is invoked at the start of a KafkaMirrorMaker2
+ * reconciliation and can mutate the {@code KafkaMirrorMaker2} resource. The exit method is invoked after the reconciliation
+ * completes and can mutate the status section of the {@code KafkaMirrorMaker2} resource.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaMirrorMaker2MutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaMirrorMaker2 reconciliation. The default implementation returns the resource unchanged.
+     *
+     * @param context   Context for the entry phase of the mutating KafkaMirrorMaker2 plugin
+     * @param kafkaMirrorMaker2   The KafkaMirrorMaker2 custom resource being reconciled
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaMirrorMaker2 resource
+     */
+    default CompletionStage<KafkaMirrorMaker2> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+        return CompletableFuture.completedFuture(kafkaMirrorMaker2);
+    }
+
+    /**
+     * Invoked after a KafkaMirrorMaker2 reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context           Context for the exit phase of the mutating KafkaMirrorMaker2 plugin
+     * @param kafkaMirrorMaker2           The KafkaMirrorMaker2 custom resource being reconciled
+     * @param newKafkaMirrorMaker2Status   The new status computed for the KafkaMirrorMaker2 resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaMirrorMaker2 status
+     */
+    default CompletionStage<KafkaMirrorMaker2Status> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status newKafkaMirrorMaker2Status) {
+        return CompletableFuture.completedFuture(newKafkaMirrorMaker2Status);
+    }
+
+    /**
+     * Invoked when a {@link KafkaMirrorMaker2} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaMirrorMaker2 plugin
+     * @param namespace The namespace of the KafkaMirrorMaker2 being deleted
+     * @param name      The name of the KafkaMirrorMaker2 being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2ValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMirrorMaker2ValidatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link KafkaMirrorMaker2} operand. The entry method is invoked at the start of a KafkaMirrorMaker2
+ * reconciliation and the exit method after it completes. Validating plugins do not mutate the resource; they can reject
+ * the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaMirrorMaker2ValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaMirrorMaker2 reconciliation. The default implementation does nothing.
+     *
+     * @param context   Context for the entry phase of the validating KafkaMirrorMaker2 plugin
+     * @param kafkaMirrorMaker2   The KafkaMirrorMaker2 custom resource being reconciled
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a KafkaMirrorMaker2 reconciliation completes. The default implementation does nothing.
+     *
+     * @param context           Context for the exit phase of the validating KafkaMirrorMaker2 plugin
+     * @param kafkaMirrorMaker2           The KafkaMirrorMaker2 custom resource being reconciled
+     * @param newKafkaMirrorMaker2Status   The new status computed for the KafkaMirrorMaker2 resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status newKafkaMirrorMaker2Status) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link KafkaMirrorMaker2} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaMirrorMaker2 plugin
+     * @param namespace The namespace of the KafkaMirrorMaker2 being deleted
+     * @param name      The name of the KafkaMirrorMaker2 being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaMutatingPlugin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link Kafka} operand and its {@link KafkaNodePool} resources. The entry method is
+ * invoked at the start of a Kafka reconciliation and can mutate the {@code Kafka} resource and its node pools. The exit
+ * methods are invoked after the reconciliation completes and can mutate the status sections of the {@code Kafka}
+ * resource and its node pools.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaMutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a Kafka reconciliation. The default implementation returns the resources unchanged.
+     *
+     * @param context           Context for the entry phase of the mutating Kafka plugin
+     * @param kafka             The Kafka custom resource being reconciled
+     * @param kafkaNodePools    The list of KafkaNodePool resources belonging to the Kafka cluster
+     *
+     * @return  A completion stage with the (possibly mutated) Kafka resource and its node pools
+     */
+    default CompletionStage<KafkaAndKafkaNodePools> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+        return CompletableFuture.completedFuture(new KafkaAndKafkaNodePools(kafka, kafkaNodePools));
+    }
+
+    /**
+     * Invoked after a Kafka reconciliation completes, once for each KafkaNodePool. The default implementation returns
+     * the status unchanged.
+     *
+     * @param context                   Context for the exit phase of the mutating Kafka plugin
+     * @param kafka                     The Kafka custom resource being reconciled
+     * @param kafkaNodePool             The KafkaNodePool resource whose status is being updated
+     * @param newKafkaNodePoolStatus    The new status computed for the KafkaNodePool resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaNodePool status
+     */
+    default CompletionStage<KafkaNodePoolStatus> kafkaNodePoolExit(GatekeeperKafkaExitContext context, Kafka kafka, KafkaNodePool kafkaNodePool, KafkaNodePoolStatus newKafkaNodePoolStatus) {
+        return CompletableFuture.completedFuture(newKafkaNodePoolStatus);
+    }
+
+    /**
+     * Invoked after a Kafka reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context           Context for the exit phase of the mutating Kafka plugin
+     * @param kafka             The Kafka custom resource being reconciled
+     * @param kafkaNodePools    The list of KafkaNodePool resources belonging to the Kafka cluster
+     * @param newKafkaStatus    The new status computed for the Kafka resource
+     *
+     * @return  A completion stage with the (possibly mutated) Kafka status
+     */
+    default CompletionStage<KafkaStatus> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+        return CompletableFuture.completedFuture(newKafkaStatus);
+    }
+
+    /**
+     * Invoked when a {@link Kafka} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the Kafka plugin
+     * @param namespace The namespace of the Kafka being deleted
+     * @param name      The name of the Kafka being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaDeletion(GatekeeperKafkaDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceDeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceDeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the KafkaRebalance plugins. It is invoked when a KafkaRebalance is being deleted.
+ */
+public interface GatekeeperKafkaRebalanceDeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceEntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceEntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the KafkaRebalance plugins (both mutating and validating). It is invoked at the start of
+ * a KafkaRebalance reconciliation.
+ */
+public interface GatekeeperKafkaRebalanceEntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the KafkaRebalance plugins (both mutating and validating). It is invoked after a KafkaRebalance
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaRebalanceExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceMutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceMutatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link KafkaRebalance} operand. The entry method is invoked at the start of a KafkaRebalance
+ * reconciliation and can mutate the {@code KafkaRebalance} resource. The exit method is invoked after the reconciliation
+ * completes and can mutate the status section of the {@code KafkaRebalance} resource.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaRebalanceMutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaRebalance reconciliation. The default implementation returns the resource unchanged.
+     *
+     * @param context   Context for the entry phase of the mutating KafkaRebalance plugin
+     * @param kafkaRebalance   The KafkaRebalance custom resource being reconciled
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaRebalance resource
+     */
+    default CompletionStage<KafkaRebalance> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+        return CompletableFuture.completedFuture(kafkaRebalance);
+    }
+
+    /**
+     * Invoked after a KafkaRebalance reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context           Context for the exit phase of the mutating KafkaRebalance plugin
+     * @param kafkaRebalance           The KafkaRebalance custom resource being reconciled
+     * @param newKafkaRebalanceStatus   The new status computed for the KafkaRebalance resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaRebalance status
+     */
+    default CompletionStage<KafkaRebalanceStatus> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus newKafkaRebalanceStatus) {
+        return CompletableFuture.completedFuture(newKafkaRebalanceStatus);
+    }
+
+    /**
+     * Invoked when a {@link KafkaRebalance} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaRebalance plugin
+     * @param namespace The namespace of the KafkaRebalance being deleted
+     * @param name      The name of the KafkaRebalance being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaRebalanceValidatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link KafkaRebalance} operand. The entry method is invoked at the start of a KafkaRebalance
+ * reconciliation and the exit method after it completes. Validating plugins do not mutate the resource; they can reject
+ * the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaRebalanceValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaRebalance reconciliation. The default implementation does nothing.
+     *
+     * @param context   Context for the entry phase of the validating KafkaRebalance plugin
+     * @param kafkaRebalance   The KafkaRebalance custom resource being reconciled
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a KafkaRebalance reconciliation completes. The default implementation does nothing.
+     *
+     * @param context           Context for the exit phase of the validating KafkaRebalance plugin
+     * @param kafkaRebalance           The KafkaRebalance custom resource being reconciled
+     * @param newKafkaRebalanceStatus   The new status computed for the KafkaRebalance resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus newKafkaRebalanceStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link KafkaRebalance} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaRebalance plugin
+     * @param namespace The namespace of the KafkaRebalance being deleted
+     * @param name      The name of the KafkaRebalance being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicDeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicDeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the KafkaTopic plugins. It is invoked when a KafkaTopic is being deleted.
+ */
+public interface GatekeeperKafkaTopicDeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicEntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicEntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the KafkaTopic plugins (both mutating and validating). It is invoked at the start of
+ * a KafkaTopic reconciliation.
+ */
+public interface GatekeeperKafkaTopicEntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the KafkaTopic plugins (both mutating and validating). It is invoked after a KafkaTopic
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaTopicExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicMutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicMutatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link KafkaTopic} operand. The entry method is invoked at the start of a KafkaTopic
+ * reconciliation and can mutate the {@code KafkaTopic} resource. The exit method is invoked after the reconciliation
+ * completes and can mutate the status section of the {@code KafkaTopic} resource.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaTopicMutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaTopic reconciliation. The default implementation returns the resource unchanged.
+     *
+     * @param context   Context for the entry phase of the mutating KafkaTopic plugin
+     * @param kafkaTopic   The KafkaTopic custom resource being reconciled
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaTopic resource
+     */
+    default CompletionStage<KafkaTopic> kafkaTopicEntry(GatekeeperKafkaTopicEntryContext context, KafkaTopic kafkaTopic) {
+        return CompletableFuture.completedFuture(kafkaTopic);
+    }
+
+    /**
+     * Invoked after a KafkaTopic reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context           Context for the exit phase of the mutating KafkaTopic plugin
+     * @param kafkaTopic           The KafkaTopic custom resource being reconciled
+     * @param newKafkaTopicStatus   The new status computed for the KafkaTopic resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaTopic status
+     */
+    default CompletionStage<KafkaTopicStatus> kafkaTopicExit(GatekeeperKafkaTopicExitContext context, KafkaTopic kafkaTopic, KafkaTopicStatus newKafkaTopicStatus) {
+        return CompletableFuture.completedFuture(newKafkaTopicStatus);
+    }
+
+    /**
+     * Invoked when a {@link KafkaTopic} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaTopic plugin
+     * @param namespace The namespace of the KafkaTopic being deleted
+     * @param name      The name of the KafkaTopic being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaTopicDeletion(GatekeeperKafkaTopicDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaTopicValidatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link KafkaTopic} operand. The entry method is invoked at the start of a KafkaTopic
+ * reconciliation and the exit method after it completes. Validating plugins do not mutate the resource; they can reject
+ * the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaTopicValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaTopic reconciliation. The default implementation does nothing.
+     *
+     * @param context   Context for the entry phase of the validating KafkaTopic plugin
+     * @param kafkaTopic   The KafkaTopic custom resource being reconciled
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaTopicEntry(GatekeeperKafkaTopicEntryContext context, KafkaTopic kafkaTopic) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a KafkaTopic reconciliation completes. The default implementation does nothing.
+     *
+     * @param context           Context for the exit phase of the validating KafkaTopic plugin
+     * @param kafkaTopic           The KafkaTopic custom resource being reconciled
+     * @param newKafkaTopicStatus   The new status computed for the KafkaTopic resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaTopicExit(GatekeeperKafkaTopicExitContext context, KafkaTopic kafkaTopic, KafkaTopicStatus newKafkaTopicStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link KafkaTopic} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaTopic plugin
+     * @param namespace The namespace of the KafkaTopic being deleted
+     * @param name      The name of the KafkaTopic being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaTopicDeletion(GatekeeperKafkaTopicDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserDeletionContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserDeletionContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the deletion hook of the KafkaUser plugins. It is invoked when a KafkaUser is being deleted.
+ */
+public interface GatekeeperKafkaUserDeletionContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserEntryContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserEntryContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the entry methods of the KafkaUser plugins (both mutating and validating). It is invoked at the start of
+ * a KafkaUser reconciliation.
+ */
+public interface GatekeeperKafkaUserEntryContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserExitContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserExitContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Context passed to the exit methods of the KafkaUser plugins (both mutating and validating). It is invoked after a KafkaUser
+ * reconciliation completes.
+ */
+public interface GatekeeperKafkaUserExitContext { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserMutatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserMutatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mutating Gatekeeper plugin for the {@link KafkaUser} operand. The entry method is invoked at the start of a KafkaUser
+ * reconciliation and can mutate the {@code KafkaUser} resource. The exit method is invoked after the reconciliation
+ * completes and can mutate the status section of the {@code KafkaUser} resource.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaUserMutatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaUser reconciliation. The default implementation returns the resource unchanged.
+     *
+     * @param context   Context for the entry phase of the mutating KafkaUser plugin
+     * @param kafkaUser   The KafkaUser custom resource being reconciled
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaUser resource
+     */
+    default CompletionStage<KafkaUser> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+        return CompletableFuture.completedFuture(kafkaUser);
+    }
+
+    /**
+     * Invoked after a KafkaUser reconciliation completes. The default implementation returns the status unchanged.
+     *
+     * @param context           Context for the exit phase of the mutating KafkaUser plugin
+     * @param kafkaUser           The KafkaUser custom resource being reconciled
+     * @param newKafkaUserStatus   The new status computed for the KafkaUser resource
+     *
+     * @return  A completion stage with the (possibly mutated) KafkaUser status
+     */
+    default CompletionStage<KafkaUserStatus> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+        return CompletableFuture.completedFuture(newKafkaUserStatus);
+    }
+
+    /**
+     * Invoked when a {@link KafkaUser} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaUser plugin
+     * @param namespace The namespace of the KafkaUser being deleted
+     * @param name      The name of the KafkaUser being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaUserValidatingPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link KafkaUser} operand. The entry method is invoked at the start of a KafkaUser
+ * reconciliation and the exit method after it completes. Validating plugins do not mutate the resource; they can reject
+ * the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaUserValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a KafkaUser reconciliation. The default implementation does nothing.
+     *
+     * @param context   Context for the entry phase of the validating KafkaUser plugin
+     * @param kafkaUser   The KafkaUser custom resource being reconciled
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a KafkaUser reconciliation completes. The default implementation does nothing.
+     *
+     * @param context           Context for the exit phase of the validating KafkaUser plugin
+     * @param kafkaUser           The KafkaUser custom resource being reconciled
+     * @param newKafkaUserStatus   The new status computed for the KafkaUser resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link KafkaUser} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the KafkaUser plugin
+     * @param namespace The namespace of the KafkaUser being deleted
+     * @param name      The name of the KafkaUser being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaValidatingPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperKafkaValidatingPlugin.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Validating Gatekeeper plugin for the {@link Kafka} operand and its {@link KafkaNodePool} resources. The entry method
+ * is invoked at the start of a Kafka reconciliation and the exit methods after it completes. Validating plugins do not
+ * mutate the resources; they can reject the reconciliation by completing the returned stage exceptionally.
+ * <p>
+ * All methods have default no-op implementations, so a plugin only needs to override the methods it is interested in.
+ */
+public interface GatekeeperKafkaValidatingPlugin extends GatekeeperPlugin {
+    /**
+     * Invoked at the start of a Kafka reconciliation. The default implementation does nothing.
+     *
+     * @param context           Context for the entry phase of the validating Kafka plugin
+     * @param kafka             The Kafka custom resource being reconciled
+     * @param kafkaNodePools    The list of KafkaNodePool resources belonging to the Kafka cluster
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a Kafka reconciliation completes, once for each KafkaNodePool. The default implementation does
+     * nothing.
+     *
+     * @param context                   Context for the exit phase of the validating Kafka plugin
+     * @param kafka                     The Kafka custom resource being reconciled
+     * @param kafkaNodePool             The KafkaNodePool resource whose status is being validated
+     * @param newKafkaNodePoolStatus    The new status computed for the KafkaNodePool resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaNodePoolExit(GatekeeperKafkaExitContext context, Kafka kafka, KafkaNodePool kafkaNodePool, KafkaNodePoolStatus newKafkaNodePoolStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked after a Kafka reconciliation completes. The default implementation does nothing.
+     *
+     * @param context           Context for the exit phase of the validating Kafka plugin
+     * @param kafka             The Kafka custom resource being reconciled
+     * @param kafkaNodePools    The list of KafkaNodePool resources belonging to the Kafka cluster
+     * @param newKafkaStatus    The new status computed for the Kafka resource
+     *
+     * @return  A completion stage that completes when the validation is done
+     */
+    default CompletionStage<Void> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a {@link Kafka} is being deleted. The default implementation does nothing. The hook cannot mutate
+     * anything (the resource no longer exists); it can react to the deletion or reject it by completing the returned
+     * stage exceptionally.
+     *
+     * @param context   Context for the deletion of the Kafka plugin
+     * @param namespace The namespace of the Kafka being deleted
+     * @param name      The name of the Kafka being deleted
+     *
+     * @return  A completion stage that completes when the plugin is done handling the deletion
+     */
+    default CompletionStage<Void> kafkaDeletion(GatekeeperKafkaDeletionContext context, String namespace, String name) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperPlugin.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperPlugin.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+/**
+ * Base interface implemented by all Strimzi Gatekeeper plugins. A plugin hooks into the reconciliation of one or more
+ * Strimzi operands. To do so, it also implements one or more of the type-specific mutating
+ * ({@code Gatekeeper<Type>MutatingPlugin}) or validating ({@code Gatekeeper<Type>ValidatingPlugin}) interfaces.
+ * <p>
+ * Plugins are loaded once at operator startup and initialized through their {@link #configure(GatekeeperPluginConfigurationContext)}
+ * method.
+ */
+public interface GatekeeperPlugin {
+    /**
+     * Configures the plugin. This method is called exactly once at operator startup, before any of the entry or exit
+     * methods are invoked. It can be used to preconfigure the plugin based on the platform it is running on or based on
+     * information from additional sources (for example, environment variables). If the configuration fails with an
+     * exception, the operator startup fails.
+     *
+     * @param context   Context providing the resources (such as the Kubernetes client and the platform features) the
+     *                  plugin can use to configure itself
+     */
+    void configure(GatekeeperPluginConfigurationContext context);
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperPluginConfigurationContext.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/GatekeeperPluginConfigurationContext.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+/**
+ * Context passed to {@link GatekeeperPlugin#configure(GatekeeperPluginConfigurationContext)} when a plugin is
+ * initialized at operator startup. It provides the resources the plugin can use to configure itself.
+ */
+public interface GatekeeperPluginConfigurationContext {
+    /**
+     * Returns the Kubernetes client which the plugin can use to interact with the Kubernetes API.
+     *
+     * @return  Kubernetes client
+     */
+    KubernetesClient kubernetesClient();
+}

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/KafkaAndKafkaNodePools.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/KafkaAndKafkaNodePools.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+
+import java.util.List;
+
+/**
+ * Wrapper holding a {@link Kafka} custom resource together with its {@link KafkaNodePool} resources. It is returned by
+ * the entry method of the mutating Kafka plugin, which can mutate both the {@code Kafka} resource and its node pools.
+ *
+ * @param kafka             The (possibly mutated) Kafka custom resource
+ * @param kafkaNodePools    The (possibly mutated) list of KafkaNodePool resources belonging to the Kafka cluster
+ */
+public record KafkaAndKafkaNodePools(Kafka kafka, List<KafkaNodePool> kafkaNodePools) { }

--- a/api/src/main/java/io/strimzi/plugin/gatekeeper/KafkaConnectAndKafkaConnectors.java
+++ b/api/src/main/java/io/strimzi/plugin/gatekeeper/KafkaConnectAndKafkaConnectors.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.plugin.gatekeeper;
+
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+
+import java.util.List;
+
+/**
+ * Wrapper holding a {@link KafkaConnect} custom resource together with its {@link KafkaConnector} resources. It is
+ * returned by the entry method of the mutating Kafka Connect plugin, which can mutate both the {@code KafkaConnect}
+ * resource and its connectors.
+ *
+ * @param kafkaConnect      The (possibly mutated) KafkaConnect custom resource
+ * @param kafkaConnectors   The (possibly mutated) list of KafkaConnector resources belonging to the Kafka Connect cluster
+ */
+public record KafkaConnectAndKafkaConnectors(KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) { }

--- a/pom.xml
+++ b/pom.xml
@@ -908,6 +908,7 @@
                                 <exclude>io/strimzi/api/**/*Builder*.class</exclude>
                                 <exclude>io/strimzi/api/kafka/model/**/*.class</exclude>
                                 <exclude>io/strimzi/api/annotations/**/*.class</exclude>
+                                <exclude>io/strimzi/plugin/**/*.class</exclude>
                                 <exclude>io/strimzi/test/**/*.class</exclude>
                                 <exclude>io/strimzi/systemtest/**/*.class</exclude>
                                 <exclude>io/strimzi/build/**/*.class</exclude>


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR adds the Gatekeeper plugin interfaces that are part of the `api` module. This includes the main Gatekeeper plugin interfaces as well as the interfaces for the validating and mutating plugins for the various resources. In this PR, the interfaces are not used yet. They will be used in the follow-up PRs as I try to keep the PRs small and easy to review.

It also modifies the code coverage configuration n the main `pom.xaml` file as these are just interfaces that cannot be really tested on its own.

This PR should resolve #12808.

### Checklist

- [x] Reference relevant issue(s) and close them after merging