### PR TITLE
Gatekeeper plugin factor and invoker

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/AbstractGatekeeperPluginInvoker.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/AbstractGatekeeperPluginInvoker.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper;
+
+import io.strimzi.plugin.gatekeeper.GatekeeperPlugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * Abstract class for invoking the Strimzi Gatekeeper plugins during reconciliations. It provides a common
+ * implementation of the plugin invocation logic, which is used by the concrete invokers for each operator.
+ */
+public abstract class AbstractGatekeeperPluginInvoker {
+    /**
+     * The reconciliation phase in which the plugins are invoked. It determines the order in which they are called:
+     * the configured order for the entry phase and the reverse order for the exit phase.
+     */
+    protected enum Phase {
+        ENTRY,
+        EXIT
+    }
+
+    /**
+     * Invokes a single chain of plugins for one operand and phase. It loads the plugins for the given operand from the
+     * factory, orders them according to the phase (the configured order for the entry phase, the reverse for the exit
+     * phase) and iterates them. Based on the interface each plugin implements, it is invoked either as a mutating or as a
+     * validating plugin. A mutating plugin receives the current value, and the (possibly modified) value it returns is
+     * passed to the next plugin. A validating plugin is invoked through the {@code validate} function (which is expected
+     * to pass it only copies of the resources and status) and the original value is passed on unchanged. The chain stops,
+     * completing exceptionally, as soon as any plugin fails.
+     *
+     * @param mutatingType      The mutating plugin interface for this operand
+     * @param validatingType    The validating plugin interface for this operand
+     * @param phase             The reconciliation phase, determining the order in which the plugins are invoked
+     * @param initialValue      The initial value passed to the first plugin
+     * @param mutate            Function invoking a mutating plugin with the current value
+     * @param validate          Function invoking a validating plugin with the current value
+     * @param <M>               The type of the mutating plugin
+     * @param <D>               The type of the validating plugin
+     * @param <V>               The type of the value chained through the plugins
+     *
+     * @return  A completion stage with the value produced by the last plugin (or the initial value if there are none)
+     */
+    protected static <M, D, V> CompletionStage<V> chain(
+            Class<M> mutatingType,
+            Class<D> validatingType,
+            Phase phase,
+            V initialValue,
+            BiFunction<M, V, CompletionStage<V>> mutate,
+            BiFunction<D, V, CompletionStage<Void>> validate) {
+        // Collect the plugins of this operand - both mutating and validating - preserving the configured order
+        List<GatekeeperPlugin> plugins = new ArrayList<>();
+        for (GatekeeperPlugin plugin : GatekeeperPluginFactory.getPlugins()) {
+            if (mutatingType.isInstance(plugin) || validatingType.isInstance(plugin)) {
+                plugins.add(plugin);
+            }
+        }
+
+        if (phase == Phase.EXIT) {
+            Collections.reverse(plugins);
+        }
+
+        CompletionStage<V> result = CompletableFuture.completedFuture(initialValue);
+
+        for (GatekeeperPlugin plugin : plugins) {
+            if (mutatingType.isInstance(plugin)) {
+                M mutating = mutatingType.cast(plugin);
+                result = result.thenCompose(current -> mutate.apply(mutating, current));
+            } else if (validatingType.isInstance(plugin)) {
+                D validating = validatingType.cast(plugin);
+                result = result.thenCompose(current -> validate.apply(validating, current).thenApply(ignored -> current));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Creates a deep copy of a value for a validating plugin, but only when the value is not {@code null}. A
+     * {@code null} value (for example, a custom resource or status during a deletion) is passed through as {@code null}
+     * instead of being turned into an empty copy, so that the plugins can recognize it.
+     *
+     * @param value     The value to copy, or {@code null}
+     * @param copy      Function creating the deep copy
+     * @param <T>       The type of the value
+     *
+     * @return  A deep copy of the value, or {@code null} when the value is {@code null}
+     */
+    protected static <T> T copy(T value, UnaryOperator<T> copy) {
+        return value == null ? null : copy.apply(value);
+    }
+
+    /**
+     * Creates a deep copy of a list of values for a validating plugin, but only when the list is not {@code null}. Each
+     * item is copied using the given function. A {@code null} list is passed through as {@code null}.
+     *
+     * @param values    The list of values to copy, or {@code null}
+     * @param copy      Function creating the deep copy of a single item
+     * @param <T>       The type of the items
+     *
+     * @return  A new list with the deep copies of the items, or {@code null} when the list is {@code null}
+     */
+    protected static <T> List<T> copyList(List<T> values, UnaryOperator<T> copy) {
+        return values == null ? null : values.stream().map(copy).toList();
+    }
+
+    /**
+     * Invokes the deletion hooks of all the plugins of one operand - both mutating and validating - as a single ordered
+     * chain. The plugins are collected in the configured order, and the chain stops, completing exceptionally, as soon as
+     * one of them fails. The deletion hook is declared separately on the mutating and validating plugin interfaces, so
+     * the caller's {@code invoke} function performs the dispatch to whichever of the two the plugin implements.
+     *
+     * @param mutatingType      The mutating plugin interface of the operand
+     * @param validatingType    The validating plugin interface of the operand
+     * @param invoke            Function invoking the deletion hook of one plugin (a mutating or validating plugin)
+     *
+     * @return  A completion stage that completes when all the deletion hooks completed
+     */
+    protected static CompletionStage<Void> deletion(Class<? extends GatekeeperPlugin> mutatingType, Class<? extends GatekeeperPlugin> validatingType, Function<GatekeeperPlugin, CompletionStage<Void>> invoke) {
+        CompletionStage<Void> result = CompletableFuture.completedFuture(null);
+
+        for (GatekeeperPlugin plugin : GatekeeperPluginFactory.getPlugins()) {
+            if (mutatingType.isInstance(plugin) || validatingType.isInstance(plugin)) {
+                result = result.thenCompose(ignored -> invoke.apply(plugin));
+            }
+        }
+
+        return result;
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/GatekeeperPluginFactory.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/GatekeeperPluginFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper;
+
+import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.plugin.gatekeeper.GatekeeperPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Factory that loads, configures, and holds the Strimzi Gatekeeper plugins used by the operator. Plugins are found and
+ * instantiated using the Java {@link ServiceLoader} mechanism based on the {@link GatekeeperPlugin} interface.
+ * <p>
+ * The plugins are stored as an ordered list. The order is significant: it is preserved exactly as requested during the
+ * initialization and is later used when the plugins are invoked during reconciliations.
+ * <p>
+ * The factory holds the plugins in a static field for the regular operator runtime. For tests, the
+ * {@link #initializeForTests(List)} method stores the plugins in a thread-local field instead, so that tests running in
+ * parallel can inject their own plugins without interfering with each other or with the static state.
+ */
+public class GatekeeperPluginFactory {
+    private static final Logger LOGGER = LogManager.getLogger(GatekeeperPluginFactory.class);
+
+    // Plugins configured for the operator process. Defaults to an empty list so that it is safe to use the factory
+    // before it is initialized (for example, in unit tests which do not use any plugins).
+    private static volatile List<GatekeeperPlugin> plugins = List.of();
+
+    // Thread-local override used by tests. When set, it takes precedence over the static field. This allows tests
+    // running in parallel to use their own set of plugins without affecting other threads.
+    private static final ThreadLocal<List<GatekeeperPlugin>> TEST_PLUGINS = new ThreadLocal<>();
+
+    private GatekeeperPluginFactory() { }
+
+    /**
+     * Initializes the factory for the regular operator runtime. It finds the requested plugins using the
+     * {@link ServiceLoader} mechanism, configures them by calling their
+     * {@link GatekeeperPlugin#configure(GatekeeperPluginConfigurationContext)} method and stores them in the order in
+     * which they are listed. The order is preserved and is significant for the order in which the plugins are invoked.
+     * <p>
+     * If any of the requested plugins is not found, or if configuring a plugin fails, an exception is thrown and the
+     * operator startup is expected to fail.
+     *
+     * @param pluginClasses     Ordered list of the canonical class names of the plugins which should be used
+     * @param context           Configuration context passed to each plugin when it is configured
+     */
+    public static void initialize(List<String> pluginClasses, GatekeeperPluginConfigurationContext context) {
+        plugins = loadConfigureAndOrder(pluginClasses, context);
+    }
+
+    /**
+     * Initializes the factory for tests. Unlike {@link #initialize(List, GatekeeperPluginConfigurationContext)}, it does
+     * not use the {@link ServiceLoader} mechanism and does not configure the plugins. Instead, it stores the provided
+     * ordered list of plugin instances in a thread-local field which is visible only to the current thread. This lets
+     * tests inject their own (e.g., mocked) plugins and run in parallel without interfering with each other.
+     * <p>
+     * Tests should call {@link #clearTestPlugins()} when they are done to avoid leaking the thread-local value.
+     *
+     * @param plugins   Ordered list of plugin instances to be used by the current thread
+     */
+    public static void initializeForTests(List<GatekeeperPlugin> plugins) {
+        TEST_PLUGINS.set(plugins == null ? List.of() : List.copyOf(plugins));
+    }
+
+    /**
+     * Removes the thread-local plugins set by {@link #initializeForTests(List)}. Tests should call this in their
+     * teardown to avoid leaking the thread-local value into other tests reusing the same thread.
+     */
+    public static void clearTestPlugins() {
+        TEST_PLUGINS.remove();
+    }
+
+    /**
+     * Returns the ordered list of all configured plugins. If a thread-local list of plugins was set using
+     * {@link #initializeForTests(List)}, it takes precedence over the plugins configured for the regular runtime.
+     *
+     * @return  Ordered, unmodifiable list of the configured plugins
+     */
+    public static List<GatekeeperPlugin> getPlugins() {
+        List<GatekeeperPlugin> testPlugins = TEST_PLUGINS.get();
+        return testPlugins != null ? testPlugins : plugins;
+    }
+
+    /**
+     * Finds the requested plugins using the ServiceLoader mechanism, orders them as requested, configures them,
+     * and returns them as an unmodifiable list.
+     *
+     * @param pluginClasses     Ordered list of the canonical class names of the plugins which should be used
+     * @param context           Configuration context passed to each plugin when it is configured
+     *
+     * @return  Ordered, unmodifiable list of the configured plugins
+     */
+    private static List<GatekeeperPlugin> loadConfigureAndOrder(List<String> pluginClasses, GatekeeperPluginConfigurationContext context) {
+        if (pluginClasses == null || pluginClasses.isEmpty()) {
+            return List.of();
+        } else {
+            // Discover all the available plugins at once and index them by their canonical class name.
+            Map<String, GatekeeperPlugin> available = new LinkedHashMap<>();
+            for (GatekeeperPlugin plugin : ServiceLoader.load(GatekeeperPlugin.class)) {
+                LOGGER.info("Found Gatekeeper plugin {}", plugin.getClass().getCanonicalName());
+                available.put(plugin.getClass().getCanonicalName(), plugin);
+            }
+
+            // Resolve the requested plugins keeping the requested order, which is significant.
+            List<GatekeeperPlugin> ordered = new ArrayList<>(pluginClasses.size());
+            for (String pluginClass : pluginClasses) {
+                GatekeeperPlugin plugin = available.get(pluginClass);
+
+                if (plugin == null) {
+                    LOGGER.error("Gatekeeper plugin {} was not found", pluginClass);
+                    throw new InvalidConfigurationException("Gatekeeper plugin " + pluginClass + " was not found.");
+                } else {
+                    ordered.add(plugin);
+                }
+            }
+
+            // Configure the plugins in order. If configuring a plugin throws, it is propagated and the operator startup fails.
+            for (GatekeeperPlugin plugin : ordered) {
+                LOGGER.info("Configuring Gatekeeper plugin {}", plugin.getClass().getCanonicalName());
+                plugin.configure(context);
+            }
+
+            // Return unmodifiable list of ordered plugins
+            return List.copyOf(ordered);
+        }
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/GatekeeperPluginFactoryTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/GatekeeperPluginFactoryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper;
+
+import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.plugin.gatekeeper.GatekeeperPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class GatekeeperPluginFactoryTest {
+    private static final String PLUGIN_A = TestGatekeeperPluginA.class.getCanonicalName();
+    private static final String PLUGIN_B = TestGatekeeperPluginB.class.getCanonicalName();
+    private static final String UNKNOWN_PLUGIN = "io.strimzi.does.not.Exist";
+
+    private final GatekeeperPluginConfigurationContext context = mock(GatekeeperPluginConfigurationContext.class);
+
+    @AfterEach
+    public void cleanup() {
+        // Reset the static state and remove any thread-local plugins so the tests do not interfere with each other.
+        GatekeeperPluginFactory.initialize(List.of(), context);
+        GatekeeperPluginFactory.clearTestPlugins();
+    }
+
+    private static List<String> classNames(List<? extends GatekeeperPlugin> plugins) {
+        return plugins.stream().map(p -> p.getClass().getCanonicalName()).toList();
+    }
+
+    @Test
+    public void testInitializeKeepsRequestedOrder() {
+        GatekeeperPluginFactory.initialize(List.of(PLUGIN_A, PLUGIN_B), context);
+
+        assertThat(classNames(GatekeeperPluginFactory.getPlugins()), contains(PLUGIN_A, PLUGIN_B));
+
+        // Different order -> B first, A second
+        GatekeeperPluginFactory.initialize(List.of(PLUGIN_B, PLUGIN_A), context);
+
+        assertThat(classNames(GatekeeperPluginFactory.getPlugins()), contains(PLUGIN_B, PLUGIN_A));
+    }
+
+    @Test
+    public void testInitializeLoadsOnlyRequestedPlugins() {
+        GatekeeperPluginFactory.initialize(List.of(PLUGIN_B), context);
+
+        assertThat(classNames(GatekeeperPluginFactory.getPlugins()), contains(PLUGIN_B));
+    }
+
+    @Test
+    public void testInitializeConfiguresEachPluginOnceWithContext() {
+        GatekeeperPluginFactory.initialize(List.of(PLUGIN_A, PLUGIN_B), context);
+
+        List<GatekeeperPlugin> plugins = GatekeeperPluginFactory.getPlugins();
+        TestGatekeeperPluginA pluginA = (TestGatekeeperPluginA) plugins.get(0);
+        TestGatekeeperPluginB pluginB = (TestGatekeeperPluginB) plugins.get(1);
+
+        assertThat(pluginA.configureCount(), is(1));
+        assertThat(pluginB.configureCount(), is(1));
+        assertThat(pluginA.context(), is(sameInstance(context)));
+        assertThat(pluginB.context(), is(sameInstance(context)));
+    }
+
+    @Test
+    public void testInitializeWithEmptyList() {
+        GatekeeperPluginFactory.initialize(List.of(), context);
+
+        assertThat(GatekeeperPluginFactory.getPlugins(), is(List.of()));
+    }
+
+    @Test
+    public void testInitializeWithUnknownPluginThrows() {
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> GatekeeperPluginFactory.initialize(List.of(PLUGIN_A, UNKNOWN_PLUGIN), context));
+
+        assertThat(e.getMessage(), is("Gatekeeper plugin " + UNKNOWN_PLUGIN + " was not found."));
+    }
+
+    @Test
+    public void testInitializeForTestsOverridesStaticPluginsViaThreadLocal() {
+        // Configure the static plugins
+        GatekeeperPluginFactory.initialize(List.of(PLUGIN_A), context);
+        assertThat(classNames(GatekeeperPluginFactory.getPlugins()), contains(PLUGIN_A));
+
+        // The thread-local plugins take precedence over the static ones
+        GatekeeperPlugin threadLocalPlugin = new TestGatekeeperPluginB();
+        GatekeeperPluginFactory.initializeForTests(List.of(threadLocalPlugin));
+        assertThat(GatekeeperPluginFactory.getPlugins(), contains(sameInstance(threadLocalPlugin)));
+
+        // Once the thread-local plugins are cleared, the static ones are visible again
+        GatekeeperPluginFactory.clearTestPlugins();
+        assertThat(classNames(GatekeeperPluginFactory.getPlugins()), contains(PLUGIN_A));
+    }
+
+    @Test
+    public void testInitializeForTestsDoesNotConfigurePlugins() {
+        TestGatekeeperPluginA plugin = new TestGatekeeperPluginA();
+        GatekeeperPluginFactory.initializeForTests(List.of(plugin));
+
+        assertThat(GatekeeperPluginFactory.getPlugins(), contains(sameInstance(plugin)));
+        assertThat(plugin.configureCount(), is(0));
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/TestGatekeeperPluginA.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/TestGatekeeperPluginA.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper;
+
+import io.strimzi.plugin.gatekeeper.GatekeeperPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+
+/**
+ * Test Gatekeeper plugin used to verify the ServiceLoader discovery, ordering and configuration done by the factory.
+ */
+public class TestGatekeeperPluginA implements GatekeeperPlugin {
+    private int configureCount = 0;
+    private GatekeeperPluginConfigurationContext context;
+
+    @Override
+    public void configure(GatekeeperPluginConfigurationContext context) {
+        this.configureCount++;
+        this.context = context;
+    }
+
+    public int configureCount() {
+        return configureCount;
+    }
+
+    public GatekeeperPluginConfigurationContext context() {
+        return context;
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/TestGatekeeperPluginB.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/TestGatekeeperPluginB.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper;
+
+import io.strimzi.plugin.gatekeeper.GatekeeperPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+
+/**
+ * Test Gatekeeper plugin used to verify the ServiceLoader discovery, ordering and configuration done by the factory.
+ */
+public class TestGatekeeperPluginB implements GatekeeperPlugin {
+    private int configureCount = 0;
+    private GatekeeperPluginConfigurationContext context;
+
+    @Override
+    public void configure(GatekeeperPluginConfigurationContext context) {
+        this.configureCount++;
+        this.context = context;
+    }
+
+    public int configureCount() {
+        return configureCount;
+    }
+
+    public GatekeeperPluginConfigurationContext context() {
+        return context;
+    }
+}

--- a/operator-common/src/test/resources/META-INF/services/io.strimzi.plugin.gatekeeper.GatekeeperPlugin
+++ b/operator-common/src/test/resources/META-INF/services/io.strimzi.plugin.gatekeeper.GatekeeperPlugin
@@ -1,0 +1,2 @@
+io.strimzi.operator.common.gatekeeper.TestGatekeeperPluginA
+io.strimzi.operator.common.gatekeeper.TestGatekeeperPluginB

--- a/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/UserOperatorGatekeeperPluginInvoker.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/UserOperatorGatekeeperPluginInvoker.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.gatekeeper;
+
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+import io.strimzi.api.kafka.model.user.KafkaUserStatusBuilder;
+import io.strimzi.operator.common.gatekeeper.AbstractGatekeeperPluginInvoker;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserValidatingPlugin;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Invokes the Strimzi Gatekeeper plugins for KafkaUser reconciliations. It provides entry, exit, and deletion methods
+ * which invoke all the KafkaUser plugins - both mutating and validating - as one ordered chain. The plugins (and their
+ * order) are provided by the {@link GatekeeperPluginFactory}.
+ */
+public class UserOperatorGatekeeperPluginInvoker extends AbstractGatekeeperPluginInvoker {
+    private UserOperatorGatekeeperPluginInvoker() { }
+
+    /**
+     * Invokes the entry of all the KafkaUser plugins (mutating and validating) as a single-ordered chain. Mutating plugins
+     * can modify the resource; validating plugins receive a copy of it and let the original pass through unchanged.
+     *
+     * @param context   The entry context passed to the plugins
+     * @param kafkaUser   The KafkaUser custom resource being reconciled
+     *
+     * @return  A completion stage with the KafkaUser resource after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaUser> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+        return chain(
+                GatekeeperKafkaUserMutatingPlugin.class,
+                GatekeeperKafkaUserValidatingPlugin.class,
+                Phase.ENTRY,
+                kafkaUser,
+                (plugin, current) -> plugin.kafkaUserEntry(context, current),
+                (plugin, current) -> plugin.kafkaUserEntry(context, copy(current, item -> new KafkaUserBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the exit of all the KafkaUser plugins (mutating and validating) as a single-ordered chain, in the reverse of
+     * the configured order. Mutating plugins can modify the status; validating plugins receive copies of the resource and
+     * the status and let the original status pass through unchanged.
+     *
+     * @param context   The exit context passed to the plugins
+     * @param kafkaUser   The KafkaUser custom resource being reconciled
+     * @param status    The status computed for the KafkaUser resource
+     *
+     * @return  A completion stage with the KafkaUser status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaUserStatus> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus status) {
+        return chain(
+                GatekeeperKafkaUserMutatingPlugin.class,
+                GatekeeperKafkaUserValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, currentStatus) -> plugin.kafkaUserExit(context, kafkaUser, currentStatus),
+                (plugin, currentStatus) -> plugin.kafkaUserExit(context, copy(kafkaUser, item -> new KafkaUserBuilder(item).build()), copy(currentStatus, item -> new KafkaUserStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the deletion hook of all the KafkaUser plugins as a single ordered chain. There is no resource to mutate
+     * during a deletion, so the hooks only react to the deletion; any of them can reject it by completing exceptionally,
+     * which stops the chain.
+     *
+     * @param context   The deletion context passed to the plugins
+     * @param namespace The namespace of the KafkaUser being deleted
+     * @param name      The name of the KafkaUser being deleted
+     *
+     * @return  A completion stage that completes when all the deletion hooks completed
+     */
+    public static CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+        return deletion(
+                GatekeeperKafkaUserMutatingPlugin.class,
+                GatekeeperKafkaUserValidatingPlugin.class,
+                plugin -> plugin instanceof GatekeeperKafkaUserMutatingPlugin mutating
+                        ? mutating.kafkaUserDeletion(context, namespace, name)
+                        : ((GatekeeperKafkaUserValidatingPlugin) plugin).kafkaUserDeletion(context, namespace, name));
+    }
+}

--- a/user-operator/src/test/java/io/strimzi/operator/user/gatekeeper/UserOperatorGatekeeperPluginInvokerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/gatekeeper/UserOperatorGatekeeperPluginInvokerTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.gatekeeper;
+
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+import io.strimzi.api.kafka.model.user.KafkaUserStatusBuilder;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UserOperatorGatekeeperPluginInvokerTest {
+    private final List<String> order = new ArrayList<>();
+
+    @AfterEach
+    public void cleanup() {
+        GatekeeperPluginFactory.clearTestPlugins();
+    }
+
+    @Test
+    public void testEntryChainsMutatingPluginsInRequestedOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserMutator("A"), new UserMutator("B")));
+
+        KafkaUser result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserEntry(null, user(""))
+                .toCompletableFuture().join();
+
+        assertThat(result.getMetadata().getName(), is("AB"));
+        assertThat(order, contains("A", "B"));
+    }
+
+    @Test
+    public void testExitChainsPluginsInReverseOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserMutator("A"), new UserMutator("B")));
+
+        UserOperatorGatekeeperPluginInvoker
+                .kafkaUserExit(null, user(""), new KafkaUserStatus())
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("B", "A"));
+    }
+
+    @Test
+    public void testMutatingAndValidatingPluginsRunInOneOrderedChain() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserMutator("A"), new UserValidator("B", false)));
+
+        KafkaUser result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserEntry(null, user(""))
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+        assertThat(result.getMetadata().getName(), is("A"));
+    }
+
+    @Test
+    public void testEntryWithNoPluginsReturnsResourceUnchanged() {
+        GatekeeperPluginFactory.initializeForTests(List.of());
+
+        KafkaUser result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserEntry(null, user("unchanged"))
+                .toCompletableFuture().join();
+
+        assertThat(result.getMetadata().getName(), is("unchanged"));
+        assertThat(order, is(empty()));
+    }
+
+    @Test
+    public void testChainStopsAtFirstValidationFailure() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserValidator("fail", true), new UserValidator("ok", false)));
+
+        CompletableFuture<KafkaUser> result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserEntry(null, user(""))
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+        assertThat(order, contains("fail"));
+    }
+
+    @Test
+    public void testValidatingPluginCannotModifyTheResource() {
+        KafkaUser base = user("original");
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserResourceMutatingValidator()));
+
+        KafkaUser result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserEntry(null, base)
+                .toCompletableFuture().join();
+
+        assertThat(result.getMetadata().getName(), is("original"));
+        assertThat(base.getMetadata().getName(), is("original"));
+    }
+
+    @Test
+    public void testValidatingPluginCopyIsNullTolerant() {
+        CapturingUserValidator validator = new CapturingUserValidator();
+        GatekeeperPluginFactory.initializeForTests(List.of(validator));
+
+        KafkaUser result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserEntry(null, null)
+                .toCompletableFuture().join();
+
+        assertThat(result, is(nullValue()));
+        assertThat(validator.invoked, is(true));
+        assertThat(validator.receivedUser, is(nullValue()));
+    }
+
+    @Test
+    public void testExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new StatusMutator()));
+
+        KafkaUserStatus status = new KafkaUserStatusBuilder()
+                .withObservedGeneration(1L)
+                .build();
+
+        KafkaUserStatus result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserExit(null, user("my-user"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testExitValidatingPluginCannotModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new StatusMutatingValidator()));
+
+        KafkaUserStatus status = new KafkaUserStatusBuilder()
+                .withObservedGeneration(1L)
+                .build();
+
+        KafkaUserStatus result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserExit(null, user("my-user"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1L));
+    }
+
+    @Test
+    public void testDeletionInvokesAllPluginsInRequestedOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserDeletionPlugin("A", false), new UserDeletionPlugin("B", false)));
+
+        UserOperatorGatekeeperPluginInvoker
+                .kafkaUserDeletion(null, "my-namespace", "my-user")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+    }
+
+    @Test
+    public void testDeletionPassesNamespaceAndName() {
+        UserDeletionPlugin plugin = new UserDeletionPlugin("A", false);
+        GatekeeperPluginFactory.initializeForTests(List.of(plugin));
+
+        UserOperatorGatekeeperPluginInvoker
+                .kafkaUserDeletion(null, "my-namespace", "my-user")
+                .toCompletableFuture().join();
+
+        assertThat(plugin.namespace, is("my-namespace"));
+        assertThat(plugin.name, is("my-user"));
+    }
+
+    @Test
+    public void testDeletionStopsAtFirstFailure() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new UserDeletionPlugin("fail", true), new UserDeletionPlugin("ok", false)));
+
+        CompletableFuture<Void> result = UserOperatorGatekeeperPluginInvoker
+                .kafkaUserDeletion(null, "my-namespace", "my-user")
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+        assertThat(order, contains("fail"));
+    }
+
+    @Test
+    public void testDeletionWithValidatingPlugin() {
+        UserValidatingDeletionPlugin plugin = new UserValidatingDeletionPlugin("A", false);
+        GatekeeperPluginFactory.initializeForTests(List.of(plugin));
+
+        UserOperatorGatekeeperPluginInvoker
+                .kafkaUserDeletion(null, "my-namespace", "my-user")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A"));
+        assertThat(plugin.namespace, is("my-namespace"));
+        assertThat(plugin.name, is("my-user"));
+    }
+
+    private static KafkaUser user(String name) {
+        return new KafkaUserBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static String append(String current, String tag) {
+        return (current == null ? "" : current) + tag;
+    }
+
+    private final class UserMutator implements GatekeeperKafkaUserMutatingPlugin {
+        private final String tag;
+
+        private UserMutator(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<KafkaUser> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(new KafkaUserBuilder(kafkaUser)
+                    .editOrNewMetadata()
+                        .withName(append(kafkaUser.getMetadata().getName(), tag))
+                    .endMetadata()
+                    .build());
+        }
+
+        @Override
+        public CompletionStage<KafkaUserStatus> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(newKafkaUserStatus);
+        }
+    }
+
+    private final class UserValidator implements GatekeeperKafkaUserValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+
+        private UserValidator(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class UserResourceMutatingValidator implements GatekeeperKafkaUserValidatingPlugin {
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            kafkaUser.getMetadata().setName("HACKED");
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class CapturingUserValidator implements GatekeeperKafkaUserValidatingPlugin {
+        private boolean invoked;
+        private KafkaUser receivedUser;
+
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            invoked = true;
+            receivedUser = kafkaUser;
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class StatusMutator implements GatekeeperKafkaUserMutatingPlugin {
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<KafkaUserStatus> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+            newKafkaUserStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaUserStatus);
+        }
+    }
+
+    private static final class StatusMutatingValidator implements GatekeeperKafkaUserValidatingPlugin {
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+            newKafkaUserStatus.setObservedGeneration(1919L);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private final class UserDeletionPlugin implements GatekeeperKafkaUserMutatingPlugin {
+        private final String tag;
+        private final boolean fail;
+        private String namespace;
+        private String name;
+
+        private UserDeletionPlugin(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            this.namespace = namespace;
+            this.name = name;
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private final class UserValidatingDeletionPlugin implements GatekeeperKafkaUserValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+        private String namespace;
+        private String name;
+
+        private UserValidatingDeletionPlugin(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            this.namespace = namespace;
+            this.name = name;
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+}


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR delivers the next chunk of the Gatekeeper plugin system implementation. It focuses on:
* Gatekeeper plugin factory that it used to load the plugins based on the configuration
    * It has the _production_ initialization method to be used for production
    * As well as _test_ initialization method that uses only thread-local initialization to avoid conflicts between tests
* The Gatekeeper plugin invoker that will be used to invoke the Gatekeeper plugins
    * The abstract invoker that will be shared between TO, CO and UO is in the `operator-common` module
    * The User Operator implementation provides an example of how it will be used as well as a basis for the unit tests

_The factory and invoker from this PR are used only for testing for the time being. (The next PR will work on plugging the Gatekeeper plugins into the User Operator)._

This should resolve #12809.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
