### PR TITLE
Add support for skipping automatic rolling updates for individual Kafka nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0
 
 * Add support for Apache Kafka 4.3.1
+* Add the `strimzi.io/skip-rolling-update` annotation on `KafkaNodePool` resources to exclude individual broker nodes from automatic rolling updates
 
 ### Major changes, deprecations, and removals
 

--- a/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
+++ b/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
@@ -126,4 +126,11 @@ public class ResourceAnnotations {
      * Annotation used to skip the check on broker scale-down
      */
     public static final String ANNO_STRIMZI_IO_SKIP_BROKER_SCALEDOWN_CHECK = STRIMZI_DOMAIN + "skip-broker-scaledown-check";
+
+    /**
+     * Annotation set on a KafkaNodePool to exclude the listed node IDs (for example `[2,5]` or `[2,4-6]`) from
+     * automatic rolling updates driven by the operator. Manual rolling updates requested through the
+     * strimzi.io/manual-rolling-update annotation are not affected by this annotation.
+     */
+    public static final String ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE = STRIMZI_DOMAIN + "skip-rolling-update";
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -9,10 +9,13 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
 import io.strimzi.api.kafka.model.kafka.exporter.KafkaExporterResources;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolList;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertIssuer;
@@ -48,6 +51,7 @@ import io.strimzi.operator.common.model.ClientsCa;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.common.operator.resource.kubernetes.SecretOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -79,6 +83,7 @@ public class CaReconciler {
     private final StrimziPodSetOperator strimziPodSetOperator;
     private final SecretOperator secretOperator;
     /* test */ final PodOperator podOperator;
+    private final CrdOperator<KubernetesClient, KafkaNodePool, KafkaNodePoolList> kafkaNodePoolOperator;
     private final AdminClientProvider adminClientProvider;
     private final KafkaAgentClientProvider kafkaAgentClientProvider;
     private final CertIssuer certIssuer;
@@ -130,6 +135,7 @@ public class CaReconciler {
         this.strimziPodSetOperator = supplier.strimziPodSetOperator;
         this.secretOperator = supplier.secretOperations;
         this.podOperator = supplier.podOperations;
+        this.kafkaNodePoolOperator = supplier.kafkaNodePoolOperator;
 
         this.adminClientProvider = supplier.adminClientProvider;
         this.kafkaAgentClientProvider = supplier.kafkaAgentClientProvider;
@@ -382,6 +388,7 @@ public class CaReconciler {
             RestartReason restartReason = RestartReason.CLUSTER_CA_CERT_KEY_REPLACED;
             TlsPemIdentity coTlsPemIdentity = new TlsPemIdentity(new PemTrustSet(clusterCaCertSecret), PemAuthIdentity.clusterOperator(coSecret));
             return patchClusterCaKeyGenerationAndReturnNodes()
+                    .compose(nodes -> filterOutNodesSkippedFromRollingUpdates(nodes))
                     .compose(nodes -> rollKafkaBrokers(nodes, RestartReasons.of(restartReason), coTlsPemIdentity))
                     .compose(i -> rollDeploymentIfExists(KafkaResources.entityOperatorDeploymentName(reconciliation.name()), restartReason))
                     .compose(i -> rollDeploymentIfExists(KafkaExporterResources.componentName(reconciliation.name()), restartReason))
@@ -487,6 +494,33 @@ public class CaReconciler {
                                 .collect(Collectors.toSet()));
                     } else {
                         return Future.succeededFuture(Set.of());
+                    }
+                });
+    }
+
+    /**
+     * Filters out the nodes which are excluded from automatic rolling updates through the
+     * strimzi.io/skip-rolling-update annotations on the KafkaNodePool resources. A CA key replacement roll is an
+     * automatic rolling update, so it must honor the skips the same way the regular rolling update does. Because
+     * {@code isClusterCaNeedFullTrust} stays set until every node trusts the new CA, the skipped nodes are rolled
+     * in a later reconciliation once they are no longer skipped.
+     *
+     * @param nodes The set of the Kafka nodes to roll
+     *
+     * @return  Future with the set of the Kafka nodes without the nodes excluded from automatic rolling updates
+     */
+    /* test */ Future<Set<NodeRef>> filterOutNodesSkippedFromRollingUpdates(Set<NodeRef> nodes) {
+        return VertxUtil.toFuture(kafkaNodePoolOperator.listAsync(reconciliation.namespace(), Labels.fromMap(Map.of(Labels.STRIMZI_CLUSTER_LABEL, reconciliation.name()))))
+                .map(nodePools -> {
+                    RollingUpdateSkips skips = RollingUpdateSkips.resolve(reconciliation, nodePools != null ? nodePools : List.of(), nodes, List.of());
+
+                    if (skips.hasSkippedNodes()) {
+                        LOGGER.warnCr(reconciliation, "Nodes {} are excluded from the rolling update for the new Cluster CA key because of the {} annotation. They will be rolled once they are no longer excluded.", skips.skippedNodeIds(), Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE);
+                        return nodes.stream()
+                                .filter(node -> !skips.skippedNodeIds().contains(node.nodeId()))
+                                .collect(Collectors.toSet());
+                    } else {
+                        return nodes;
                     }
                 });
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -66,11 +66,41 @@ public class KRaftMetadataManager {
             String desiredMetadataVersion,
             KafkaStatus status
     ) {
+        return maybeUpdateMetadataVersion(reconciliation, coTlsPemIdentity, adminClientProvider, desiredMetadataVersion, status, false);
+    }
+
+    /**
+     * Utility method for managing the KRaft metadata version with support for deferring any version change.
+     *
+     * This method behaves like {@link #maybeUpdateMetadataVersion(Reconciliation, TlsPemIdentity, AdminClientProvider, String, KafkaStatus)}.
+     * But when {@code deferVersionChange} is true and the current and desired metadata versions differ, the change is
+     * not applied. Instead, a warning condition is added to the Kafka custom resource status and the currently used
+     * metadata version is kept. This is used while one or more nodes are excluded from automatic rolling updates,
+     * because finalizing a metadata version change without the excluded nodes could leave them unable to rejoin the
+     * cluster.
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param coTlsPemIdentity          Trust set and identity for TLS client authentication for connecting to the Kafka cluster
+     * @param adminClientProvider       Kafka Admin client provider
+     * @param desiredMetadataVersion    Desired metadata version
+     * @param status                    Kafka status
+     * @param deferVersionChange        When true, any metadata version change is deferred instead of applied
+     *
+     * @return  CompletionStage that completes when the metadata update is finished (or was not needed or was deferred) and the status is updated
+     */
+    public static CompletionStage<Void> maybeUpdateMetadataVersion(
+            Reconciliation reconciliation,
+            TlsPemIdentity coTlsPemIdentity,
+            AdminClientProvider adminClientProvider,
+            String desiredMetadataVersion,
+            KafkaStatus status,
+            boolean deferVersionChange
+    ) {
         String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
         LOGGER.debugCr(reconciliation, "Creating AdminClient for Kafka cluster in namespace {}", reconciliation.namespace());
         Admin kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
 
-        return maybeUpdateMetadataVersion(reconciliation, kafkaAdmin, desiredMetadataVersion, status)
+        return maybeUpdateMetadataVersion(reconciliation, kafkaAdmin, desiredMetadataVersion, status, deferVersionChange)
                 .whenComplete((result, error) -> {
                     // Close the Admin client and return the original result
                     LOGGER.debugCr(reconciliation, "Closing the Kafka Admin API connection");
@@ -82,7 +112,8 @@ public class KRaftMetadataManager {
             Reconciliation reconciliation,
             Admin kafkaAdmin,
             String desiredMetadataVersion,
-            KafkaStatus status
+            KafkaStatus status,
+            boolean deferVersionChange
     )    {
         short desiredMetadataLevel = MetadataVersion.fromVersionString(desiredMetadataVersion, false).featureLevel();
 
@@ -95,6 +126,15 @@ public class KRaftMetadataManager {
                         String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString();
                         LOGGER.debugCr(reconciliation, "Metadata version is already set to the desired version {}", metadataVersion);
                         status.setKafkaMetadataVersion(MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString());
+                        return CompletableFuture.completedFuture(null);
+                    } else if (deferVersionChange)  {
+                        // A metadata version change is needed, but one or more nodes are excluded from automatic
+                        // rolling updates. Changing the metadata version without them could leave them unable to
+                        // rejoin the cluster, so the change is deferred until all nodes are managed again.
+                        String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString();
+                        LOGGER.warnCr(reconciliation, "Deferring the metadata version change to {} because one or more nodes are excluded from automatic rolling updates (the current version {} will be kept)", desiredMetadataVersion, metadataVersion);
+                        status.addCondition(StatusUtils.buildWarningCondition("MetadataVersionChangeDeferred", "The metadata version change to " + desiredMetadataVersion + " is deferred because one or more nodes are excluded from automatic rolling updates"));
+                        status.setKafkaMetadataVersion(metadataVersion);
                         return CompletableFuture.completedFuture(null);
                     } else {
                         return updateVersion(reconciliation, kafkaAdmin, currentMetadataLevel, desiredMetadataLevel)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1157,8 +1157,9 @@ public class KafkaReconciler {
                                     "Nodes excluded from automatic rolling updates through the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotation hold the sole in-sync replica of the following partitions: " + partitions));
                         }
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         LOGGER.warnCr(reconciliation, "Interrupted while checking the in-sync replicas of the nodes excluded from automatic rolling updates", e);
-                    } catch (Exception e) {
+                    } catch (ExecutionException | RuntimeException e) {
                         // The check is best-effort and must never fail the reconciliation
                         LOGGER.warnCr(reconciliation, "Failed to check the in-sync replicas of the nodes excluded from automatic rolling updates", e);
                     } finally {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -330,11 +330,12 @@ public class KafkaReconciler {
 
     /**
      * Resolves the strimzi.io/skip-rolling-update annotations from the KafkaNodePool resources into the set of node
-     * IDs which are excluded from automatic rolling updates during this reconciliation. When any node is skipped (or
-     * any requested skip had to be ignored or rejected), a RollingUpdateSkipped condition is added to the Kafka status
-     * and Kubernetes Events are emitted when nodes enter or leave the skipped state.
+     * IDs which are excluded from automatic rolling updates during this reconciliation. When any node is skipped, a
+     * RollingUpdateSkipped condition is added to the Kafka status and Kubernetes Events are emitted when the set of
+     * skipped nodes changes. Node IDs which had to be ignored (controller role) or rejected (invalid values) are
+     * reported through separate Warning conditions.
      *
-     * @param kafkaStatus   The Kafka Status where the RollingUpdateSkipped condition will be added
+     * @param kafkaStatus   The Kafka Status where the conditions will be added
      *
      * @return  Completes when the skips are resolved
      */
@@ -360,11 +361,11 @@ public class KafkaReconciler {
     }
 
     /**
-     * Adds the RollingUpdateSkipped condition to the Kafka status, logs a warning on every reconciliation while a skip
-     * is active, and emits Kubernetes Events when the set of skipped nodes changes compared to the previous
-     * reconciliation.
+     * Adds the RollingUpdateSkipped condition (and the warning conditions about ignored or rejected node IDs) to the
+     * Kafka status, logs a warning on every reconciliation while a skip is active, and emits Kubernetes Events when
+     * the set of skipped nodes changes compared to the previous reconciliation.
      *
-     * @param kafkaStatus   The Kafka Status where the RollingUpdateSkipped condition will be added
+     * @param kafkaStatus   The Kafka Status where the conditions will be added
      */
     private void handleRollingUpdateSkips(KafkaStatus kafkaStatus) {
         if (rollingUpdateSkips.hasSkippedNodes()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -167,8 +167,10 @@ public class KafkaReconciler {
     private final List<String> secretsToDelete = new ArrayList<>();
     /* test */ TlsPemIdentity coTlsPemIdentity;
     /* test */ KafkaListenersReconciler.ReconciliationResult listenerReconciliationResults; // Result of the listener reconciliation with the listener details
+    /* test */ RollingUpdateSkips rollingUpdateSkips = RollingUpdateSkips.EMPTY; // Nodes excluded from automatic rolling updates, resolved at the start of the reconciliation
 
     private final KafkaAutoRebalanceStatus kafkaAutoRebalanceStatus;
+    private final Condition previousRollingUpdateSkippedCondition;
 
     /**
      * Constructs the Kafka reconciler
@@ -213,6 +215,9 @@ public class KafkaReconciler {
         this.imagePullSecrets = config.getImagePullSecrets();
         this.isPodDisruptionBudgetGeneration = config.isPodDisruptionBudgetGeneration();
         this.kafkaAutoRebalanceStatus = kafkaCr.getStatus() != null ? kafkaCr.getStatus().getAutoRebalance() : null;
+        this.previousRollingUpdateSkippedCondition = kafkaCr.getStatus() != null && kafkaCr.getStatus().getConditions() != null
+                ? kafkaCr.getStatus().getConditions().stream().filter(condition -> RollingUpdateSkips.ROLLING_UPDATE_SKIPPED_CONDITION_TYPE.equals(condition.getType())).findFirst().orElse(null)
+                : null;
 
         this.strimziPodSetOperator = supplier.strimziPodSetOperator;
         this.secretOperator = supplier.secretOperations;
@@ -250,6 +255,7 @@ public class KafkaReconciler {
      */
     public Future<Void> reconcile(KafkaStatus kafkaStatus, Clock clock)    {
         return modelWarnings(kafkaStatus)
+                .compose(i -> resolveRollingUpdateSkips(kafkaStatus))
                 .compose(i -> initClientAuthenticationCertificates())
                 .compose(i -> manualPodCleaning())
                 .compose(i -> networkPolicy())
@@ -313,6 +319,64 @@ public class KafkaReconciler {
         kafkaStatus.addConditions(conditions);
 
         return Future.succeededFuture();
+    }
+
+    /**
+     * Resolves the strimzi.io/skip-rolling-update annotations from the KafkaNodePool resources into the set of node
+     * IDs which are excluded from automatic rolling updates during this reconciliation. When any node is skipped (or
+     * any requested skip had to be ignored or rejected), a RollingUpdateSkipped condition is added to the Kafka status
+     * and Kubernetes Events are emitted when nodes enter or leave the skipped state.
+     *
+     * @param kafkaStatus   The Kafka Status where the RollingUpdateSkipped condition will be added
+     *
+     * @return  Completes when the skips are resolved
+     */
+    protected Future<Void> resolveRollingUpdateSkips(KafkaStatus kafkaStatus) {
+        boolean anySkipAnnotation = kafkaNodePoolCrs != null
+                && kafkaNodePoolCrs.stream().anyMatch(pool -> Annotations.hasAnnotation(pool, Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE));
+
+        if (!anySkipAnnotation) {
+            this.rollingUpdateSkips = RollingUpdateSkips.EMPTY;
+            handleRollingUpdateSkips(kafkaStatus);
+            return Future.succeededFuture();
+        } else {
+            // The role check considers the role labels of the existing Pods in addition to the desired roles, so we
+            // list the current Kafka pods
+            return VertxUtil.toFuture(podOperator.listAsync(reconciliation.namespace(), kafka.getSelectorLabels()))
+                    .map(pods -> {
+                        this.rollingUpdateSkips = RollingUpdateSkips.resolve(reconciliation, kafkaNodePoolCrs, kafka.nodes(), pods);
+                        handleRollingUpdateSkips(kafkaStatus);
+                        return null;
+                    })
+                    .mapEmpty();
+        }
+    }
+
+    /**
+     * Adds the RollingUpdateSkipped condition to the Kafka status, logs a warning on every reconciliation while a skip
+     * is active, and emits Kubernetes Events when the set of skipped nodes changes compared to the previous
+     * reconciliation.
+     *
+     * @param kafkaStatus   The Kafka Status where the RollingUpdateSkipped condition will be added
+     */
+    private void handleRollingUpdateSkips(KafkaStatus kafkaStatus) {
+        if (rollingUpdateSkips.shouldReportCondition()) {
+            kafkaStatus.addCondition(rollingUpdateSkips.kafkaStatusCondition());
+        }
+
+        if (rollingUpdateSkips.hasSkippedNodes()) {
+            LOGGER.warnCr(reconciliation, "Nodes {} are excluded from automatic rolling updates through the {} annotation. The skip should be short-lived and must not be held across an upgrade or CA renewal.", rollingUpdateSkips.skippedNodeIds(), Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE);
+        }
+
+        Set<Integer> previouslySkippedNodeIds = RollingUpdateSkips.skippedNodeIdsFromCondition(previousRollingUpdateSkippedCondition);
+
+        if (rollingUpdateSkips.hasSkippedNodes() && !rollingUpdateSkips.skippedNodeIds().equals(previouslySkippedNodeIds)) {
+            eventsPublisher.publishClusterEvent(reconciliation, "StrimziSkipRollingUpdate", "RollingUpdateSkipEnabled", "Warning",
+                    "Nodes " + rollingUpdateSkips.skippedNodeIds() + " are excluded from automatic rolling updates");
+        } else if (!rollingUpdateSkips.hasSkippedNodes() && !previouslySkippedNodeIds.isEmpty()) {
+            eventsPublisher.publishClusterEvent(reconciliation, "StrimziSkipRollingUpdate", "RollingUpdateSkipDisabled", "Normal",
+                    "All nodes are again included in automatic rolling updates");
+        }
     }
 
     /**
@@ -936,8 +1000,19 @@ public class KafkaReconciler {
      * @return  Future which completes when any of the Kafka pods which need rolling is rolled
      */
     protected Future<Void> rollingUpdate(Map<String, ReconcileResult<StrimziPodSet>> podSetDiffs) {
+        Set<NodeRef> nodes = kafka.nodes();
+
+        if (rollingUpdateSkips.hasSkippedNodes())   {
+            // Nodes excluded from automatic rolling updates are removed from the working set, so the roller never
+            // considers them and none of its internal not-ready / force-restart paths can fire for them
+            nodes = nodes.stream()
+                    .filter(node -> !rollingUpdateSkips.skippedNodeIds().contains(node.nodeId()))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            LOGGER.infoCr(reconciliation, "Nodes {} are excluded from this rolling update because of the {} annotation", rollingUpdateSkips.skippedNodeIds(), Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE);
+        }
+
         return maybeRollKafka(
-                kafka.nodes(),
+                nodes,
                 pod -> ReconcilerUtils.reasonsToRestartPod(
                         reconciliation,
                         podSetDiffs.get(ReconcilerUtils.getControllerNameFromPodName(pod.getMetadata().getName())).resource(),
@@ -964,7 +1039,12 @@ public class KafkaReconciler {
                         reconciliation,
                         podOperator,
                         operationTimeoutMs,
-                        kafka.nodes().stream().map(node -> node.podName()).toList()
+                        // Nodes excluded from automatic rolling updates are not waited on, otherwise a NotReady
+                        // skipped Pod would time this stage out on every reconciliation
+                        kafka.nodes().stream()
+                                .filter(node -> !rollingUpdateSkips.skippedNodeIds().contains(node.nodeId()))
+                                .map(node -> node.podName())
+                                .toList()
                 );
     }
 
@@ -1088,7 +1168,9 @@ public class KafkaReconciler {
      * @return  Future which completes when the KRaft metadata version is set to the current version or updated.
      */
     protected Future<Void> metadataVersion(KafkaStatus kafkaStatus) {
-        return VertxUtil.toFuture(KRaftMetadataManager.maybeUpdateMetadataVersion(reconciliation, this.coTlsPemIdentity, adminClientProvider, kafka.getMetadataVersion(), kafkaStatus));
+        // While any node is excluded from automatic rolling updates, a metadata version change is deferred: the
+        // skipped node stays on its old version and finalizing the change without it could leave it unable to rejoin
+        return VertxUtil.toFuture(KRaftMetadataManager.maybeUpdateMetadataVersion(reconciliation, this.coTlsPemIdentity, adminClientProvider, kafka.getMetadataVersion(), kafkaStatus, rollingUpdateSkips.hasSkippedNodes()));
     }
 
     /**
@@ -1251,11 +1333,17 @@ public class KafkaReconciler {
         for (KafkaNodePool nodePool : kafkaNodePoolCrs) {
             statusesForKafka.add(new UsedNodePoolStatusBuilder().withName(nodePool.getMetadata().getName()).build());
 
+            KafkaNodePoolStatusBuilder statusBuilder = new KafkaNodePoolStatusBuilder(statuses.get(nodePool.getMetadata().getName()))
+                    .withObservedGeneration(nodePool.getMetadata().getGeneration());
+
+            // Mirror the details about nodes excluded from automatic rolling updates on the owning node pool
+            Set<Integer> skippedNodeIdsInPool = rollingUpdateSkips.skippedNodeIdsByPool().get(nodePool.getMetadata().getName());
+            if (skippedNodeIdsInPool != null && !skippedNodeIdsInPool.isEmpty()) {
+                statusBuilder.addToConditions(RollingUpdateSkips.nodePoolStatusCondition(skippedNodeIdsInPool));
+            }
+
             KafkaNodePool updatedNodePool = new KafkaNodePoolBuilder(nodePool)
-                    .withStatus(
-                            new KafkaNodePoolStatusBuilder(statuses.get(nodePool.getMetadata().getName()))
-                                    .withObservedGeneration(nodePool.getMetadata().getGeneration())
-                                    .build())
+                    .withStatus(statusBuilder.build())
                     .build();
 
             StatusDiff diff = new StatusDiff(nodePool.getStatus(), updatedNodePool.getStatus());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -79,6 +79,7 @@ import io.strimzi.operator.common.model.ClientsCa;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NodeUtils;
 import io.strimzi.operator.common.model.StatusDiff;
+import io.strimzi.operator.common.model.StatusUtils;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.common.operator.resource.kubernetes.SecretOperator;
@@ -86,7 +87,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartitionInfo;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -115,6 +118,9 @@ import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_SERVER_CERT_HA
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaReconciler {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaReconciler.class.getName());
+
+    // Maximal number of partitions listed in the SkippedNodeSoleInSyncReplica warning condition
+    private static final int SOLE_ISR_PARTITIONS_IN_CONDITION = 10;
 
     // Various settings
     private final long operationTimeoutMs;
@@ -282,6 +288,7 @@ public class KafkaReconciler {
                 .compose(i -> defaultKafkaQuotas())
                 .compose(i -> nodeUnregistration())
                 .compose(i -> metadataVersion(kafkaStatus))
+                .compose(i -> skippedNodesSoleInSyncReplicaCheck(kafkaStatus))
                 .compose(i -> deletePersistentClaims())
                 .compose(i -> sharedKafkaConfigurationCleanup())
                 .compose(i -> deleteOldCertificateSecrets())
@@ -360,18 +367,24 @@ public class KafkaReconciler {
      * @param kafkaStatus   The Kafka Status where the RollingUpdateSkipped condition will be added
      */
     private void handleRollingUpdateSkips(KafkaStatus kafkaStatus) {
-        if (rollingUpdateSkips.shouldReportCondition()) {
+        if (rollingUpdateSkips.hasSkippedNodes()) {
             kafkaStatus.addCondition(rollingUpdateSkips.kafkaStatusCondition());
+            LOGGER.warnCr(reconciliation, "Nodes {} are excluded from automatic rolling updates through the {} annotation. The skip should be short-lived and must not be held across an upgrade or CA renewal.", rollingUpdateSkips.skippedNodeIds(), Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE);
         }
 
-        if (rollingUpdateSkips.hasSkippedNodes()) {
-            LOGGER.warnCr(reconciliation, "Nodes {} are excluded from automatic rolling updates through the {} annotation. The skip should be short-lived and must not be held across an upgrade or CA renewal.", rollingUpdateSkips.skippedNodeIds(), Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE);
+        if (rollingUpdateSkips.hasIgnoredControllerNodeIds()) {
+            kafkaStatus.addCondition(rollingUpdateSkips.ignoredControllersWarningCondition());
+        }
+
+        if (rollingUpdateSkips.hasRejectedNodeIds()) {
+            kafkaStatus.addCondition(rollingUpdateSkips.rejectedNodeIdsWarningCondition());
         }
 
         Set<Integer> previouslySkippedNodeIds = RollingUpdateSkips.skippedNodeIdsFromCondition(previousRollingUpdateSkippedCondition);
 
         if (rollingUpdateSkips.hasSkippedNodes() && !rollingUpdateSkips.skippedNodeIds().equals(previouslySkippedNodeIds)) {
-            eventsPublisher.publishClusterEvent(reconciliation, "StrimziSkipRollingUpdate", "RollingUpdateSkipEnabled", "Warning",
+            String reason = previouslySkippedNodeIds.isEmpty() ? "RollingUpdateSkipEnabled" : "RollingUpdateSkipChanged";
+            eventsPublisher.publishClusterEvent(reconciliation, "StrimziSkipRollingUpdate", reason, "Warning",
                     "Nodes " + rollingUpdateSkips.skippedNodeIds() + " are excluded from automatic rolling updates");
         } else if (!rollingUpdateSkips.hasSkippedNodes() && !previouslySkippedNodeIds.isEmpty()) {
             eventsPublisher.publishClusterEvent(reconciliation, "StrimziSkipRollingUpdate", "RollingUpdateSkipDisabled", "Normal",
@@ -1088,6 +1101,65 @@ public class KafkaReconciler {
                         LOGGER.warnCr(reconciliation, "Interrupted exception getting clusterId {}", e.getMessage());
                     } catch (ExecutionException e) {
                         LOGGER.warnCr(reconciliation, "Execution exception getting clusterId {}", e.getMessage());
+                    } finally {
+                        if (kafkaAdmin != null) {
+                            kafkaAdmin.close();
+                        }
+                    }
+
+                    return null;
+                });
+    }
+
+    /**
+     * While any node is excluded from automatic rolling updates, checks whether a skipped node is the sole in-sync
+     * replica of any partition and surfaces it as a warning condition. Because podsReady() does not wait for skipped
+     * nodes, the Kafka custom resource can become Ready while a skipped node is down. This check keeps the status
+     * honest by flagging the partitions which are unavailable (or would become unavailable) without the skipped node.
+     * The check is best-effort and never fails the reconciliation.
+     *
+     * @param kafkaStatus   The Kafka Status where the warning condition will be added
+     *
+     * @return  Future which completes when the check is finished
+     */
+    protected Future<Void> skippedNodesSoleInSyncReplicaCheck(KafkaStatus kafkaStatus) {
+        if (!rollingUpdateSkips.hasSkippedNodes()) {
+            return Future.succeededFuture();
+        }
+
+        return vertx.createSharedWorkerExecutor("kubernetes-ops-pool")
+                .executeBlocking(() -> {
+                    Admin kafkaAdmin = null;
+
+                    try {
+                        String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
+                        LOGGER.debugCr(reconciliation, "Creating AdminClient for checking in-sync replicas of the nodes excluded from automatic rolling updates using {}", bootstrapHostname);
+                        kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, this.coTlsPemIdentity.pemTrustSet(), this.coTlsPemIdentity.pemAuthIdentity());
+
+                        Set<String> topicNames = kafkaAdmin.listTopics().names().get();
+                        List<String> soleIsrPartitions = new ArrayList<>();
+
+                        for (TopicDescription topic : kafkaAdmin.describeTopics(topicNames).allTopicNames().get().values()) {
+                            for (TopicPartitionInfo partition : topic.partitions()) {
+                                if (partition.isr().size() == 1 && rollingUpdateSkips.skippedNodeIds().contains(partition.isr().get(0).id())) {
+                                    soleIsrPartitions.add(topic.name() + "-" + partition.partition());
+                                }
+                            }
+                        }
+
+                        if (!soleIsrPartitions.isEmpty()) {
+                            String partitions = soleIsrPartitions.size() > SOLE_ISR_PARTITIONS_IN_CONDITION
+                                    ? soleIsrPartitions.subList(0, SOLE_ISR_PARTITIONS_IN_CONDITION) + " and " + (soleIsrPartitions.size() - SOLE_ISR_PARTITIONS_IN_CONDITION) + " more"
+                                    : soleIsrPartitions.toString();
+                            LOGGER.warnCr(reconciliation, "Nodes excluded from automatic rolling updates hold the sole in-sync replica of partitions {}", partitions);
+                            kafkaStatus.addCondition(StatusUtils.buildWarningCondition("SkippedNodeSoleInSyncReplica",
+                                    "Nodes excluded from automatic rolling updates through the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotation hold the sole in-sync replica of the following partitions: " + partitions));
+                        }
+                    } catch (InterruptedException e) {
+                        LOGGER.warnCr(reconciliation, "Interrupted while checking the in-sync replicas of the nodes excluded from automatic rolling updates", e);
+                    } catch (Exception e) {
+                        // The check is best-effort and must never fail the reconciliation
+                        LOGGER.warnCr(reconciliation, "Failed to check the in-sync replicas of the nodes excluded from automatic rolling updates", e);
                     } finally {
                         if (kafkaAdmin != null) {
                             kafkaAdmin.close();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkips.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkips.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.common.ConditionBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.operator.cluster.model.NodeRef;
+import io.strimzi.operator.cluster.model.nodepools.NodeIdRange;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.StatusUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Holds the result of resolving the strimzi.io/skip-rolling-update annotations from the KafkaNodePool resources
+ * into the set of node IDs which are excluded from automatic rolling updates.
+ *
+ * @param skippedNodeIds            Node IDs which are excluded from automatic rolling updates
+ * @param skippedNodeIdsByPool      Skipped node IDs grouped by the name of the KafkaNodePool which owns them
+ * @param ignoredControllerNodeIds  Node IDs which were requested to be skipped but are ignored because they have
+ *                                  (or might have) the controller role
+ * @param rejectedNodeIds           Annotation values or node IDs which were rejected as invalid (wrong format,
+ *                                  unknown node ID, or node ID not belonging to the annotated pool)
+ */
+public record RollingUpdateSkips(Set<Integer> skippedNodeIds, Map<String, Set<Integer>> skippedNodeIdsByPool, Set<Integer> ignoredControllerNodeIds, List<String> rejectedNodeIds) {
+    /**
+     * Type of the Kafka and KafkaNodePool status condition used to surface active skips
+     */
+    public static final String ROLLING_UPDATE_SKIPPED_CONDITION_TYPE = "RollingUpdateSkipped";
+
+    /**
+     * An empty resolution => no nodes are excluded from automatic rolling updates
+     */
+    public static final RollingUpdateSkips EMPTY = new RollingUpdateSkips(Set.of(), Map.of(), Set.of(), List.of());
+
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(RollingUpdateSkips.class.getName());
+
+    // Used to extract the skipped node IDs back from the message of a previously set RollingUpdateSkipped condition
+    private static final Pattern CONDITION_MESSAGE_PATTERN = Pattern.compile("^Nodes \\[([0-9, ]*)] are excluded");
+
+    /**
+     * Resolves the strimzi.io/skip-rolling-update annotations set on the KafkaNodePool resources into the set of node
+     * IDs which should be excluded from automatic rolling updates. Node IDs which do not belong to the annotated pool
+     * or have an invalid format are rejected. Node IDs which resolve to a node with the controller role (either by the
+     * desired role of the pool or by the role labels of an existing Pod) are ignored and remain fully managed.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param nodePools         List of the KafkaNodePool resources belonging to the cluster
+     * @param nodes             Set of the desired nodes of the Kafka cluster
+     * @param pods              List of the existing Kafka Pods used to check the actual node roles
+     *
+     * @return  The resolved skips
+     */
+    public static RollingUpdateSkips resolve(Reconciliation reconciliation, List<KafkaNodePool> nodePools, Set<NodeRef> nodes, List<Pod> pods)   {
+        Map<Integer, NodeRef> nodesById = nodes.stream().collect(Collectors.toMap(NodeRef::nodeId, Function.identity()));
+        Map<String, Pod> podsByName = pods.stream().collect(Collectors.toMap(pod -> pod.getMetadata().getName(), Function.identity()));
+
+        Set<Integer> skipped = new TreeSet<>();
+        Map<String, Set<Integer>> skippedByPool = new HashMap<>();
+        Set<Integer> ignoredControllers = new TreeSet<>();
+        List<String> rejected = new ArrayList<>();
+
+        for (KafkaNodePool pool : nodePools)    {
+            String skipAnnotation = Annotations.stringAnnotation(pool, Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, null);
+
+            if (skipAnnotation == null || skipAnnotation.isBlank())   {
+                continue;
+            }
+
+            String poolName = pool.getMetadata().getName();
+
+            for (Integer nodeId : parseNodeIds(reconciliation, poolName, skipAnnotation, rejected))  {
+                NodeRef node = nodesById.get(nodeId);
+
+                if (node == null || !poolName.equals(node.poolName()))    {
+                    LOGGER.warnCr(reconciliation, "Node ID {} from the {} annotation on KafkaNodePool {} does not belong to this node pool and will be ignored", nodeId, Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, poolName);
+                    rejected.add(poolName + ": " + nodeId);
+                } else if (node.controller() || podClaimsControllerRole(podsByName.get(node.podName()))) {
+                    LOGGER.warnCr(reconciliation, "Node ID {} from the {} annotation on KafkaNodePool {} has the controller role and will remain fully managed", nodeId, Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, poolName);
+                    ignoredControllers.add(nodeId);
+                } else {
+                    skipped.add(nodeId);
+                    skippedByPool.computeIfAbsent(poolName, name -> new TreeSet<>()).add(nodeId);
+                }
+            }
+        }
+
+        return new RollingUpdateSkips(skipped, Map.copyOf(skippedByPool), ignoredControllers, List.copyOf(rejected));
+    }
+
+    /**
+     * Parses the value of the skip-rolling-update annotation (for example `[2,5]` or `[2,4-6]`) into individual node
+     * IDs. Invalid entries are rejected individually, and the remaining valid entries are still applied.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param poolName          Name of the KafkaNodePool the annotation was found on (used in log and status messages)
+     * @param skipAnnotation    The value of the annotation
+     * @param rejected          List where the rejected values are collected
+     *
+     * @return  Set with the valid node IDs from the annotation
+     */
+    private static Set<Integer> parseNodeIds(Reconciliation reconciliation, String poolName, String skipAnnotation, List<String> rejected)  {
+        Set<Integer> nodeIds = new TreeSet<>();
+        String trimmed = skipAnnotation.trim();
+
+        if (!trimmed.startsWith("[") || !trimmed.endsWith("]"))  {
+            LOGGER.warnCr(reconciliation, "The {} annotation on KafkaNodePool {} has an invalid format and will be ignored: {}", Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, poolName, skipAnnotation);
+            rejected.add(poolName + ": " + skipAnnotation);
+            return nodeIds;
+        }
+
+        String content = trimmed.substring(1, trimmed.length() - 1).trim();
+
+        if (content.isEmpty())  {
+            return nodeIds;
+        }
+
+        for (String entry : content.split(","))    {
+            String trimmedEntry = entry.trim();
+
+            try {
+                NodeIdRange range = new NodeIdRange("[" + trimmedEntry + "]");
+                Integer nodeId;
+                while ((nodeId = range.getNextNodeId()) != null)    {
+                    nodeIds.add(nodeId);
+                }
+            } catch (NodeIdRange.InvalidNodeIdRangeException e) {
+                LOGGER.warnCr(reconciliation, "Node ID {} from the {} annotation on KafkaNodePool {} is invalid and will be ignored", trimmedEntry, Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, poolName);
+                rejected.add(poolName + ": " + trimmedEntry);
+            }
+        }
+
+        return nodeIds;
+    }
+
+    /**
+     * Checks whether an existing Pod claims the controller role through its role labels. Desired and actual roles can
+     * diverge during a role transition, so the skip is honored only when the existing Pod does not claim the
+     * controller role either.
+     *
+     * @param pod   The Pod to check. Might be null when the Pod does not exist.
+     *
+     * @return  True when the Pod exists and its labels claim the controller role. False otherwise.
+     */
+    private static boolean podClaimsControllerRole(Pod pod) {
+        return pod != null
+                && pod.getMetadata().getLabels() != null
+                && "true".equals(pod.getMetadata().getLabels().get(Labels.STRIMZI_CONTROLLER_ROLE_LABEL));
+    }
+
+    /**
+     * Indicates whether any node is excluded from automatic rolling updates
+     *
+     * @return  True when at least one node is excluded from automatic rolling updates. False otherwise.
+     */
+    public boolean hasSkippedNodes()    {
+        return !skippedNodeIds.isEmpty();
+    }
+
+    /**
+     * Indicates whether the RollingUpdateSkipped condition should be set on the Kafka custom resource status
+     *
+     * @return  True when the resolution found any skipped, ignored or rejected node IDs and the status condition
+     *          should be set. False otherwise.
+     */
+    public boolean shouldReportCondition()    {
+        return !skippedNodeIds.isEmpty() || !ignoredControllerNodeIds.isEmpty() || !rejectedNodeIds.isEmpty();
+    }
+
+    /**
+     * Generates the RollingUpdateSkipped condition for the Kafka custom resource status
+     *
+     * @return  The condition describing the active skips
+     */
+    public Condition kafkaStatusCondition()   {
+        StringBuilder message = new StringBuilder("Nodes ").append(skippedNodeIds).append(" are excluded from automatic rolling updates through the ").append(Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE).append(" annotation.");
+
+        if (!ignoredControllerNodeIds.isEmpty())    {
+            message.append(" Node IDs ignored because of the controller role: ").append(ignoredControllerNodeIds).append(".");
+        }
+
+        if (!rejectedNodeIds.isEmpty())    {
+            message.append(" Rejected invalid node IDs: ").append(rejectedNodeIds).append(".");
+        }
+
+        return new ConditionBuilder()
+                .withLastTransitionTime(StatusUtils.iso8601Now())
+                .withType(ROLLING_UPDATE_SKIPPED_CONDITION_TYPE)
+                .withStatus("True")
+                .withReason("SkipRollingUpdateAnnotation")
+                .withMessage(message.toString())
+                .build();
+    }
+
+    /**
+     * Generates the RollingUpdateSkipped condition for a KafkaNodePool status
+     *
+     * @param skippedNodeIdsInPool  The skipped node IDs belonging to the node pool
+     *
+     * @return  The condition describing the active skips in this node pool
+     */
+    public static Condition nodePoolStatusCondition(Set<Integer> skippedNodeIdsInPool)   {
+        return new ConditionBuilder()
+                .withLastTransitionTime(StatusUtils.iso8601Now())
+                .withType(ROLLING_UPDATE_SKIPPED_CONDITION_TYPE)
+                .withStatus("True")
+                .withReason("SkipRollingUpdateAnnotation")
+                .withMessage("Nodes " + skippedNodeIdsInPool + " are excluded from automatic rolling updates through the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotation.")
+                .build();
+    }
+
+    /**
+     * Extracts the skipped node IDs from the message of a previously set RollingUpdateSkipped condition. This is used
+     * to detect changes to the set of skipped nodes between reconciliations for emitting Kubernetes Events.
+     *
+     * @param condition The RollingUpdateSkipped condition from the previous reconciliation. Might be null.
+     *
+     * @return  Set with the node IDs which were skipped in the previous reconciliation
+     */
+    public static Set<Integer> skippedNodeIdsFromCondition(Condition condition)   {
+        Set<Integer> nodeIds = new TreeSet<>();
+
+        if (condition != null && condition.getMessage() != null)   {
+            Matcher matcher = CONDITION_MESSAGE_PATTERN.matcher(condition.getMessage());
+
+            if (matcher.find())    {
+                for (String id : matcher.group(1).split(","))   {
+                    String trimmedId = id.trim();
+                    if (!trimmedId.isEmpty())   {
+                        nodeIds.add(Integer.parseInt(trimmedId));
+                    }
+                }
+            }
+        }
+
+        return nodeIds;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkips.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkips.java
@@ -267,7 +267,14 @@ public record RollingUpdateSkips(Set<Integer> skippedNodeIds, Map<String, Set<In
                 for (String id : matcher.group(1).split(","))   {
                     String trimmedId = id.trim();
                     if (!trimmedId.isEmpty())   {
-                        nodeIds.add(Integer.parseInt(trimmedId));
+                        try {
+                            nodeIds.add(Integer.parseInt(trimmedId));
+                        } catch (NumberFormatException e) {
+                            // The status could have been modified by something else. A corrupted message must never
+                            // fail the reconciliation => the unparseable ID is ignored (worst case, a duplicate
+                            // Kubernetes Event is emitted).
+                            LOGGER.warnOp("Ignoring unparseable node ID {} from the {} condition message", trimmedId, ROLLING_UPDATE_SKIPPED_CONDITION_TYPE);
+                        }
                     }
                 }
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkips.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkips.java
@@ -51,7 +51,10 @@ public record RollingUpdateSkips(Set<Integer> skippedNodeIds, Map<String, Set<In
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(RollingUpdateSkips.class.getName());
 
-    // Used to extract the skipped node IDs back from the message of a previously set RollingUpdateSkipped condition
+    // The message of the RollingUpdateSkipped condition is also parsed back by skippedNodeIdsFromCondition() to detect
+    // changes to the set of skipped nodes between reconciliations. CONDITION_MESSAGE_PATTERN must always match the
+    // message generated from CONDITION_MESSAGE_FORMAT.
+    private static final String CONDITION_MESSAGE_FORMAT = "Nodes %s are excluded from automatic rolling updates through the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotation.";
     private static final Pattern CONDITION_MESSAGE_PATTERN = Pattern.compile("^Nodes \\[([0-9, ]*)] are excluded");
 
     /**
@@ -174,38 +177,59 @@ public record RollingUpdateSkips(Set<Integer> skippedNodeIds, Map<String, Set<In
     }
 
     /**
-     * Indicates whether the RollingUpdateSkipped condition should be set on the Kafka custom resource status
+     * Indicates whether any requested node ID had to be ignored because of the controller role
      *
-     * @return  True when the resolution found any skipped, ignored or rejected node IDs and the status condition
-     *          should be set. False otherwise.
+     * @return  True when at least one node ID was ignored. False otherwise.
      */
-    public boolean shouldReportCondition()    {
-        return !skippedNodeIds.isEmpty() || !ignoredControllerNodeIds.isEmpty() || !rejectedNodeIds.isEmpty();
+    public boolean hasIgnoredControllerNodeIds()    {
+        return !ignoredControllerNodeIds.isEmpty();
     }
 
     /**
-     * Generates the RollingUpdateSkipped condition for the Kafka custom resource status
+     * Indicates whether any annotation value or node ID was rejected as invalid
+     *
+     * @return  True when at least one value was rejected. False otherwise.
+     */
+    public boolean hasRejectedNodeIds()    {
+        return !rejectedNodeIds.isEmpty();
+    }
+
+    /**
+     * Generates the RollingUpdateSkipped condition for the Kafka custom resource status. Should be used only when
+     * some nodes are actually skipped.
      *
      * @return  The condition describing the active skips
      */
     public Condition kafkaStatusCondition()   {
-        StringBuilder message = new StringBuilder("Nodes ").append(skippedNodeIds).append(" are excluded from automatic rolling updates through the ").append(Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE).append(" annotation.");
-
-        if (!ignoredControllerNodeIds.isEmpty())    {
-            message.append(" Node IDs ignored because of the controller role: ").append(ignoredControllerNodeIds).append(".");
-        }
-
-        if (!rejectedNodeIds.isEmpty())    {
-            message.append(" Rejected invalid node IDs: ").append(rejectedNodeIds).append(".");
-        }
-
         return new ConditionBuilder()
                 .withLastTransitionTime(StatusUtils.iso8601Now())
                 .withType(ROLLING_UPDATE_SKIPPED_CONDITION_TYPE)
                 .withStatus("True")
                 .withReason("SkipRollingUpdateAnnotation")
-                .withMessage(message.toString())
+                .withMessage(CONDITION_MESSAGE_FORMAT.formatted(skippedNodeIds))
                 .build();
+    }
+
+    /**
+     * Generates a warning condition about node IDs which were requested to be skipped but are ignored because they
+     * have the controller role. Should be used only when some node IDs were ignored.
+     *
+     * @return  The warning condition listing the ignored node IDs
+     */
+    public Condition ignoredControllersWarningCondition()   {
+        return StatusUtils.buildWarningCondition("SkipRollingUpdateControllersIgnored",
+                "Node IDs " + ignoredControllerNodeIds + " from the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotation are ignored because they have the controller role and remain fully managed.");
+    }
+
+    /**
+     * Generates a warning condition about annotation values or node IDs which were rejected as invalid. Should be
+     * used only when some values were rejected.
+     *
+     * @return  The warning condition listing the rejected values
+     */
+    public Condition rejectedNodeIdsWarningCondition()   {
+        return StatusUtils.buildWarningCondition("InvalidSkipRollingUpdateAnnotation",
+                "The following node IDs from the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotations are invalid or do not belong to the annotated node pool and are ignored: " + rejectedNodeIds + ".");
     }
 
     /**
@@ -221,7 +245,7 @@ public record RollingUpdateSkips(Set<Integer> skippedNodeIds, Map<String, Set<In
                 .withType(ROLLING_UPDATE_SKIPPED_CONDITION_TYPE)
                 .withStatus("True")
                 .withReason("SkipRollingUpdateAnnotation")
-                .withMessage("Nodes " + skippedNodeIdsInPool + " are excluded from automatic rolling updates through the " + Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE + " annotation.")
+                .withMessage(CONDITION_MESSAGE_FORMAT.formatted(skippedNodeIdsInPool))
                 .build();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
@@ -84,6 +84,43 @@ public class KubernetesRestartEventPublisher {
     }
 
     /**
+     * Publishes a Kubernetes Event about the cluster custom resource being reconciled, for example when nodes are
+     * excluded from or again included in automatic rolling updates.
+     *
+     * @param reconciliation    Reconciliation marker identifying the custom resource the event is about
+     * @param action            The action which is being taken by the operator
+     * @param reason            The reason for the event in PascalCase
+     * @param type              The type of the Kubernetes event: "Normal", or "Warning"
+     * @param note              The note to attach to the event
+     */
+    public void publishClusterEvent(Reconciliation reconciliation, String action, String reason, String type, String note) {
+        MicroTime k8sEventTime = new MicroTime(K8S_MICROTIME.format(ZonedDateTime.now(clock)));
+        ObjectReference resourceReference = createResourceReference(reconciliation);
+
+        try {
+            EventBuilder builder = new EventBuilder();
+
+            builder.withNewMetadata()
+                    .withGenerateName("strimzi-event")
+                    .endMetadata()
+                    .withAction(action)
+                    .withReportingController(CONTROLLER)
+                    .withReportingInstance(operatorName)
+                    .withRegarding(resourceReference)
+                    .withReason(reason)
+                    .withType(type)
+                    .withEventTime(k8sEventTime)
+                    .withNote(maybeTruncated(note));
+
+            LOG.debug("Publishing K8s event, time={}, type={}, reason={}, note={}, resource={}",
+                    k8sEventTime, type, reason, note, resourceReference);
+            client.events().v1().events().inNamespace(reconciliation.namespace()).resource(builder.build()).create();
+        } catch (Exception e) {
+            LOG.error("Exception on K8s event publication", e);
+        }
+    }
+
+    /**
      * Publish a Kubernetes Event referring to certain KafkaRoller pod action
      *
      * @param eventTime         - Microtime to use for event

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
@@ -98,23 +98,9 @@ public class KubernetesRestartEventPublisher {
         ObjectReference resourceReference = createResourceReference(reconciliation);
 
         try {
-            EventBuilder builder = new EventBuilder();
-
-            builder.withNewMetadata()
-                    .withGenerateName("strimzi-event")
-                    .endMetadata()
-                    .withAction(action)
-                    .withReportingController(CONTROLLER)
-                    .withReportingInstance(operatorName)
-                    .withRegarding(resourceReference)
-                    .withReason(reason)
-                    .withType(type)
-                    .withEventTime(k8sEventTime)
-                    .withNote(maybeTruncated(note));
-
             LOG.debug("Publishing K8s event, time={}, type={}, reason={}, note={}, resource={}",
                     k8sEventTime, type, reason, note, resourceReference);
-            client.events().v1().events().inNamespace(reconciliation.namespace()).resource(builder.build()).create();
+            createAndPublishEvent(k8sEventTime, resourceReference, null, action, reason, type, maybeTruncated(note));
         } catch (Exception e) {
             LOG.error("Exception on K8s event publication", e);
         }
@@ -131,12 +117,16 @@ public class KubernetesRestartEventPublisher {
      * @param note              - the note to attach to the event
      */
     protected void publishEvent(MicroTime eventTime, ObjectReference resourceReference, ObjectReference podReference, String reason, String type, String note) {
+        createAndPublishEvent(eventTime, resourceReference, podReference, ACTION, reason, type, note);
+    }
+
+    private void createAndPublishEvent(MicroTime eventTime, ObjectReference resourceReference, ObjectReference podReference, String action, String reason, String type, String note) {
         EventBuilder builder = new EventBuilder();
 
         builder.withNewMetadata()
                 .withGenerateName("strimzi-event")
                 .endMetadata()
-                .withAction(ACTION)
+                .withAction(action)
                 .withReportingController(CONTROLLER)
                 .withReportingInstance(operatorName)
                 .withRegarding(resourceReference)
@@ -146,7 +136,7 @@ public class KubernetesRestartEventPublisher {
                 .withEventTime(eventTime)
                 .withNote(note);
 
-        client.events().v1().events().inNamespace(podReference.getNamespace()).resource(builder.build()).create();
+        client.events().v1().events().inNamespace(resourceReference.getNamespace()).resource(builder.build()).create();
     }
 
     ObjectReference createPodReference(Pod pod) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -17,6 +17,9 @@ import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.certs.CertAndKey;
@@ -969,6 +972,58 @@ public class CaReconcilerTest {
         deps.put("my-cluster-kafka-exporter", deploymentWithName("my-cluster-kafka-exporter"));
         DeploymentOperator depsOperator = supplier.deploymentOperations;
         when(depsOperator.getAsync(any(), any())).thenAnswer(i -> CompletableFuture.completedFuture(deps.get(i.getArgument(1, String.class))));
+    }
+
+    @Test
+    public void testNodesSkippedFromRollingUpdatesAreFilteredOutOfCaKeyReplacementRoll(VertxTestContext context) {
+        KafkaNodePool brokersPool = new KafkaNodePoolBuilder()
+                .withNewMetadata()
+                    .withName("brokers")
+                    .withNamespace(NAMESPACE)
+                    .withAnnotations(Map.of(ResourceAnnotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, "[1]"))
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(2)
+                    .withRoles(ProcessRoles.BROKER)
+                .endSpec()
+                .build();
+
+        when(supplier.kafkaNodePoolOperator.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(CompletableFuture.completedFuture(List.of(brokersPool)));
+
+        Set<NodeRef> nodes = Set.of(
+                new NodeRef(NAME + "-brokers-0", 0, "brokers", false, true),
+                new NodeRef(NAME + "-brokers-1", 1, "brokers", false, true),
+                new NodeRef(NAME + "-controllers-2", 2, "controllers", true, false));
+
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
+
+        Checkpoint async = context.checkpoint();
+        mockCaReconciler.filterOutNodesSkippedFromRollingUpdates(nodes)
+                .onComplete(context.succeeding(filteredNodes -> context.verify(() -> {
+                    // Node 1 is excluded from automatic rolling updates and is not rolled for the new CA key either
+                    assertThat(filteredNodes.stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 2)));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testNoSkipAnnotationKeepsCaKeyReplacementRollUnfiltered(VertxTestContext context) {
+        when(supplier.kafkaNodePoolOperator.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        Set<NodeRef> nodes = Set.of(
+                new NodeRef(NAME + "-brokers-0", 0, "brokers", false, true),
+                new NodeRef(NAME + "-brokers-1", 1, "brokers", false, true));
+
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(KAFKA, supplier);
+
+        Checkpoint async = context.checkpoint();
+        mockCaReconciler.filterOutNodesSkippedFromRollingUpdates(nodes)
+                .onComplete(context.succeeding(filteredNodes -> context.verify(() -> {
+                    assertThat(filteredNodes, is(nodes));
+
+                    async.flag();
+                })));
     }
 
     static class MockCaReconciler extends CaReconciler {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManagerTest.java
@@ -85,6 +85,43 @@ public class KRaftMetadataManagerTest {
     }
 
     @Test
+    public void testMetadataVersionChangeIsDeferredWhileNodesAreSkipped()   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeVersion(mockAdminClient);
+
+        // Mock the Admin client provider
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        // A metadata version change is needed, but it is deferred because nodes are excluded from rolling updates
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.6", status, true)
+                .toCompletableFuture()
+                .join();
+
+        // The current version is kept and no update is attempted
+        assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
+        verify(mockAdminClient, never()).updateFeatures(any(), any());
+
+        // A warning condition is added to the status
+        assertThat(status.getConditions().size(), is(1));
+        assertThat(status.getConditions().get(0).getReason(), is("MetadataVersionChangeDeferred"));
+
+        // When no metadata version change is needed, no condition is added even when deferring is requested
+        KafkaStatus statusWithoutChange = new KafkaStatus();
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, DUMMY_IDENTITY, mockAdminClientProvider, "3.6-IV1", statusWithoutChange, true)
+                .toCompletableFuture()
+                .join();
+
+        assertThat(statusWithoutChange.getKafkaMetadataVersion(), is("3.6-IV1"));
+        assertThat(statusWithoutChange.getConditions(), is(nullValue()));
+    }
+
+    @Test
     public void testSuccessfulMetadataVersionUpgrade()   {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerSkipRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerSkipRollingUpdateTest.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.platform.KubernetesVersion;
 import io.vertx.core.Future;
@@ -36,6 +37,13 @@ import io.vertx.core.WorkerExecutor;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -57,10 +65,12 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -142,11 +152,15 @@ public class KafkaReconcilerSkipRollingUpdateTest {
     }
 
     private MockKafkaReconciler prepareReconciler(ResourceOperatorSupplier supplier, List<KafkaNodePool> nodePools)  {
+        return prepareReconciler(supplier, KAFKA, nodePools);
+    }
+
+    private MockKafkaReconciler prepareReconciler(ResourceOperatorSupplier supplier, Kafka kafka, List<KafkaNodePool> nodePools)  {
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME);
 
         KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(
                 reconciliation,
-                KAFKA,
+                kafka,
                 nodePools,
                 Map.of(),
                 KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
@@ -169,7 +183,7 @@ public class KafkaReconcilerSkipRollingUpdateTest {
                 config,
                 supplier,
                 new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
-                KAFKA,
+                kafka,
                 nodePools,
                 kafkaCluster);
     }
@@ -282,10 +296,11 @@ public class KafkaReconcilerSkipRollingUpdateTest {
                     assertThat(kr.rollingUpdateSkips.ignoredControllerNodeIds(), is(Set.of(0, 1)));
                     assertThat(kr.kafkaNodesConsideredForRolling, hasItems("my-cluster-controllers-0", "my-cluster-controllers-1", "my-cluster-controllers-2", "my-cluster-brokers-10", "my-cluster-brokers-11", "my-cluster-brokers-12"));
 
-                    // The condition reports the ignored controller IDs
-                    Condition condition = skippedCondition(status);
-                    assertThat(condition, is(notNullValue()));
-                    assertThat(condition.getMessage(), containsString("controller role: [0, 1]"));
+                    // No node is skipped => no RollingUpdateSkipped condition, but a warning reports the ignored IDs
+                    assertThat(skippedCondition(status), is(nullValue()));
+                    Condition warning = warningCondition(status, "SkipRollingUpdateControllersIgnored");
+                    assertThat(warning, is(notNullValue()));
+                    assertThat(warning.getMessage(), containsString("[0, 1]"));
 
                     // No skip event was published as no node entered the skipped state
                     verify(supplier.restartEventsPublisher, never()).publishClusterEvent(any(), anyString(), anyString(), anyString(), anyString());
@@ -313,10 +328,84 @@ public class KafkaReconcilerSkipRollingUpdateTest {
                 })));
     }
 
+    @Test
+    public void testChangedSkipSetEmitsChangedEvent(VertxTestContext context)  {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // The previous reconciliation skipped node 10 only
+        Kafka kafkaWithStatus = new KafkaBuilder(KAFKA)
+                .withNewStatus()
+                    .addNewCondition()
+                        .withType(RollingUpdateSkips.ROLLING_UPDATE_SKIPPED_CONDITION_TYPE)
+                        .withStatus("True")
+                        .withMessage("Nodes [10] are excluded from automatic rolling updates through the strimzi.io/skip-rolling-update annotation.")
+                    .endCondition()
+                .endStatus()
+                .build();
+
+        MockKafkaReconciler kr = prepareReconciler(supplier, kafkaWithStatus, List.of(controllersPool(), brokersPool("[10,12]")));
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        kr.reconcile(status, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    verify(supplier.restartEventsPublisher).publishClusterEvent(any(), anyString(), eq("RollingUpdateSkipChanged"), eq("Warning"), contains("[10, 12]"));
+                    verify(supplier.restartEventsPublisher, never()).publishClusterEvent(any(), anyString(), eq("RollingUpdateSkipEnabled"), anyString(), anyString());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testSkippedNodeSoleInSyncReplicaIsFlagged(VertxTestContext context)  {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Partition my-topic-0 has node 10 (which is skipped) as its only in-sync replica. Partition my-topic-1 is
+        // fully in-sync and must not be flagged.
+        Node node10 = new Node(10, "broker-10", 9092);
+        Node node11 = new Node(11, "broker-11", 9092);
+        TopicDescription topicDescription = new TopicDescription("my-topic", false, List.of(
+                new TopicPartitionInfo(0, node10, List.of(node10, node11), List.of(node10)),
+                new TopicPartitionInfo(1, node11, List.of(node10, node11), List.of(node10, node11))
+        ));
+
+        Admin mockAdmin = supplier.adminClientProvider.createAdminClient(null, null, null);
+        ListTopicsResult ltr = mock(ListTopicsResult.class);
+        when(ltr.names()).thenReturn(KafkaFuture.completedFuture(Set.of("my-topic")));
+        when(mockAdmin.listTopics()).thenReturn(ltr);
+        DescribeTopicsResult dtr = mock(DescribeTopicsResult.class);
+        when(dtr.allTopicNames()).thenReturn(KafkaFuture.completedFuture(Map.of("my-topic", topicDescription)));
+        when(mockAdmin.describeTopics(anyCollection())).thenReturn(dtr);
+
+        MockKafkaReconciler kr = prepareReconciler(supplier, List.of(controllersPool(), brokersPool("[10,12]")));
+        kr.coTlsPemIdentity = new TlsPemIdentity(null, null);
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        kr.reconcile(status, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    Condition warning = warningCondition(status, "SkippedNodeSoleInSyncReplica");
+                    assertThat(warning, is(notNullValue()));
+                    assertThat(warning.getMessage(), containsString("my-topic-0"));
+                    assertThat(warning.getMessage(), not(containsString("my-topic-1")));
+
+                    async.flag();
+                })));
+    }
+
     // Internal utility methods
     private static Condition skippedCondition(KafkaStatus status)   {
         return status.getConditions() == null ? null : status.getConditions().stream()
                 .filter(condition -> RollingUpdateSkips.ROLLING_UPDATE_SKIPPED_CONDITION_TYPE.equals(condition.getType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static Condition warningCondition(KafkaStatus status, String reason)   {
+        return status.getConditions() == null ? null : status.getConditions().stream()
+                .filter(condition -> "Warning".equals(condition.getType()) && reason.equals(condition.getReason()))
                 .findFirst()
                 .orElse(null);
     }
@@ -334,7 +423,8 @@ public class KafkaReconcilerSkipRollingUpdateTest {
             return resolveRollingUpdateSkips(kafkaStatus)
                     .compose(i -> manualRollingUpdate())
                     .compose(i -> rollingUpdate(Map.of()))
-                    .compose(i -> podsReady());
+                    .compose(i -> podsReady())
+                    .compose(i -> skippedNodesSoleInSyncReplicaCheck(kafkaStatus));
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerSkipRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerSkipRollingUpdateTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.NodeRef;
+import io.strimzi.operator.cluster.model.RestartReasons;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.platform.KubernetesVersion;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaReconcilerSkipRollingUpdateTest {
+    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+    private final static String NAMESPACE = "my-namespace";
+    private final static String CLUSTER_NAME = "my-cluster";
+
+    private static final Kafka KAFKA = new KafkaBuilder()
+            .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withNewKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName("plain")
+                            .withPort(9092)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(false)
+                            .build())
+                .endKafka()
+            .endSpec()
+            .build();
+
+    private static Vertx vertx;
+
+    @SuppressWarnings("unused")
+    private static WorkerExecutor sharedWorkerExecutor;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+        sharedWorkerExecutor = vertx.createSharedWorkerExecutor("kubernetes-ops-pool");
+    }
+
+    @AfterAll
+    public static void after() {
+        sharedWorkerExecutor.close();
+        vertx.close();
+    }
+
+    private static KafkaNodePool controllersPool()  {
+        return controllersPool(null);
+    }
+
+    private static KafkaNodePool controllersPool(String skipAnnotation)  {
+        return pool("controllers", "[0-9]", skipAnnotation, ProcessRoles.CONTROLLER);
+    }
+
+    private static KafkaNodePool brokersPool(String skipAnnotation)  {
+        return pool("brokers", "[10-99]", skipAnnotation, ProcessRoles.BROKER);
+    }
+
+    private static KafkaNodePool pool(String name, String nextNodeIds, String skipAnnotation, ProcessRoles... roles)  {
+        KafkaNodePoolBuilder builder = new KafkaNodePoolBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME))
+                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, nextNodeIds))
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(3)
+                    .withNewJbodStorage()
+                        .withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withStorageClass("gp99").build())
+                    .endJbodStorage()
+                    .withRoles(roles)
+                .endSpec();
+
+        if (skipAnnotation != null) {
+            builder.editMetadata().addToAnnotations(Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, skipAnnotation).endMetadata();
+        }
+
+        return builder.build();
+    }
+
+    private MockKafkaReconciler prepareReconciler(ResourceOperatorSupplier supplier, List<KafkaNodePool> nodePools)  {
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME);
+
+        KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(
+                reconciliation,
+                KAFKA,
+                nodePools,
+                Map.of(),
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                VERSIONS,
+                supplier.sharedEnvironmentProvider
+        );
+
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.listAsync(any(), any(Labels.class))).thenReturn(CompletableFuture.completedFuture(kafkaCluster.generatePodSets(null, null, node -> null)));
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(CompletableFuture.completedFuture(List.of()));
+        when(mockPodOps.readiness(any(), any(), any(), anyLong(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+
+        ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
+
+        return new MockKafkaReconciler(
+                reconciliation,
+                vertx,
+                config,
+                supplier,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                KAFKA,
+                nodePools,
+                kafkaCluster);
+    }
+
+    @Test
+    public void testSkippedNodesAreExcludedFromRollingUpdateAndPodsReady(VertxTestContext context)  {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        MockKafkaReconciler kr = prepareReconciler(supplier, List.of(controllersPool(), brokersPool("[10,12]")));
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        kr.reconcile(status, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // The skips were resolved
+                    assertThat(kr.rollingUpdateSkips.skippedNodeIds(), is(Set.of(10, 12)));
+
+                    // The automatic rolling update never considered the skipped nodes
+                    assertThat(kr.kafkaNodesConsideredForRolling, hasItems("my-cluster-controllers-0", "my-cluster-controllers-1", "my-cluster-controllers-2", "my-cluster-brokers-11"));
+                    assertThat(kr.kafkaNodesConsideredForRolling, not(hasItems("my-cluster-brokers-10", "my-cluster-brokers-12")));
+
+                    // The readiness of the skipped Pods was not waited on
+                    verify(supplier.podOperations, never()).readiness(any(), eq(NAMESPACE), eq("my-cluster-brokers-10"), anyLong(), anyLong());
+                    verify(supplier.podOperations, never()).readiness(any(), eq(NAMESPACE), eq("my-cluster-brokers-12"), anyLong(), anyLong());
+                    verify(supplier.podOperations).readiness(any(), eq(NAMESPACE), eq("my-cluster-brokers-11"), anyLong(), anyLong());
+                    verify(supplier.podOperations).readiness(any(), eq(NAMESPACE), eq("my-cluster-controllers-0"), anyLong(), anyLong());
+
+                    // The RollingUpdateSkipped condition is set on the Kafka status
+                    Condition condition = skippedCondition(status);
+                    assertThat(condition, is(notNullValue()));
+                    assertThat(condition.getMessage(), containsString("Nodes [10, 12] are excluded from automatic rolling updates"));
+
+                    // The skip enabled event was published
+                    verify(supplier.restartEventsPublisher).publishClusterEvent(any(), anyString(), eq("RollingUpdateSkipEnabled"), eq("Warning"), contains("[10, 12]"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testManualRollingUpdateIsNotFiltered(VertxTestContext context)  {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        List<KafkaNodePool> nodePools = List.of(controllersPool(), brokersPool("[10,12]"));
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME);
+
+        KafkaCluster kafkaCluster = KafkaClusterCreator.createKafkaCluster(
+                reconciliation,
+                KAFKA,
+                nodePools,
+                Map.of(),
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                VERSIONS,
+                supplier.sharedEnvironmentProvider
+        );
+
+        // The manual rolling update annotation is set on the brokers PodSet
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.listAsync(any(), any(Labels.class))).thenAnswer(i -> {
+            var podSets = kafkaCluster.generatePodSets(null, null, node -> null);
+            podSets.stream()
+                    .filter(ps -> (CLUSTER_NAME + "-brokers").equals(ps.getMetadata().getName()))
+                    .findFirst()
+                    .orElseThrow()
+                    .getMetadata()
+                    .getAnnotations()
+                    .put(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true");
+            return CompletableFuture.completedFuture(podSets);
+        });
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(CompletableFuture.completedFuture(List.of()));
+        when(mockPodOps.readiness(any(), any(), any(), anyLong(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+
+        ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
+
+        MockKafkaReconciler kr = new MockKafkaReconciler(
+                reconciliation,
+                vertx,
+                config,
+                supplier,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                KAFKA,
+                nodePools,
+                kafkaCluster);
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        kr.reconcile(status, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // The manual rolling update includes the skipped nodes => a fresh human action outranks a standing skip
+                    assertThat(kr.kafkaNodesConsideredForRolling, hasItems("my-cluster-brokers-10", "my-cluster-brokers-11", "my-cluster-brokers-12"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testControllerSkipIsIgnored(VertxTestContext context)  {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        MockKafkaReconciler kr = prepareReconciler(supplier, List.of(controllersPool("[0,1]"), brokersPool(null)));
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        kr.reconcile(status, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // No node is skipped => the controllers stay fully managed
+                    assertThat(kr.rollingUpdateSkips.hasSkippedNodes(), is(false));
+                    assertThat(kr.rollingUpdateSkips.ignoredControllerNodeIds(), is(Set.of(0, 1)));
+                    assertThat(kr.kafkaNodesConsideredForRolling, hasItems("my-cluster-controllers-0", "my-cluster-controllers-1", "my-cluster-controllers-2", "my-cluster-brokers-10", "my-cluster-brokers-11", "my-cluster-brokers-12"));
+
+                    // The condition reports the ignored controller IDs
+                    Condition condition = skippedCondition(status);
+                    assertThat(condition, is(notNullValue()));
+                    assertThat(condition.getMessage(), containsString("controller role: [0, 1]"));
+
+                    // No skip event was published as no node entered the skipped state
+                    verify(supplier.restartEventsPublisher, never()).publishClusterEvent(any(), anyString(), anyString(), anyString(), anyString());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testNoSkipAnnotationLeavesBehaviorUnchanged(VertxTestContext context)  {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        MockKafkaReconciler kr = prepareReconciler(supplier, List.of(controllersPool(), brokersPool(null)));
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        kr.reconcile(status, Clock.systemUTC())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(kr.rollingUpdateSkips.hasSkippedNodes(), is(false));
+                    assertThat(kr.kafkaNodesConsideredForRolling.size(), is(6));
+                    assertThat(skippedCondition(status), is(nullValue()));
+                    verify(supplier.restartEventsPublisher, never()).publishClusterEvent(any(), anyString(), anyString(), anyString(), anyString());
+
+                    async.flag();
+                })));
+    }
+
+    // Internal utility methods
+    private static Condition skippedCondition(KafkaStatus status)   {
+        return status.getConditions() == null ? null : status.getConditions().stream()
+                .filter(condition -> RollingUpdateSkips.ROLLING_UPDATE_SKIPPED_CONDITION_TYPE.equals(condition.getType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    static class MockKafkaReconciler extends KafkaReconciler   {
+        List<String> kafkaNodesConsideredForRolling = new ArrayList<>();
+
+        public MockKafkaReconciler(Reconciliation reconciliation, Vertx vertx, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, PlatformFeaturesAvailability pfa, Kafka kafkaAssembly, List<KafkaNodePool> nodePools, KafkaCluster kafkaCluster) {
+            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, null, null, config, supplier, pfa, vertx);
+            this.listenerReconciliationResults = new KafkaListenersReconciler.ReconciliationResult();
+        }
+
+        @Override
+        public Future<Void> reconcile(KafkaStatus kafkaStatus, Clock clock)    {
+            return resolveRollingUpdateSkips(kafkaStatus)
+                    .compose(i -> manualRollingUpdate())
+                    .compose(i -> rollingUpdate(Map.of()))
+                    .compose(i -> podsReady());
+        }
+
+        @Override
+        protected Future<Void> maybeRollKafka(
+                Set<NodeRef> nodes,
+                Function<Pod, RestartReasons> podNeedsRestart,
+                Map<Integer, Map<String, String>> kafkaAdvertisedHostnames,
+                Map<Integer, Map<String, String>> kafkaAdvertisedPorts,
+                boolean allowReconfiguration
+        ) {
+            kafkaNodesConsideredForRolling.addAll(nodes.stream().map(NodeRef::podName).toList());
+            return Future.succeededFuture();
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkipsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkipsTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
@@ -223,5 +224,18 @@ public class RollingUpdateSkipsTest {
         // The skipped node IDs can be extracted back from the condition of the previous reconciliation
         assertThat(RollingUpdateSkips.skippedNodeIdsFromCondition(condition), is(Set.of(10, 12)));
         assertThat(RollingUpdateSkips.skippedNodeIdsFromCondition(null), is(Set.of()));
+    }
+
+    @Test
+    public void testCorruptedConditionMessageDoesNotThrow()   {
+        // The status could have been modified by something else => an unparseable ID (e.g. an int overflow) must be
+        // ignored instead of failing the reconciliation
+        Condition corrupted = new ConditionBuilder()
+                .withType("RollingUpdateSkipped")
+                .withStatus("True")
+                .withMessage("Nodes [10, 99999999999999999999] are excluded from automatic rolling updates through the strimzi.io/skip-rolling-update annotation.")
+                .build();
+
+        assertThat(RollingUpdateSkips.skippedNodeIdsFromCondition(corrupted), is(Set.of(10)));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkipsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkipsTest.java
@@ -65,7 +65,8 @@ public class RollingUpdateSkipsTest {
         );
 
         assertThat(skips.hasSkippedNodes(), is(false));
-        assertThat(skips.shouldReportCondition(), is(false));
+        assertThat(skips.hasRejectedNodeIds(), is(false));
+        assertThat(skips.hasIgnoredControllerNodeIds(), is(false));
         assertThat(skips.skippedNodeIds(), is(Set.of()));
     }
 
@@ -121,7 +122,7 @@ public class RollingUpdateSkipsTest {
         );
 
         assertThat(skips.hasSkippedNodes(), is(false));
-        assertThat(skips.shouldReportCondition(), is(true));
+        assertThat(skips.hasRejectedNodeIds(), is(true));
         assertThat(skips.rejectedNodeIds(), is(List.of("brokers: 10,11")));
     }
 
@@ -135,7 +136,8 @@ public class RollingUpdateSkipsTest {
         );
 
         assertThat(skips.hasSkippedNodes(), is(false));
-        assertThat(skips.shouldReportCondition(), is(false));
+        assertThat(skips.hasRejectedNodeIds(), is(false));
+        assertThat(skips.hasIgnoredControllerNodeIds(), is(false));
     }
 
     @Test
@@ -206,8 +208,17 @@ public class RollingUpdateSkipsTest {
         assertThat(condition.getType(), is("RollingUpdateSkipped"));
         assertThat(condition.getStatus(), is("True"));
         assertThat(condition.getMessage(), containsString("Nodes [10, 12] are excluded from automatic rolling updates"));
-        assertThat(condition.getMessage(), containsString("controller role: [0]"));
-        assertThat(condition.getMessage(), containsString("Rejected invalid node IDs: [brokers: 99]"));
+
+        // The ignored and rejected node IDs are reported through separate warning conditions
+        Condition ignoredCondition = skips.ignoredControllersWarningCondition();
+        assertThat(ignoredCondition.getType(), is("Warning"));
+        assertThat(ignoredCondition.getReason(), is("SkipRollingUpdateControllersIgnored"));
+        assertThat(ignoredCondition.getMessage(), containsString("[0]"));
+
+        Condition rejectedCondition = skips.rejectedNodeIdsWarningCondition();
+        assertThat(rejectedCondition.getType(), is("Warning"));
+        assertThat(rejectedCondition.getReason(), is("InvalidSkipRollingUpdateAnnotation"));
+        assertThat(rejectedCondition.getMessage(), containsString("[brokers: 99]"));
 
         // The skipped node IDs can be extracted back from the condition of the previous reconciliation
         assertThat(RollingUpdateSkips.skippedNodeIdsFromCondition(condition), is(Set.of(10, 12)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkipsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/RollingUpdateSkipsTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
+import io.strimzi.operator.cluster.model.NodeRef;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RollingUpdateSkipsTest {
+    private final static Reconciliation RECONCILIATION = Reconciliation.DUMMY_RECONCILIATION;
+
+    private final static Set<NodeRef> NODES = Set.of(
+            new NodeRef("my-cluster-controllers-0", 0, "controllers", true, false),
+            new NodeRef("my-cluster-controllers-1", 1, "controllers", true, false),
+            new NodeRef("my-cluster-controllers-2", 2, "controllers", true, false),
+            new NodeRef("my-cluster-brokers-10", 10, "brokers", false, true),
+            new NodeRef("my-cluster-brokers-11", 11, "brokers", false, true),
+            new NodeRef("my-cluster-brokers-12", 12, "brokers", false, true)
+    );
+
+    private static KafkaNodePool pool(String name, String skipAnnotation, ProcessRoles... roles)   {
+        KafkaNodePoolBuilder builder = new KafkaNodePoolBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(3)
+                    .withRoles(roles)
+                .endSpec();
+
+        if (skipAnnotation != null) {
+            builder.editMetadata().withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, skipAnnotation)).endMetadata();
+        }
+
+        return builder.build();
+    }
+
+    @Test
+    public void testNoAnnotationsMeansNoSkips()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("controllers", null, ProcessRoles.CONTROLLER), pool("brokers", null, ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.hasSkippedNodes(), is(false));
+        assertThat(skips.shouldReportCondition(), is(false));
+        assertThat(skips.skippedNodeIds(), is(Set.of()));
+    }
+
+    @Test
+    public void testSkipsSingleIdsAndRanges()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("controllers", null, ProcessRoles.CONTROLLER), pool("brokers", "[10,11-12]", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.hasSkippedNodes(), is(true));
+        assertThat(skips.skippedNodeIds(), is(Set.of(10, 11, 12)));
+        assertThat(skips.skippedNodeIdsByPool(), is(Map.of("brokers", Set.of(10, 11, 12))));
+        assertThat(skips.ignoredControllerNodeIds(), is(Set.of()));
+        assertThat(skips.rejectedNodeIds(), is(List.of()));
+    }
+
+    @Test
+    public void testIdsNotBelongingToThePoolAreRejected()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("controllers", null, ProcessRoles.CONTROLLER), pool("brokers", "[10,99]", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.skippedNodeIds(), is(Set.of(10)));
+        assertThat(skips.rejectedNodeIds(), is(List.of("brokers: 99")));
+    }
+
+    @Test
+    public void testInvalidEntriesAreRejectedIndividually()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("brokers", "[10,abc,-5,11]", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.skippedNodeIds(), is(Set.of(10, 11)));
+        assertThat(skips.rejectedNodeIds(), hasItems("brokers: abc", "brokers: -5"));
+    }
+
+    @Test
+    public void testCompletelyInvalidAnnotationIsRejected()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("brokers", "10,11", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.hasSkippedNodes(), is(false));
+        assertThat(skips.shouldReportCondition(), is(true));
+        assertThat(skips.rejectedNodeIds(), is(List.of("brokers: 10,11")));
+    }
+
+    @Test
+    public void testEmptyAnnotationMeansNoSkips()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("brokers", "[]", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.hasSkippedNodes(), is(false));
+        assertThat(skips.shouldReportCondition(), is(false));
+    }
+
+    @Test
+    public void testControllerNodesAreIgnored()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("controllers", "[0,1]", ProcessRoles.CONTROLLER), pool("brokers", "[10]", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        assertThat(skips.skippedNodeIds(), is(Set.of(10)));
+        assertThat(skips.ignoredControllerNodeIds(), is(Set.of(0, 1)));
+    }
+
+    @Test
+    public void testCombinedNodesAreIgnored()   {
+        Set<NodeRef> combinedNodes = Set.of(
+                new NodeRef("my-cluster-combined-0", 0, "combined", true, true),
+                new NodeRef("my-cluster-combined-1", 1, "combined", true, true),
+                new NodeRef("my-cluster-combined-2", 2, "combined", true, true)
+        );
+
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("combined", "[0]", ProcessRoles.CONTROLLER, ProcessRoles.BROKER)),
+                combinedNodes,
+                List.of()
+        );
+
+        assertThat(skips.hasSkippedNodes(), is(false));
+        assertThat(skips.ignoredControllerNodeIds(), is(Set.of(0)));
+    }
+
+    @Test
+    public void testPodClaimingControllerRoleIsIgnored()   {
+        // The desired role is broker-only, but the existing Pod still claims the controller role (e.g. during a role
+        // transition), so the skip must not be honored
+        Pod transitioningPod = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-cluster-brokers-10")
+                    .withLabels(Map.of(Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true"))
+                .endMetadata()
+                .build();
+
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("brokers", "[10,11]", ProcessRoles.BROKER)),
+                NODES,
+                List.of(transitioningPod)
+        );
+
+        assertThat(skips.skippedNodeIds(), is(Set.of(11)));
+        assertThat(skips.ignoredControllerNodeIds(), is(Set.of(10)));
+    }
+
+    @Test
+    public void testConditionAndRoundTrip()   {
+        RollingUpdateSkips skips = RollingUpdateSkips.resolve(
+                RECONCILIATION,
+                List.of(pool("controllers", "[0]", ProcessRoles.CONTROLLER), pool("brokers", "[10,12,99]", ProcessRoles.BROKER)),
+                NODES,
+                List.of()
+        );
+
+        Condition condition = skips.kafkaStatusCondition();
+
+        assertThat(condition.getType(), is("RollingUpdateSkipped"));
+        assertThat(condition.getStatus(), is("True"));
+        assertThat(condition.getMessage(), containsString("Nodes [10, 12] are excluded from automatic rolling updates"));
+        assertThat(condition.getMessage(), containsString("controller role: [0]"));
+        assertThat(condition.getMessage(), containsString("Rejected invalid node IDs: [brokers: 99]"));
+
+        // The skipped node IDs can be extracted back from the condition of the previous reconciliation
+        assertThat(RollingUpdateSkips.skippedNodeIdsFromCondition(condition), is(Set.of(10, 12)));
+        assertThat(RollingUpdateSkips.skippedNodeIdsFromCondition(null), is(Set.of()));
+    }
+}

--- a/documentation/assemblies/deploying/assembly-rolling-updates.adoc
+++ b/documentation/assemblies/deploying/assembly-rolling-updates.adoc
@@ -21,3 +21,5 @@ However, rather than deleting the pods directly, if you perform the rolling upda
 include::../../modules/managing/proc-manual-rolling-update-strimzipodset.adoc[leveloffset=+1]
 //steps for manual rolling update with pods
 include::../../modules/managing/proc-manual-rolling-update-pods.adoc[leveloffset=+1]
+//steps for excluding nodes from automatic rolling updates
+include::../../modules/managing/proc-skip-rolling-update-node.adoc[leveloffset=+1]

--- a/documentation/modules/managing/proc-skip-rolling-update-node.adoc
+++ b/documentation/modules/managing/proc-skip-rolling-update-node.adoc
@@ -1,0 +1,60 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// deploying/assembly-rolling-updates.adoc
+
+[id='proc-skip-rolling-update-node-{context}']
+= Excluding Kafka nodes from automatic rolling updates
+
+[role="_abstract"]
+This procedure describes how to temporarily exclude individual Kafka broker nodes from automatic rolling updates driven by the Cluster Operator using the `strimzi.io/skip-rolling-update` annotation on a `KafkaNodePool` resource.
+
+Use this annotation in exceptional situations only, for example to protect a broker performing a long log recovery from being restarted.
+While a node is excluded, the operator continues to reconcile everything else: configuration, certificates, scaling, storage, and rolling updates of all other nodes.
+
+The exclusion applies only to *automatic* rolling updates and only to *broker* nodes:
+
+* A manual rolling update requested through the `strimzi.io/manual-rolling-update` annotation still rolls the node. This includes the annotation set on a `StrimziPodSet`, which applies to all its pods, and evictions handled by the Strimzi Drain Cleaner, which use the same mechanism.
+* A node ID that resolves to a controller (including combined broker and controller nodes) is ignored and the node remains fully managed.
+* The exclusion does not prevent Kubernetes itself from restarting or evicting the pod, and it does not prevent the pod being deleted by a scale-down. Do not scale down a node pool while one of its nodes is excluded.
+
+While any node is excluded, the operator:
+
+* Sets a `RollingUpdateSkipped` condition on the `Kafka` and owning `KafkaNodePool` statuses, and emits `RollingUpdateSkipEnabled` and `RollingUpdateSkipDisabled` Kubernetes events when nodes enter or leave the excluded state.
+* Defers any `metadata.version` change and surfaces it with a `MetadataVersionChangeDeferred` warning condition, because finalizing the change without the excluded node could leave it unable to rejoin the cluster.
+* Does not wait for the readiness of the excluded pods, so the `Kafka` resource can become `Ready` while an excluded node is down. If an excluded node holds the sole in-sync replica of any partition, the operator flags it with a `SkippedNodeSoleInSyncReplica` warning condition.
+* Excludes the node from the rolling update for a replaced CA key. The node is rolled to trust the new CA once it is no longer excluded.
+
+The exclusion is intended to be short-lived.
+Do not keep it in place across a Kafka version upgrade or a CA renewal.
+
+.Prerequisites
+
+* A running Cluster Operator and Kafka cluster.
+
+.Procedure
+
+. Annotate the `KafkaNodePool` resource with the IDs of the broker nodes to exclude.
+Node IDs can be listed individually or as ranges, using the same format as the `strimzi.io/next-node-ids` annotation:
++
+[source,shell,subs=+quotes]
+----
+kubectl annotate kafkanodepool _<node_pool_name>_ strimzi.io/skip-rolling-update="[2]"
+----
+
+. Check the `RollingUpdateSkipped` condition in the `Kafka` resource status to confirm the exclusion is active:
++
+[source,shell,subs=+quotes]
+----
+kubectl get kafka _<cluster_name>_ -o jsonpath='{.status.conditions}'
+----
+
+. When the node no longer needs protection, remove the annotation:
++
+[source,shell,subs=+quotes]
+----
+kubectl annotate kafkanodepool _<node_pool_name>_ strimzi.io/skip-rolling-update-
+----
++
+On the next reconciliation, the operator rolls the node if it has any pending changes and applies any deferred `metadata.version` change.

--- a/documentation/modules/managing/proc-skip-rolling-update-node.adoc
+++ b/documentation/modules/managing/proc-skip-rolling-update-node.adoc
@@ -2,7 +2,7 @@
 
 // Module included in the following assemblies:
 //
-// deploying/assembly-rolling-updates.adoc
+// managing/assembly-rolling-updates.adoc
 
 [id='proc-skip-rolling-update-node-{context}']
 = Excluding Kafka nodes from automatic rolling updates

--- a/documentation/modules/managing/proc-skip-rolling-update-node.adoc
+++ b/documentation/modules/managing/proc-skip-rolling-update-node.adoc
@@ -21,7 +21,7 @@ The exclusion applies only to *automatic* rolling updates and only to *broker* n
 
 While any node is excluded, the operator:
 
-* Sets a `RollingUpdateSkipped` condition on the `Kafka` and owning `KafkaNodePool` statuses, and emits `RollingUpdateSkipEnabled` and `RollingUpdateSkipDisabled` Kubernetes events when nodes enter or leave the excluded state.
+* Sets a `RollingUpdateSkipped` condition on the `Kafka` and owning `KafkaNodePool` statuses, and emits `RollingUpdateSkipEnabled`, `RollingUpdateSkipChanged`, and `RollingUpdateSkipDisabled` Kubernetes events when the set of excluded nodes changes.
 * Defers any `metadata.version` change and surfaces it with a `MetadataVersionChangeDeferred` warning condition, because finalizing the change without the excluded node could leave it unable to rejoin the cluster.
 * Does not wait for the readiness of the excluded pods, so the `Kafka` resource can become `Ready` while an excluded node is down. If an excluded node holds the sole in-sync replica of any partition, the operator flags it with a `SkippedNodeSoleInSyncReplica` warning condition.
 * Excludes the node from the rolling update for a replaced CA key. The node is rolled to trust the new CA once it is no longer excluded.

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodAffinity;
 import io.fabric8.kubernetes.api.model.PodAffinityBuilder;
@@ -46,6 +47,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
 import io.strimzi.testclients.clients.kafka.KafkaProducerConsumer;
 import io.strimzi.testclients.clients.kafka.KafkaProducerConsumerBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +58,7 @@ import org.junit.jupiter.api.Tag;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -524,6 +527,90 @@ public class KafkaRollerST extends AbstractST {
 
         // The cluster should remain Ready and CO should not be stuck with TimeoutException
         KafkaUtils.waitForKafkaReady(testStorage.getNamespaceName(), testStorage.getClusterName());
+    }
+
+    /**
+     * @description This test case verifies that a broker node annotated through the strimzi.io/skip-rolling-update
+     * annotation on its KafkaNodePool is excluded from automatic rolling updates, and catches up on the pending
+     * changes once the annotation is removed.
+     *
+     * @steps
+     *  1. - Deploy a Kafka cluster with dedicated controller and broker KafkaNodePools, each with 3 replicas.
+     *  2. - Annotate the broker KafkaNodePool with strimzi.io/skip-rolling-update listing one broker node ID.
+     *  3. - Trigger an automatic rolling update through a broker-only Kafka configuration change.
+     *     - All broker nodes except the skipped one are rolled.
+     *  4. - Verify the RollingUpdateSkipped condition on the Kafka and KafkaNodePool statuses and that the skipped
+     *       Pod was not restarted.
+     *  5. - Remove the annotation.
+     *     - The skipped node catches up on the pending configuration change and is rolled.
+     *  6. - Verify the RollingUpdateSkipped condition is removed from the Kafka status.
+     *
+     * @usecase
+     *  - kafka-node-skip-rolling-update
+     *  - kafka-node-pool-management
+     */
+    @ParallelNamespaceTest
+    void testSkipRollingUpdateOfAnnotatedBrokerNode() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        final int brokerReplicas = 3;
+        final int controllerReplicas = 3;
+
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), brokerReplicas).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), controllerReplicas).build()
+        );
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), brokerReplicas).build());
+
+        Map<String, String> brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
+
+        // The broker Pods are named <cluster>-<pool>-<nodeId> => the node ID is taken from the Pod name
+        final String skippedPodName = brokerPods.keySet().stream().sorted().findFirst().orElseThrow();
+        final int skippedNodeId = Integer.parseInt(skippedPodName.substring(skippedPodName.lastIndexOf('-') + 1));
+        final Map<String, String> skippedPodSnapshot = Map.of(skippedPodName, brokerPods.get(skippedPodName));
+
+        LOGGER.info("Excluding node {} (Pod: {}/{}) from automatic rolling updates", skippedNodeId, testStorage.getNamespaceName(), skippedPodName);
+        KafkaNodePoolUtils.replace(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(),
+            knp -> knp.setMetadata(new ObjectMetaBuilder(knp.getMetadata())
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE, "[" + skippedNodeId + "]")
+                .build()));
+
+        LOGGER.info("Triggering an automatic rolling update through a broker-only configuration change");
+        KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "initial.broker.registration.timeout.ms", 33500);
+
+        LOGGER.info("Waiting for all broker nodes except node {} to roll", skippedNodeId);
+        Map<String, String> nonSkippedBrokerPods = new HashMap<>(brokerPods);
+        nonSkippedBrokerPods.remove(skippedPodName);
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), nonSkippedBrokerPods);
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), brokerReplicas, true);
+        KafkaUtils.waitForKafkaReady(testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        LOGGER.info("Verifying the RollingUpdateSkipped condition on the Kafka and KafkaNodePool statuses");
+        KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(testStorage.getNamespaceName(), testStorage.getClusterName(),
+            ".*Nodes \\[" + skippedNodeId + "\\] are excluded from automatic rolling updates.*");
+        TestUtils.waitFor("RollingUpdateSkipped condition on the KafkaNodePool status", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT,
+            () -> KafkaNodePoolUtils.getKafkaNodePool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName()).getStatus().getConditions() != null
+                && KafkaNodePoolUtils.getKafkaNodePool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName()).getStatus().getConditions().stream()
+                    .anyMatch(condition -> "RollingUpdateSkipped".equals(condition.getType())));
+
+        LOGGER.info("Verifying the skipped Pod {} is not rolled", skippedPodName);
+        RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), skippedPodSnapshot);
+        assertThat("The skipped node should not be rolled",
+            PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(skippedPodName), is(brokerPods.get(skippedPodName)));
+
+        LOGGER.info("Removing the skip annotation; node {} should catch up on the pending configuration change", skippedNodeId);
+        KafkaNodePoolUtils.replace(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(),
+            knp -> knp.setMetadata(new ObjectMetaBuilder(knp.getMetadata())
+                .removeFromAnnotations(Annotations.ANNO_STRIMZI_IO_SKIP_ROLLING_UPDATE)
+                .build()));
+
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), skippedPodSnapshot);
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), brokerReplicas, true);
+        KafkaUtils.waitForKafkaReady(testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        LOGGER.info("Verifying the RollingUpdateSkipped condition is removed from the Kafka status");
+        TestUtils.waitFor("RollingUpdateSkipped condition to be removed from the Kafka status", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT,
+            () -> CrdClients.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getConditions().stream()
+                .noneMatch(condition -> "RollingUpdateSkipped".equals(condition.getType())));
     }
 
     @BeforeAll


### PR DESCRIPTION
## Type of change

- Enhancement / new feature

## Description

Implements [strimzi/proposals#229](https://github.com/strimzi/proposals/pull/229): a new `strimzi.io/skip-rolling-update` annotation on `KafkaNodePool` resources that excludes individual broker nodes from operator-driven automatic rolling updates. This is intended as a short-lived escape hatch when a specific node must not be restarted (for example during an incident investigation or a delicate recovery), while the rest of the cluster keeps rolling normally.

Opened as a draft since the proposal is still under review.

### Behavior

- The annotation takes a comma-separated list of node IDs (e.g. `strimzi.io/skip-rolling-update: "10,12"`). Skipped nodes are excluded from automatic rolling updates and from the pod readiness wait, including the rolling update triggered by Cluster CA key replacement.
- Manual rolling updates (`strimzi.io/manual-rolling-update`) always take precedence and roll the node regardless of the skip.
- Only broker-role nodes can be skipped. Controller and mixed-role node IDs are ignored and reported through a Warning condition; invalid entries (non-numeric, not part of the pool) are likewise rejected with a Warning condition.
- While any node is skipped, KRaft metadata version changes are deferred so a skipped node cannot be orphaned mid-upgrade.
- A `RollingUpdateSkipped` condition is set on the `Kafka` and owning `KafkaNodePool` statuses while skips are active, and `RollingUpdateSkipEnabled` / `RollingUpdateSkipChanged` / `RollingUpdateSkipDisabled` Kubernetes events are emitted when the skipped set changes.
- A best-effort check warns (via a Warning condition) if a skipped node is the sole in-sync replica for any partition, since restart-relevant changes cannot be applied to it.
- Once the annotation is removed, the node catches up on the pending changes in the next reconciliation.

### Main changes

- New `RollingUpdateSkips` class that parses and validates the annotation and builds the status conditions.
- `KafkaReconciler`: resolves skips early in the reconciliation, filters skipped nodes from `rollingUpdate()` and `podsReady()`, defers `metadataVersion()` while skips are active, and adds the sole-ISR warning check.
- `CaReconciler`: honors skips during the Cluster CA key replacement roll.
- `KubernetesRestartEventPublisher`: new cluster-scoped event publishing used for the skip lifecycle events.
- Documentation procedure (`proc-skip-rolling-update-node.adoc`) and CHANGELOG entry.

## Checklist

- [x] Write tests (unit tests for `RollingUpdateSkips`, `KafkaReconciler` skip paths, and `CaReconciler` filtering)
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Update CHANGELOG.md
- [ ] Reference relevant issue(s) and close them after merging (proposal: strimzi/proposals#229)

## Testing

- Unit tests added: `RollingUpdateSkipsTest`, `KafkaReconcilerSkipRollingUpdateTest`, and new `CaReconcilerTest` cases.
- Verified end-to-end on a local minikube cluster: applying the annotation, triggering a rolling update and confirming the node is skipped (conditions + events), metadata version deferral, CA key replacement skip, sole-ISR warning, and catch-up after removing the annotation.