### PR TITLE
Removed Vert.x usage from `DefaultKafkaQuotasManager` class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
@@ -13,7 +13,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
-import org.apache.kafka.common.KafkaFuture;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -171,38 +170,5 @@ public final class VertxUtil {
         handler.handle(null);
 
         return promise.future();
-    }
-
-    /**
-     * Converts Kafka Future to Vert.x future
-     *
-     * @param reconciliation    Reconciliation marker
-     * @param vertx             Vert.x instance
-     * @param kf                Kafka future
-     *
-     * @return  Vert.x future based on the Kafka future
-     *
-     * @param <T>   Return type of the future
-     */
-    public static <T> Future<T> kafkaFutureToVertxFuture(Reconciliation reconciliation, Vertx vertx, KafkaFuture<T> kf) {
-        Promise<T> promise = Promise.promise();
-        if (kf != null) {
-            kf.whenComplete((result, error) -> vertx.runOnContext(ignored -> {
-                if (error != null) {
-                    promise.fail(error);
-                } else {
-                    promise.complete(result);
-                }
-            }));
-            return promise.future();
-        } else {
-            if (reconciliation != null) {
-                LOGGER.traceCr(reconciliation, "KafkaFuture is null");
-            } else {
-                LOGGER.traceOp("KafkaFuture is null");
-            }
-
-            return Future.succeededFuture();
-        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
@@ -8,14 +8,11 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.quotas.QuotasPlugin;
 import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginKafka;
 import io.strimzi.operator.cluster.model.KafkaCluster;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.auth.PemAuthIdentity;
 import io.strimzi.operator.common.auth.PemTrustSet;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -27,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Class containing methods for handling the configuration around {@link QuotasPluginKafka}
@@ -90,17 +89,15 @@ public class DefaultKafkaQuotasManager {
      * Based on configuration in {@param quotasPlugin}, it configures the default user quota in Kafka.
      *
      * @param reconciliation            Reconciliation marker
-     * @param vertx                     Vert.x instance
      * @param adminClientProvider       Kafka Admin client provider
      * @param pemTrustSet               Trust set for TLS authentication in PEM format
      * @param pemAuthIdentity           Identity for TLS client authentication in PEM format
      * @param quotasPlugin              Configuration of Kafka quotas plugin
      *
-     * @return  Future that completes when the default user quota configuration is completed
+     * @return  CompletionStage that completes when the default user quota configuration is completed
      */
-    public static Future<Void> reconcileDefaultUserQuotas(
+    public static CompletionStage<Void> reconcileDefaultUserQuotas(
         Reconciliation reconciliation,
-        Vertx vertx,
         AdminClientProvider adminClientProvider,
         PemTrustSet pemTrustSet,
         PemAuthIdentity pemAuthIdentity,
@@ -117,20 +114,23 @@ public class DefaultKafkaQuotasManager {
 
         List<ClientQuotaAlteration.Op> ops = prepareQuotaConfigurationRequest(quotasPluginKafka);
 
-        return shouldAlterDefaultQuotasConfig(reconciliation, vertx, kafkaAdmin, ops, isNotKafkaPlugin)
-            .compose(shouldUpdateQuotas -> {
+        return shouldAlterDefaultQuotasConfig(reconciliation, kafkaAdmin, ops, isNotKafkaPlugin)
+            .thenCompose(shouldUpdateQuotas -> {
                 if (shouldUpdateQuotas) {
                     ClientQuotaAlteration clientQuotaAlteration = new ClientQuotaAlteration(DEFAULT_USER_ENTITY, ops);
 
                     LOGGER.debugCr(reconciliation, "Default user quotas differ and will be updated");
-                    return alterQuotas(reconciliation, vertx, kafkaAdmin, clientQuotaAlteration)
-                        .onSuccess(result -> LOGGER.debugCr(reconciliation, "Successfully altered default user quotas"))
-                        .onFailure(cause -> LOGGER.errorCr(reconciliation, "Failed to alter default user quotas", cause));
+                    return alterQuotas(reconciliation, kafkaAdmin, clientQuotaAlteration);
                 } else {
-                    return Future.succeededFuture();
+                    return CompletableFuture.completedFuture(null);
                 }
             })
-            .onComplete(result -> {
+            .whenComplete((result, error) -> {
+                if (error != null) {
+                    LOGGER.errorCr(reconciliation, "Failed to alter default user quotas", error);
+                } else {
+                    LOGGER.debugCr(reconciliation, "Successfully altered default user quotas");
+                }
                 LOGGER.debugCr(reconciliation, "Closing the Kafka Admin API connection");
                 kafkaAdmin.close();
             });
@@ -141,35 +141,32 @@ public class DefaultKafkaQuotasManager {
      * It gets the current default quotas for users from Kafka and compares them with the desired configuration
      *
      * @param reconciliation          Reconciliation marker
-     * @param vertx                   Vert.x instance
      * @param kafkaAdmin              Kafka Admin object
      * @param ops                     List of {@link ClientQuotaAlteration.Op}
      * @param isNotKafkaPlugin        boolean parameter determining if the Kafka built-in quotas plugin is used
      *
      * @return  result determining if the new quotas configuration should be applied or not
      */
-    /* test */ static Future<Boolean> shouldAlterDefaultQuotasConfig(Reconciliation reconciliation, Vertx vertx, Admin kafkaAdmin, List<ClientQuotaAlteration.Op> ops, boolean isNotKafkaPlugin) {
-        return VertxUtil.kafkaFutureToVertxFuture(reconciliation,
-                vertx,
-                kafkaAdmin.describeClientQuotas(ClientQuotaFilter.containsOnly(List.of(ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.USER)))).entities())
-            .compose(clientQuotaEntityMapMap -> {
+    /* test */ static CompletionStage<Boolean> shouldAlterDefaultQuotasConfig(Reconciliation reconciliation, Admin kafkaAdmin, List<ClientQuotaAlteration.Op> ops, boolean isNotKafkaPlugin) {
+        return kafkaAdmin.describeClientQuotas(ClientQuotaFilter.containsOnly(List.of(ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.USER)))).entities().toCompletionStage()
+            .thenApply(clientQuotaEntityMapMap -> {
                 Map<String, Double> currentQuotas = clientQuotaEntityMapMap.get(DEFAULT_USER_ENTITY);
 
                 if (currentQuotas == null) {
                     if (isNotKafkaPlugin) {
                         // 1. if the current quotas set in Kafka are null and quotas configuration in Kafka CR is not of type `QuotasPluginKafka`, skip alteration
                         LOGGER.debugCr(reconciliation, "There are no default user quotas set in Kafka and the Kafka built-in plugin is not configured, skipping the alteration");
-                        return Future.succeededFuture(false);
+                        return false;
                     } else if (ops.stream().allMatch(op -> Objects.isNull(op.value()))) {
                         // 2. if the current quotas set in Kafka are null and quotas configuration in Kafka CR is type of `QuotasPluginKafka`, but there is no fields configured, skip alteration
                         LOGGER.debugCr(reconciliation, "There are no default user quotas set in Kafka and no quotas are configured, skipping the alteration");
-                        return Future.succeededFuture(false);
+                        return false;
                     } else {
                         // 3. in case that the current quotas are null, but desired quotas contains some non-null values, we should alter the quotas
-                        return Future.succeededFuture(true);
+                        return true;
                     }
                 } else {
-                    return Future.succeededFuture(currentAndDesiredQuotasDiffer(currentQuotas, ops));
+                    return currentAndDesiredQuotasDiffer(currentQuotas, ops);
                 }
             });
     }
@@ -178,23 +175,19 @@ public class DefaultKafkaQuotasManager {
      * Method for altering the default Kafka user quotas using Kafka Admin client
      *
      * @param reconciliation            Reconciliation marker
-     * @param vertx                     Vert.x instance
      * @param kafkaAdmin                Kafka Admin object
      * @param clientQuotaAlteration     Quota alteration operation
      *
-     * @return  Future after completion of the alter operation
+     * @return  CompletionStage after completion of the alter operation
      */
-    private static Future<Void> alterQuotas(
+    private static CompletionStage<Void> alterQuotas(
         Reconciliation reconciliation,
-        Vertx vertx,
         Admin kafkaAdmin,
         ClientQuotaAlteration clientQuotaAlteration
     ) {
         LOGGER.debugCr(reconciliation, "Altering default user quotas to: {}", clientQuotaAlteration.toString());
 
-        return VertxUtil
-            .kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.alterClientQuotas(List.of(clientQuotaAlteration)).values().get(DEFAULT_USER_ENTITY))
-            .mapEmpty();
+        return kafkaAdmin.alterClientQuotas(List.of(clientQuotaAlteration)).values().get(DEFAULT_USER_ENTITY).toCompletionStage();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1024,7 +1024,7 @@ public class KafkaReconciler {
      * @return  Future which completes when the default quotas are configured
      */
     protected Future<Void> defaultKafkaQuotas() {
-        return DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(reconciliation, vertx, adminClientProvider, this.coTlsPemIdentity.pemTrustSet(), this.coTlsPemIdentity.pemAuthIdentity(), kafka.quotas());
+        return VertxUtil.toFuture(DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(reconciliation, adminClientProvider, this.coTlsPemIdentity.pemTrustSet(), this.coTlsPemIdentity.pemAuthIdentity(), kafka.quotas()));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManagerTest.java
@@ -9,10 +9,6 @@ import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginKafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginStrimzi;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
-import io.vertx.core.Vertx;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterClientQuotasResult;
 import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
@@ -21,16 +17,15 @@ import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.operator.common.auth.TlsPemIdentity.DUMMY_IDENTITY;
 import static org.hamcrest.CoreMatchers.is;
@@ -43,24 +38,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(VertxExtension.class)
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class DefaultKafkaQuotasManagerTest {
     private final static Long DEFAULT_PRODUCER_BYTE_RATE = 2000L;
     private final static Long DEFAULT_CONSUMER_BYTE_RATE = 2000L;
     private final static Double DEFAULT_MUTATION_RATE = 0.5;
     private final static Integer DEFAULT_REQUEST_PERCENTAGE = 25;
-
-    private static Vertx vertx;
-
-    @BeforeAll
-    public static void before() {
-        vertx = Vertx.vertx();
-    }
-
-    @AfterAll
-    public static void after() {
-        vertx.close();
-    }
 
     /**
      * Checks whether {@link DefaultKafkaQuotasManager#currentAndDesiredQuotasDiffer(Map, List)} is able to handle the
@@ -116,14 +99,12 @@ public class DefaultKafkaQuotasManagerTest {
     }
 
     /**
-     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Admin, List, boolean)}
      * when there are no default Kafka quotas set and none (or Strimzi Quotas plugin) are desired.
      * The result of this check should be false.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testShouldAlterQuotasWithNoneCurrentAndNotAKafkaQuotasPlugin(VertxTestContext context) {
+    void testShouldAlterQuotasWithNoneCurrentAndNotAKafkaQuotasPlugin() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -132,25 +113,20 @@ public class DefaultKafkaQuotasManagerTest {
 
         List<ClientQuotaAlteration.Op> noneQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
 
-        Checkpoint checkpoint = context.checkpoint();
+        Boolean result = DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, mockAdminClient, noneQuotas, true)
+            .toCompletableFuture()
+            .join();
 
-        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, noneQuotas, true)
-            .onComplete(context.succeeding(result -> {
-                assertThat(result, is(false));
-
-                checkpoint.flag();
-            }));
+        assertThat(result, is(false));
     }
 
     /**
-     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Admin, List, boolean)}
      * when there are no default Kafka quotas set and there are Kafka quotas specified.
      * The result of this check should be true.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testShouldAlterQuotasWithNoneCurrentAndFilledKafkaQuotas(VertxTestContext context) {
+    void testShouldAlterQuotasWithNoneCurrentAndFilledKafkaQuotas() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -163,25 +139,20 @@ public class DefaultKafkaQuotasManagerTest {
 
         List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
 
-        Checkpoint checkpoint = context.checkpoint();
+        Boolean result = DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, mockAdminClient, desiredQuotas, false)
+            .toCompletableFuture()
+            .join();
 
-        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
-            .onComplete(context.succeeding(result -> {
-                assertThat(result, is(true));
-
-                checkpoint.flag();
-            }));
+        assertThat(result, is(true));
     }
 
     /**
-     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Admin, List, boolean)}
      * when there are default Kafka quotas set and none (or Strimzi Quotas plugin) are desired.
      * The result of this check should be true.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testShouldAlterQuotasWithFilledCurrentAndNotAKafkaQuotasPlugin(VertxTestContext context) {
+    void testShouldAlterQuotasWithFilledCurrentAndNotAKafkaQuotasPlugin() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -190,25 +161,20 @@ public class DefaultKafkaQuotasManagerTest {
 
         List<ClientQuotaAlteration.Op> noneQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
 
-        Checkpoint checkpoint = context.checkpoint();
+        Boolean result = DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, mockAdminClient, noneQuotas, true)
+            .toCompletableFuture()
+            .join();
 
-        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, noneQuotas, true)
-            .onComplete(context.succeeding(result -> {
-                assertThat(result, is(true));
-
-                checkpoint.flag();
-            }));
+        assertThat(result, is(true));
     }
 
     /**
-     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Admin, List, boolean)}
      * when there are default Kafka quotas set and different Kafka quotas are desired.
      * The result of this check should be true.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testShouldAlterQuotasWithFilledCurrentAndDifferentKafkaQuotas(VertxTestContext context) {
+    void testShouldAlterQuotasWithFilledCurrentAndDifferentKafkaQuotas() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -221,25 +187,20 @@ public class DefaultKafkaQuotasManagerTest {
 
         List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
 
-        Checkpoint checkpoint = context.checkpoint();
+        Boolean result = DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, mockAdminClient, desiredQuotas, false)
+            .toCompletableFuture()
+            .join();
 
-        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
-            .onComplete(context.succeeding(result -> {
-                assertThat(result, is(true));
-
-                checkpoint.flag();
-            }));
+        assertThat(result, is(true));
     }
 
     /**
-     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Admin, List, boolean)}
      * when there are default Kafka quotas set and same Kafka quotas are desired.
      * The result of this check should be false.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testShouldAlterQuotasWithSameCurrentAndDesiredKafkaQuotas(VertxTestContext context) {
+    void testShouldAlterQuotasWithSameCurrentAndDesiredKafkaQuotas() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -255,29 +216,22 @@ public class DefaultKafkaQuotasManagerTest {
 
         List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
 
-        Checkpoint checkpoint = context.checkpoint();
+        Boolean result = DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, mockAdminClient, desiredQuotas, false)
+            .toCompletableFuture()
+            .join();
 
-        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
-            .onComplete(context.succeeding(result -> {
-                assertThat(result, is(false));
-
-                checkpoint.flag();
-            }));
+        assertThat(result, is(false));
     }
 
     /**
      * Tests that the default Kafka quotas are altered in case of different configuration specified by user.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testReconfigureDefaultQuotasSetInKafka(VertxTestContext context) {
+    void testReconfigureDefaultQuotasSetInKafka() {
         long consumerByteRate = 1000;
         long producerByteRate = 1000;
         double mutationRate = 0.1;
         int requestPercentage = 33;
-
-        Checkpoint checkpoint = context.checkpoint();
 
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
@@ -303,29 +257,24 @@ public class DefaultKafkaQuotasManagerTest {
         List<ClientQuotaAlteration.Op> expectedResult = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
 
         // Scenario with configured QuotasPluginKafka and default user quota set in Kafka (all options) -> but with different values in both configurations
-        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), quotasPluginKafka)
-            .onComplete(context.succeeding(s -> {
-                verify(mockAdminClient, times(1)).describeClientQuotas(any());
-                verify(mockAdminClient, times(1)).alterClientQuotas(any());
+        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), quotasPluginKafka)
+            .toCompletableFuture()
+            .join();
 
-                assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+        verify(mockAdminClient, times(1)).describeClientQuotas(any());
+        verify(mockAdminClient, times(1)).alterClientQuotas(any());
 
-                List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
-                assertEquals(expectedResult, valuesSet);
+        assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
 
-                checkpoint.flag();
-            }));
+        List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
+        assertEquals(expectedResult, valuesSet);
     }
 
     /**
      * Tests that the default Kafka quotas are set to null (deleted) in case that none quotas plugin is specified by user.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testRemoveDefaultQuotasIfNoneQuotasPluginIsDesired(VertxTestContext context) {
-        Checkpoint checkpoint = context.checkpoint();
-
+    void testRemoveDefaultQuotasIfNoneQuotasPluginIsDesired() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -343,28 +292,24 @@ public class DefaultKafkaQuotasManagerTest {
         List<ClientQuotaAlteration.Op> expectedResult = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
 
         // Scenario with configured QuotasPluginKafka and default user quota set in Kafka (all options) -> but with different values in both configurations
-        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), null)
-            .onComplete(context.succeeding(s -> {
-                verify(mockAdminClient, times(1)).describeClientQuotas(any());
-                verify(mockAdminClient, times(1)).alterClientQuotas(any());
+        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), null)
+            .toCompletableFuture()
+            .join();
 
-                assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+        verify(mockAdminClient, times(1)).describeClientQuotas(any());
+        verify(mockAdminClient, times(1)).alterClientQuotas(any());
 
-                List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
-                assertEquals(expectedResult, valuesSet);
-                checkpoint.flag();
-            }));
+        assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+
+        List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
+        assertEquals(expectedResult, valuesSet);
     }
 
     /**
      * Tests that the default Kafka quotas are set to null (deleted) in case that Strimzi quotas plugin is specified by user.
-     *
-     * @param context   Vertx test context
      */
     @Test
-    void testRemoveDefaultQuotasIfStrimziQuotasPluginIsDesired(VertxTestContext context) {
-        Checkpoint checkpoint = context.checkpoint();
-
+    void testRemoveDefaultQuotasIfStrimziQuotasPluginIsDesired() {
         // Mock the Admin client
         Admin mockAdminClient = mock(Admin.class);
 
@@ -382,17 +327,17 @@ public class DefaultKafkaQuotasManagerTest {
         List<ClientQuotaAlteration.Op> expectedResult = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
 
         // Scenario with configured QuotasPluginKafka and default user quota set in Kafka (all options) -> but with different values in both configurations
-        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), new QuotasPluginStrimzi())
-            .onComplete(context.succeeding(s -> {
-                verify(mockAdminClient, times(1)).describeClientQuotas(any());
-                verify(mockAdminClient, times(1)).alterClientQuotas(any());
+        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), new QuotasPluginStrimzi())
+            .toCompletableFuture()
+            .join();
 
-                assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+        verify(mockAdminClient, times(1)).describeClientQuotas(any());
+        verify(mockAdminClient, times(1)).alterClientQuotas(any());
 
-                List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
-                assertEquals(expectedResult, valuesSet);
-                checkpoint.flag();
-            }));
+        assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+
+        List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
+        assertEquals(expectedResult, valuesSet);
     }
 
     private Map<String, Double> createMapOfCurrentQuotas(
@@ -428,7 +373,8 @@ public class DefaultKafkaQuotasManagerTest {
     }
 
     private void mockAlterQuotas(Admin mockAdminClient, ArgumentCaptor<List<ClientQuotaAlteration>> quotaAlterationCaptor) {
-        when(mockAdminClient.alterClientQuotas(quotaAlterationCaptor.capture())).thenAnswer(i -> new AlterClientQuotasResult(Map.of()));
+        ClientQuotaEntity defaultUserEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, null));
+        when(mockAdminClient.alterClientQuotas(quotaAlterationCaptor.capture())).thenReturn(new AlterClientQuotasResult(Map.of(defaultUserEntity, KafkaFuture.completedFuture(null))));
     }
 
     private AdminClientProvider mockAdminClientProvider(Admin adminClient)  {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the usage of Vert.x from the `DefaultKafkaQuotasManager` class by using `CompletableFuture` and `CompletionStage`.
With the `DefaultKafkaQuotasManagerTest`, it also fixes the `mockAlterQuotas` helper which was returning an empty map with no entity entries. 
This didn't match the real Kafka Admin API behavior, where `alterClientQuotas().values()` always contains a `KafkaFuture` keyed by each entity in the request. The old code worked only because `VertxUtil.kafkaFutureToVertxFuture` (now removed because not used anymore) silently handled null `KafkaFuture` inputs.
The PR fixes the mock to return a completed future for the DEFAULT_USER_ENTITY, consistent with how `mockDescribeQuotasResultPresent` already works.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
