### PR TITLE
Replace CompletableFuture with CompletionStage in `SimpleAclOperator`

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -158,7 +158,7 @@ public class SimpleAclOperator implements AdminApiOperator<Set<SimpleAclRule>, S
      *
      * @return the Future with reconcile result
      */
-    private CompletableFuture<ReconcileResult<Collection<AclBinding>>> createAcls(Reconciliation reconciliation, String username, Set<SimpleAclRule> desired) {
+    private CompletionStage<ReconcileResult<Collection<AclBinding>>> createAcls(Reconciliation reconciliation, String username, Set<SimpleAclRule> desired) {
         LOGGER.debugCr(reconciliation, "Creating ACLs for user {}", username);
 
         CompletableFuture<ReconcileResult<Collection<AclBinding>>> future = new CompletableFuture<>();
@@ -289,7 +289,7 @@ public class SimpleAclOperator implements AdminApiOperator<Set<SimpleAclRule>, S
      *
      * @return  The Future with reconcile result
      */
-    private CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> deleteAcls(Reconciliation reconciliation, String username, Set<SimpleAclRule> current)   {
+    private CompletionStage<ReconcileResult<Collection<AclBindingFilter>>> deleteAcls(Reconciliation reconciliation, String username, Set<SimpleAclRule> current)   {
         LOGGER.debugCr(reconciliation, "Deleting ACLs of user {}", username);
 
         CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> future = new CompletableFuture<>();


### PR DESCRIPTION
### Type of change

- Task

### Description

Replaces `CompletableFuture` with `CompletionStage` in the API method return types of `SimpleAclOperator`, as requested in #12914 (subtask of #12878).

Only `createAcls(...)` and `deleteAcls(...)` remained on `CompletableFuture` — the public API (`reconcile`, `getAllUsers`) and the `internal*` helpers were already `CompletionStage`. These two private methods are changed for consistency (same approach as #12936); `CompletableFuture` is kept internally where an instance is created/completed and passed to the batch `ReconcileRequest`.

No caller or test changes were required.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))

Closes #12914
