### PR TITLE
Configure Codecov to report status on the PR after all testing jobs finish

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,13 @@
-# Validate changes with curl -X POST --data-binary @.github/codecov.yaml https://codecov.io/validate
+# Validate changes with curl -X POST --data-binary @.github/codecov.yml https://codecov.io/validate
+
+# Wait for all test uploads before posting status checks.
+# Count = 1 (unit-test-strimzi) + 2 (integration-test-strimzi matrix entries).
+# Update if the matrix in build.yml changes.
+codecov:
+  notify:
+    after_n_builds: 3
+    wait_for_ci: true
+
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After spliting unit and integration tests in separated jobs, Codecov started to paste status after first job finishes (unit tests) and updates it when other jobs finishes. This could be misleading and produce confusing events and notifications. This change will hopefully ensure that Codecov will paste status after all reporting jobs finish.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
