### PR TITLE
Add basic Gatekeeper plugins for testing and as examples

### DIFF
--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -107,10 +107,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -185,8 +187,6 @@
                                 <!-- Fabric8 Kubernetes Client and HttpClient are required by the tests -->
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
-                                <!-- Needed for logging in tests -->
-                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <!-- Needed for logging in tests using the Kubernetes Client (uses SLF4J) -->
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>

--- a/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/plugin/DebugGatekeeperPlugin.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/plugin/DebugGatekeeperPlugin.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper.plugin;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2DeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2EntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaValidatingPlugin;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Gatekeeper plugin useful for debugging. For every entry, exit, and deletion it logs a short human-readable
+ * message at the INFO level.
+ * <p>
+ * Optionally, it can dump the full resource as YAML, but only when the custom resource opts into it through an
+ * annotation.
+ * <ul>
+ *     <li>On <em>entry</em>, the custom resource is logged as YAML when it has the
+ *     {@code debug.gatekeeper.strimzi.io/entry: true} annotation.</li>
+ *     <li>On <em>exit</em>, the status of the custom resource is logged as YAML when it has the
+ *     {@code debug.gatekeeper.strimzi.io/exit: true} annotation.</li>
+ * </ul>
+ * <p>
+ * This plugin also serves as an example of validating plugins.
+ */
+@SuppressWarnings("checkstyle:ClassFanOutComplexity") // This class intentionally references the types of all the operands, which raises its fan-out above the limit
+public class DebugGatekeeperPlugin implements
+        GatekeeperKafkaValidatingPlugin,
+        GatekeeperKafkaConnectValidatingPlugin,
+        GatekeeperKafkaMirrorMaker2ValidatingPlugin,
+        GatekeeperKafkaBridgeValidatingPlugin,
+        GatekeeperKafkaRebalanceValidatingPlugin,
+        GatekeeperKafkaTopicValidatingPlugin,
+        GatekeeperKafkaUserValidatingPlugin {
+    private static final Logger LOGGER = LogManager.getLogger(DebugGatekeeperPlugin.class);
+
+    /**
+     * Prefix added to every message logged by this plugin, so the debug output is easy to find and filter.
+     */
+    /* test */ static final String LOG_PREFIX = "[GATEKEEPER] ";
+
+    /**
+     * Annotation which, when set to {@code true} on a custom resource, makes the plugin log the resource as YAML during
+     * the entry phase.
+     */
+    /* test */ static final String ENTRY_DEBUG_ANNOTATION = "debug.gatekeeper.strimzi.io/entry";
+
+    /**
+     * Annotation which, when set to {@code true} on a custom resource, makes the plugin log the resource status as YAML
+     * during the exit phase.
+     */
+    /* test */ static final String EXIT_DEBUG_ANNOTATION = "debug.gatekeeper.strimzi.io/exit";
+
+    /**
+     * Creates the debug plugin.
+     */
+    public DebugGatekeeperPlugin() { }
+
+    // Kafka
+
+    @Override
+    public CompletionStage<Void> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+        logEntry(kafka);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+        logExit(kafka, newKafkaStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaNodePoolExit(GatekeeperKafkaExitContext context, Kafka kafka, KafkaNodePool kafkaNodePool, KafkaNodePoolStatus newKafkaNodePoolStatus) {
+        logExit(kafkaNodePool, newKafkaNodePoolStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaDeletion(GatekeeperKafkaDeletionContext context, String namespace, String name) {
+        logDeletion("Kafka", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // KafkaConnect
+
+    @Override
+    public CompletionStage<Void> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+        logEntry(kafkaConnect);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus newKafkaConnectStatus) {
+        logExit(kafkaConnect, newKafkaConnectStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaConnectorExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, KafkaConnector kafkaConnector, KafkaConnectorStatus newKafkaConnectorStatus) {
+        logExit(kafkaConnector, newKafkaConnectorStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+        logDeletion("KafkaConnect", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // KafkaMirrorMaker2
+
+    @Override
+    public CompletionStage<Void> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+        logEntry(kafkaMirrorMaker2);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status newKafkaMirrorMaker2Status) {
+        logExit(kafkaMirrorMaker2, newKafkaMirrorMaker2Status);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+        logDeletion("KafkaMirrorMaker2", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // KafkaBridge
+
+    @Override
+    public CompletionStage<Void> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+        logEntry(kafkaBridge);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus newKafkaBridgeStatus) {
+        logExit(kafkaBridge, newKafkaBridgeStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+        logDeletion("KafkaBridge", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // KafkaRebalance
+
+    @Override
+    public CompletionStage<Void> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+        logEntry(kafkaRebalance);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus newKafkaRebalanceStatus) {
+        logExit(kafkaRebalance, newKafkaRebalanceStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+        logDeletion("KafkaRebalance", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // KafkaTopic
+
+    @Override
+    public CompletionStage<Void> kafkaTopicEntry(GatekeeperKafkaTopicEntryContext context, KafkaTopic kafkaTopic) {
+        logEntry(kafkaTopic);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaTopicExit(GatekeeperKafkaTopicExitContext context, KafkaTopic kafkaTopic, KafkaTopicStatus newKafkaTopicStatus) {
+        logExit(kafkaTopic, newKafkaTopicStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaTopicDeletion(GatekeeperKafkaTopicDeletionContext context, String namespace, String name) {
+        logDeletion("KafkaTopic", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // KafkaUser
+
+    @Override
+    public CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+        logEntry(kafkaUser);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+        logExit(kafkaUser, newKafkaUserStatus);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+        logDeletion("KafkaUser", namespace, name);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Logs the entry event for a custom resource. When the resource carries the debug annotation, the resource itself
+     * is also logged as YAML.
+     *
+     * @param resource  The custom resource entering the reconciliation
+     */
+    private void logEntry(HasMetadata resource) {
+        String yamlMessage = "";
+        if (Annotations.booleanAnnotation(resource, ENTRY_DEBUG_ANNOTATION, false)) {
+            yamlMessage = yamlMessage("resource", resource);
+        }
+
+        LOGGER.info(eventMessage(resource, "entered the reconciliation", yamlMessage));
+    }
+
+    /**
+     * Logs the exit event for a custom resource. When the resource carries the debug annotation, the resource status
+     * is also logged as YAML.
+     *
+     * @param resource  The custom resource exiting the reconciliation
+     * @param status    The status computed for the custom resource (might be null)
+     */
+    private void logExit(HasMetadata resource, Object status) {
+        String yamlMessage = "";
+        if (Annotations.booleanAnnotation(resource, EXIT_DEBUG_ANNOTATION, false)) {
+            yamlMessage = yamlMessage("status", status);
+        }
+
+        LOGGER.info(eventMessage(resource, "exited the reconciliation", yamlMessage));
+    }
+
+    /**
+     * Logs the deletion event for a custom resource.
+     *
+     * @param kind          The kind of the operand being deleted (for example {@code KafkaUser})
+     * @param namespace     The namespace of the resource being deleted
+     * @param name          The name of the resource being deleted
+     */
+    private void logDeletion(String kind, String namespace, String name) {
+        LOGGER.info(deletionMessage(kind, namespace, name));
+    }
+
+    /**
+     * Builds the short event message describing what is happening to a resource. The message is prefixed with
+     * {@link #LOG_PREFIX} and includes the kind, namespace, and name of the resource.
+     *
+     * @param resource          The custom resource the event relates to
+     * @param eventDescription  The event being described
+     * @param yaml              The YAML representation of the resource
+     *
+     * @return  The formatted event message
+     */
+    /* test */ static String eventMessage(HasMetadata resource, String eventDescription, String yaml) {
+        return LOG_PREFIX + resource.getKind() + " " + resource.getMetadata().getNamespace() + "/" + resource.getMetadata().getName() + " " + eventDescription + yaml;
+    }
+
+    /**
+     * Builds the message with the given resource or status serialized as YAML.
+     *
+     * @param what      What is being serialized (for example {@code resource} or {@code status})
+     * @param object    The object to serialize as YAML
+     *
+     * @return  The formatted YAML message
+     */
+    /* test */ static String yamlMessage(String what, Object object) {
+        return " with " + what + ":" + System.lineSeparator() + Serialization.asYaml(object) + System.lineSeparator();
+    }
+
+    /**
+     * Builds the message for a deletion. There is no resource to serialize (it no longer exists), so only the kind,
+     * namespace, and name are included.
+     *
+     * @param kind          The kind of the operand being deleted (for example {@code KafkaUser})
+     * @param namespace     The namespace of the resource being deleted
+     * @param name          The name of the resource being deleted
+     *
+     * @return  The formatted deletion message
+     */
+    /* test */ static String deletionMessage(String kind, String namespace, String name) {
+        return LOG_PREFIX + " " + kind + " " + namespace + "/" + name + " is being deleted";
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/plugin/InjectedFailureGatekeeperPlugin.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/plugin/InjectedFailureGatekeeperPlugin.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper.plugin;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2DeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2EntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaTopicValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaValidatingPlugin;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Gatekeeper plugin useful for testing how the operators handle failures of the Gatekeeper plugins. It is a
+ * validating plugin that never modifies the resources. It only completes the returned stage exceptionally to
+ * simulate a plugin rejecting a resource.
+ * <p>
+ * The entry and exit failures are opted into per-resource through annotations, so a failure can be injected for a single
+ * resource being tested without affecting the others:
+ * <ul>
+ *     <li>The <em>entry</em> method fails when the custom resource has the
+ *     {@code injected.failure.gatekeeper.strimzi.io/entry: true} annotation.</li>
+ *     <li>The <em>exit</em> method fails when the custom resource has the
+ *     {@code injected.failure.gatekeeper.strimzi.io/exit: true} annotation.</li>
+ * </ul>
+ * <p>
+ * The deletion hook does not receive the resource (only its namespace and name), so it cannot read an
+ * annotation. It therefore fails unconditionally whenever the plugin is enabled.
+ * <p>
+ * This plugin also serves as an example of how validating plugins can reject resources.
+ */
+@SuppressWarnings("checkstyle:ClassFanOutComplexity") // This class intentionally references the types of all the operands, which raises its fan-out above the limit
+public class InjectedFailureGatekeeperPlugin implements
+        GatekeeperKafkaValidatingPlugin,
+        GatekeeperKafkaConnectValidatingPlugin,
+        GatekeeperKafkaMirrorMaker2ValidatingPlugin,
+        GatekeeperKafkaBridgeValidatingPlugin,
+        GatekeeperKafkaRebalanceValidatingPlugin,
+        GatekeeperKafkaTopicValidatingPlugin,
+        GatekeeperKafkaUserValidatingPlugin {
+    private static final Logger LOGGER = LogManager.getLogger(InjectedFailureGatekeeperPlugin.class);
+
+    /**
+     * Annotation which, when set to {@code true} on a custom resource, makes the plugin fail during the entry phase.
+     */
+    /* test */ static final String ENTRY_FAILURE_ANNOTATION = "injected.failure.gatekeeper.strimzi.io/entry";
+
+    /**
+     * Annotation which, when set to {@code true} on a custom resource, makes the plugin fail during the exit phase.
+     */
+    /* test */ static final String EXIT_FAILURE_ANNOTATION = "injected.failure.gatekeeper.strimzi.io/exit";
+
+    /**
+     * Creates the injected failure plugin.
+     */
+    public InjectedFailureGatekeeperPlugin() { }
+
+    // Kafka
+
+    @Override
+    public CompletionStage<Void> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+        return maybeFailEntry(kafka);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+        return maybeFailExit(kafka);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaNodePoolExit(GatekeeperKafkaExitContext context, Kafka kafka, KafkaNodePool kafkaNodePool, KafkaNodePoolStatus newKafkaNodePoolStatus) {
+        return maybeFailExit(kafkaNodePool);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaDeletion(GatekeeperKafkaDeletionContext context, String namespace, String name) {
+        return failDeletion("Kafka", namespace, name);
+    }
+
+    // KafkaConnect
+
+    @Override
+    public CompletionStage<Void> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+        return maybeFailEntry(kafkaConnect);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus newKafkaConnectStatus) {
+        return maybeFailExit(kafkaConnect);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaConnectorExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, KafkaConnector kafkaConnector, KafkaConnectorStatus newKafkaConnectorStatus) {
+        return maybeFailExit(kafkaConnector);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+        return failDeletion("KafkaConnect", namespace, name);
+    }
+
+    // KafkaMirrorMaker2
+
+    @Override
+    public CompletionStage<Void> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+        return maybeFailEntry(kafkaMirrorMaker2);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status newKafkaMirrorMaker2Status) {
+        return maybeFailExit(kafkaMirrorMaker2);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+        return failDeletion("KafkaMirrorMaker2", namespace, name);
+    }
+
+    // KafkaBridge
+
+    @Override
+    public CompletionStage<Void> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+        return maybeFailEntry(kafkaBridge);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus newKafkaBridgeStatus) {
+        return maybeFailExit(kafkaBridge);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+        return failDeletion("KafkaBridge", namespace, name);
+    }
+
+    // KafkaRebalance
+
+    @Override
+    public CompletionStage<Void> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+        return maybeFailEntry(kafkaRebalance);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus newKafkaRebalanceStatus) {
+        return maybeFailExit(kafkaRebalance);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+        return failDeletion("KafkaRebalance", namespace, name);
+    }
+
+    // KafkaTopic
+
+    @Override
+    public CompletionStage<Void> kafkaTopicEntry(GatekeeperKafkaTopicEntryContext context, KafkaTopic kafkaTopic) {
+        return maybeFailEntry(kafkaTopic);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaTopicExit(GatekeeperKafkaTopicExitContext context, KafkaTopic kafkaTopic, KafkaTopicStatus newKafkaTopicStatus) {
+        return maybeFailExit(kafkaTopic);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaTopicDeletion(GatekeeperKafkaTopicDeletionContext context, String namespace, String name) {
+        return failDeletion("KafkaTopic", namespace, name);
+    }
+
+    // KafkaUser
+
+    @Override
+    public CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+        return maybeFailEntry(kafkaUser);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+        return maybeFailExit(kafkaUser);
+    }
+
+    @Override
+    public CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+        return failDeletion("KafkaUser", namespace, name);
+    }
+
+    /**
+     * Fails the entry phase when the resource carries the annotation. Otherwise, the returned stage completes normally.
+     *
+     * @param resource  The custom resource entering the reconciliation
+     *
+     * @return  A completion stage that completes exceptionally when the failure is injected, normally otherwise
+     */
+    private CompletionStage<Void> maybeFailEntry(HasMetadata resource) {
+        return maybeFail(resource, ENTRY_FAILURE_ANNOTATION, "entry");
+    }
+
+    /**
+     * Fails the exit phase when the resource carries the annotation. Otherwise, the returned stage completes normally.
+     *
+     * @param resource  The custom resource exiting the reconciliation
+     *
+     * @return  A completion stage that completes exceptionally when the failure is injected, normally otherwise
+     */
+    private CompletionStage<Void> maybeFailExit(HasMetadata resource) {
+        return maybeFail(resource, EXIT_FAILURE_ANNOTATION, "exit");
+    }
+
+    /**
+     * Fails the given phase when the resource carries the given annotation set to true. Otherwise, the returned
+     * stage completes normally.
+     *
+     * @param resource      The custom resource being reconciled
+     * @param annotation    The annotation that enables the failure
+     * @param phase         The reconciliation phase (used in the log and exception messages)
+     *
+     * @return  A completion stage that completes exceptionally when the failure is injected, normally otherwise
+     */
+    private CompletionStage<Void> maybeFail(HasMetadata resource, String annotation, String phase) {
+        if (Annotations.booleanAnnotation(resource, annotation, false)) {
+            LOGGER.warn("[GATEKEEPER] Injecting a Gatekeeper failure for {} {}/{} during the {} phase", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName(), phase);
+            return CompletableFuture.failedFuture(new RuntimeException("Injected Gatekeeper failure for " + resource.getKind() + " " + resource.getMetadata().getNamespace() + "/" + resource.getMetadata().getName() + " during the " + phase + " phase"));
+        } else {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    /**
+     * Fails the deletion hook unconditionally. The deletion hook does not receive the resource (only its namespace and
+     * name), so it cannot read an annotation and always injects the failure.
+     *
+     * @param kind          The kind of the operand being deleted
+     * @param namespace     The namespace of the resource being deleted
+     * @param name          The name of the resource being deleted
+     *
+     * @return  A completion stage that always completes exceptionally
+     */
+    private CompletionStage<Void> failDeletion(String kind, String namespace, String name) {
+        LOGGER.warn("[GATEKEEPER] Injecting a Gatekeeper failure for {} {}/{} during the deletion phase", kind, namespace, name);
+        return CompletableFuture.failedFuture(new RuntimeException("Injected Gatekeeper failure for " + kind + " " + namespace + "/" + name + " during the deletion phase"));
+    }
+}

--- a/operator-common/src/main/resources/META-INF/services/io.strimzi.plugin.gatekeeper.GatekeeperPlugin
+++ b/operator-common/src/main/resources/META-INF/services/io.strimzi.plugin.gatekeeper.GatekeeperPlugin
@@ -1,0 +1,2 @@
+io.strimzi.operator.common.gatekeeper.plugin.DebugGatekeeperPlugin
+io.strimzi.operator.common.gatekeeper.plugin.InjectedFailureGatekeeperPlugin

--- a/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/plugin/DebugGatekeeperPluginTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/plugin/DebugGatekeeperPluginTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper.plugin;
+
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceBuilder;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.topic.KafkaTopicBuilder;
+import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+public class DebugGatekeeperPluginTest {
+    private static final String NAMESPACE = "my-namespace";
+    private static final String NAME = "my-user";
+    private static final KafkaUser USER = new KafkaUserBuilder()
+            .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(NAME)
+            .endMetadata()
+            .withNewStatus()
+                .withUsername(NAME)
+            .endStatus()
+            .build();
+
+    private final DebugGatekeeperPlugin plugin = new DebugGatekeeperPlugin();
+
+    private ListAppender appender;
+    private Logger logger;
+
+    @BeforeEach
+    public void beforeEach() {
+        // Attach an in-memory appender to the plugin's logger so the emitted messages can be asserted
+        appender = new ListAppender();
+        appender.start();
+        logger = (Logger) LogManager.getLogger(DebugGatekeeperPlugin.class);
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        logger.removeAppender(appender);
+        appender.stop();
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for the message-building helpers
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testEventMessageStartsWithPrefixAndDescribesTheEvent() {
+        String message = DebugGatekeeperPlugin.eventMessage(kafkaUser(Map.of()), "entered the reconciliation", "");
+
+        assertThat(message, allOf(
+                startsWith(DebugGatekeeperPlugin.LOG_PREFIX),
+                containsString("KafkaUser"),
+                containsString(NAMESPACE + "/" + NAME),
+                containsString("entered the reconciliation")));
+    }
+
+    @Test
+    public void testEventMessageAppendsTheYaml() {
+        String message = DebugGatekeeperPlugin.eventMessage(kafkaUser(Map.of()), "entered the reconciliation", " with resource:\nfoo");
+
+        assertThat(message, allOf(
+                containsString("entered the reconciliation with resource:"),
+                containsString("foo")));
+    }
+
+    @Test
+    public void testDeletionMessageStartsWithPrefixAndDescribesTheEvent() {
+        String message = DebugGatekeeperPlugin.deletionMessage("KafkaUser", NAMESPACE, NAME);
+
+        assertThat(message, allOf(
+                startsWith(DebugGatekeeperPlugin.LOG_PREFIX),
+                containsString(NAMESPACE + "/" + NAME),
+                containsString("is being deleted")));
+    }
+
+    @Test
+    public void testYamlMessageSerializesTheObject() {
+        String message = DebugGatekeeperPlugin.yamlMessage("resource", kafkaUser(Map.of()));
+
+        assertThat(message, allOf(
+                startsWith(" with resource:"),
+                // The object is serialized as YAML, so the kind and metadata name appear in the message
+                containsString("kind"),
+                containsString(NAME)));
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for the message-building helpers
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testAllOperandHooksCompleteWithoutModifyingTheResources() {
+        Kafka kafka = new KafkaBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        KafkaNodePool pool = new KafkaNodePoolBuilder().withNewMetadata().withNamespace(NAMESPACE).withName("pool").endMetadata().build();
+        plugin.kafkaEntry(null, kafka, List.of(pool)).toCompletableFuture().join();
+        plugin.kafkaExit(null, kafka, List.of(pool), new KafkaStatus()).toCompletableFuture().join();
+        plugin.kafkaNodePoolExit(null, kafka, pool, new KafkaNodePoolStatus()).toCompletableFuture().join();
+        plugin.kafkaDeletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+        assertThat(kafka.getMetadata().getName(), is(NAME));
+
+        KafkaConnect connect = new KafkaConnectBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        KafkaConnector connector = new KafkaConnectorBuilder().withNewMetadata().withNamespace(NAMESPACE).withName("connector").endMetadata().build();
+        plugin.kafkaConnectEntry(null, connect, List.of(connector)).toCompletableFuture().join();
+        plugin.kafkaConnectExit(null, connect, List.of(connector), new KafkaConnectStatus()).toCompletableFuture().join();
+        plugin.kafkaConnectorExit(null, connect, connector, new KafkaConnectorStatus()).toCompletableFuture().join();
+        plugin.kafkaConnectDeletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+        assertThat(connect.getMetadata().getName(), is(NAME));
+
+        KafkaMirrorMaker2 mirrorMaker2 = new KafkaMirrorMaker2Builder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        plugin.kafkaMirrorMaker2Entry(null, mirrorMaker2).toCompletableFuture().join();
+        plugin.kafkaMirrorMaker2Exit(null, mirrorMaker2, new KafkaMirrorMaker2Status()).toCompletableFuture().join();
+        plugin.kafkaMirrorMaker2Deletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+
+        KafkaBridge bridge = new KafkaBridgeBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        plugin.kafkaBridgeEntry(null, bridge).toCompletableFuture().join();
+        plugin.kafkaBridgeExit(null, bridge, new KafkaBridgeStatus()).toCompletableFuture().join();
+        plugin.kafkaBridgeDeletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+
+        KafkaRebalance rebalance = new KafkaRebalanceBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        plugin.kafkaRebalanceEntry(null, rebalance).toCompletableFuture().join();
+        plugin.kafkaRebalanceExit(null, rebalance, new KafkaRebalanceStatus()).toCompletableFuture().join();
+        plugin.kafkaRebalanceDeletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+
+        KafkaTopic topic = new KafkaTopicBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        plugin.kafkaTopicEntry(null, topic).toCompletableFuture().join();
+        plugin.kafkaTopicExit(null, topic, new KafkaTopicStatus()).toCompletableFuture().join();
+        plugin.kafkaTopicDeletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for the actual logging behaviour of the hooks
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testEntryAlwaysLogsTheEventMessage() {
+        plugin.kafkaUserEntry(null, kafkaUser(Map.of())).toCompletableFuture().join();
+
+        // The short event message is always logged ...
+        assertThat(loggedEventMessages(), is(List.of(DebugGatekeeperPlugin.LOG_PREFIX + "KafkaUser " + NAMESPACE + "/" + NAME + " entered the reconciliation")));
+        // ... but the resource YAML is not logged without the annotation
+        assertThat(loggedYaml("resource"), is(Collections.emptyList()));
+    }
+
+    @Test
+    public void testEntryLogsTheResourceYamlWhenAnnotated() {
+        plugin.kafkaUserEntry(null, kafkaUser(Map.of(DebugGatekeeperPlugin.ENTRY_DEBUG_ANNOTATION, "true"))).toCompletableFuture().join();
+
+        List<String> yaml = loggedYaml("resource");
+        assertThat(yaml.size(), is(1));
+        // The event message and the dumped resource YAML are logged as a single message
+        assertThat(yaml.get(0), allOf(containsString("entered the reconciliation"), containsString("kind"), containsString(NAME)));
+    }
+
+    @Test
+    public void testEntryDoesNotLogTheResourceYamlWhenTheExitAnnotationIsUsed() {
+        // Only the entry annotation enables the entry YAML dump
+        plugin.kafkaUserEntry(null, kafkaUser(Map.of(DebugGatekeeperPlugin.EXIT_DEBUG_ANNOTATION, "true"))).toCompletableFuture().join();
+
+        assertThat(loggedYaml("resource"), is(Collections.emptyList()));
+    }
+
+    @Test
+    public void testExitAlwaysLogsTheEventMessage() {
+        plugin.kafkaUserExit(null, kafkaUser(Map.of()), USER.getStatus()).toCompletableFuture().join();
+
+        assertThat(loggedEventMessages(), is(List.of(DebugGatekeeperPlugin.LOG_PREFIX + "KafkaUser " + NAMESPACE + "/" + NAME + " exited the reconciliation")));
+        assertThat(loggedYaml("status"), is(Collections.emptyList()));
+    }
+
+    @Test
+    public void testExitLogsTheStatusYamlWhenAnnotated() {
+        plugin.kafkaUserExit(null, kafkaUser(Map.of(DebugGatekeeperPlugin.EXIT_DEBUG_ANNOTATION, "true")), USER.getStatus()).toCompletableFuture().join();
+
+        List<String> yaml = loggedYaml("status");
+        assertThat(yaml.size(), is(1));
+        // The event message and the dumped status YAML are logged as a single message
+        assertThat(yaml.get(0), allOf(containsString("exited the reconciliation"), containsString("username")));
+    }
+
+    @Test
+    public void testDeletionLogsTheEventMessage() {
+        plugin.kafkaUserDeletion(null, NAMESPACE, NAME).toCompletableFuture().join();
+
+        assertThat(loggedEventMessages(), is(List.of(DebugGatekeeperPlugin.LOG_PREFIX + " KafkaUser " + NAMESPACE + "/" + NAME + " is being deleted")));
+    }
+
+    //////////////////////////////////////////////////
+    // Helper methods
+    //////////////////////////////////////////////////
+
+    private List<String> loggedEventMessages() {
+        return appender.messages.stream().filter(message -> !message.contains(System.lineSeparator())).toList();
+    }
+
+    private List<String> loggedYaml(String what) {
+        return appender.messages.stream().filter(message -> message.contains(" " + what + ":" + System.lineSeparator())).toList();
+    }
+
+    private static KafkaUser kafkaUser(Map<String, String> annotations) {
+        return new KafkaUserBuilder(USER)
+                .editMetadata()
+                    .withAnnotations(annotations)
+                .endMetadata()
+                .build();
+    }
+
+
+    /**
+     * Minimal in-memory Log4j2 appender collecting the formatted messages of the events it receives.
+     */
+    private static final class ListAppender extends AbstractAppender {
+        private final List<String> messages = Collections.synchronizedList(new ArrayList<>());
+
+        private ListAppender() {
+            super("DebugGatekeeperPluginTestAppender", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/plugin/InjectedFailureGatekeeperPluginTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/gatekeeper/plugin/InjectedFailureGatekeeperPluginTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper.plugin;
+
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceBuilder;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.topic.KafkaTopicBuilder;
+import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class InjectedFailureGatekeeperPluginTest {
+    private static final String NAMESPACE = "my-namespace";
+    private static final String NAME = "my-user";
+    private static final KafkaUser USER = new KafkaUserBuilder()
+            .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(NAME)
+            .endMetadata()
+            .build();
+
+    private final InjectedFailureGatekeeperPlugin plugin = new InjectedFailureGatekeeperPlugin();
+
+    @Test
+    public void testEntryFailsWhenAnnotated() {
+        CompletableFuture<Void> result = plugin
+                .kafkaUserEntry(null, kafkaUser(Map.of(InjectedFailureGatekeeperPlugin.ENTRY_FAILURE_ANNOTATION, "true")))
+                .toCompletableFuture();
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertThat(thrown.getCause(), instanceOf(RuntimeException.class));
+        assertThat(thrown.getCause().getMessage(), allOf(containsString("Injected Gatekeeper failure"), containsString("entry")));
+    }
+
+    @Test
+    public void testEntryCompletesWhenNotAnnotated() {
+        Void result = assertDoesNotThrow(() -> plugin.kafkaUserEntry(null, kafkaUser(Map.of())).toCompletableFuture().join());
+
+        assertThat(result, is((Void) null));
+    }
+
+    @Test
+    public void testEntryDoesNotFailWhenOnlyTheExitAnnotationIsSet() {
+        // Only the entry annotation enables the entry failure
+        assertDoesNotThrow(() -> plugin.kafkaUserEntry(null, kafkaUser(Map.of(InjectedFailureGatekeeperPlugin.EXIT_FAILURE_ANNOTATION, "true"))).toCompletableFuture().join());
+    }
+
+    @Test
+    public void testExitFailsWhenAnnotated() {
+        CompletableFuture<Void> result = plugin
+                .kafkaUserExit(null, kafkaUser(Map.of(InjectedFailureGatekeeperPlugin.EXIT_FAILURE_ANNOTATION, "true")), null)
+                .toCompletableFuture();
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertThat(thrown.getCause().getMessage(), allOf(containsString("Injected Gatekeeper failure"), containsString("exit")));
+    }
+
+    @Test
+    public void testExitCompletesWhenNotAnnotated() {
+        assertDoesNotThrow(() -> plugin.kafkaUserExit(null, kafkaUser(Map.of()), null).toCompletableFuture().join());
+    }
+
+    @Test
+    public void testExitDoesNotFailWhenOnlyTheEntryAnnotationIsSet() {
+        // Only the exit annotation enables the exit failure
+        assertDoesNotThrow(() -> plugin.kafkaUserExit(null, kafkaUser(Map.of(InjectedFailureGatekeeperPlugin.ENTRY_FAILURE_ANNOTATION, "true")), null).toCompletableFuture().join());
+    }
+
+    @Test
+    public void testDeletionAlwaysFails() {
+        CompletableFuture<Void> result = plugin
+                .kafkaUserDeletion(null, NAMESPACE, NAME)
+                .toCompletableFuture();
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertThat(thrown.getCause().getMessage(), allOf(containsString("Injected Gatekeeper failure"), containsString("deletion")));
+    }
+
+    @Test
+    public void testAllOperandEntryAndExitHooksPassThroughWithoutAnnotations() {
+        // Without the failure annotations, every operand's entry and exit hooks must complete normally
+        Kafka kafka = new KafkaBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        KafkaNodePool pool = new KafkaNodePoolBuilder().withNewMetadata().withNamespace(NAMESPACE).withName("pool").endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaEntry(null, kafka, List.of(pool)).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaExit(null, kafka, List.of(pool), new KafkaStatus()).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaNodePoolExit(null, kafka, pool, new KafkaNodePoolStatus()).toCompletableFuture().join());
+
+        KafkaConnect connect = new KafkaConnectBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        KafkaConnector connector = new KafkaConnectorBuilder().withNewMetadata().withNamespace(NAMESPACE).withName("connector").endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaConnectEntry(null, connect, List.of(connector)).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaConnectExit(null, connect, List.of(connector), new KafkaConnectStatus()).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaConnectorExit(null, connect, connector, new KafkaConnectorStatus()).toCompletableFuture().join());
+
+        KafkaMirrorMaker2 mirrorMaker2 = new KafkaMirrorMaker2Builder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaMirrorMaker2Entry(null, mirrorMaker2).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaMirrorMaker2Exit(null, mirrorMaker2, new KafkaMirrorMaker2Status()).toCompletableFuture().join());
+
+        KafkaBridge bridge = new KafkaBridgeBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaBridgeEntry(null, bridge).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaBridgeExit(null, bridge, new KafkaBridgeStatus()).toCompletableFuture().join());
+
+        KafkaRebalance rebalance = new KafkaRebalanceBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaRebalanceEntry(null, rebalance).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaRebalanceExit(null, rebalance, new KafkaRebalanceStatus()).toCompletableFuture().join());
+
+        KafkaTopic topic = new KafkaTopicBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaTopicEntry(null, topic).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaTopicExit(null, topic, new KafkaTopicStatus()).toCompletableFuture().join());
+
+        KafkaUser user = new KafkaUserBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(NAME).endMetadata().build();
+        assertDoesNotThrow(() -> plugin.kafkaUserEntry(null, user).toCompletableFuture().join());
+        assertDoesNotThrow(() -> plugin.kafkaUserExit(null, user, new KafkaUserStatus()).toCompletableFuture().join());
+    }
+
+    @Test
+    public void testAllOperandDeletionHooksAlwaysFail() {
+        assertThrows(CompletionException.class, () -> plugin.kafkaDeletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+        assertThrows(CompletionException.class, () -> plugin.kafkaConnectDeletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+        assertThrows(CompletionException.class, () -> plugin.kafkaMirrorMaker2Deletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+        assertThrows(CompletionException.class, () -> plugin.kafkaBridgeDeletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+        assertThrows(CompletionException.class, () -> plugin.kafkaRebalanceDeletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+        assertThrows(CompletionException.class, () -> plugin.kafkaTopicDeletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+        assertThrows(CompletionException.class, () -> plugin.kafkaUserDeletion(null, NAMESPACE, NAME).toCompletableFuture().join());
+    }
+
+    //////////////////////////////////////////////////
+    // Helper methods
+    //////////////////////////////////////////////////
+
+    private static KafkaUser kafkaUser(Map<String, String> annotations) {
+        return new KafkaUserBuilder(USER)
+                .editMetadata()
+                    .withAnnotations(annotations)
+                .endMetadata()
+                .build();
+    }
+}


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR adds two basic Gatekeeper plugins that are used for testing and serve as examples:
* A debug plugin, that logs the reconciliation start/end and based on an annotation value logs the full YAML of the custom resource or its status
* A failure injection plugin that emulated Gatekeeper plugin failing a validation

This should resolve #12821.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
