### PR TITLE
Integrate Gatekeeper plugins into User Operator

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/config/ConfigParameterParser.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/config/ConfigParameterParser.java
@@ -69,6 +69,17 @@ public interface ConfigParameterParser<T> {
     };
 
     /**
+     * A comma-delimited list of strings. Surrounding whitespace around the separators is trimmed.
+     */
+    ConfigParameterParser<List<String>> COMMA_SEPARATED_LIST = configValue -> {
+        List<String> commaSeparatedList = null;
+        if (configValue != null && !configValue.trim().isEmpty()) {
+            commaSeparatedList = asList(configValue.trim().split("\\s*,+\\s*"));
+        }
+        return commaSeparatedList;
+    };
+
+    /**
      * Returns Properties based on its String format
      */
     ConfigParameterParser<Properties> PROPERTIES = configValue -> {

--- a/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/GatekeeperPluginFactory.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/GatekeeperPluginFactory.java
@@ -118,6 +118,7 @@ public class GatekeeperPluginFactory {
                     LOGGER.error("Gatekeeper plugin {} was not found", pluginClass);
                     throw new InvalidConfigurationException("Gatekeeper plugin " + pluginClass + " was not found.");
                 } else {
+                    LOGGER.info("Using Gatekeeper plugin {}", plugin.getClass().getCanonicalName());
                     ordered.add(plugin);
                 }
             }

--- a/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/impl/GatekeeperPluginConfigurationContextImpl.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/gatekeeper/impl/GatekeeperPluginConfigurationContextImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.gatekeeper.impl;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+
+/**
+ * Default implementation of the {@link GatekeeperPluginConfigurationContext} passed to the plugins when they are
+ * configured at operator startup.
+ */
+public class GatekeeperPluginConfigurationContextImpl implements GatekeeperPluginConfigurationContext {
+    private final KubernetesClient kubernetesClient;
+
+    /**
+     * Creates the configuration context.
+     *
+     * @param kubernetesClient  Kubernetes client which the plugins can use to interact with the Kubernetes API
+     */
+    public GatekeeperPluginConfigurationContextImpl(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
+
+    @Override
+    public KubernetesClient kubernetesClient() {
+        return kubernetesClient;
+    }
+
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/config/ConfigParameterParserTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/config/ConfigParameterParserTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.common.config;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -16,6 +17,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConfigParameterParserTest {
+    @Test
+    public void testCommaSeparatedList() {
+        assertThat(ConfigParameterParser.COMMA_SEPARATED_LIST.parse(null), is(nullValue()));
+        assertThat(ConfigParameterParser.COMMA_SEPARATED_LIST.parse(""), is(nullValue()));
+        assertThat(ConfigParameterParser.COMMA_SEPARATED_LIST.parse("   "), is(nullValue()));
+        assertThat(ConfigParameterParser.COMMA_SEPARATED_LIST.parse("a"), is(List.of("a")));
+        assertThat(ConfigParameterParser.COMMA_SEPARATED_LIST.parse("a,b,c"), is(List.of("a", "b", "c")));
+        // Surrounding whitespace and repeated separators are collapsed and the order is preserved
+        assertThat(ConfigParameterParser.COMMA_SEPARATED_LIST.parse("  a , b ,c  "), is(List.of("a", "b", "c")));
+    }
+
     @Test
     public void testPatternConfig() {
         assertThat(ConfigParameterParser.PATTERN.parse(null), is(nullValue()));

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -25,6 +25,8 @@ import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.auth.PemAuthIdentity;
 import io.strimzi.operator.common.auth.PemTrustSet;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.operator.common.gatekeeper.impl.GatekeeperPluginConfigurationContextImpl;
 import io.strimzi.operator.common.http.HealthCheckAndMetricsServer;
 import io.strimzi.operator.common.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.common.operator.resource.kubernetes.SecretOperator;
@@ -80,6 +82,10 @@ public class Main {
         // Create KubernetesClient, AdminClient and KafkaUserOperator classes
         ExecutorService kafkaUserOperatorExecutor = Executors.newFixedThreadPool(config.getUserOperationsThreadPoolSize(), new OperatorWorkThreadFactory());
         KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-user-operator", Main.class.getPackage().getImplementationVersion()).build();
+
+        // Load and configure the Gatekeeper plugins
+        GatekeeperPluginFactory.initialize(config.getGatekeeperPlugins(), new GatekeeperPluginConfigurationContextImpl(client));
+
         SecretOperator secretOperator = new SecretOperator(kafkaUserOperatorExecutor, client);
         Admin adminClient = createAdminClient(config, secretOperator, new DefaultAdminClientProvider());
         var kafkaUserCrdOperator = new CrdOperator<>(kafkaUserOperatorExecutor, client, KafkaUser.class, KafkaUserList.class, "KafkaUser");

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -8,6 +8,7 @@ import io.strimzi.operator.common.config.ConfigParameter;
 import io.strimzi.operator.common.featuregates.FeatureGates;
 import io.strimzi.operator.common.model.Labels;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static io.strimzi.operator.common.config.ConfigParameterParser.BOOLEAN;
+import static io.strimzi.operator.common.config.ConfigParameterParser.COMMA_SEPARATED_LIST;
 import static io.strimzi.operator.common.config.ConfigParameterParser.INTEGER;
 import static io.strimzi.operator.common.config.ConfigParameterParser.LABEL_PREDICATE;
 import static io.strimzi.operator.common.config.ConfigParameterParser.LONG;
@@ -32,6 +34,14 @@ import static io.strimzi.operator.common.config.ConfigParameterParser.strictlyPo
  * Cluster Operator configuration
  */
 public class UserOperatorConfig {
+    /**
+     * List of mandatory Gatekeeper plugins that are not user-configurable but are hardcoded by Strimzi
+     */
+    private static final List<String> MANDATORY_GATEKEEPER_PLUGINS = List.of();
+    /**
+     * List of default Gatekeeper plugins that are used by default, but users can change / reconfigure them.
+     */
+    private static final List<String> DEFAULT_GATEKEEPER_PLUGINS = List.of();
 
     private static final Map<String, ConfigParameter<?>> CONFIG_VALUES = new HashMap<>();
 
@@ -151,6 +161,14 @@ public class UserOperatorConfig {
      * Set true to generate PKCS12 stores in CA and User secrets
      */
     public static final ConfigParameter<Boolean> PKCS12_KEYSTORE_GENERATION = new ConfigParameter<>("STRIMZI_PKCS12_KEYSTORE_GENERATION", BOOLEAN, "true", CONFIG_VALUES);
+    /**
+     * Comma-separated list of custom Gatekeeper plugins that should be enabled
+     */
+    public static final ConfigParameter<List<String>> GATEKEEPER_CUSTOM_PLUGINS = new ConfigParameter<>("STRIMZI_GATEKEEPER_CUSTOM_PLUGINS", COMMA_SEPARATED_LIST, "", CONFIG_VALUES);
+    /**
+     * Comma-separated list of default Gatekeeper plugins. If not set, the default list of default plugins is used.
+     */
+    public static final ConfigParameter<List<String>> GATEKEEPER_DEFAULT_PLUGINS = new ConfigParameter<>("STRIMZI_GATEKEEPER_DEFAULT_PLUGINS", COMMA_SEPARATED_LIST, "", CONFIG_VALUES);
 
     private final Map<String, Object> map;
 
@@ -502,6 +520,52 @@ public class UserOperatorConfig {
         return get(PKCS12_KEYSTORE_GENERATION);
     }
 
+    /**
+     * Gets the list of custom Gatekeeper plugins.
+     *
+     * @return List of custom Gatekeeper plugins
+     */
+    public List<String> getGatekeeperCustomPlugins() {
+        return get(GATEKEEPER_CUSTOM_PLUGINS);
+    }
+
+    /**
+     * Gets the list of default Gatekeeper plugins.
+     *
+     * @return List of default Gatekeeper plugins
+     */
+    public List<String> getGatekeeperDefaultPlugins() {
+        return get(GATEKEEPER_DEFAULT_PLUGINS);
+    }
+
+    /**
+     * Gets the full list of the Gatekeeper plugins that should be used. This is constructed from the partial lists:
+     *   - Custom
+     *   - Default
+     *   - Mandatory
+     *
+     * @return  List of all Gatekeeper plugins that should be used
+     */
+    public List<String> getGatekeeperPlugins() {
+        List<String> plugins = new ArrayList<>();
+
+        List<String> customPlugins = get(GATEKEEPER_CUSTOM_PLUGINS);
+        if (customPlugins != null) {
+            plugins.addAll(customPlugins);
+        }
+
+        List<String> defaultPlugins = get(GATEKEEPER_DEFAULT_PLUGINS);
+        if (defaultPlugins != null) {
+            plugins.addAll(defaultPlugins);
+        } else {
+            plugins.addAll(DEFAULT_GATEKEEPER_PLUGINS);
+        }
+
+        plugins.addAll(MANDATORY_GATEKEEPER_PLUGINS);
+
+        return plugins;
+    }
+
     @Override
     public String toString() {
         return "UserOperatorBuilderConfig{" +
@@ -534,6 +598,9 @@ public class UserOperatorConfig {
                 "\n\tfeatureGates='" + featureGates() + "'" +
                 "\n\tignoredUsersPattern='" + (ignoredUsersPattern() != null ? ignoredUsersPattern().pattern() : null) + "'" +
                 "\n\tisPkcs12KeystoreGeneration='" + isPkcs12KeystoreGeneration() + "'" +
+                "\n\tgatekeeperCustomPlugins='" + getGatekeeperCustomPlugins() + "'" +
+                "\n\tgatekeeperDefaultPlugins='" + getGatekeeperDefaultPlugins() + "'" +
+                "\n\tgatekeeperPlugins='" + getGatekeeperPlugins() + "'" +
                 '}';
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/impl/GatekeeperKafkaUserDeletionContextImpl.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/impl/GatekeeperKafkaUserDeletionContextImpl.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.gatekeeper.impl;
+
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserDeletionContext;
+
+/**
+ * Default implementation of the {@link GatekeeperKafkaUserDeletionContext} passed to the KafkaUser plugins when a KafkaUser
+ * is being deleted. It currently carries no data and exists so that the operator has a concrete context instance to pass
+ * to the plugins. Fields can be added later without breaking the plugins.
+ */
+public class GatekeeperKafkaUserDeletionContextImpl implements GatekeeperKafkaUserDeletionContext {
+    /**
+     * Creates the KafkaUser deletion context.
+     */
+    public GatekeeperKafkaUserDeletionContextImpl() { }
+}

--- a/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/impl/GatekeeperKafkaUserEntryContextImpl.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/impl/GatekeeperKafkaUserEntryContextImpl.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.gatekeeper.impl;
+
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserEntryContext;
+
+/**
+ * Default implementation of the {@link GatekeeperKafkaUserEntryContext} passed to the KafkaUser plugins at the start of
+ * a KafkaUser reconciliation. It currently carries no data and exists so that the operator has a concrete context
+ * instance to pass to the plugins. Fields can be added later without breaking the plugins.
+ */
+public class GatekeeperKafkaUserEntryContextImpl implements GatekeeperKafkaUserEntryContext {
+    /**
+     * Creates the KafkaUser entry context.
+     */
+    public GatekeeperKafkaUserEntryContextImpl() { }
+}

--- a/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/impl/GatekeeperKafkaUserExitContextImpl.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/gatekeeper/impl/GatekeeperKafkaUserExitContextImpl.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.gatekeeper.impl;
+
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserExitContext;
+
+/**
+ * Default implementation of the {@link GatekeeperKafkaUserExitContext} passed to the KafkaUser plugins after a KafkaUser
+ * reconciliation completes. It currently carries no data and exists so that the operator has a concrete context instance
+ * to pass to the plugins. Fields can be added later without breaking the plugins.
+ */
+public class GatekeeperKafkaUserExitContextImpl implements GatekeeperKafkaUserExitContext {
+    /**
+     * Creates the KafkaUser exit context.
+     */
+    public GatekeeperKafkaUserExitContextImpl() { }
+}

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -26,6 +26,10 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.common.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.user.UserOperatorConfig;
+import io.strimzi.operator.user.gatekeeper.UserOperatorGatekeeperPluginInvoker;
+import io.strimzi.operator.user.gatekeeper.impl.GatekeeperKafkaUserDeletionContextImpl;
+import io.strimzi.operator.user.gatekeeper.impl.GatekeeperKafkaUserEntryContextImpl;
+import io.strimzi.operator.user.gatekeeper.impl.GatekeeperKafkaUserExitContextImpl;
 import io.strimzi.operator.user.model.KafkaUserModel;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
 
@@ -186,9 +190,11 @@ public class KafkaUserOperator {
     public CompletionStage<KafkaUserStatus> reconcile(Reconciliation reconciliation, KafkaUser kafkaUser, Secret userSecret)  {
         if (kafkaUser != null)  {
             // Create or update
-            return createOrUpdate(reconciliation, kafkaUser, userSecret);
+            return UserOperatorGatekeeperPluginInvoker.kafkaUserEntry(new GatekeeperKafkaUserEntryContextImpl(), kafkaUser) // Gatekeeper invocation
+                    .thenCompose(user -> createOrUpdate(reconciliation, user, userSecret)
+                            .thenCompose(status -> UserOperatorGatekeeperPluginInvoker.kafkaUserExit(new GatekeeperKafkaUserExitContextImpl(), user, status))); // Gatekeeper invocation
         } else {
-            // Delete the user from everywhere with both the TLS and SCRAM-SHa name variants
+            // Delete the user from everywhere with both the TLS and SCRAM-SHA name variants
             return delete(reconciliation).thenApply(i -> null);
         }
     }
@@ -214,7 +220,8 @@ public class KafkaUserOperator {
                 config.isAclsAdminApiSupported() ? aclOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture() : CompletableFuture.completedFuture(ReconcileResult.noop(null)),
                 scramCredentialsOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture(),
                 quotasOperator.reconcile(reconciliation, KafkaUserModel.getTlsUserName(user), null).toCompletableFuture(),
-                quotasOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture()
+                quotasOperator.reconcile(reconciliation, KafkaUserModel.getScramUserName(user), null).toCompletableFuture(),
+                UserOperatorGatekeeperPluginInvoker.kafkaUserDeletion(new GatekeeperKafkaUserDeletionContextImpl(), reconciliation.namespace(), reconciliation.name()).toCompletableFuture() // Gatekeeper invocation
         );
     }
 
@@ -230,6 +237,7 @@ public class KafkaUserOperator {
      * @return a CompletionStage
      */
     private CompletionStage<KafkaUserStatus> createOrUpdate(Reconciliation reconciliation, KafkaUser kafkaUser, Secret userSecret) {
+        // Reconciliation is not paused => we do the actual work
         KafkaUserModel user;
         KafkaUserStatus userStatus = new KafkaUserStatus();
 
@@ -248,7 +256,7 @@ public class KafkaUserOperator {
                 // Reconcile the user: update everything in Kafka and in the Secret
                 .thenCompose(i -> reconcileCredentialsQuotasAndAcls(reconciliation, user, userSecret, userStatus))
                 .handle((i, e) -> {
-                    if (e != null)  {
+                    if (e != null) {
                         throw new CompletionException(e);
                     } else {
                         StatusUtils.setStatusConditionAndObservedGeneration(kafkaUser, userStatus, (Throwable) null);

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -20,8 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UserOperatorConfigTest {
     private static final Map<String, String> ENV_VARS = new HashMap<>(8);
-    private static final Labels EXPECTED_LABELS;
-
     static {
         ENV_VARS.put(UserOperatorConfig.NAMESPACE.key(), "namespace");
         ENV_VARS.put(UserOperatorConfig.RECONCILIATION_INTERVAL_MS.key(), "30000");
@@ -34,14 +32,21 @@ public class UserOperatorConfigTest {
         ENV_VARS.put(UserOperatorConfig.ACLS_ADMIN_API_SUPPORTED.key(), "false");
         ENV_VARS.put(UserOperatorConfig.SCRAM_SHA_PASSWORD_LENGTH.key(), "20");
         ENV_VARS.put(UserOperatorConfig.PKCS12_KEYSTORE_GENERATION.key(), "false");
+    }
 
-
+    private static final Labels EXPECTED_LABELS;
+    static {
         Map<String, String> labels = new HashMap<>(2);
         labels.put("label1", "value1");
         labels.put("label2", "value2");
 
         EXPECTED_LABELS = Labels.fromMap(labels);
     }
+
+    private static final String CUSTOM_PLUGIN_1 = "io.strimzi.Custom1";
+    private static final String CUSTOM_PLUGIN_2 = "io.strimzi.Custom2";
+    private static final String DEFAULT_PLUGIN_1 = "io.strimzi.Default1";
+    private static final String DEFAULT_PLUGIN_2 = "io.strimzi.Default2";
 
     @Test
     public void testDefaults() {
@@ -272,11 +277,38 @@ public class UserOperatorConfigTest {
     @Test
     public void testFeatureGatesParsing()    {
         // We test that the configuration is really parsing the feature gates environment variable. We test it on
-        // non-existing feature gate instead of a real one so that we do not have to change it when the FGs are promoted
+        // a non-existing feature gate instead of a real one so that we do not have to change it when the FGs are promoted
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.ENV_VARS);
         envVars.put(UserOperatorConfig.FEATURE_GATES.key(), "-NonExistingGate");
 
         InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> UserOperatorConfig.buildFromMap(envVars));
         assertThat(e.getMessage(), is("Unknown feature gate NonExistingGate found in the configuration"));
+    }
+
+    // TODO: Once we have some mandatory and default default plugins (i.e. default plugins configured by default),
+    //       we should add dedicated tests for their handling as well. But as they are currently empty, it cannot be
+    //       checked right now
+
+    @Test
+    public void testGatekeeperPluginsDefaultToEmpty() {
+        UserOperatorConfig config = UserOperatorConfig.buildFromMap(ENV_VARS);
+
+        assertThat(config.getGatekeeperCustomPlugins(), is(nullValue()));
+        assertThat(config.getGatekeeperDefaultPlugins(), is(nullValue()));
+        assertThat(config.getGatekeeperPlugins(), is(List.of()));
+    }
+
+    @Test
+    public void testGatekeeperPluginsOrdering() {
+        // The custom plugins are invoked first, then the default plugins. The User Operator has no mandatory plugins.
+        Map<String, String> envVars = new HashMap<>(ENV_VARS);
+        envVars.put(UserOperatorConfig.GATEKEEPER_DEFAULT_PLUGINS.key(), DEFAULT_PLUGIN_2 + ", " + DEFAULT_PLUGIN_1);
+        envVars.put(UserOperatorConfig.GATEKEEPER_CUSTOM_PLUGINS.key(), CUSTOM_PLUGIN_1 + "," + CUSTOM_PLUGIN_2);
+
+        UserOperatorConfig config = UserOperatorConfig.buildFromMap(envVars);
+
+        assertThat(config.getGatekeeperCustomPlugins(), is(List.of(CUSTOM_PLUGIN_1, CUSTOM_PLUGIN_2)));
+        assertThat(config.getGatekeeperDefaultPlugins(), is(List.of(DEFAULT_PLUGIN_2, DEFAULT_PLUGIN_1)));
+        assertThat(config.getGatekeeperPlugins(), is(List.of(CUSTOM_PLUGIN_1, CUSTOM_PLUGIN_2, DEFAULT_PLUGIN_2, DEFAULT_PLUGIN_1)));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorGatekeeperTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorGatekeeperTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.operator;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import io.strimzi.api.kafka.model.user.KafkaUserList;
+import io.strimzi.api.kafka.model.user.KafkaUserQuotas;
+import io.strimzi.api.kafka.model.user.KafkaUserStatus;
+import io.strimzi.certs.CertIssuer;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.operator.common.operator.MockCertIssuer;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.kubernetes.CrdOperator;
+import io.strimzi.operator.common.operator.resource.kubernetes.SecretOperator;
+import io.strimzi.operator.user.ResourceUtils;
+import io.strimzi.operator.user.model.acl.SimpleAclRule;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaUserValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperPluginConfigurationContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests focusing on the Gatekeeper integration in {@link KafkaUserOperator}. All the Kafka Admin API operators and the
+ * Kubernetes operators are mocked to return already-completed stages, so the whole {@code reconcile(...)} chain runs
+ * synchronously on the test thread. This is important because {@link GatekeeperPluginFactory#initializeForTests(List)}
+ * stores the plugins in a thread-local field, which is only visible to the code running on the same thread. Keeping the
+ * whole reconciliation on the test thread makes the injected test plugins visible during the entry, create/update and
+ * exit phases.
+ */
+public class KafkaUserOperatorGatekeeperTest {
+    private final CertIssuer mockCertIssuer = new MockCertIssuer();
+
+    // The order in which the plugin hooks are invoked
+    private final List<String> order = new ArrayList<>();
+
+    private SecretOperator secretOps;
+    @SuppressWarnings("unchecked")
+    private final CrdOperator<KubernetesClient, KafkaUser, KafkaUserList> kafkaUserOps = mock(CrdOperator.class);
+
+    private ScramCredentialsOperator scramOps;
+    private QuotasOperator quotasOps;
+    private ArgumentCaptor<KafkaUserQuotas> quotasCaptor;
+    private SimpleAclOperator aclOps;
+
+    @BeforeEach
+    public void beforeEach() {
+        mockKafkaOperators();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        GatekeeperPluginFactory.clearTestPlugins();
+    }
+
+    private void mockKafkaOperators() {
+        secretOps = mock(SecretOperator.class);
+        when(secretOps.reconcile(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> CompletableFuture.completedStage(ReconcileResult.patched((Secret) invocation.getArgument(4))));
+        when(secretOps.deleteAsync(any(), any(), any(), anyBoolean()))
+                .thenReturn(CompletableFuture.completedStage(null));
+
+        scramOps = mock(ScramCredentialsOperator.class);
+        when(scramOps.reconcile(any(), any(), any())).thenAnswer(invocation -> {
+            String desired = invocation.getArgument(2);
+            return CompletableFuture.completedStage(desired == null ? ReconcileResult.deleted() : ReconcileResult.patched(desired));
+        });
+
+        quotasOps = mock(QuotasOperator.class);
+        quotasCaptor = ArgumentCaptor.forClass(KafkaUserQuotas.class);
+        when(quotasOps.reconcile(any(), any(), quotasCaptor.capture())).thenAnswer(invocation -> {
+            KafkaUserQuotas desired = invocation.getArgument(2);
+            return CompletableFuture.completedStage(desired == null ? ReconcileResult.deleted() : ReconcileResult.patched(desired));
+        });
+
+        aclOps = mock(SimpleAclOperator.class);
+        when(aclOps.reconcile(any(), any(), any())).thenAnswer(invocation -> {
+            Set<SimpleAclRule> desired = invocation.getArgument(2);
+            return CompletableFuture.completedStage(desired == null ? ReconcileResult.deleted() : ReconcileResult.created(desired));
+        });
+    }
+
+    private KafkaUserOperator operator() {
+        return new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(ResourceUtils.NAMESPACE), mockCertIssuer, secretOps, kafkaUserOps, scramOps, quotasOps, aclOps);
+    }
+
+    private static Reconciliation reconciliation() {
+        return new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME);
+    }
+
+    // A plain SCRAM-SHA-512 user without any quotas or authorization. It keeps the reconciliation simple (no certificate
+    // generation, no extra secrets to fetch) so the tests can focus on the Gatekeeper hooks.
+    private static KafkaUser scramUser() {
+        return new KafkaUserBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafkaUserScramSha512ClientAuthentication()
+                    .endKafkaUserScramSha512ClientAuthentication()
+                .endSpec()
+                .build();
+    }
+
+    @Test
+    public void testEntryAndExitHooksInvokedOnCreateOrUpdate() {
+        RecordingUserPlugin plugin = new RecordingUserPlugin();
+        GatekeeperPluginFactory.initializeForTests(List.of(plugin));
+
+        KafkaUserStatus status = operator()
+                .reconcile(reconciliation(), scramUser(), null)
+                .toCompletableFuture().join();
+
+        assertThat(status, is(notNullValue()));
+        assertThat(plugin.entryInvoked, is(true));
+        assertThat(plugin.exitInvoked, is(true));
+        assertThat(plugin.deletionInvoked, is(false));
+        // The entry hook runs before the reconciliation, the exit hook after it
+        assertThat(order, contains("entry", "exit"));
+    }
+
+    @Test
+    public void testEntryMutationFlowsIntoReconciliation() {
+        // The entry plugin adds a consumer byte rate quota to a user which originally has none. If the mutated resource
+        // is really the one being reconciled, the quota operator must receive the added quota.
+        GatekeeperPluginFactory.initializeForTests(List.of(new QuotaAddingEntryPlugin(4242)));
+
+        operator()
+                .reconcile(reconciliation(), scramUser(), null)
+                .toCompletableFuture().join();
+
+        // One of the quotas passed to the quota operator must carry the byte rate added by the entry plugin
+        boolean quotaFromPluginReconciled = quotasCaptor.getAllValues().stream()
+                .anyMatch(quotas -> quotas != null && Integer.valueOf(4242).equals(quotas.getConsumerByteRate()));
+        assertThat(quotaFromPluginReconciled, is(true));
+    }
+
+    @Test
+    public void testExitMutationReachesReturnedStatus() {
+        // The exit plugin mutates the status. The mutated status must be the one returned by the reconciliation.
+        GatekeeperPluginFactory.initializeForTests(List.of(new ObservedGenerationExitPlugin(1874L)));
+
+        KafkaUserStatus status = operator()
+                .reconcile(reconciliation(), scramUser(), null)
+                .toCompletableFuture().join();
+
+        assertThat(status.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testEntryRejectionFailsReconciliationAndSkipsWork() {
+        // The recording plugin is first, so its entry hook records the invocation. The rejecting validating plugin is
+        // second and fails, which stops the chain before the reconciliation runs.
+        RecordingUserPlugin recording = new RecordingUserPlugin();
+        GatekeeperPluginFactory.initializeForTests(List.of(recording, new RejectingEntryPlugin()));
+
+        CompletableFuture<KafkaUserStatus> result = operator()
+                .reconcile(reconciliation(), scramUser(), null)
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+
+        // The entry hook of the recording plugin ran, but the reconciliation (and therefore the exit hook) did not
+        assertThat(recording.entryInvoked, is(true));
+        assertThat(recording.exitInvoked, is(false));
+        // The actual reconciliation work was skipped because the entry plugin rejected the resource
+        verify(quotasOps, never()).reconcile(any(), any(), any());
+        verify(scramOps, never()).reconcile(any(), any(), any());
+        verify(secretOps, never()).reconcile(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testDeletionHookInvokedOnDeleteAndEntryExitSkipped() {
+        RecordingUserPlugin plugin = new RecordingUserPlugin();
+        GatekeeperPluginFactory.initializeForTests(List.of(plugin));
+
+        // A null KafkaUser triggers the deletion path
+        KafkaUserStatus status = operator()
+                .reconcile(reconciliation(), null, null)
+                .toCompletableFuture().join();
+
+        assertThat(status, is(nullValue()));
+        assertThat(plugin.deletionInvoked, is(true));
+        assertThat(plugin.deletionNamespace, is(ResourceUtils.NAMESPACE));
+        assertThat(plugin.deletionName, is(ResourceUtils.NAME));
+
+        // The entry and exit hooks are only invoked for create/update, not for deletion
+        assertThat(plugin.entryInvoked, is(false));
+        assertThat(plugin.exitInvoked, is(false));
+    }
+
+    @Test
+    public void testDeletionRejectionFailsReconciliation() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new RejectingDeletionPlugin()));
+
+        CompletableFuture<KafkaUserStatus> result = operator()
+                .reconcile(reconciliation(), null, null)
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+    }
+
+    @Test
+    public void testReconcileWithoutPluginsSucceeds() {
+        // With no plugins configured, the reconciliation must behave exactly as before - the Gatekeeper hooks are pure
+        // pass-throughs.
+        GatekeeperPluginFactory.initializeForTests(List.of());
+
+        KafkaUserStatus status = operator()
+                .reconcile(reconciliation(), scramUser(), null)
+                .toCompletableFuture().join();
+
+        assertThat(status, is(notNullValue()));
+        assertThat(status.getConditions(), hasSize(1));
+        assertThat(status.getConditions().get(0).getType(), is("Ready"));
+        assertThat(status.getConditions().get(0).getStatus(), is("True"));
+    }
+
+    /**
+     * Records which hooks were invoked without mutating anything. Used to assert which phases fire for create/update
+     * versus deletion.
+     */
+    private final class RecordingUserPlugin implements GatekeeperKafkaUserMutatingPlugin {
+        private boolean entryInvoked;
+        private boolean exitInvoked;
+        private boolean deletionInvoked;
+        private String deletionNamespace;
+        private String deletionName;
+
+        @Override
+        public void configure(GatekeeperPluginConfigurationContext context) {
+            // not used in these tests
+        }
+
+        @Override
+        public CompletionStage<KafkaUser> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            entryInvoked = true;
+            order.add("entry");
+            return CompletableFuture.completedFuture(kafkaUser);
+        }
+
+        @Override
+        public CompletionStage<KafkaUserStatus> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+            exitInvoked = true;
+            order.add("exit");
+            return CompletableFuture.completedFuture(newKafkaUserStatus);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+            deletionInvoked = true;
+            deletionNamespace = namespace;
+            deletionName = name;
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    /**
+     * Mutating entry plugin that adds a consumer byte rate quota to the KafkaUser. Used to verify that the mutation
+     * flows into the reconciliation.
+     */
+    private static final class QuotaAddingEntryPlugin implements GatekeeperKafkaUserMutatingPlugin {
+        private final int consumerByteRate;
+
+        private QuotaAddingEntryPlugin(int consumerByteRate) {
+            this.consumerByteRate = consumerByteRate;
+        }
+
+        @Override
+        public CompletionStage<KafkaUser> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            return CompletableFuture.completedFuture(new KafkaUserBuilder(kafkaUser)
+                    .editSpec()
+                        .withNewQuotas()
+                            .withConsumerByteRate(consumerByteRate)
+                        .endQuotas()
+                    .endSpec()
+                    .build());
+        }
+    }
+
+    /**
+     * Mutating exit plugin that sets the observed generation on the status.
+     */
+    private static final class ObservedGenerationExitPlugin implements GatekeeperKafkaUserMutatingPlugin {
+        private final long observedGeneration;
+
+        private ObservedGenerationExitPlugin(long observedGeneration) {
+            this.observedGeneration = observedGeneration;
+        }
+
+        @Override
+        public CompletionStage<KafkaUserStatus> kafkaUserExit(GatekeeperKafkaUserExitContext context, KafkaUser kafkaUser, KafkaUserStatus newKafkaUserStatus) {
+            newKafkaUserStatus.setObservedGeneration(observedGeneration);
+            return CompletableFuture.completedFuture(newKafkaUserStatus);
+        }
+    }
+
+    /**
+     * Validating entry plugin that rejects the reconciliation by completing exceptionally.
+     */
+    private static final class RejectingEntryPlugin implements GatekeeperKafkaUserValidatingPlugin {
+        @Override
+        public CompletionStage<Void> kafkaUserEntry(GatekeeperKafkaUserEntryContext context, KafkaUser kafkaUser) {
+            return CompletableFuture.failedFuture(new RuntimeException("rejected by the entry plugin"));
+        }
+    }
+
+    /**
+     * Validating a deletion plugin that completes exceptionally
+     */
+    private static final class RejectingDeletionPlugin implements GatekeeperKafkaUserValidatingPlugin {
+        @Override
+        public CompletionStage<Void> kafkaUserDeletion(GatekeeperKafkaUserDeletionContext context, String namespace, String name) {
+            return CompletableFuture.failedFuture(new RuntimeException("deletion gatekeeping failed"));
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR integrates the Gatekeeper plugins into the User Operator. It adds the configuration options for configuring the plugins and plugs the plugins into the `KafkaUser` reconciliation. It also improves the logging in the `GatekeeperPluginFactory` to more clearly log which plugins it is using.

This should resolve #12810.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
