### PR TITLE
Bump actions versions and pin them by sha digest

### DIFF
--- a/.github/actions/build/build-docs/action.yml
+++ b/.github/actions/build/build-docs/action.yml
@@ -25,7 +25,7 @@ runs:
       run: tar -cvpf documentation.tar ./documentation/html ./documentation/htmlnoheader ./documentation/pdf
       
     - name: Upload documentation artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifactName }}
         path: documentation.tar

--- a/.github/actions/build/integration-test-strimzi/action.yml
+++ b/.github/actions/build/integration-test-strimzi/action.yml
@@ -10,25 +10,25 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         javaVersion: "21"
 
     - name: Install Docker
-      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         version: "v4.6.3"
 
     - name: Install Helm
-      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         helmVersion: "v3.16.0"
 
     - name: Restore Maven cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}
@@ -36,7 +36,7 @@ runs:
           maven-
 
     - name: Setup Kind cluster
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         controlNodes: 1
         workerNodes: 3
@@ -57,7 +57,7 @@ runs:
         STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: false
 
     - name: Publish test results
-      uses: dorny/test-reporter@v3
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       if: always()
       with:
         name: 'Integration Tests (${{ inputs.kindNodeImage }})'
@@ -66,7 +66,7 @@ runs:
         fail-on-error: false
 
     - name: Upload test coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./**/target/site/jacoco/jacoco.xml
         flags: integrationtests

--- a/.github/actions/build/publish-docs/action.yml
+++ b/.github/actions/build/publish-docs/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Download documentation artifact
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifactName }}
         path: ./

--- a/.github/actions/build/unit-test-strimzi/action.yml
+++ b/.github/actions/build/unit-test-strimzi/action.yml
@@ -5,25 +5,25 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         javaVersion: "21"
 
     - name: Install Docker
-      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         version: "v4.6.3"
 
     - name: Install Helm
-      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         helmVersion: "v3.16.0"
 
     - name: Restore Maven cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}
@@ -43,7 +43,7 @@ runs:
         STRIMZI_TEST_CONTAINER_LOGGING_ENABLED: false
 
     - name: Publish test results
-      uses: dorny/test-reporter@v3
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       if: always()
       with:
         name: 'Unit Tests'
@@ -52,7 +52,7 @@ runs:
         fail-on-error: false
 
     - name: Upload test coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./**/target/site/jacoco/jacoco.xml
         flags: unittests

--- a/.github/actions/systemtests/generate-matrix/action.yml
+++ b/.github/actions/systemtests/generate-matrix/action.yml
@@ -46,7 +46,7 @@ runs:
   steps:
     # yq is required for generate-matrix action
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         version: 'v4.6.3'
         architecture: ${{ inputs.runnerArch }}

--- a/.github/actions/systemtests/parse-comment/action.yml
+++ b/.github/actions/systemtests/parse-comment/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - name: Build Comment
       id: build_comment
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         INPUT_PIPELINE: ${{ inputs.pipeline }}
         INPUT_KAFKA_VERSION: ${{ inputs.kafkaVersion }}
@@ -80,7 +80,7 @@ runs:
 
     - name: Parse Comment
       id: parse_comment
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         INPUT_RELEASE_VERSION: ${{ inputs.releaseVersion }}
         BUILT_COMMENT: ${{ steps.build_comment.outputs.builtComment }}

--- a/.github/actions/systemtests/run-perf-report/action.yml
+++ b/.github/actions/systemtests/run-perf-report/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Download performance results
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: ${{ inputs.artifacts-pattern }}
         path: ${{ inputs.artifacts-path }}
@@ -27,7 +27,7 @@ runs:
 
     - name: Generate performance report
       id: generate_report
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PERF_DIR: ${{ inputs.artifacts-path }}
       with:

--- a/.github/actions/systemtests/validate-matrix/action.yml
+++ b/.github/actions/systemtests/validate-matrix/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Validate Matrix
       id: validate
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const matrix = JSON.parse(process.env.MATRIX || '[]');

--- a/.github/actions/utils/add-comment/action.yml
+++ b/.github/actions/utils/add-comment/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Add comment
       id: comment-and-check
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         MESSAGE: ${{ inputs.commentMessage }}
         COMMENT_ID: ${{ inputs.commentId }}

--- a/.github/actions/utils/check-and-status/action.yml
+++ b/.github/actions/utils/check-and-status/action.yml
@@ -22,7 +22,7 @@ runs:
       id: comment-and-check
       # Run only if action wasn't triggered by comment or manually
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         CHECK_STATE: ${{ inputs.checkState }}
         CHECK_NAME: ${{ inputs.checkName }}

--- a/.github/actions/utils/compare-merge-commit/action.yml
+++ b/.github/actions/utils/compare-merge-commit/action.yml
@@ -38,7 +38,7 @@ runs:
   steps:
     - name: Find Build Workflow Run
       id: find-build
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         INPUT_SHA: ${{ inputs.commitSha }}
         WAIT_FOR_BUILD: ${{ inputs.waitForBuild }}
@@ -139,7 +139,7 @@ runs:
     - name: Download build metadata
       id: download-metadata
       continue-on-error: true
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: commit-sha.txt
         run-id: ${{ steps.find-build.outputs.run_id }}
@@ -148,7 +148,7 @@ runs:
 
     - name: Compare commit SHA
       id: compare-sha
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         BUILD_RUN_ID: ${{ steps.find-build.outputs.run_id }}
         MERGE_COMMIT_SHA: ${{ inputs.mergeCommitSha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Build workflow trigger via pull_request will have merge commit sha in github.sha
       - name: Store build commit sha
@@ -34,7 +34,7 @@ jobs:
           echo "Stored commit SHA: ${{ github.sha }}"
 
       - name: Upload build metadata
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: commit-sha.txt
           path: commit-sha.txt
@@ -44,27 +44,27 @@ jobs:
           rm -rf commit-sha.txt
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           helmVersion: "v3.16.0"
 
       - name: Restore Kafka binaries cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docker-images/artifacts/binaries/kafka/archives
           key: kafka-binaries-${{ hashFiles('kafka-versions.yaml') }}
@@ -72,7 +72,7 @@ jobs:
             kafka-binaries-
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@v2
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           mainJavaBuild: "true"
           artifactSuffix: "operators"
@@ -84,7 +84,7 @@ jobs:
       - name: Save Kafka binaries cache
         # Save maven cache only after pushes into default branch
         if: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docker-images/artifacts/binaries/kafka/archives
           key: kafka-binaries-${{ hashFiles('kafka-versions.yaml') }}
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/build/unit-test-strimzi
 
   # Runs Strimzi integration tests (Failsafe only) against multiple Kubernetes versions
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/build/integration-test-strimzi
         with:
           kindNodeImage: ${{ matrix.kindNodeImage }}
@@ -129,15 +129,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install AsciiDoctor
-        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           rubyVersion: "3.2"
 
@@ -160,22 +160,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@v2
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           architecture: ${{ matrix.architecture }}
           imagesLocation: "./docker-images/container-archives"
@@ -198,23 +198,23 @@ jobs:
       # Required for keyless signing with GitHub OIDC
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@v2
+        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/build/publish-docs
         with:
           artifactName: "documentation.tar"
@@ -256,20 +256,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Deploy to Maven Central
-        uses: strimzi/github-actions/.github/actions/build/deploy-java@v2
+        uses: strimzi/github-actions/.github/actions/build/deploy-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           modules: "./,crd-annotations,crd-generator,test,api"
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,21 +42,21 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         javaVersion: "21"
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       with:
         version: "v4.6.3"
 
     # Setup Maven cache
     - name: Restore Maven cache
-      uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@429e1977040da7a23b6822b13c129cd1ba93dbb2 # v3.26.2
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -80,4 +80,4 @@ jobs:
 
     # Analyze the code
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@429e1977040da7a23b6822b13c129cd1ba93dbb2 # v3.26.2
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -29,10 +29,10 @@ jobs:
     permissions:
       packages: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v2
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Login to GHCR
         run: echo "${{ github.token }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -45,7 +45,7 @@ jobs:
           REPOSITORY: "strimzi"
 
       - name: Upload as workflow artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-operators.tar
           path: binaries-operators.tar
@@ -66,22 +66,22 @@ jobs:
           - ppc64le
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@v2
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           architecture: ${{ matrix.architecture }}
           imagesLocation: "./docker-images/container-archives"
@@ -98,23 +98,23 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@v2
+        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -151,23 +151,23 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@v2
+        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -46,17 +46,17 @@ jobs:
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
@@ -64,7 +64,7 @@ jobs:
         run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
 
       - name: Run FOSSA Maven scan
-        uses: strimzi/github-actions/.github/actions/security/fossa-maven-scan@main
+        uses: strimzi/github-actions/.github/actions/security/fossa-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           scanName: operators
           fossaTest: "true"
@@ -82,7 +82,7 @@ jobs:
       images: ${{ steps.list-images.outputs.images }}
     steps:
       - name: Download container archive
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: containers-operators-amd64.tar
           run-id: ${{ inputs.sourceBuildRunId || github.event.workflow_run.id }}
@@ -120,7 +120,7 @@ jobs:
         image: ${{ fromJson(needs.prepare-container-scan.outputs.images) }}
     steps:
       - name: Download container archive
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.CONTAINERS_ARCHIVE }}
           run-id: ${{ inputs.sourceBuildRunId || github.event.workflow_run.id }}
@@ -130,10 +130,10 @@ jobs:
         run: tar -xvf "$CONTAINERS_ARCHIVE"
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Run FOSSA container scan
-        uses: strimzi/github-actions/.github/actions/security/fossa-container-scan@main
+        uses: strimzi/github-actions/.github/actions/security/fossa-container-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           imageFile: docker-images/container-archives/${{ matrix.image }}.tar.gz
           image: ${{ matrix.image }}

--- a/.github/workflows/github-actions-integration.yml
+++ b/.github/workflows/github-actions-integration.yml
@@ -28,7 +28,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: docker://rhysd/actionlint:1.7.10
         with:
           args: -color
@@ -38,7 +38,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Install dependencies
       - name: Install act
@@ -48,7 +48,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
@@ -124,7 +124,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Install dependencies
       - name: Install act
@@ -134,7 +134,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
@@ -211,7 +211,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Install dependencies
       - name: Install act
@@ -221,7 +221,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
@@ -308,7 +308,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Install dependencies
       - name: Install act
@@ -318,7 +318,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
@@ -399,7 +399,7 @@ jobs:
           echo "🎉 All $TOTAL perf-report scenarios passed!"
 
   test-github-actions-integration:
-    uses: strimzi/github-actions/.github/workflows/reusable-test-integrations.yml@v2
+    uses: strimzi/github-actions/.github/workflows/reusable-test-integrations.yml@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
     with:
       repo: ${{ github.repository }}
       ref: ${{ github.sha }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,36 +34,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           helmVersion: "v3.16.0"
 
       - name: Install AsciiDoctor
-        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           rubyVersion: "3.2"
 
       - name: Prepare release artifacts
-        uses: strimzi/github-actions/.github/actions/build/release-artifacts@v2
+        uses: strimzi/github-actions/.github/actions/build/release-artifacts@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "operators"
 
       - name: Deploy to Maven Central
-        uses: strimzi/github-actions/.github/actions/build/deploy-java@v2
+        uses: strimzi/github-actions/.github/actions/build/deploy-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           modules: "./,crd-annotations,crd-generator,test,api"
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -86,13 +86,13 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v2
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Download strimzi binaries from source build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binaries-operators.tar
           run-id: ${{ inputs.sourceBuildRunId }}
@@ -121,23 +121,23 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@v2
+        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -169,23 +169,23 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@v2
+        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -210,15 +210,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           helmVersion: "v3.16.0"
 
       - name: Publish Helm charts using publish-helm action
-        uses: strimzi/github-actions/.github/actions/build/publish-helm-chart@v2
+        uses: strimzi/github-actions/.github/actions/build/publish-helm-chart@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           registryUser: ${{ secrets.QUAY_HELM_USER }}
           registryPassword: ${{ secrets.QUAY_HELM_PASS }}

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -81,7 +81,7 @@ jobs:
       KUBE_VERSION: ${{ inputs.kubeVersion }}
     # Job steps
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.ref }}
 
@@ -94,28 +94,28 @@ jobs:
           checkDescription: "Test run for ${{ matrix.config.jobName }}"
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
           architecture: ${{ matrix.config.arch }}
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           helmVersion: "v3.16.0"
 
       - name: Setup Kind cluster
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           architecture: ${{ matrix.config.arch }}
           controlNodes: 1
@@ -153,7 +153,7 @@ jobs:
       - name: Download container images from Build workflow
         id: download-containers
         if: ${{ inputs.buildRunId != '' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: "containers-operators-${{ matrix.config.arch }}.tar"
           run-id: ${{ inputs.buildRunId }}
@@ -162,7 +162,7 @@ jobs:
       - name: Download container images from this build
         id: download-containers-local
         if: ${{ inputs.buildRunId == '' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: "containers-operators-${{ matrix.config.arch }}.tar"
 
@@ -175,14 +175,14 @@ jobs:
           registry: "kind"
 
       - name: Restore Maven cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - name: Restore Kafka cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docker-images/artifacts/binaries/kafka/archives
           key: kafka-binaries-${{ hashFiles('kafka-versions.yaml') }}
@@ -287,27 +287,27 @@ jobs:
 
       - name: Archive JUnit test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-results-${{ matrix.config.pipeline }}-${{ matrix.config.profile }}-${{ matrix.config.agent }}
           path: systemtest/target/failsafe-reports/**/TEST-*.xml
 
       - name: Archive systemtest logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: systemtest-logs-${{ matrix.config.pipeline }}-${{ matrix.config.profile }}-${{ matrix.config.agent }}
           path: systemtest-logs
 
       - name: Archive performance results
         if: ${{ always() && matrix.config.profile == 'performance' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: performance-results-${{ matrix.config.pipeline }}-${{ matrix.config.profile }}-${{ matrix.config.agent }}
           path: systemtest/target/performance
 
       - name: Publish test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: 'System tests'

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -58,6 +58,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -47,17 +47,17 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
@@ -86,7 +86,7 @@ jobs:
           MAVEN_TEST_MODULES: "systemtest,mockkube,test"
 
       - name: Run Snyk Maven scan (prod)
-        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@v2
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           scanName: operators-prod
           snykMonitor: "true"
@@ -95,7 +95,7 @@ jobs:
           exclude: "${{ steps.compute-excludes.outputs.maven-test-modules }},docker-images"
 
       - name: Run Snyk Maven scan (test)
-        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@v2
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           scanName: operators-test
           snykMonitor: "true"
@@ -104,7 +104,7 @@ jobs:
           exclude: "${{ steps.compute-excludes.outputs.maven-prod-modules }},docker-images"
 
       - name: Run Snyk Maven scan (3rd-party)
-        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@v2
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           scanName: kafka-3rd-party
           snykMonitor: "true"
@@ -124,7 +124,7 @@ jobs:
       images: ${{ steps.list-images.outputs.images }}
     steps:
       - name: Download container archive
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: containers-operators-amd64.tar
           run-id: ${{ inputs.sourceBuildRunId || github.event.workflow_run.id }}
@@ -163,7 +163,7 @@ jobs:
         image: ${{ fromJson(needs.prepare-container-scan.outputs.images) }}
     steps:
       - name: Download container archive
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.CONTAINERS_ARCHIVE }}
           run-id: ${{ inputs.sourceBuildRunId || github.event.workflow_run.id }}
@@ -173,10 +173,10 @@ jobs:
         run: tar -xvf "$CONTAINERS_ARCHIVE"
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Run Snyk container scan
-        uses: strimzi/github-actions/.github/actions/security/snyk-container-scan@v2
+        uses: strimzi/github-actions/.github/actions/security/snyk-container-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           imageFile: docker-images/container-archives/${{ matrix.image }}.tar.gz
           image: ${{ matrix.image }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -46,11 +46,11 @@ jobs:
     steps:
       - name: Should Run
         id: should_run
-        uses: strimzi/github-actions/.github/actions/utils/should-run@v2
+        uses: strimzi/github-actions/.github/actions/utils/should-run@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
       - name: Determine checkout ref
         id: determine_ref
         if: steps.should_run.outputs.shouldRun == 'true'
-        uses: strimzi/github-actions/.github/actions/utils/determine-ref@v2
+        uses: strimzi/github-actions/.github/actions/utils/determine-ref@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
   check-rights:
     needs:
@@ -63,7 +63,7 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: strimzi/github-actions/.github/actions/utils/check-permissions@v2
+      - uses: strimzi/github-actions/.github/actions/utils/check-permissions@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
   check-build:
     needs:
@@ -84,7 +84,7 @@ jobs:
       buildMetadataSha: ${{ steps.verify.outputs.buildMetadataSha }}
       commentId: ${{ steps.initial-comment.outputs.commentId }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - name: Add initial comment
@@ -145,7 +145,7 @@ jobs:
       message: ${{ steps.validate.outputs.message }}
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - name: Parse Comment
@@ -216,32 +216,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
 
       - name: Setup Java and Maven
-        uses: frawless/github-actions/.github/actions/dependencies/setup-java@v6.1
+        uses: frawless/github-actions/.github/actions/dependencies/setup-java@897fd114058a9a3b32fd4fd8cbb1de5c49352b29 # v6.7
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           helmVersion: "v3.16.0"
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@v2
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           mainJavaBuild: "true"
           artifactSuffix: "operators"
@@ -273,24 +273,24 @@ jobs:
     runs-on: cncf-ubuntu-2-8-arm
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@v2
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@v2
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
         with:
           architecture: ${{ matrix.architecture }}
           imagesLocation: "./docker-images/container-archives"
@@ -355,7 +355,7 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - name: Add comment
@@ -397,7 +397,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - uses: ./.github/actions/systemtests/run-perf-report


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR bump several actions we use into latest versions and also pin all of them via sha-digest. This is one of the improvements for better security in our CI.

### Checklist

- [x] Make sure all tests pass
