### PR TITLE
Templating Additional Volumes for Pods with Stable Identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0
 
 * Add support for Apache Kafka 4.3.1
+* Support templated (per-pod) additional volumes for Kafka, Kafka Connect and Kafka MirrorMaker 2 operands
 * The `ServerSideApplyPhase1` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
 
 ### Major changes, deprecations, and removals

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalTemplatedVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalTemplatedVolume.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.OneOf;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of additional templated volumes for Strimzi resources.
+ */
+@Buildable(editableEnabled = false, builderPackage = Constants.FABRIC8_KUBERNETES_API)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "name", "secret", "configMap", "persistentVolumeClaim" })
+@OneOf({
+    @OneOf.Alternative({
+        @OneOf.Alternative.Property(value = "secret", required = false),
+        @OneOf.Alternative.Property(value = "configMap", required = false),
+        @OneOf.Alternative.Property(value = "persistentVolumeClaim", required = false),
+        })
+})
+@EqualsAndHashCode
+@ToString
+public class AdditionalTemplatedVolume implements UnknownPropertyPreserving {
+    private String name;
+    private SecretVolumeSource secret;
+    private ConfigMapVolumeSource configMap;
+    private PersistentVolumeClaimVolumeSource persistentVolumeClaim;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Name to use for the volume. Required.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Description("`Secret` to use to populate the volume. " +
+            "The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. " +
+            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
+    @KubeLink(group = "core", version = "v1", kind = "secretvolumesource")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public SecretVolumeSource getSecret() {
+        return secret;
+    }
+
+    public void setSecret(SecretVolumeSource secret) {
+        this.secret = secret;
+    }
+
+    @Description("`ConfigMap` to use to populate the volume. " +
+            "The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. " +
+            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
+    @KubeLink(group = "core", version = "v1", kind = "configmapvolumesource")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ConfigMapVolumeSource getConfigMap() {
+        return configMap;
+    }
+
+    public void setConfigMap(ConfigMapVolumeSource configMap) {
+        this.configMap = configMap;
+    }
+
+    @Description("`PersistentVolumeClaim` object to use to populate the volume. " +
+            "The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. " +
+            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
+    @KubeLink(group = "core", version = "v1", kind = "persistentvolumeclaimvolumesource")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public PersistentVolumeClaimVolumeSource getPersistentVolumeClaim() {
+        return persistentVolumeClaim;
+    }
+
+    public void setPersistentVolumeClaim(PersistentVolumeClaimVolumeSource persistentVolumeClaim) {
+        this.persistentVolumeClaim = persistentVolumeClaim;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulPodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulPodTemplate.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation of a pod template for Strimzi resources.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"metadata", "imagePullSecrets", "securityContext", "terminationGracePeriodSeconds", "affinity",
+    "tolerations", "topologySpreadConstraints", "priorityClassName", "schedulerName", "hostAliases", "dnsPolicy", "dnsConfig", 
+    "enableServiceLinks", "tmpDirSizeLimit", "volumes", "templatedVolumes", "hostUsers"})
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@DescriptionFile
+public class StatefulPodTemplate extends PodTemplate {
+    private List<AdditionalTemplatedVolume> templatedVolumes;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Additional volumes that can be mounted to the pod. " +
+            "These volumes can use templates to mount different volumes into individual Pods.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<AdditionalTemplatedVolume> getTemplatedVolumes() {
+        return templatedVolumes;
+    }
+
+    public void setTemplatedVolumes(List<AdditionalTemplatedVolume> templatedVolumes) {
+        this.templatedVolumes = templatedVolumes;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -38,7 +39,7 @@ import java.util.Map;
 @ToString
 public class KafkaConnectTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
     private ResourceTemplate podSet;
-    private PodTemplate pod;
+    private StatefulPodTemplate pod;
     private PodTemplate buildPod;
     private InternalServiceTemplate apiService;
     private InternalServiceTemplate headlessService;
@@ -65,11 +66,11 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, UnknownProper
 
     @Description("Template for Kafka Connect `Pods`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public PodTemplate getPod() {
+    public StatefulPodTemplate getPod() {
         return pod;
     }
 
-    public void setPod(PodTemplate pod) {
+    public void setPod(StatefulPodTemplate pod) {
         this.pod = pod;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
@@ -12,8 +12,8 @@ import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.HasJmxSecretTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
-import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -38,7 +38,7 @@ import java.util.Map;
 @ToString
 public class KafkaClusterTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
     private ResourceTemplate podSet;
-    private PodTemplate pod;
+    private StatefulPodTemplate pod;
     private InternalServiceTemplate bootstrapService;
     private InternalServiceTemplate brokersService;
     private ResourceTemplate externalBootstrapService;
@@ -69,11 +69,11 @@ public class KafkaClusterTemplate implements HasJmxSecretTemplate, UnknownProper
 
     @Description("Template for Kafka `Pods`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public PodTemplate getPod() {
+    public StatefulPodTemplate getPod() {
         return pod;
     }
 
-    public void setPod(PodTemplate pod) {
+    public void setPod(StatefulPodTemplate pod) {
         this.pod = pod;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -300,7 +300,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     }
 
     @Description("Configures the template for generating the advertised hostnames of the individual brokers. " +
-            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
+            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getAdvertisedHostTemplate() {
         return advertisedHostTemplate;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.Spec;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
-import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -33,7 +33,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaNodePoolTemplate extends Spec {
     private ResourceTemplate podSet;
-    private PodTemplate pod;
+    private StatefulPodTemplate pod;
     private ResourceTemplate perPodService;
     private ResourceTemplate perPodRoute;
     private ResourceTemplate perPodIngress;
@@ -54,11 +54,11 @@ public class KafkaNodePoolTemplate extends Spec {
 
     @Description("Template for Kafka `Pods`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public PodTemplate getPod() {
+    public StatefulPodTemplate getPod() {
         return pod;
     }
 
-    public void setPod(PodTemplate pod) {
+    public void setPod(StatefulPodTemplate pod) {
         this.pod = pod;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -53,8 +53,8 @@ import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
-import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpec;
@@ -1434,7 +1434,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return List of non-data volumes used by the Kafka pods
      */
-    private List<Volume> getNonDataVolumes(NodeRef node, PodTemplate templatePod) {
+    private List<Volume> getNonDataVolumes(NodeRef node, StatefulPodTemplate templatePod) {
         List<Volume> volumeList = new ArrayList<>();
 
         volumeList.add(VolumeUtils.createTempDirVolume(templatePod));
@@ -1450,6 +1450,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
 
         TemplateUtils.addAdditionalVolumes(templatePod, volumeList);
+        TemplateUtils.addAdditionalTemplatedVolumes(node, templatePod, volumeList);
 
         return volumeList;
     }
@@ -1464,7 +1465,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return              List of volumes to be included in the StrimziPodSet pod
      */
-    private List<Volume> getPodSetVolumes(NodeRef node, Storage storage, PodTemplate templatePod) {
+    private List<Volume> getPodSetVolumes(NodeRef node, Storage storage, StatefulPodTemplate templatePod) {
         List<Volume> volumeList = new ArrayList<>();
 
         volumeList.addAll(VolumeUtils.createPodSetVolumes(node.podName(), storage, false));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -39,8 +39,8 @@ import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
-import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
 import io.strimzi.api.kafka.model.connect.ImageArtifact;
@@ -166,7 +166,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected PodDisruptionBudgetTemplate templatePodDisruptionBudget;
     protected ResourceTemplate templateInitClusterRoleBinding;
     protected ResourceTemplate templatePodSet;
-    protected PodTemplate templatePod;
+    protected StatefulPodTemplate templatePod;
     protected InternalServiceTemplate templateService;
     protected InternalServiceTemplate templateHeadlessService;
     protected ContainerTemplate templateInitContainer;
@@ -390,7 +390,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         return portList;
     }
 
-    protected List<Volume> getVolumes() {
+    protected List<Volume> getVolumes(NodeRef node) {
         List<Volume> volumeList = new ArrayList<>(2);
         volumeList.add(VolumeUtils.createTempDirVolume(templatePod));
         volumeList.add(VolumeUtils.createConfigMapVolume(KAFKA_CONNECT_CONFIG_VOLUME_NAME, connectConfigMapName));
@@ -402,6 +402,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         volumeList.addAll(getMountedPluginVolumes());
         
         TemplateUtils.addAdditionalVolumes(templatePod, volumeList);
+        TemplateUtils.addAdditionalTemplatedVolumes(node, templatePod, volumeList);
 
         return volumeList;
     }
@@ -528,7 +529,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                         ModelUtils.affinityWithRackLabelSelector(templatePod, rack),
                         ContainerUtils.listOrNull(createInitContainer(imagePullPolicy)),
                         List.of(createContainer(imagePullPolicy, customContainerImage)),
-                        getVolumes(),
+                        getVolumes(new NodeRef(componentName + "-" + podId, podId, null, false, false)),
                         imagePullSecrets,
                         securityProvider.kafkaConnectPodSecurityContext(podSecurityProviderContext),
                         securityProvider.kafkaConnectHostUsers(podSecurityProviderContext))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -8,8 +8,8 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
-import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -67,7 +67,7 @@ public class KafkaPool extends AbstractModel {
     // Templates
     protected ResourceTemplate templatePersistentVolumeClaims;
     protected ResourceTemplate templatePodSet;
-    protected PodTemplate templatePod;
+    protected StatefulPodTemplate templatePod;
     protected ResourceTemplate templatePerBrokerService;
     protected ResourceTemplate templatePerBrokerRoute;
     protected ResourceTemplate templatePerBrokerIngress;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -398,7 +398,7 @@ public class ListenersUtils {
             return Collections.emptyMap();
         } else {
             return template.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> renderHostTemplate(entry.getValue(), node)));
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> ModelUtils.renderTemplate(entry.getValue(), node)));
         }
     }
 
@@ -490,20 +490,6 @@ public class ListenersUtils {
     }
 
     /**
-     * Replaces the template fields in the template string with the corresponding values from the node reference.
-     *
-     * @param template  Template with the placeholders
-     * @param node      Node reference that should be used to provide the final values
-     *
-     * @return  The rendered template
-     */
-    /* test */ static String renderHostTemplate(String template, NodeRef node) {
-        return template
-                .replace("{nodeId}", Integer.toString(node.nodeId()))
-                .replace("{nodePodName}", node.podName());
-    }
-
-    /**
      * Finds per-broker host configuration based on node ID.
      *
      * @param listenerConfiguration     Configuration of the listener for which the host should be found
@@ -538,7 +524,7 @@ public class ListenersUtils {
 
             if (host == null && listener.getConfiguration().getHostTemplate() != null)   {
                 // There is no host defined specifically for given broker, so we try to use the template
-                host = renderHostTemplate(listener.getConfiguration().getHostTemplate(), node);
+                host = ModelUtils.renderTemplate(listener.getConfiguration().getHostTemplate(), node);
             }
 
             return host;
@@ -582,7 +568,7 @@ public class ListenersUtils {
 
             if (advertisedHost == null && listener.getConfiguration().getAdvertisedHostTemplate() != null)   {
                 // There is no advertised host defined specifically for given broker, so we try to use the template
-                advertisedHost = renderHostTemplate(listener.getConfiguration().getAdvertisedHostTemplate(), node);
+                advertisedHost = ModelUtils.renderTemplate(listener.getConfiguration().getAdvertisedHostTemplate(), node);
             }
 
             return advertisedHost;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -364,4 +364,20 @@ public class ModelUtils {
         }
         return errors;
     }
+
+    /**
+     * Replaces the template fields in the template string with the corresponding values from the node reference. This
+     * method is currently used in listener and volume templates.
+     *
+     * @param template  Template with the placeholders
+     * @param node      Node reference that should be used to provide the final values
+     *
+     * @return  The rendered template
+     */
+    static String renderTemplate(String template, NodeRef node) {
+        // TODO: Fix the duplication with ListenerUtils
+        return template
+                .replace("{nodeId}", Integer.toString(node.nodeId()))
+                .replace("{nodePodName}", node.podName());
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -375,7 +375,6 @@ public class ModelUtils {
      * @return  The rendered template
      */
     static String renderTemplate(String template, NodeRef node) {
-        // TODO: Fix the duplication with ListenerUtils
         return template
                 .replace("{nodeId}", Integer.toString(node.nodeId()))
                 .replace("{nodePodName}", node.podName());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -4,13 +4,11 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
@@ -205,17 +203,23 @@ public class TemplateUtils {
         VolumeBuilder volumeBuilder = new VolumeBuilder().withName(volumeConfig.getName());
 
         if (volumeConfig.getConfigMap() != null) {
-            ConfigMapVolumeSource configMap = new ConfigMapVolumeSourceBuilder(volumeConfig.getConfigMap())
-                    .withName(ModelUtils.renderTemplate(volumeConfig.getConfigMap().getName(), node))
-                    .withItems(volumeConfig.getConfigMap().getItems().stream().map(item -> new KeyToPathBuilder(item).withKey(ModelUtils.renderTemplate(item.getKey(), node)).withPath(ModelUtils.renderTemplate(item.getPath(), node)).build()).toList())
-                    .build();
-            volumeBuilder.withConfigMap(configMap);
+            ConfigMapVolumeSourceBuilder configMapBuilder = new ConfigMapVolumeSourceBuilder(volumeConfig.getConfigMap())
+                    .withName(ModelUtils.renderTemplate(volumeConfig.getConfigMap().getName(), node));
+
+            if (volumeConfig.getConfigMap().getItems() != null && !volumeConfig.getConfigMap().getItems().isEmpty()) {
+                configMapBuilder.withItems(volumeConfig.getConfigMap().getItems().stream().map(item -> new KeyToPathBuilder(item).withKey(ModelUtils.renderTemplate(item.getKey(), node)).withPath(ModelUtils.renderTemplate(item.getPath(), node)).build()).toList());
+            }
+
+            volumeBuilder.withConfigMap(configMapBuilder.build());
         } else if (volumeConfig.getSecret() != null) {
-            SecretVolumeSource secret = new SecretVolumeSourceBuilder(volumeConfig.getSecret())
-                    .withSecretName(ModelUtils.renderTemplate(volumeConfig.getSecret().getSecretName(), node))
-                    .withItems(volumeConfig.getSecret().getItems().stream().map(item -> new KeyToPathBuilder(item).withKey(ModelUtils.renderTemplate(item.getKey(), node)).withPath(ModelUtils.renderTemplate(item.getPath(), node)).build()).toList())
-                    .build();
-            volumeBuilder.withSecret(secret);
+            SecretVolumeSourceBuilder secretBuilder = new SecretVolumeSourceBuilder(volumeConfig.getSecret())
+                    .withSecretName(ModelUtils.renderTemplate(volumeConfig.getSecret().getSecretName(), node));
+
+            if (volumeConfig.getSecret().getItems() != null)    {
+                secretBuilder.withItems(volumeConfig.getSecret().getItems().stream().map(item -> new KeyToPathBuilder(item).withKey(ModelUtils.renderTemplate(item.getKey(), node)).withPath(ModelUtils.renderTemplate(item.getPath(), node)).build()).toList());
+            }
+
+            volumeBuilder.withSecret(secretBuilder.build());
         } else if (volumeConfig.getPersistentVolumeClaim() != null) {
             PersistentVolumeClaimVolumeSource pvc = new PersistentVolumeClaimVolumeSourceBuilder(volumeConfig.getPersistentVolumeClaim())
                     .withClaimName(ModelUtils.renderTemplate(volumeConfig.getPersistentVolumeClaim().getClaimName(), node))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -4,15 +4,24 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.HasMetadataTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.operator.common.model.InvalidResourceException;
 
@@ -94,6 +103,46 @@ public class TemplateUtils {
     }
 
     /**
+     * Add additional templated volumes for a given pod template and a list of existing volumes.
+     *
+     * @param node              The node for which these volumes are used
+     * @param templatePod       The pod template that contains the additional volumes.
+     * @param existingVolumes   The list of existing volumes to which the additional volumes will be added.
+     */
+    public static void addAdditionalTemplatedVolumes(NodeRef node, StatefulPodTemplate templatePod, List<Volume> existingVolumes) {
+        if (templatePod == null || templatePod.getTemplatedVolumes() == null) {
+            return;
+        }
+
+        // Extract the names and paths of the existing volumes
+        List<String> existingVolumeNames = existingVolumes.stream().map(Volume::getName).toList();
+
+        // Check if there are any invalid volume names
+        List<String> invalidNames = templatePod.getTemplatedVolumes().stream()
+                .map(AdditionalTemplatedVolume::getName)
+                .filter(name -> !VOLUME_NAME_REGEX.matcher(name).matches())
+                .toList();
+
+        // Find duplicate names in the additional volumes
+        List<String> duplicateNames = templatePod.getTemplatedVolumes().stream()
+                .map(AdditionalTemplatedVolume::getName)
+                .filter(existingVolumeNames::contains)
+                .toList();
+
+        // Throw an exception if there are any invalid volume names
+        if (!invalidNames.isEmpty()) {
+            throw new InvalidResourceException("Volume names " + invalidNames + " are invalid and do not match the pattern " + VOLUME_NAME_REGEX);
+        }
+
+        // Throw an exception if duplicates are found
+        if (!duplicateNames.isEmpty()) {
+            throw new InvalidResourceException("Duplicate volume names found in additional volumes: " + duplicateNames);
+        }
+
+        templatePod.getTemplatedVolumes().forEach(volumeConfig -> existingVolumes.add(createTemplatedVolumeFromConfig(node, volumeConfig)));
+    }
+
+    /**
      * Add additional volume mounts to the given list of volume mounts. Validation is performed to ensure none of the
      * additional volume mount paths are forbidden.
      *
@@ -116,7 +165,7 @@ public class TemplateUtils {
     }
 
     /**
-     * Creates a kubernetes Volume object from the provided Volume configuration
+     * Creates a Kubernetes Volume object from the provided Volume configuration
      *
      * @param volumeConfig The configuration for the additional volume
      * @return A Volume object
@@ -139,6 +188,39 @@ public class TemplateUtils {
             volumeBuilder.withCsi(volumeConfig.getCsi());
         } else if (volumeConfig.getImage() != null) {
             volumeBuilder.withImage(volumeConfig.getImage());
+        }
+
+        return volumeBuilder.build();
+    }
+
+    /**
+     * Creates a Templated Kubernetes Volume object from the provided Volume configuration
+     *
+     * @param node          The node for which these volumes are used
+     * @param volumeConfig  The configuration for the additional volume
+     *
+     * @return  A Volume object
+     */
+    private static Volume createTemplatedVolumeFromConfig(NodeRef node, AdditionalTemplatedVolume volumeConfig) {
+        VolumeBuilder volumeBuilder = new VolumeBuilder().withName(volumeConfig.getName());
+
+        if (volumeConfig.getConfigMap() != null) {
+            ConfigMapVolumeSource configMap = new ConfigMapVolumeSourceBuilder(volumeConfig.getConfigMap())
+                    .withName(ModelUtils.renderTemplate(volumeConfig.getConfigMap().getName(), node))
+                    .withItems(volumeConfig.getConfigMap().getItems().stream().map(item -> new KeyToPathBuilder(item).withKey(ModelUtils.renderTemplate(item.getKey(), node)).withPath(ModelUtils.renderTemplate(item.getPath(), node)).build()).toList())
+                    .build();
+            volumeBuilder.withConfigMap(configMap);
+        } else if (volumeConfig.getSecret() != null) {
+            SecretVolumeSource secret = new SecretVolumeSourceBuilder(volumeConfig.getSecret())
+                    .withSecretName(ModelUtils.renderTemplate(volumeConfig.getSecret().getSecretName(), node))
+                    .withItems(volumeConfig.getSecret().getItems().stream().map(item -> new KeyToPathBuilder(item).withKey(ModelUtils.renderTemplate(item.getKey(), node)).withPath(ModelUtils.renderTemplate(item.getPath(), node)).build()).toList())
+                    .build();
+            volumeBuilder.withSecret(secret);
+        } else if (volumeConfig.getPersistentVolumeClaim() != null) {
+            PersistentVolumeClaimVolumeSource pvc = new PersistentVolumeClaimVolumeSourceBuilder(volumeConfig.getPersistentVolumeClaim())
+                    .withClaimName(ModelUtils.renderTemplate(volumeConfig.getPersistentVolumeClaim().getClaimName(), node))
+                    .build();
+            volumeBuilder.withPersistentVolumeClaim(pvc);
         }
 
         return volumeBuilder.build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.strimzi.api.kafka.model.common.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
@@ -249,7 +250,7 @@ public class WorkloadUtils {
             Labels labels,
             String strimziPodSetName,
             String serviceAccountName,
-            PodTemplate template,
+            StatefulPodTemplate template,
             Map<String, String> defaultPodLabels,
             Map<String, String> podAnnotations,
             String headlessServiceName,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -54,6 +55,8 @@ import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuild
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolume;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
@@ -3637,6 +3640,16 @@ public class KafkaClusterTest {
                 .withSubPath("def")
                 .build();
 
+        AdditionalTemplatedVolume additionalTemplatedVolume  = new AdditionalTemplatedVolumeBuilder()
+                .withName("pvc-volume-name")
+                .withPersistentVolumeClaim(new PersistentVolumeClaimVolumeSourceBuilder().withClaimName("my-pvc-{nodeId}").build())
+                .build();
+
+        VolumeMount additionalTemplatedVolumeMount = new VolumeMountBuilder()
+                .withName("pvc-volume-name")
+                .withMountPath("/mnt/pvc-volume-name")
+                .build();
+
         // Use the template values in Kafka CR
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -3672,12 +3685,13 @@ public class KafkaClusterTest {
                                 .withImagePullSecrets(secret1, secret2)
                                 .withSecurityContext(new PodSecurityContextBuilder().withFsGroup(123L).withRunAsGroup(456L).withRunAsUser(789L).build())
                                 .withVolumes(additionalVolume)
+                                .withTemplatedVolumes(additionalTemplatedVolume)
                                 .withHostUsers(false)
                             .endPod()
                             .withNewKafkaContainer()
                                 .withEnv(envVar1, envVar2, envVar3)
                                 .withSecurityContext(securityContext)
-                                .withVolumeMounts(additionalVolumeMount)
+                                .withVolumeMounts(additionalVolumeMount, additionalTemplatedVolumeMount)
                             .endKafkaContainer()
                         .endTemplate()
                     .endKafka()
@@ -3723,7 +3737,7 @@ public class KafkaClusterTest {
                 assertThat(pod.getSpec().getTolerations(), is(toleration));
                 assertThat(pod.getSpec().getHostUsers(), is(false));
 
-                assertThat(pod.getSpec().getVolumes().size(), is(5));
+                assertThat(pod.getSpec().getVolumes().size(), is(6));
                 assertThat(pod.getSpec().getVolumes().get(0).getName(), is("data-0"));
                 assertThat(pod.getSpec().getVolumes().get(0).getPersistentVolumeClaim(), is(notNullValue()));
                 assertThat(pod.getSpec().getVolumes().get(1).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -3735,6 +3749,8 @@ public class KafkaClusterTest {
                 assertThat(pod.getSpec().getVolumes().get(3).getEmptyDir(), is(notNullValue()));
                 assertThat(pod.getSpec().getVolumes().get(4).getName(), is("secret-volume-name"));
                 assertThat(pod.getSpec().getVolumes().get(4).getSecret(), is(notNullValue()));
+                assertThat(pod.getSpec().getVolumes().get(5).getName(), is("pvc-volume-name"));
+                assertThat(pod.getSpec().getVolumes().get(5).getPersistentVolumeClaim().getClaimName(), is("my-pvc-" + pod.getMetadata().getName().substring(pod.getMetadata().getName().lastIndexOf("-") + 1)));
 
                 // Containers
                 assertThat(pod.getSpec().getContainers().size(), is(1));
@@ -3755,7 +3771,7 @@ public class KafkaClusterTest {
                 assertThat(pod.getSpec().getContainers().get(0).getEnv().stream().filter(e -> envVar2.getName().equals(e.getName())).findFirst().orElseThrow().getValue(), is(envVar2.getValue()));
                 assertThat(pod.getSpec().getContainers().get(0).getEnv().stream().filter(e -> envVar3.getName().equals(e.getName())).findFirst().orElseThrow().getValue(), is(not(envVar3.getValue())));
 
-                assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(5));
+                assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(6));
                 assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("data-0"));
                 assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/var/lib/kafka/data-0"));
                 assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -3766,6 +3782,8 @@ public class KafkaClusterTest {
                 assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getMountPath(), is("/var/opt/kafka"));
                 assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(4).getName(), is("secret-volume-name"));
                 assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(4).getMountPath(), is("/mnt/secret-volume"));
+                assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(5).getName(), is("pvc-volume-name"));
+                assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(5).getMountPath(), is("/mnt/pvc-volume-name"));
             }
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodDNSConfig;
 import io.fabric8.kubernetes.api.model.PodDNSConfigBuilder;
@@ -55,6 +56,8 @@ import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolume;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
@@ -831,6 +834,16 @@ public class KafkaConnectClusterTest {
                 .withSubPath("def")
                 .build();
 
+        AdditionalTemplatedVolume additionalTemplatedVolume  = new AdditionalTemplatedVolumeBuilder()
+                .withName("pvc-volume-name")
+                .withPersistentVolumeClaim(new PersistentVolumeClaimVolumeSourceBuilder().withClaimName("my-pvc-{nodeId}").build())
+                .build();
+
+        VolumeMount additionalTemplatedVolumeMount = new VolumeMountBuilder()
+                .withName("pvc-volume-name")
+                .withMountPath("/mnt/pvc-volume-name")
+                .build();
+
         KafkaConnect resource = new KafkaConnectBuilder(RESOURCE)
                 .editSpec()
                     .withNewTopologyLabelRack()
@@ -857,10 +870,11 @@ public class KafkaConnectClusterTest {
                             .withEnableServiceLinks(false)
                             .withTmpDirSizeLimit("10Mi")
                             .withVolumes(additionalVolumeSecret, additionalVolumeEmptyDir, additionalVolumeConfigMap)
+                            .withTemplatedVolumes(additionalTemplatedVolume)
                             .withHostUsers(false)
                         .endPod()
                         .withNewConnectContainer()
-                            .withVolumeMounts(additionalVolumeMountSecret, additionalVolumeMountEmptyDir)
+                            .withVolumeMounts(additionalVolumeMountSecret, additionalVolumeMountEmptyDir, additionalTemplatedVolumeMount)
                         .endConnectContainer()
                         .withNewInitContainer()
                             .withVolumeMounts(additionalVolumeMountConfigMap)
@@ -913,7 +927,7 @@ public class KafkaConnectClusterTest {
             assertThat(pod.getSpec().getEnableServiceLinks(), is(false));
             assertThat(pod.getSpec().getHostUsers(), is(false));
 
-            assertThat(pod.getSpec().getVolumes().size(), is(6));
+            assertThat(pod.getSpec().getVolumes().size(), is(7));
             assertThat(pod.getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir(), is(notNullValue()));
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("10Mi")));
@@ -929,6 +943,8 @@ public class KafkaConnectClusterTest {
             assertThat(pod.getSpec().getVolumes().get(4).getEmptyDir().getMedium(), is("Memory"));
             assertThat(pod.getSpec().getVolumes().get(5).getName(), is("config-map-volume-name"));
             assertThat(pod.getSpec().getVolumes().get(5).getConfigMap().getName(), is("configMap1"));
+            assertThat(pod.getSpec().getVolumes().get(6).getName(), is("pvc-volume-name"));
+            assertThat(pod.getSpec().getVolumes().get(6).getPersistentVolumeClaim().getClaimName(), is("my-pvc-" + pod.getMetadata().getName().substring(pod.getMetadata().getName().lastIndexOf("-") + 1)));
 
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().size(), is(2));
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().get(0).getName(), is("rack-volume"));
@@ -936,7 +952,7 @@ public class KafkaConnectClusterTest {
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().get(1).getName(), is("config-map-volume-name"));
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/mnt/config"));
 
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(5));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(6));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("kafka-connect-configurations"));
@@ -947,6 +963,8 @@ public class KafkaConnectClusterTest {
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getMountPath(), is("/mnt/secret"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(4).getName(), is("empty-dir-volume-name"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(4).getMountPath(), is("/mnt/empty-dir"));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(5).getName(), is("pvc-volume-name"));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(5).getMountPath(), is("/mnt/pvc-volume-name"));
         });
 
         // Check Service

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -50,6 +50,8 @@ import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolume;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
@@ -904,6 +906,16 @@ public class KafkaMirrorMaker2ClusterTest {
                 .withMountPath("/mnt/mypvc")
                 .build();
 
+        AdditionalTemplatedVolume additionalTemplatedVolume  = new AdditionalTemplatedVolumeBuilder()
+                .withName("pvc-templated-volume-name")
+                .withPersistentVolumeClaim(new PersistentVolumeClaimVolumeSourceBuilder().withClaimName("my-pvc-{nodeId}").build())
+                .build();
+
+        VolumeMount additionalTemplatedVolumeMount = new VolumeMountBuilder()
+                .withName("pvc-templated-volume-name")
+                .withMountPath("/mnt/pvc-templated-volume-name")
+                .build();
+
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(RESOURCE)
                 .editSpec()
                     .withNewTopologyLabelRack()
@@ -929,13 +941,14 @@ public class KafkaMirrorMaker2ClusterTest {
                             .withEnableServiceLinks(false)
                             .withTmpDirSizeLimit("10Mi")
                             .withVolumes(additionalVolumeConfigMap, additionalVolumePvc)
+                            .withTemplatedVolumes(additionalTemplatedVolume)
                             .withHostUsers(false)
                         .endPod()
                         .withNewInitContainer()
                             .withVolumeMounts(additionalVolumeMountPvc)
                         .endInitContainer()
                         .withNewConnectContainer()
-                            .withVolumeMounts(additionalVolumeMountConfigMap)
+                            .withVolumeMounts(additionalVolumeMountConfigMap, additionalTemplatedVolumeMount)
                         .endConnectContainer()
                         .withNewApiService()
                             .withNewMetadata()
@@ -984,7 +997,7 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(pod.getSpec().getEnableServiceLinks(), is(false));
             assertThat(pod.getSpec().getHostUsers(), is(false));
 
-            assertThat(pod.getSpec().getVolumes().size(), is(5));
+            assertThat(pod.getSpec().getVolumes().size(), is(6));
             assertThat(pod.getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir(), is(notNullValue()));
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("10Mi")));
@@ -997,6 +1010,8 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(pod.getSpec().getVolumes().get(3).getConfigMap().getName(), is("configMap1"));
             assertThat(pod.getSpec().getVolumes().get(4).getName(), is("pvc-volume-name"));
             assertThat(pod.getSpec().getVolumes().get(4).getPersistentVolumeClaim().getClaimName(), is("pvc-name"));
+            assertThat(pod.getSpec().getVolumes().get(5).getName(), is("pvc-templated-volume-name"));
+            assertThat(pod.getSpec().getVolumes().get(5).getPersistentVolumeClaim().getClaimName(), is("my-pvc-" + pod.getMetadata().getName().substring(pod.getMetadata().getName().lastIndexOf("-") + 1)));
 
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().size(), is(2));
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().get(0).getName(), is("rack-volume"));
@@ -1004,7 +1019,7 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().get(1).getName(), is("pvc-volume-name"));
             assertThat(pod.getSpec().getInitContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/mnt/mypvc"));
 
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(4));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), is(5));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("kafka-connect-configurations"));
@@ -1013,6 +1028,8 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/opt/kafka/init"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getName(), is("config-map-volume-name"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getMountPath(), is("/mnt/myconfigmap"));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(4).getName(), is("pvc-templated-volume-name"));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(4).getMountPath(), is("/mnt/pvc-templated-volume-name"));
         });
 
         // Check Service

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -592,17 +592,6 @@ public class ListenersUtilsTest {
     }
 
     @Test
-    public void testHostTemplateRendering() {
-        assertThat(ListenersUtils.renderHostTemplate("my-host", NODE_1), is("my-host"));
-        assertThat(ListenersUtils.renderHostTemplate("my-host-{nodeId}", NODE_1), is("my-host-1"));
-        assertThat(ListenersUtils.renderHostTemplate("{nodePodName}", NODE_1), is("my-cluster-kafka-1"));
-        assertThat(ListenersUtils.renderHostTemplate("my-host-{nodePodName}-{nodeId}", NODE_1), is("my-host-my-cluster-kafka-1-1"));
-        assertThat(ListenersUtils.renderHostTemplate("my-{nodeId}-host-{nodeId}", NODE_1), is("my-1-host-1"));
-        assertThat(ListenersUtils.renderHostTemplate("my-{nodeId}-host-{nodeID}", NODE_1), is("my-1-host-{nodeID}"));
-        assertThat(ListenersUtils.renderHostTemplate("my-{nodeId}-host-nodeId", NODE_1), is("my-1-host-nodeId"));
-    }
-
-    @Test
     public void testBrokerHost() {
         assertThat(ListenersUtils.brokerHost(newLoadBalancer, NODE_1), is(nullValue()));
         assertThat(ListenersUtils.brokerHost(oldExternal, NODE_0), is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -269,4 +269,17 @@ public class ModelUtilsTest {
 
         assertThat(ModelUtils.affinityWithRackLabelSelector(new PodTemplateBuilder().withAffinity(userAffinity).build(), new TopologyLabelRackBuilder().withTopologyKey("topology.key/my").build()), is(expectedAffinity));
     }
+
+    @Test
+    public void testHostTemplateRendering() {
+        NodeRef node = new NodeRef("my-cluster-kafka-1", 1, "kafka", false, true);
+
+        assertThat(ModelUtils.renderTemplate("my-host", node), is("my-host"));
+        assertThat(ModelUtils.renderTemplate("my-host-{nodeId}", node), is("my-host-1"));
+        assertThat(ModelUtils.renderTemplate("{nodePodName}", node), is("my-cluster-kafka-1"));
+        assertThat(ModelUtils.renderTemplate("my-host-{nodePodName}-{nodeId}", node), is("my-host-my-cluster-kafka-1-1"));
+        assertThat(ModelUtils.renderTemplate("my-{nodeId}-host-{nodeId}", node), is("my-1-host-1"));
+        assertThat(ModelUtils.renderTemplate("my-{nodeId}-host-{nodeID}", node), is("my-1-host-{nodeID}"));
+        assertThat(ModelUtils.renderTemplate("my-{nodeId}-host-nodeId", node), is("my-1-host-nodeId"));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.CSIVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.ImageVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
@@ -14,6 +15,7 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
@@ -24,6 +26,8 @@ import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplateBuilder;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplateBuilder;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Test;
 
@@ -237,5 +241,123 @@ public class TemplateUtilsTest {
         InvalidResourceException exception = assertThrows(InvalidResourceException.class, () -> TemplateUtils.addAdditionalVolumeMounts(volumeMounts, containerTemplate));
 
         assertThat(exception.getMessage(), is(String.format("Forbidden path found in additional volumes. Should start with %s", ALLOWED_MOUNT_PATH)));
+    }
+
+    @Test
+    public void testAddAdditionalTemplatedVolumes() {
+        List<Volume> existingVolumes = new ArrayList<>();
+        existingVolumes.add(new VolumeBuilder().withName("existingVolume1").build());
+        NodeRef node = new NodeRef("my-cluster-brokers-5", 5, "brokers", false, true);
+
+        StatefulPodTemplate templatePod = new StatefulPodTemplateBuilder()
+                .withTemplatedVolumes(
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("secret-volume")
+                                .withSecret(new SecretVolumeSourceBuilder().withSecretName("my-secret-{nodeId}").build())
+                                .build(),
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("secret-volume2")
+                                .withSecret(new SecretVolumeSourceBuilder().withSecretName("my-secret").withItems(new KeyToPathBuilder().withKey("{nodePodName}.crt").withPath("certificates-{nodeId}/tls.crt").build()).build())
+                                .build(),
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("cm-volume")
+                                .withConfigMap(new ConfigMapVolumeSourceBuilder().withName("my-cm-{nodeId}").build())
+                                .build(),
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("cm-volume2")
+                                .withConfigMap(new ConfigMapVolumeSourceBuilder().withName("my-cm").withItems(new KeyToPathBuilder().withKey("{nodePodName}.cfg").withPath("my-config/{nodeId}.cfg").build()).build())
+                                .build(),
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("pvc-volume")
+                                .withPersistentVolumeClaim(new PersistentVolumeClaimVolumeSourceBuilder().withClaimName("pvc-{nodeId}-{nodePodName}").build())
+                                .build())
+                .build();
+
+        TemplateUtils.addAdditionalTemplatedVolumes(node, templatePod, existingVolumes);
+
+        assertThat(existingVolumes.size(), is(6));
+
+        assertThat(existingVolumes.get(0).getName(), is("existingVolume1"));
+
+        assertThat(existingVolumes.get(1).getName(), is("secret-volume"));
+        assertThat(existingVolumes.get(1).getSecret().getSecretName(), is("my-secret-5"));
+        assertThat(existingVolumes.get(1).getConfigMap(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getImage(), is(nullValue()));
+
+        assertThat(existingVolumes.get(2).getName(), is("secret-volume2"));
+        assertThat(existingVolumes.get(2).getSecret().getSecretName(), is("my-secret"));
+        assertThat(existingVolumes.get(2).getSecret().getItems().size(), is(1));
+        assertThat(existingVolumes.get(2).getSecret().getItems().getFirst().getKey(), is("my-cluster-brokers-5.crt"));
+        assertThat(existingVolumes.get(2).getSecret().getItems().getFirst().getPath(), is("certificates-5/tls.crt"));
+        assertThat(existingVolumes.get(2).getConfigMap(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getImage(), is(nullValue()));
+
+        assertThat(existingVolumes.get(3).getName(), is("cm-volume"));
+        assertThat(existingVolumes.get(3).getConfigMap().getName(), is("my-cm-5"));
+        assertThat(existingVolumes.get(3).getSecret(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getImage(), is(nullValue()));
+
+        assertThat(existingVolumes.get(4).getName(), is("cm-volume2"));
+        assertThat(existingVolumes.get(4).getConfigMap().getName(), is("my-cm"));
+        assertThat(existingVolumes.get(4).getConfigMap().getItems().size(), is(1));
+        assertThat(existingVolumes.get(4).getConfigMap().getItems().getFirst().getKey(), is("my-cluster-brokers-5.cfg"));
+        assertThat(existingVolumes.get(4).getConfigMap().getItems().getFirst().getPath(), is("my-config/5.cfg"));
+        assertThat(existingVolumes.get(4).getSecret(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getImage(), is(nullValue()));
+
+        assertThat(existingVolumes.get(5).getName(), is("pvc-volume"));
+        assertThat(existingVolumes.get(5).getPersistentVolumeClaim().getClaimName(), is("pvc-5-my-cluster-brokers-5"));
+        assertThat(existingVolumes.get(5).getSecret(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getConfigMap(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getImage(), is(nullValue()));
+    }
+
+    @Test
+    public void testAddAdditionalTemplatedVolumesWithDuplicateName() {
+        List<Volume> existingVolumes = new ArrayList<>();
+        existingVolumes.add(new VolumeBuilder().withName("duplicate").build());
+        NodeRef node = new NodeRef("my-cluster-brokers-5", 5, "brokers", false, true);
+
+        StatefulPodTemplate templatePod = new StatefulPodTemplateBuilder()
+                .withTemplatedVolumes(
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("duplicate")
+                                .withSecret(new SecretVolumeSourceBuilder().withSecretName("my-secret-{nodeId}").build())
+                                .build())
+                .build();
+
+        InvalidResourceException exception = assertThrows(InvalidResourceException.class, () -> TemplateUtils.addAdditionalTemplatedVolumes(node, templatePod, existingVolumes));
+        assertThat(exception.getMessage(), is("Duplicate volume names found in additional volumes: [duplicate]"));
+    }
+
+    @Test
+    public void testAddAdditionalTemplatedVolumesWithInvalidName() {
+        List<Volume> existingVolumes = new ArrayList<>();
+        NodeRef node = new NodeRef("my-cluster-brokers-5", 5, "brokers", false, true);
+
+        StatefulPodTemplate templatePod = new StatefulPodTemplateBuilder()
+                .withTemplatedVolumes(
+                        new AdditionalTemplatedVolumeBuilder()
+                                .withName("invalid_name!")
+                                .withSecret(new SecretVolumeSourceBuilder().withSecretName("my-secret-{nodeId}").build())
+                                .build())
+                .build();
+
+        InvalidResourceException exception = assertThrows(InvalidResourceException.class, () -> TemplateUtils.addAdditionalTemplatedVolumes(node, templatePod, existingVolumes));
+        assertThat(exception.getMessage(), is("Volume names [invalid_name!] are invalid and do not match the pattern " + VOLUME_NAME_REGEX));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -35,6 +35,8 @@ import io.strimzi.api.kafka.model.common.template.DnsPolicy;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplateBuilder;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplateBuilder;
 import io.strimzi.api.kafka.model.common.template.StrimziDeploymentStrategy;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
@@ -529,7 +531,7 @@ public class WorkloadUtilsTest {
                 LABELS,
                 NAME,   // => Workload name
                 NAME + "-sa",   // => Service Account name
-                new PodTemplate(),
+                new StatefulPodTemplate(),
                 Map.of("default-label", "default-value"),
                 Map.of("extra", "annotations"),
                 HEADLESS_SERVICE_NAME,
@@ -584,7 +586,7 @@ public class WorkloadUtilsTest {
                 LABELS,
                 NAME,   // => Workload name
                 NAME + "-sa",   // => Service Account name
-                new PodTemplateBuilder()
+                new StatefulPodTemplateBuilder()
                         .withNewMetadata()
                             .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
                             .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))

--- a/development-docs/systemtests/io.strimzi.systemtest.kafka.KafkaST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.kafka.KafkaST.md
@@ -16,7 +16,7 @@
 
 ## testAdditionalVolumes
 
-**Description:** This test validates the mounting and usage of additional volumes for Kafka, Kafka Connect, and Kafka Bridge components. It tests whether secret and config map volumes are correctly created, mounted, and accessible across various deployments.
+**Description:** This test validates the mounting and usage of additional volumes for Kafka, Kafka Connect, and Kafka Bridge components. It tests whether secret and config map volumes are correctly created, mounted, and accessible across various deployments. For Kafka and Kafka Connect, it also validates the additional templated volumes that use the {nodeId} and {nodePodName} placeholders to mount different content into each Pod.
 
 **Steps:**
 
@@ -24,8 +24,10 @@
 | - | - | - |
 | 1. | Setup environment prerequisites and configure test storage. | Ensure the environment is in KRaft mode. |
 | 2. | Create necessary Kafka resources with additional volumes for secrets and config maps. | Resources are correctly instantiated with specified volumes. |
-| 3. | Deploy Kafka, Kafka Connect, and Kafka Bridge with these volumes. | Components are correctly configured with additional volumes. |
-| 4. | Verify that all pods (Kafka, Connect, and Bridge) have additional volumes mounted and accessible. | Volumes are correctly mounted and usable within pods. |
+| 3. | Create the Secret and ConfigMaps used by the additional templated volumes. | Resources referenced by the templated volumes exist before the Pods are started. |
+| 4. | Deploy Kafka, Kafka Connect, and Kafka Bridge with these volumes. | Components are correctly configured with additional volumes. |
+| 5. | Verify that all pods (Kafka, Connect, and Bridge) have additional volumes mounted and accessible. | Volumes are correctly mounted and usable within pods. |
+| 6. | Verify that Kafka and Connect pods have the additional templated volumes mounted with per-node content. | Templated volumes are correctly mounted and each Pod sees the content belonging to its node ID and Pod name. |
 
 **Labels:**
 

--- a/documentation/api/io.strimzi.api.kafka.model.common.template.StatefulPodTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.template.StatefulPodTemplate.adoc
@@ -27,6 +27,6 @@ template:
     #...
 ----
 
-Use the `hostAliases` property to a specify a list of hosts and IP addresses,
+Use the `hostAliases` property to specify a list of hosts and IP addresses,
 which are injected into the `/etc/hosts` file of the pod.
 This configuration is especially useful for Kafka Connect or MirrorMaker when a connection outside of the cluster is also requested by users.

--- a/documentation/api/io.strimzi.api.kafka.model.common.template.StatefulPodTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.template.StatefulPodTemplate.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: CONCEPT
 
-Configures the template for non-stateful pods.
+Configures the template for stateful pods (Kafka, Connect, and MirrorMaker 2 nodes).
 
-.Example `PodTemplate` configuration
+.Example `StatefulPodTemplate` configuration
 [source,yaml,subs=attributes+]
 ----
 # ...

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -778,7 +778,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |====
 |Property |Property type |Description
 |pod
-|xref:type-PodTemplate-{context}[`PodTemplate`]
+|xref:type-StatefulPodTemplate-{context}[`StatefulPodTemplate`]
 |Template for Kafka `Pods`.
 |bootstrapService
 |xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
@@ -833,17 +833,17 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |Template for Kafka `StrimziPodSet` resource.
 |====
 
-[id='type-PodTemplate-{context}']
-= `PodTemplate` schema reference
+[id='type-StatefulPodTemplate-{context}']
+= `StatefulPodTemplate` schema reference
 
-Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaNodePoolTemplate-{context}[`KafkaNodePoolTemplate`]
+Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaNodePoolTemplate-{context}[`KafkaNodePoolTemplate`]
 
-xref:type-PodTemplate-schema-{context}[Full list of `PodTemplate` schema properties]
+xref:type-StatefulPodTemplate-schema-{context}[Full list of `StatefulPodTemplate` schema properties]
 
-include::../api/io.strimzi.api.kafka.model.common.template.PodTemplate.adoc[leveloffset=+1]
+include::../api/io.strimzi.api.kafka.model.common.template.StatefulPodTemplate.adoc[leveloffset=+1]
 
-[id='type-PodTemplate-schema-{context}']
-== `PodTemplate` schema properties
+[id='type-StatefulPodTemplate-schema-{context}']
+== `StatefulPodTemplate` schema properties
 
 
 [cols="2,2,3a",options="header"]
@@ -894,6 +894,9 @@ include::../api/io.strimzi.api.kafka.model.common.template.PodTemplate.adoc[leve
 |volumes
 |xref:type-AdditionalVolume-{context}[`AdditionalVolume`] array
 |Additional volumes that can be mounted to the pod.
+|templatedVolumes
+|xref:type-AdditionalTemplatedVolume-{context}[`AdditionalTemplatedVolume`] array
+|Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
 |hostUsers
 |boolean
 |Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature.
@@ -902,7 +905,7 @@ include::../api/io.strimzi.api.kafka.model.common.template.PodTemplate.adoc[leve
 [id='type-MetadataTemplate-{context}']
 = `MetadataTemplate` schema reference
 
-Used in: xref:type-BuildConfigTemplate-{context}[`BuildConfigTemplate`], xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`], xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+Used in: xref:type-BuildConfigTemplate-{context}[`BuildConfigTemplate`], xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`], xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`], xref:type-StatefulPodTemplate-{context}[`StatefulPodTemplate`]
 
 xref:type-MetadataTemplate-schema-{context}[Full list of `MetadataTemplate` schema properties]
 
@@ -926,7 +929,7 @@ include::../api/io.strimzi.api.kafka.model.common.template.MetadataTemplate.adoc
 [id='type-AdditionalVolume-{context}']
 = `AdditionalVolume` schema reference
 
-Used in: xref:type-PodTemplate-{context}[`PodTemplate`]
+Used in: xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-StatefulPodTemplate-{context}[`StatefulPodTemplate`]
 
 
 [cols="2,2,3a",options="header"]
@@ -970,6 +973,29 @@ Used in: xref:type-AdditionalVolume-{context}[`AdditionalVolume`]
 |sizeLimit
 |string
 |The total amount of local storage required for this EmptyDir volume (for example 1Gi).
+|====
+
+[id='type-AdditionalTemplatedVolume-{context}']
+= `AdditionalTemplatedVolume` schema reference
+
+Used in: xref:type-StatefulPodTemplate-{context}[`StatefulPodTemplate`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|name
+|string
+|Name to use for the volume. Required.
+|secret
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#secretvolumesource-v1-core[SecretVolumeSource]
+|`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
+|configMap
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
+|`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
+|persistentVolumeClaim
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#persistentvolumeclaimvolumesource-v1-core[PersistentVolumeClaimVolumeSource]
+|`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
 |====
 
 [id='type-InternalServiceTemplate-{context}']
@@ -1369,6 +1395,72 @@ include::../api/io.strimzi.api.kafka.model.common.template.DeploymentTemplate.ad
 |deploymentStrategy
 |string (one of [RollingUpdate, Recreate])
 |Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+|====
+
+[id='type-PodTemplate-{context}']
+= `PodTemplate` schema reference
+
+Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`]
+
+xref:type-PodTemplate-schema-{context}[Full list of `PodTemplate` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.common.template.PodTemplate.adoc[leveloffset=+1]
+
+[id='type-PodTemplate-schema-{context}']
+== `PodTemplate` schema properties
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|metadata
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|Metadata applied to the resource.
+|imagePullSecrets
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core[LocalObjectReference] array
+|List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored.
+|securityContext
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podsecuritycontext-v1-core[PodSecurityContext]
+|Configures pod-level security attributes and common container settings.
+|terminationGracePeriodSeconds
+|integer
+|The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds.
+|affinity
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#affinity-v1-core[Affinity]
+|The pod's affinity rules.
+|tolerations
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#toleration-v1-core[Toleration] array
+|The pod's tolerations.
+|topologySpreadConstraints
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
+|The pod's topology spread constraints.
+|priorityClassName
+|string
+|The name of the priority class used to assign priority to the pods. 
+|schedulerName
+|string
+|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+|hostAliases
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#hostalias-v1-core[HostAlias] array
+|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+|dnsPolicy
+|string (one of [ClusterFirstWithHostNet, ClusterFirst, Default, None])
+|The pod's DNSPolicy. Defaults to `ClusterFirst`. Valid values are `ClusterFirstWithHostNet`, `ClusterFirst`, `Default` or `None`.
+|dnsConfig
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#poddnsconfig-v1-core[PodDNSConfig]
+|The pod's DNSConfig. If specified, it will be merged to the generated DNS configuration based on the DNSPolicy.
+|enableServiceLinks
+|boolean
+|Indicates whether information about services should be injected into Pod's environment variables.
+|tmpDirSizeLimit
+|string
+|Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources.
+|volumes
+|xref:type-AdditionalVolume-{context}[`AdditionalVolume`] array
+|Additional volumes that can be mounted to the pod.
+|hostUsers
+|boolean
+|Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature.
 |====
 
 [id='type-CertificateAuthority-{context}']
@@ -2163,7 +2255,7 @@ Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Kaf
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |Template for Kafka Connect `StrimziPodSet` resource.
 |pod
-|xref:type-PodTemplate-{context}[`PodTemplate`]
+|xref:type-StatefulPodTemplate-{context}[`StatefulPodTemplate`]
 |Template for Kafka Connect `Pods`.
 |apiService
 |xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
@@ -3897,7 +3989,7 @@ Used in: xref:type-KafkaNodePoolSpec-{context}[`KafkaNodePoolSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |Template for Kafka `StrimziPodSet` resource.
 |pod
-|xref:type-PodTemplate-{context}[`PodTemplate`]
+|xref:type-StatefulPodTemplate-{context}[`StatefulPodTemplate`]
 |Template for Kafka `Pods`.
 |perPodService
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]

--- a/documentation/modules/configuring/con-common-configuration.adoc
+++ b/documentation/modules/configuring/con-common-configuration.adoc
@@ -132,6 +132,36 @@ spec:
   # ...          
 ----
 
+For `Kafka`, `KafkaConnect`, and `KafkaMirrorMaker2` components, you can also add templated volumes to use a different volume for each pod.
+You can use the `{nodeId}` and `{nodePodName}` placeholders in the volume configuration to create a unique volume for each pod.
+The placeholders can be used in:
+* `Secret`, `ConfigMap`, or `PersistentVolumeClaim` names in the templated volumes
+* `key` and `path` option in the `items` sections of the `Secret` and `ConfigMap` volumes
+
+The templated volumes are mounted through the `volumeMounts` section of the container template in the same way as regular additional volumes.
+
+.Example templated additional volumes
+[source,yaml]
+----
+# ...
+spec:
+  kafka:
+    template:
+      pod:
+        templatedVolumes:
+          - name: example-secret
+            secret:
+              secretName: secret-name
+              items:
+                - key: "{nodePodName}.crt"
+                  path: "{nodePodName}.crt"
+      kafkaContainer:
+        volumeMounts:
+          - name: example-secret
+            mountPath: /mnt/secret-volume
+  # ...
+----
+
 NOTE: You can use `template` configuration to add other customizations to pods and containers, such as affinity and security context. 
 For more information, see xref:assembly-scheduling-str[Configuring pod scheduling] and xref:assembly-security-providers-str[Applying security context to Strimzi pods and containers].
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1275,6 +1275,70 @@ spec:
                                       csi: {}
                                       image: {}
                               description: Additional volumes that can be mounted to the pod.
+                            templatedVolumes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    description: Name to use for the volume. Required.
+                                  secret:
+                                    type: object
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                      optional:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                    description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                  persistentVolumeClaim:
+                                    type: object
+                                    properties:
+                                      claimName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                oneOf:
+                                  - properties:
+                                      secret: {}
+                                      configMap: {}
+                                      persistentVolumeClaim: {}
+                              description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                             hostUsers:
                               type: boolean
                               description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1061,6 +1061,70 @@ spec:
                                   csi: {}
                                   image: {}
                           description: Additional volumes that can be mounted to the pod.
+                        templatedVolumes:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name to use for the volume. Required.
+                              secret:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              configMap:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              persistentVolumeClaim:
+                                type: object
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  persistentVolumeClaim: {}
+                          description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                         hostUsers:
                           type: boolean
                           description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -883,6 +883,70 @@ spec:
                                   csi: {}
                                   image: {}
                           description: Additional volumes that can be mounted to the pod.
+                        templatedVolumes:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name to use for the volume. Required.
+                              secret:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              configMap:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              persistentVolumeClaim:
+                                type: object
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  persistentVolumeClaim: {}
+                          description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                         hostUsers:
                           type: boolean
                           description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1311,6 +1311,70 @@ spec:
                                   csi: {}
                                   image: {}
                           description: Additional volumes that can be mounted to the pod.
+                        templatedVolumes:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name to use for the volume. Required.
+                              secret:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              configMap:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              persistentVolumeClaim:
+                                type: object
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  persistentVolumeClaim: {}
+                          description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                         hostUsers:
                           type: boolean
                           description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1274,6 +1274,70 @@ spec:
                                   csi: {}
                                   image: {}
                             description: Additional volumes that can be mounted to the pod.
+                          templatedVolumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  persistentVolumeClaim: {}
+                            description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                           hostUsers:
                             type: boolean
                             description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1060,6 +1060,70 @@ spec:
                               csi: {}
                               image: {}
                         description: Additional volumes that can be mounted to the pod.
+                      templatedVolumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              persistentVolumeClaim: {}
+                        description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                       hostUsers:
                         type: boolean
                         description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -882,6 +882,70 @@ spec:
                               csi: {}
                               image: {}
                         description: Additional volumes that can be mounted to the pod.
+                      templatedVolumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              persistentVolumeClaim: {}
+                        description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                       hostUsers:
                         type: boolean
                         description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1310,6 +1310,70 @@ spec:
                               csi: {}
                               image: {}
                         description: Additional volumes that can be mounted to the pod.
+                      templatedVolumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: "`Secret` to use to populate the volume. The name of the Secret and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: "`ConfigMap` to use to populate the volume. The name of the ConfigMap and the items key and path fields can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: "`PersistentVolumeClaim` object to use to populate the volume. The name of the Persistent Volume Claim can use placeholders that would be replaced for every individual node. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              persistentVolumeClaim: {}
+                        description: Additional volumes that can be mounted to the pod. These volumes can use templates to mount different volumes into individual Pods.
                       hostUsers:
                         type: boolean
                         description: "Use the host user namespace. Optional. Defaults to `true`. When `true` or not set, the pod runs in the host user namespace. This is required when the pod needs features available only in the host namespace, such as loading kernel modules with `CAP_SYS_MODULE`.When set to `false`, the pod runs in a new user namespace. Setting `false` helps mitigate container breakout vulnerabilities and allows containers to run as `root` without granting `root` privileges on the host. This property is alpha-level in Kubernetes and is supported only by Kubernetes clusters that enable the `UserNamespacesSupport` feature."

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -7,12 +7,14 @@ package io.strimzi.systemtest.kafka;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -30,6 +32,8 @@ import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.JvmOptionsBuilder;
 import io.strimzi.api.kafka.model.common.SystemProperty;
 import io.strimzi.api.kafka.model.common.SystemPropertyBuilder;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolume;
+import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
@@ -47,6 +51,7 @@ import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -108,7 +113,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @Tag(REGRESSION)
-@SuppressWarnings("checkstyle:ClassFanOutComplexity")
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 @SuiteDoc(
     description = @Desc("Test suite containing Kafka related stuff (i.e., JVM resources, EO, TO or UO removal from Kafka cluster), which ensures proper functioning of Kafka clusters."),
     beforeTestSteps = {
@@ -1179,17 +1184,20 @@ class KafkaST extends AbstractST {
     @Tag(CONNECT)
     @Tag(BRIDGE)
     @TestDoc(
-        description = @Desc("This test validates the mounting and usage of additional volumes for Kafka, Kafka Connect, and Kafka Bridge components. It tests whether secret and config map volumes are correctly created, mounted, and accessible across various deployments."),
+        description = @Desc("This test validates the mounting and usage of additional volumes for Kafka, Kafka Connect, and Kafka Bridge components. It tests whether secret and config map volumes are correctly created, mounted, and accessible across various deployments. For Kafka and Kafka Connect, it also validates the additional templated volumes that use the {nodeId} and {nodePodName} placeholders to mount different content into each Pod."),
         steps = {
             @Step(value = "Setup environment prerequisites and configure test storage.", expected = "Ensure the environment is in KRaft mode."),
             @Step(value = "Create necessary Kafka resources with additional volumes for secrets and config maps.", expected = "Resources are correctly instantiated with specified volumes."),
+            @Step(value = "Create the Secret and ConfigMaps used by the additional templated volumes.", expected = "Resources referenced by the templated volumes exist before the Pods are started."),
             @Step(value = "Deploy Kafka, Kafka Connect, and Kafka Bridge with these volumes.", expected = "Components are correctly configured with additional volumes."),
-            @Step(value = "Verify that all pods (Kafka, Connect, and Bridge) have additional volumes mounted and accessible.", expected = "Volumes are correctly mounted and usable within pods.")
+            @Step(value = "Verify that all pods (Kafka, Connect, and Bridge) have additional volumes mounted and accessible.", expected = "Volumes are correctly mounted and usable within pods."),
+            @Step(value = "Verify that Kafka and Connect pods have the additional templated volumes mounted with per-node content.", expected = "Templated volumes are correctly mounted and each Pod sees the content belonging to its node ID and Pod name.")
         },
         labels = {
             @Label(value = TestDocsLabels.KAFKA)
         }
     )
+    @SuppressWarnings("checkstyle:MethodLength")
     void testAdditionalVolumes() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         final int numberOfKafkaReplicas = 3;
@@ -1205,14 +1213,64 @@ class KafkaST extends AbstractST {
         final String configMapValue = "VALUE";
         final String configMapMountPath = "/mnt/configmap-volume";
 
+        final String templatedSecretName = "templated-secret";
+        final String templatedSecretItemPath = "node-id";
+        final String templatedSecretMountPath = "/mnt/templated-secret-volume";
+
+        final String templatedConfigMapName = "templated-configmap";
+        final String templatedConfigMapKey = "NODE_POD_NAME";
+        final String templatedConfigMapMountPath = "/mnt/templated-configmap-volume";
+
+        // The node IDs are pre-configured through the strimzi.io/next-node-ids annotations, so that the node IDs and
+        // Pod names are known upfront and the resources used by the templated volumes can be prepared before the Pods
+        // are started
         KubeResourceManager.get().createResourceWithWait(
-            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), numberOfKafkaReplicas).build(),
-            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), numberOfKafkaReplicas)
+                .editOrNewMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[0-2]")
+                .endMetadata()
+                .build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3)
+                .editOrNewMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[100-102]")
+                .endMetadata()
+                .build()
         );
 
         SecretUtils.createSecret(testStorage.getNamespaceName(), secretName, secretKeyBase64, secretValueBase64);
         KubeResourceManager.get().createResourceWithWait(ConfigMapTemplates.buildConfigMap(testStorage.getNamespaceName(), configMapName,
             configMapKey, configMapValue));
+
+        // Pods with stable identities that will use the templated volumes: Kafka brokers (node IDs 0-2), Kafka
+        // controllers (node IDs 100-102), and Kafka Connect (node ID 0)
+        final List<String> statefulPodNames = new ArrayList<>();
+        for (int nodeId = 0; nodeId < numberOfKafkaReplicas; nodeId++) {
+            statefulPodNames.add(testStorage.getBrokerComponentName() + "-" + nodeId);
+        }
+        for (int nodeId = 100; nodeId <= 102; nodeId++) {
+            statefulPodNames.add(testStorage.getControllerComponentName() + "-" + nodeId);
+        }
+        statefulPodNames.add(KafkaConnectResources.componentName(testStorage.getClusterName()) + "-0");
+
+        // Secret with one key per node ID that is mounted through a templated volume using the {nodeId} placeholder in
+        // the item key, and one ConfigMap per Pod that is mounted through a templated volume using the {nodePodName}
+        // placeholder in the ConfigMap name
+        final Map<String, String> templatedSecretData = new HashMap<>();
+        for (String podName : statefulPodNames) {
+            final String nodeId = podName.substring(podName.lastIndexOf('-') + 1);
+            templatedSecretData.put("node-" + nodeId, nodeId);
+            KubeResourceManager.get().createResourceWithWait(ConfigMapTemplates.buildConfigMap(testStorage.getNamespaceName(), templatedConfigMapName + "-" + podName,
+                templatedConfigMapKey, podName));
+        }
+
+        KubeResourceManager.get().createResourceWithWait(new SecretBuilder()
+            .withNewMetadata()
+                .withName(templatedSecretName)
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .withType("Opaque")
+            .withStringData(templatedSecretData)
+            .build());
 
         AdditionalVolume[] additionalVolumes = new AdditionalVolume[]{
             // Secret additional volume
@@ -1241,15 +1299,48 @@ class KafkaST extends AbstractST {
                 .build()
         };
 
+        AdditionalTemplatedVolume[] templatedVolumes = new AdditionalTemplatedVolume[]{
+            // Secret templated volume with the {nodeId} placeholder in the item key
+            new AdditionalTemplatedVolumeBuilder()
+                .withName(templatedSecretName)
+                .withSecret(new SecretVolumeSourceBuilder()
+                    .withSecretName(templatedSecretName)
+                    .withItems(new KeyToPathBuilder()
+                        .withKey("node-{nodeId}")
+                        .withPath(templatedSecretItemPath)
+                        .build())
+                    .build())
+                .build(),
+            // ConfigMap templated volume with the {nodePodName} placeholder in the ConfigMap name
+            new AdditionalTemplatedVolumeBuilder()
+                .withName(templatedConfigMapName)
+                .withConfigMap(new ConfigMapVolumeSourceBuilder()
+                    .withName(templatedConfigMapName + "-{nodePodName}")
+                    .build())
+                .build()
+        };
+        VolumeMount[] templatedVolumeMounts = new VolumeMount[]{
+            new VolumeMountBuilder()
+                .withName(templatedSecretName)
+                .withMountPath(templatedSecretMountPath)
+                .build(),
+            new VolumeMountBuilder()
+                .withName(templatedConfigMapName)
+                .withMountPath(templatedConfigMapMountPath)
+                .build()
+        };
+
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), numberOfKafkaReplicas)
             .editSpec()
                 .editKafka()
                     .editTemplate()
                         .editPod()
                             .addToVolumes(additionalVolumes)
+                            .addToTemplatedVolumes(templatedVolumes)
                         .endPod()
                         .editKafkaContainer()
                             .addToVolumeMounts(volumeMounts)
+                            .addToVolumeMounts(templatedVolumeMounts)
                         .endKafkaContainer()
                     .endTemplate()
                 .endKafka()
@@ -1261,9 +1352,11 @@ class KafkaST extends AbstractST {
                 .editTemplate()
                     .editPod()
                         .addToVolumes(additionalVolumes)
+                        .addToTemplatedVolumes(templatedVolumes)
                     .endPod()
                     .editConnectContainer()
                         .addToVolumeMounts(volumeMounts)
+                        .addToVolumeMounts(templatedVolumeMounts)
                     .endConnectContainer()
                 .endTemplate()
             .endSpec()
@@ -1291,6 +1384,12 @@ class KafkaST extends AbstractST {
         for (Pod kafkaPod : kafkaPods) {
             verifyPodSecretVolume(testStorage.getNamespaceName(), kafkaPod, "kafka", secretMountPath, secretValueBase64, secretKeyBase64);
             verifyPodConfigMapVolume(testStorage.getNamespaceName(), kafkaPod, "kafka", configMapMountPath, configMapValue, configMapKey);
+
+            // Check the templated volumes => each Pod should see the content belonging to its own node ID and Pod name
+            final String kafkaPodName = kafkaPod.getMetadata().getName();
+            final String kafkaNodeId = kafkaPodName.substring(kafkaPodName.lastIndexOf('-') + 1);
+            verifyPodSecretVolume(testStorage.getNamespaceName(), kafkaPod, "kafka", templatedSecretMountPath, kafkaNodeId, templatedSecretItemPath);
+            verifyPodConfigMapVolume(testStorage.getNamespaceName(), kafkaPod, "kafka", templatedConfigMapMountPath, kafkaPodName, templatedConfigMapKey);
         }
 
         // 2. check Connect pods
@@ -1298,9 +1397,15 @@ class KafkaST extends AbstractST {
         for (Pod connectPod : connectPods) {
             verifyPodSecretVolume(testStorage.getNamespaceName(), connectPod, KafkaConnectResources.componentName(testStorage.getClusterName()), secretMountPath, secretValueBase64, secretKeyBase64);
             verifyPodConfigMapVolume(testStorage.getNamespaceName(), connectPod, KafkaConnectResources.componentName(testStorage.getClusterName()), configMapMountPath, configMapValue, configMapKey);
+
+            // Check the templated volumes => each Pod should see the content belonging to its own node ID and Pod name
+            final String connectPodName = connectPod.getMetadata().getName();
+            final String connectNodeId = connectPodName.substring(connectPodName.lastIndexOf('-') + 1);
+            verifyPodSecretVolume(testStorage.getNamespaceName(), connectPod, KafkaConnectResources.componentName(testStorage.getClusterName()), templatedSecretMountPath, connectNodeId, templatedSecretItemPath);
+            verifyPodConfigMapVolume(testStorage.getNamespaceName(), connectPod, KafkaConnectResources.componentName(testStorage.getClusterName()), templatedConfigMapMountPath, connectPodName, templatedConfigMapKey);
         }
 
-        // 3. check Bridge pods
+        // 3. check Bridge pods (Bridge Pods do not have stable identities, so the templated volumes are not supported there)
         List<Pod> bridgePods = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(),
             testStorage.getBridgeSelector());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -18,7 +18,7 @@ import io.fabric8.kubernetes.api.model.PodAffinityBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.skodjob.kubetest4j.resources.KubeResourceManager;
-import io.strimzi.api.kafka.model.common.template.PodTemplate;
+import io.strimzi.api.kafka.model.common.template.StatefulPodTemplate;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterTemplateBuilder;
@@ -315,7 +315,7 @@ public class KafkaRollerST extends AbstractST {
                 .endNodeAffinity()
                 .build();
 
-        PodTemplate pt = new PodTemplate();
+        StatefulPodTemplate pt = new StatefulPodTemplate();
         pt.setAffinity(affinity);
 
         KafkaClusterTemplate kct = new KafkaClusterTemplateBuilder()


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the [SEP-147 proposal](https://github.com/strimzi/proposals/blob/main/147-templating-additional-volumes.md) and allows templating of additional volumes for Pods with stable identities (Kafka, Connect, MM2). It allows to mount different volumes into different pods based on their name or node ID.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md (if present)
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
