### PR TITLE
Use role-based default allowlists for Strimzi Metrics Reporter

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -206,7 +206,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         if (spec.getMetricsConfig() instanceof JmxPrometheusExporterMetrics) {
             result.metrics = new JmxPrometheusExporterModel(spec);
         } else if (spec.getMetricsConfig() instanceof StrimziMetricsReporter) {
-            result.metrics = new StrimziMetricsReporterModel(spec, DEFAULT_METRICS_ALLOW_LIST);
+            result.metrics = new StrimziMetricsReporterModel(spec);
         }
 
         result.setTls(spec.getTls() != null ? spec.getTls() : null);
@@ -672,7 +672,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         if (metrics instanceof JmxPrometheusExporterModel jmxPrometheusExporterModel) {
             builder.withJmxPrometheusExporter(jmxPrometheusExporterModel);
         } else if (metrics instanceof StrimziMetricsReporterModel strimziMetricsReporterModel) {
-            builder.withStrimziMetricsReporter(strimziMetricsReporterModel);
+            builder.withStrimziMetricsReporter(strimziMetricsReporterModel, DEFAULT_METRICS_ALLOW_LIST);
         }
 
         data.put(BRIDGE_CONFIGURATION_FILENAME, builder.build());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilder.java
@@ -29,6 +29,7 @@ import io.strimzi.operator.common.Reconciliation;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter.TYPE_STRIMZI_METRICS_REPORTER;
@@ -353,18 +354,19 @@ public class KafkaBridgeConfigurationBuilder {
     /**
      * Configures the Strimzi Metrics Reporter. It is set only if user enables Strimzi Metrics Reporter.
      *
-     * @param model     Strimzi Metrics Reporter configuration
+     * @param model            Strimzi Metrics Reporter configuration
+     * @param defaultAllowList Role-specific default allow list used when the user has not configured one
      *
      * @return Returns the builder instance
      */
-    public KafkaBridgeConfigurationBuilder withStrimziMetricsReporter(StrimziMetricsReporterModel model)   {
+    public KafkaBridgeConfigurationBuilder withStrimziMetricsReporter(StrimziMetricsReporterModel model, List<String> defaultAllowList)   {
         if (model != null) {
             printSectionHeader("Strimzi Metrics Reporter configuration");
             writer.println("bridge.metrics=" + TYPE_STRIMZI_METRICS_REPORTER);
             // the kafka. prefix is required by the Bridge to pass Kafka client configurations
             writer.println("kafka.metric.reporters=" + StrimziMetricsReporterConfig.CLIENT_CLASS);
             writer.println("kafka." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=false");
-            writer.println("kafka." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + model.getAllowList());
+            writer.println("kafka." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + model.getAllowListOrDefault(defaultAllowList));
             writer.println();
         }
         return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -136,16 +136,17 @@ public class KafkaBrokerConfigurationBuilder {
     /**
      * Configures the Strimzi Metrics Reporter. It is set only if user enables Strimzi Metrics Reporter.
      *
-     * @param model Strimzi Metrics Reporter configuration
+     * @param model            Strimzi Metrics Reporter configuration
+     * @param defaultAllowList Role-specific default allow list used when the user has not configured one
      *
      * @return Returns the builder instance
      */
-    public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(MetricsModel model) {
+    public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(MetricsModel model, List<String> defaultAllowList) {
         if (model instanceof StrimziMetricsReporterModel reporterModel) {
             printSectionHeader("Strimzi Metrics Reporter configuration");
             writer.println(StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println(StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowListOrDefault(defaultAllowList));
             writer.println();
         }
         return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -117,13 +117,11 @@ import static java.util.Collections.singletonMap;
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class KafkaCluster extends AbstractModel implements SupportsMetrics, SupportsLogging, SupportsJmx {
     /**
-     * Default Strimzi Metrics Reporter allow list.
+     * Default Strimzi Metrics Reporter allow list for broker nodes.
      * If modifying this list, make sure example dashboards are compatible with the regexes.
      */
-    private static final List<String> DEFAULT_METRICS_ALLOW_LIST = List.of(
+    private static final List<String> BROKER_DEFAULT_METRICS_ALLOW_LIST = List.of(
             "kafka_cluster_partition.*",
-            "kafka_controller_kafkacontroller.*",
-            "kafka_controller_controllerstats_uncleanleaderelectionspersec",
             "kafka_log_log_size",
             "kafka_network_requestmetrics.*",
             "kafka_network_socketserver_networkprocessoravgidlepercent",
@@ -133,11 +131,44 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             "kafka_server_kafkaserver_brokerstate",
             "kafka_server_kafkaserver_clusterid",
             "kafka_server_kafkaserver_linux.*",
-            "kafka_server_raft.*",
             "kafka_server_replicamanager.*",
             "kafka_server_request_queue_size",
             "kafka_server_socket_server.*"
     );
+
+    /**
+     * Default Strimzi Metrics Reporter allow list for controller nodes.
+     * If modifying this list, make sure example dashboards are compatible with the regexes.
+     */
+    private static final List<String> CONTROLLER_DEFAULT_METRICS_ALLOW_LIST = List.of(
+            "kafka_controller_kafkacontroller.*",
+            "kafka_controller_controllerstats_uncleanleaderelectionspersec",
+            "kafka_network_requestmetrics.*",
+            "kafka_network_socketserver_networkprocessoravgidlepercent",
+            "kafka_server_app_info.*",
+            "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent",
+            "kafka_server_kafkaserver_clusterid",
+            "kafka_server_kafkaserver_linux.*",
+            "kafka_server_raft.*",
+            "kafka_server_request_queue_size",
+            "kafka_server_socket_server.*"
+    );
+
+    /**
+     * Default Strimzi Metrics Reporter allow list for mixed (broker + controller) nodes.
+     * This is the union of broker and controller allow lists.
+     * If modifying this list, make sure example dashboards are compatible with the regexes.
+     */
+    private static final List<String> MIXED_DEFAULT_METRICS_ALLOW_LIST;
+    static {
+        List<String> mixed = new ArrayList<>(BROKER_DEFAULT_METRICS_ALLOW_LIST);
+        for (String s : CONTROLLER_DEFAULT_METRICS_ALLOW_LIST) {
+            if (!mixed.contains(s)) {
+                mixed.add(s);
+            }
+        }
+        MIXED_DEFAULT_METRICS_ALLOW_LIST = List.copyOf(mixed);
+    }
 
     /**
      * Component type used by Kubernetes labels
@@ -335,7 +366,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         if (kafkaClusterSpec.getMetricsConfig() instanceof JmxPrometheusExporterMetrics) {
             result.metrics = new JmxPrometheusExporterModel(kafkaClusterSpec);
         } else if (kafkaClusterSpec.getMetricsConfig() instanceof StrimziMetricsReporter) {
-            result.metrics = new StrimziMetricsReporterModel(kafkaClusterSpec, DEFAULT_METRICS_ALLOW_LIST);
+            result.metrics = new StrimziMetricsReporterModel(kafkaClusterSpec);
         }
 
         result.logging = new LoggingModel(kafkaClusterSpec, result.getClass().getSimpleName());
@@ -1800,6 +1831,24 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
+     * Returns the default metrics allow list for the given pool based on its role.
+     * Broker-only pools get the broker list, controller-only pools get the controller list,
+     * and mixed pools get the union of both.
+     *
+     * @param pool  The Kafka node pool
+     * @return      The appropriate default metrics allow list
+     */
+    private static List<String> defaultMetricsAllowListForPool(KafkaPool pool) {
+        if (pool.isBroker() && pool.isController()) {
+            return MIXED_DEFAULT_METRICS_ALLOW_LIST;
+        } else if (pool.isBroker()) {
+            return BROKER_DEFAULT_METRICS_ALLOW_LIST;
+        } else {
+            return CONTROLLER_DEFAULT_METRICS_ALLOW_LIST;
+        }
+    }
+
+    /**
      * Internal method used to generate a Kafka configuration for given broker node.
      *
      * @param node                  Node reference with Node ID and pod name
@@ -1825,7 +1874,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 .withCruiseControl(cluster, ccMetricsReporter, node.broker())
                 .withTieredStorage(cluster, tieredStorage)
                 .withQuotas(cluster, quotas)
-                .withStrimziMetricsReporter(metrics)
+                .withStrimziMetricsReporter(metrics, defaultMetricsAllowListForPool(pool))
                 .withUserConfiguration(
                         configuration,
                         node.broker() && ccMetricsReporter != null,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -279,7 +279,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         if (spec.getMetricsConfig() instanceof JmxPrometheusExporterMetrics) {
             result.metrics = new JmxPrometheusExporterModel(spec);
         } else if (spec.getMetricsConfig() instanceof StrimziMetricsReporter) {
-            result.metrics = new StrimziMetricsReporterModel(spec, result.getDefaultMetricsAllowList());
+            result.metrics = new StrimziMetricsReporterModel(spec);
         }
 
         result.logging = new LoggingModel(spec, result.getClass().getSimpleName());
@@ -839,7 +839,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                         .withTls(tls, cluster)
                         .withAuthentication(authentication)
                         .withRackId(rack)
-                        .withStrimziMetricsReporter(metrics)
+                        .withStrimziMetricsReporter(metrics, getDefaultMetricsAllowList())
                         .withUserConfiguration(
                                 configuration,
                                 metrics instanceof JmxPrometheusExporterModel,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilder.java
@@ -383,23 +383,25 @@ public class KafkaConnectConfigurationBuilder {
      *
      * @param model Strimzi Metrics Reporter configuration
      *
+     * @param defaultAllowList Role-specific default allow list used when the user has not configured one
+     *
      * @return Returns the builder instance
      */
-    public KafkaConnectConfigurationBuilder withStrimziMetricsReporter(MetricsModel model) {
+    public KafkaConnectConfigurationBuilder withStrimziMetricsReporter(MetricsModel model, List<String> defaultAllowList) {
         if (model instanceof StrimziMetricsReporterModel reporterModel) {
             printSectionHeader("Strimzi Metrics Reporter configuration");
             writer.println(StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println(StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowListOrDefault(defaultAllowList));
             writer.println("admin." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println("admin." + StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println("admin." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println("admin." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowListOrDefault(defaultAllowList));
             writer.println("producer." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println("producer." + StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println("producer." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println("producer." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowListOrDefault(defaultAllowList));
             writer.println("consumer." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println("consumer." + StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println("consumer." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println("consumer." + StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowListOrDefault(defaultAllowList));
             writer.println();
         }
         return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
@@ -19,34 +19,35 @@ import java.util.regex.PatternSyntaxException;
  */
 public class StrimziMetricsReporterModel implements MetricsModel {
     /**
-     * Fully qualified class name of the Strimzi Metrics Reporter.
+     * The user-configured allow list of regex patterns, or null if not set by the user.
      */
     private final List<String> allowList;
 
-        /**
-         * Constructs the Metrics Model for managing configurable metrics to Strimzi.
-         *
-         * @param spec Custom resource section configuring metrics.
-         * @param defaultAllowList Default allow list to be used when no value is provided.
-         */
-    public StrimziMetricsReporterModel(HasConfigurableMetrics spec, List<String> defaultAllowList) {
+    /**
+     * Constructs the Metrics Model from a custom resource spec.
+     * Stores the user-configured allowlist if provided, otherwise stores null.
+     *
+     * @param spec Custom resource section configuring metrics.
+     */
+    public StrimziMetricsReporterModel(HasConfigurableMetrics spec) {
         if (spec.getMetricsConfig() != null) {
             StrimziMetricsReporter config = (StrimziMetricsReporter) spec.getMetricsConfig();
             validate(config);
-            this.allowList = config.getValues() != null && config.getValues().getAllowList() != null
-                    ? config.getValues().getAllowList() : defaultAllowList;
+            this.allowList = config.getValues() != null ? config.getValues().getAllowList() : null;
         } else {
             throw new InvalidConfigurationException("Unexpected empty metrics config");
         }
     }
 
     /**
-     * Gets the comma-separated list of allow regex expressions.
+     * Gets the comma-separated allow list, falling back to the provided default if the user did not configure one.
      *
-     * @return Comma separated list of allow regex expressions.
+     * @param defaultAllowList Role-specific default allow list to use when the user has not set one.
+     * @return Comma-separated list of allow regex expressions.
      */
-    public String getAllowList() {
-        return String.join(",", allowList);
+    public String getAllowListOrDefault(List<String> defaultAllowList) {
+        List<String> effective = allowList != null ? allowList : defaultAllowList;
+        return String.join(",", effective);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -1285,7 +1285,7 @@ public class KafkaBridgeClusterTest {
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
 
         assertThat(kbc.metrics(), is(notNullValue()));
-        assertThat(((StrimziMetricsReporterModel) kbc.metrics()).getAllowList(), is("kafka_producer_producer_metrics.*,kafka_producer_kafka_metrics_count_count"));
+        assertThat(((StrimziMetricsReporterModel) kbc.metrics()).getAllowListOrDefault(List.of()), is("kafka_producer_producer_metrics.*,kafka_producer_kafka_metrics_count_count"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeConfigurationBuilderTest.java
@@ -728,10 +728,10 @@ public class KafkaBridgeConfigurationBuilderTest {
                                     .withAllowList("kafka_producer_producer_metrics.*,kafka_producer_kafka_metrics_count_count")
                                 .endValues()
                         .endStrimziMetricsReporterConfig()
-                        .build(), List.of(".*"));
+                        .build());
 
         String configuration = new KafkaBridgeConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BRIDGE_CLUSTER, BRIDGE_BOOTSTRAP_SERVERS)
-                .withStrimziMetricsReporter(model)
+                .withStrimziMetricsReporter(model, List.of())
                 .build();
 
         assertThat(configuration, isEquivalent(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -216,10 +216,10 @@ public class KafkaBrokerConfigurationBuilderTest {
                                 .withAllowList(List.of("kafka_log.*", "kafka_network.*"))
                             .endValues()
                             .build())
-                        .build(), List.of(".*"));
+                        .build());
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
-                .withStrimziMetricsReporter(model)
+                .withStrimziMetricsReporter(model, List.of())
                 .build();
 
         assertThat(configuration, isEquivalent("node.id=2",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -338,6 +338,62 @@ public class KafkaClusterTest {
     }
 
     @Test
+    public void testStrimziMetricsReporterDefaultAllowListIsRoleBased() {
+        // When no custom allowlist is set, each node pool should receive a role-specific default allowlist
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withNewStrimziMetricsReporterConfig()
+                        .endStrimziMetricsReporterConfig()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+
+        List<ConfigMap> cms = kc.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
+        assertThat(cms.size(), is(8));
+
+        for (ConfigMap cm : cms) {
+            String podName = cm.getMetadata().getName();
+            String data = cm.getData().toString();
+
+            if (podName.startsWith("controllers-")) {
+                // Controller-only nodes: must have controller metrics, must NOT have broker-only metrics
+                assertThat(podName + " should have controller metrics",
+                        data, containsString("kafka_controller_kafkacontroller"));
+                assertThat(podName + " should have raft metrics",
+                        data, containsString("kafka_server_raft"));
+                assertThat(podName + " should NOT have broker-only partition metrics",
+                        data, not(containsString("kafka_cluster_partition")));
+                assertThat(podName + " should NOT have broker topic metrics",
+                        data, not(containsString("kafka_server_brokertopicmetrics")));
+            } else if (podName.startsWith("mixed-")) {
+                // Mixed nodes: must have both broker and controller metrics
+                assertThat(podName + " should have controller metrics",
+                        data, containsString("kafka_controller_kafkacontroller"));
+                assertThat(podName + " should have raft metrics",
+                        data, containsString("kafka_server_raft"));
+                assertThat(podName + " should have broker partition metrics",
+                        data, containsString("kafka_cluster_partition"));
+                assertThat(podName + " should have broker topic metrics",
+                        data, containsString("kafka_server_brokertopicmetrics"));
+            } else if (podName.startsWith("brokers-")) {
+                // Broker-only nodes: must have broker metrics, must NOT have controller-only metrics
+                assertThat(podName + " should have broker partition metrics",
+                        data, containsString("kafka_cluster_partition"));
+                assertThat(podName + " should have broker topic metrics",
+                        data, containsString("kafka_server_brokertopicmetrics"));
+                assertThat(podName + " should NOT have controller metrics",
+                        data, not(containsString("kafka_controller_kafkacontroller")));
+                assertThat(podName + " should NOT have raft metrics",
+                        data, not(containsString("kafka_server_raft")));
+            }
+        }
+    }
+
+    @Test
     public void  testJavaSystemProperties() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1458,7 +1458,7 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaConnect, VERSIONS, SHARED_ENV_PROVIDER);
 
         assertThat(kc.metrics(), is(notNullValue()));
-        assertThat(((StrimziMetricsReporterModel) kc.metrics()).getAllowList(), is("kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*"));
+        assertThat(((StrimziMetricsReporterModel) kc.metrics()).getAllowListOrDefault(List.of()), is("kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*"));
 
         NetworkPolicy np = kc.generateNetworkPolicy(true, null, null);
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress().stream()
@@ -1660,7 +1660,7 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaConnect, VERSIONS, SHARED_ENV_PROVIDER);
 
         assertThat(kc.metrics(), is(notNullValue()));
-        String allowList = ((StrimziMetricsReporterModel) kc.metrics()).getAllowList();
+        String allowList = ((StrimziMetricsReporterModel) kc.metrics()).getAllowListOrDefault(kc.getDefaultMetricsAllowList());
         
         // Verify MM2 metrics are NOT included in Kafka Connect default configuration
         assertThat(allowList, not(containsString("mirrorcheckpointconnector")));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -589,10 +589,10 @@ class KafkaConnectConfigurationBuilderTest {
                         .withAllowList("kafka_connect_connector_metrics.*", "kafka_connect_connector_task_metrics.*")
                     .endValues()
                     .build())
-                .build(), List.of(".*"));
+                .build());
 
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
-                .withStrimziMetricsReporter(model)
+                .withStrimziMetricsReporter(model, List.of())
                 .build();
 
         assertThat(configuration, isEquivalent(
@@ -687,11 +687,11 @@ class KafkaConnectConfigurationBuilderTest {
                         .withAllowList("kafka_connect_connector_metrics.*", "kafka_connect_connector_task_metrics.*")
                     .endValues()
                     .build())
-                .build(), List.of(".*"));
+                .build());
 
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
                 .withUserConfiguration(userConfig, false, true)
-                .withStrimziMetricsReporter(model)
+                .withStrimziMetricsReporter(model, List.of())
                 .build();
 
         assertThat(configuration, isEquivalent("bootstrap.servers=my-cluster-kafka-bootstrap:9092\n"

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1519,7 +1519,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kc = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, VERSIONS, SHARED_ENV_PROVIDER);
 
         assertThat(kc.metrics(), is(notNullValue()));
-        assertThat(((StrimziMetricsReporterModel) kc.metrics()).getAllowList(), is("kafka_log.*,kafka_network.*"));
+        assertThat(((StrimziMetricsReporterModel) kc.metrics()).getAllowListOrDefault(List.of()), is("kafka_log.*,kafka_network.*"));
 
         NetworkPolicy np = kc.generateNetworkPolicy(true, null, null);
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress().stream()
@@ -1613,7 +1613,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, VERSIONS, SHARED_ENV_PROVIDER);
 
         assertThat(kmm2.metrics(), is(notNullValue()));
-        String allowList = ((StrimziMetricsReporterModel) kmm2.metrics()).getAllowList();
+        String allowList = ((StrimziMetricsReporterModel) kmm2.metrics()).getAllowListOrDefault(kmm2.getDefaultMetricsAllowList());
         
         // Verify MM2 metrics ARE included in MirrorMaker 2 default configuration
         assertThat(allowList, containsString("mirrorcheckpointconnector"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class StrimziMetricsReporterModelTest {
     @Test
     public void testDisabled() {
-        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> new StrimziMetricsReporterModel(new KafkaConnectSpecBuilder().build(), List.of(".*")));
+        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> new StrimziMetricsReporterModel(new KafkaConnectSpecBuilder().build()));
         assertThat(ex.getMessage(), is("Unexpected empty metrics config"));
     }
 
@@ -35,10 +35,10 @@ public class StrimziMetricsReporterModelTest {
                 .endValues()
                 .build();
         StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(new KafkaClusterSpecBuilder()
-                .withMetricsConfig(metricsConfig).build(), List.of(".*"));
+                .withMetricsConfig(metricsConfig).build());
 
-        assertThat(metrics.getAllowList().isEmpty(), is(false));
-        assertThat(metrics.getAllowList(), is("kafka_log.*,kafka_network.*"));
+        assertThat(metrics.getAllowListOrDefault(List.of()).isEmpty(), is(false));
+        assertThat(metrics.getAllowListOrDefault(List.of()), is("kafka_log.*,kafka_network.*"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Closes #12181

Currently, the Strimzi Metrics Reporter uses a single default allowlist for all Kafka nodes regardless of their role. This means broker-only metrics are sent to controller nodes and controller-only metrics are sent to broker nodes.

## Changes

- Split `DEFAULT_METRICS_ALLOW_LIST` into three role-specific lists:
  - `BROKER_DEFAULT_METRICS_ALLOW_LIST` — broker-only metrics
  - `CONTROLLER_DEFAULT_METRICS_ALLOW_LIST` — controller-only metrics
  - `MIXED_DEFAULT_METRICS_ALLOW_LIST` — union of both (for mixed nodes)
- Added `metricsForPool(KafkaPool)` helper in `KafkaCluster` to select the appropriate model per pool at config generation time
- Added `isCustomAllowList()` to `StrimziMetricsReporterModel` to distinguish user-configured vs default allowlists
- Added `StrimziMetricsReporterModel(List<String>)` constructor for direct default injection
- Added test `testStrimziMetricsReporterDefaultAllowListIsRoleBased` verifying role-based defaults per pool

## Type of change
- [x] New feature

## Checklist
- [x] Write tests
- [x] Make sure all tests pass