### PR TITLE
Fix additional volume name validation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -72,7 +72,10 @@ public class TemplateUtils {
         List<String> existingVolumeNames = existingVolumes.stream().map(Volume::getName).toList();
 
         // Check if there are any invalid volume names
-        List<String> invalidNames = existingVolumeNames.stream().filter(name -> !VOLUME_NAME_REGEX.matcher(name).matches()).toList();
+        List<String> invalidNames = templatePod.getVolumes().stream()
+                .map(AdditionalVolume::getName)
+                .filter(name -> !VOLUME_NAME_REGEX.matcher(name).matches())
+                .toList();
 
         // Find duplicate names in the additional volumes
         List<String> duplicateNames = templatePod.getVolumes().stream()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
@@ -82,8 +82,7 @@ public class TemplateUtilsTest {
     @Test
     public void testAddAdditionalVolumes_InvalidNames() {
         List<Volume> existingVolumes = new ArrayList<>();
-        existingVolumes.add(new VolumeBuilder().withName("invalid_name!").build());
-        PodTemplate templatePod = new PodTemplateBuilder().withVolumes(new ArrayList<>()).build();
+        PodTemplate templatePod = new PodTemplateBuilder().withVolumes(new AdditionalVolumeBuilder().withName("invalid_name!").build()).build();
 
         InvalidResourceException exception = assertThrows(InvalidResourceException.class, () -> TemplateUtils.addAdditionalVolumes(templatePod, existingVolumes));
 


### PR DESCRIPTION
### Type of Change

- Bugfix

### Description

While working on #12964 I found out that the validation of invalid names for the additional volumes does not work properly as it checks the pre-existing volumes and not the additional volumes. This PR fixes it.

### Checklist

- [x] Make sure all tests pass