### PR TITLE
Split Strimzi Metrics Reporter defaults by Kafka node role

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -136,16 +136,21 @@ public class KafkaBrokerConfigurationBuilder {
     /**
      * Configures the Strimzi Metrics Reporter. It is set only if user enables Strimzi Metrics Reporter.
      *
-     * @param model Strimzi Metrics Reporter configuration
+     * @param model              Strimzi Metrics Reporter configuration
+     * @param defaultAllowList   Default allow list to use when the user did not configure a custom one.
+     *                           The caller (which knows whether this node is a broker, a controller,
+     *                           or both) decides which default is appropriate and passes it in here.
      *
      * @return Returns the builder instance
      */
-    public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(MetricsModel model) {
+    public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(
+            final MetricsModel model,
+            final List<String> defaultAllowList) {
         if (model instanceof StrimziMetricsReporterModel reporterModel) {
             printSectionHeader("Strimzi Metrics Reporter configuration");
             writer.println(StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
             writer.println(StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
-            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
+            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList(defaultAllowList));
             writer.println();
         }
         return this;
@@ -544,7 +549,7 @@ public class KafkaBrokerConfigurationBuilder {
     @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     private void printConfigProviders(KafkaConfiguration userConfig)    {
         printSectionHeader("Config providers");
-        
+
         writer.println("# Configuration providers configured by the user and by Strimzi");
         writer.println("config.providers=" + getConfigProviderAliases(userConfig));
 
@@ -562,10 +567,10 @@ public class KafkaBrokerConfigurationBuilder {
 
         writer.println();
     }
-    
+
     /**
      * Get the Kafka configuration provider aliases, throwing an InvalidConfigurationException if any user provided aliases are found that would overwrite the Strimzi defined configuration providers
-     * 
+     *
      * @param userConfig                The user configuration to extract the possible user-provided config provider configuration from
      * @return                          The Kafka configuration provider aliases
      */
@@ -578,15 +583,15 @@ public class KafkaBrokerConfigurationBuilder {
             strimziAliases.add("strimzifile");
             strimziAliases.add("strimzidir");
         }
-        
+
         if (userConfig != null
                 && !userConfig.getConfiguration().isEmpty()
                 && userConfig.getConfigOption("config.providers") != null) {
             String userAliases = userConfig.getConfigOption("config.providers");
-            
+
             Arrays.asList(userAliases.split(",")).stream().forEach(userAlias -> {
                 if (strimziAliases.contains(userAlias)) {
-                    throw new InvalidConfigurationException("config.provider " + userAlias + " not permitted as it reserved for Strimzi. Not permitted aliases: " + strimziAliases); 
+                    throw new InvalidConfigurationException("config.provider " + userAlias + " not permitted as it reserved for Strimzi. Not permitted aliases: " + strimziAliases);
                 }
             });
 
@@ -595,7 +600,7 @@ public class KafkaBrokerConfigurationBuilder {
         } else {
             return String.join(",", strimziAliases);
         }
-        
+
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -117,7 +117,55 @@ import static java.util.Collections.singletonMap;
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class KafkaCluster extends AbstractModel implements SupportsMetrics, SupportsLogging, SupportsJmx {
     /**
-     * Default Strimzi Metrics Reporter allow list.
+     * Default Strimzi Metrics Reporter allow list entries shared by broker
+     * and controller nodes. Used to build
+     * {@link #DEFAULT_BROKER_METRICS_ALLOW_LIST} and
+     * {@link #DEFAULT_CONTROLLER_METRICS_ALLOW_LIST}.
+     */
+    private static final List<String> DEFAULT_SHARED_METRICS_ALLOW_LIST = List.of(
+            "kafka_network_requestmetrics.*",
+            "kafka_network_socketserver_networkprocessoravgidlepercent",
+            "kafka_server_app_info.*",
+            "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent",
+            "kafka_server_kafkaserver_clusterid",
+            "kafka_server_kafkaserver_linux.*",
+            "kafka_server_request_queue_size",
+            "kafka_server_socket_server.*"
+    );
+
+    /**
+     * Default Strimzi Metrics Reporter allow list used for nodes which are
+     * brokers only (combines the broker-only metrics with
+     * {@link #DEFAULT_SHARED_METRICS_ALLOW_LIST}). If modifying this list,
+     * make sure example dashboards are compatible with the regexes.
+     */
+    private static final List<String> DEFAULT_BROKER_METRICS_ALLOW_LIST =
+            metricsAllowList(DEFAULT_SHARED_METRICS_ALLOW_LIST, List.of(
+                    "kafka_cluster_partition.*",
+                    "kafka_log_log_size",
+                    "kafka_server_brokertopicmetrics.*",
+                    "kafka_server_kafkaserver_brokerstate",
+                    "kafka_server_replicamanager.*"
+            ));
+
+    /**
+     * Default Strimzi Metrics Reporter allow list used for nodes which are
+     * controllers only (combines the controller-only metrics with
+     * {@link #DEFAULT_SHARED_METRICS_ALLOW_LIST}). If modifying this list,
+     * make sure example dashboards are compatible with the regexes.
+     */
+    private static final List<String> DEFAULT_CONTROLLER_METRICS_ALLOW_LIST =
+            metricsAllowList(DEFAULT_SHARED_METRICS_ALLOW_LIST, List.of(
+                    "kafka_controller_kafkacontroller.*",
+                    "kafka_controller_controllerstats_uncleanleaderelectionspersec",
+                    "kafka_server_raft.*"
+            ));
+
+    /**
+     * Default Strimzi Metrics Reporter allow list used for mixed nodes (both
+     * broker and controller). Also used as the fallback default passed to the
+     * {@link io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel}
+     * constructor.
      * If modifying this list, make sure example dashboards are compatible with the regexes.
      */
     private static final List<String> DEFAULT_METRICS_ALLOW_LIST = List.of(
@@ -396,6 +444,44 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         return result;
     }
 
+    /**
+     * Merges the shared Strimzi Metrics Reporter allow list with a
+     * role-specific allow list, removing duplicates while preserving
+     * insertion order.
+     *
+     * @param sharedAllowList        Allow list entries shared across node roles.
+     * @param roleSpecificAllowList  Allow list entries specific to a single node role.
+     *
+     * @return Combined allow list with duplicates removed.
+     */
+    private static List<String> metricsAllowList(
+            final List<String> sharedAllowList,
+            final List<String> roleSpecificAllowList) {
+        Set<String> allowList = new LinkedHashSet<>();
+        allowList.addAll(sharedAllowList);
+        allowList.addAll(roleSpecificAllowList);
+        return List.copyOf(allowList);
+    }
+
+    /**
+     * Picks the default Strimzi Metrics Reporter allow list appropriate for
+     * the given node, based on whether it is a broker, a controller, or both
+     * (mixed node). This is where the "generic" {@code StrimziMetricsReporterModel}
+     * is told which default applies - the model itself has no notion of node roles.
+     *
+     * @param node  Node for which the default allow list should be picked.
+     *
+     * @return Default allow list to use for this node when the user did not configure a custom one.
+     */
+    private static List<String> defaultMetricsAllowList(final NodeRef node) {
+        if (node.broker() && !node.controller()) {
+            return DEFAULT_BROKER_METRICS_ALLOW_LIST;
+        } else if (!node.broker() && node.controller()) {
+            return DEFAULT_CONTROLLER_METRICS_ALLOW_LIST;
+        } else {
+            return DEFAULT_METRICS_ALLOW_LIST;
+        }
+    }
     /**
      * Generates list of references to Kafka nodes for this Kafka cluster. The references contain both the pod name and
      * the ID of the Kafka node.
@@ -1825,7 +1911,9 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 .withCruiseControl(cluster, ccMetricsReporter, node.broker())
                 .withTieredStorage(cluster, tieredStorage)
                 .withQuotas(cluster, quotas)
-                .withStrimziMetricsReporter(metrics)
+                .withStrimziMetricsReporter(
+                        metrics,
+                        defaultMetricsAllowList(node))
                 .withUserConfiguration(
                         configuration,
                         node.broker() && ccMetricsReporter != null,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
@@ -23,6 +23,15 @@ public class StrimziMetricsReporterModel implements MetricsModel {
      */
     private final List<String> allowList;
 
+    /**
+     * Allow list explicitly configured by the user, or {@code null} when
+     * the user relied on the default. Tracked separately from
+     * {@link #allowList} (which already has the constructor's default list
+     * mixed in) so that {@link #getAllowList(List)} can later be given a
+     * different default without losing the ability to tell whether the user
+     * actually customized the value.
+     */
+    private final List<String> customAllowList;
         /**
          * Constructs the Metrics Model for managing configurable metrics to Strimzi.
          *
@@ -33,8 +42,8 @@ public class StrimziMetricsReporterModel implements MetricsModel {
         if (spec.getMetricsConfig() != null) {
             StrimziMetricsReporter config = (StrimziMetricsReporter) spec.getMetricsConfig();
             validate(config);
-            this.allowList = config.getValues() != null && config.getValues().getAllowList() != null
-                    ? config.getValues().getAllowList() : defaultAllowList;
+            this.customAllowList = config.getValues() != null ? config.getValues().getAllowList() : null;
+            this.allowList = customAllowList != null ? customAllowList : defaultAllowList;
         } else {
             throw new InvalidConfigurationException("Unexpected empty metrics config");
         }
@@ -48,7 +57,25 @@ public class StrimziMetricsReporterModel implements MetricsModel {
     public String getAllowList() {
         return String.join(",", allowList);
     }
-
+    /**
+     * Gets the comma-separated list of allow regex expressions, falling back
+     * to the given default allow list instead of the one passed to the
+     * constructor when the user did not configure a custom allow list.
+     * <p>
+     * This lets a single model instance serve callers that manage several
+     * kinds of nodes with different default allow lists (for example Kafka
+     * brokers vs. controllers), without this generic model class needing any
+     * knowledge of those roles - the caller decides which default is
+     * appropriate for the current context and passes it in here. A
+     * user-configured allow list always takes precedence, regardless of
+     * which default is passed.
+     *
+     * @param defaultAllowList Default allow list to be used when no custom value was configured by the user.
+     * @return Comma separated list of allow regex expressions.
+     */
+    public String getAllowList(final List<String> defaultAllowList) {
+        return String.join(",", customAllowList != null ? customAllowList : defaultAllowList);
+    }
     /**
      * Validates user configuration.
      *

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -219,7 +219,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                         .build(), List.of(".*"));
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
-                .withStrimziMetricsReporter(model)
+                .withStrimziMetricsReporter(model, List.of(".*"))
                 .build();
 
         assertThat(configuration, isEquivalent("node.id=2",
@@ -460,7 +460,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider",
                 "min.insync.replicas=1"));
     }
-    
+
     @Test
     public void testUserConfigurationWithInvalidConfigProviders()  {
         Map<String, Object> userConfiguration = new HashMap<>();
@@ -498,8 +498,14 @@ public class KafkaBrokerConfigurationBuilderTest {
 
     @Test
     public void testNullUserConfigurationWithStrimziMetricsReporter() {
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
-                .withUserConfiguration(null, false, false, true)
+        String configuration = new KafkaBrokerConfigurationBuilder(
+                Reconciliation.DUMMY_RECONCILIATION,
+                NODE_REF)
+                .withUserConfiguration(
+                        null,
+                        false,
+                        false,
+                        true)
                 .build();
         assertThat(configuration, isEquivalent("node.id=2",
                 "config.providers=strimzienv,strimzisecrets,strimzifile,strimzidir",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -54,6 +54,7 @@ import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuild
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolumeBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerEnvVar;
@@ -335,6 +336,123 @@ public class KafkaClusterTest {
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(StrimziMetricsReporterModel.METRICS_PORT))).toList();
 
         assertThat(rules.size(), is(1));
+    }
+
+    @Test
+    public void testStrimziMetricsReporterDefaultAllowListPerNodeRole() {
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                .editKafka()
+                .withMetricsConfig(new StrimziMetricsReporterBuilder().build())
+                .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafkaAssembly,
+                List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS),
+                Map.of(),
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                SHARED_ENV_PROVIDER);
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafkaAssembly,
+                pools,
+                VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                null,
+                SHARED_ENV_PROVIDER);
+
+        // Controller-only node (from POOL_CONTROLLERS) => controller metrics only, no broker-only metrics
+        String controllerConfig = kafkaCluster.generatePerBrokerConfiguration(
+                1,
+                ADVERTISED_HOSTNAMES,
+                ADVERTISED_PORTS);
+        assertThat(controllerConfig, containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "="));
+        assertThat(controllerConfig, containsString("kafka_controller_kafkacontroller.*"));
+        assertThat(controllerConfig, containsString("kafka_server_raft.*"));
+        assertThat(controllerConfig, not(containsString("kafka_server_brokertopicmetrics.*")));
+        assertThat(controllerConfig, not(containsString("kafka_server_replicamanager.*")));
+        assertThat(controllerConfig, not(containsString("kafka_log_log_size")));
+
+        // Broker-only node (from POOL_BROKERS) => broker metrics only, no controller-only metrics
+        String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(
+                6,
+                ADVERTISED_HOSTNAMES,
+                ADVERTISED_PORTS);
+        assertThat(brokerConfig, containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "="));
+        assertThat(brokerConfig, containsString("kafka_server_brokertopicmetrics.*"));
+        assertThat(brokerConfig, containsString("kafka_server_replicamanager.*"));
+        assertThat(brokerConfig, containsString("kafka_log_log_size"));
+        assertThat(brokerConfig, not(containsString("kafka_controller_kafkacontroller.*")));
+        assertThat(brokerConfig, not(containsString("kafka_server_raft.*")));
+
+        // Mixed node (from POOL_MIXED) => both broker and controller metrics, unchanged from before this change
+        String mixedConfig = kafkaCluster.generatePerBrokerConfiguration(
+                3,
+                ADVERTISED_HOSTNAMES,
+                ADVERTISED_PORTS);
+        assertThat(mixedConfig, containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "="));
+        assertThat(mixedConfig, containsString("kafka_controller_kafkacontroller.*"));
+        assertThat(mixedConfig, containsString("kafka_server_raft.*"));
+        assertThat(mixedConfig, containsString("kafka_server_brokertopicmetrics.*"));
+        assertThat(mixedConfig, containsString("kafka_server_replicamanager.*"));
+        assertThat(mixedConfig, containsString("kafka_log_log_size"));
+    }
+
+    @Test
+    public void testStrimziMetricsReporterCustomAllowListAppliesToAllNodeRoles() {
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                .editKafka()
+                .withMetricsConfig(new StrimziMetricsReporterBuilder()
+                        .withNewValues()
+                        .withAllowList(List.of("custom_metric.*"))
+                        .endValues()
+                        .build())
+                .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafkaAssembly,
+                List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS),
+                Map.of(),
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                SHARED_ENV_PROVIDER);
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafkaAssembly,
+                pools,
+                VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
+                null,
+                SHARED_ENV_PROVIDER);
+
+        // A custom allow list must apply as-is to every node role - controller, broker, and mixed alike
+        String expectedAllowList = StrimziMetricsReporterConfig.ALLOW_LIST + "=custom_metric.*";
+
+        assertThat(kafkaCluster.generatePerBrokerConfiguration(
+                        1,
+                        ADVERTISED_HOSTNAMES,
+                        ADVERTISED_PORTS),
+                containsString(expectedAllowList));
+
+        assertThat(kafkaCluster.generatePerBrokerConfiguration(
+                        3,
+                        ADVERTISED_HOSTNAMES,
+                        ADVERTISED_PORTS),
+                containsString(expectedAllowList));
+
+        assertThat(kafkaCluster.generatePerBrokerConfiguration(
+                        6,
+                        ADVERTISED_HOSTNAMES,
+                        ADVERTISED_PORTS),
+                containsString(expectedAllowList));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
@@ -42,6 +42,45 @@ public class StrimziMetricsReporterModelTest {
     }
 
     @Test
+    public void testDefaultAllowListCanBeOverriddenPerCall() {
+        // No custom allow list configured => getAllowList(List) should use
+        // whatever default the caller passes in, regardless of what default
+        // was passed to the constructor. This is what lets a single model
+        // instance serve callers such as KafkaCluster that need a different
+        // default per node role, without this class having any notion of
+        // node roles itself.
+        StrimziMetricsReporter metricsConfig = new StrimziMetricsReporterBuilder().build();
+        StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(
+                new KafkaClusterSpecBuilder()
+                        .withMetricsConfig(metricsConfig)
+                        .build(),
+                List.of("mixed.*"));
+
+        assertThat(metrics.getAllowList(), is("mixed.*"));
+        assertThat(metrics.getAllowList(List.of("broker.*")), is("broker.*"));
+        assertThat(metrics.getAllowList(List.of("controller.*")), is("controller.*"));
+    }
+
+    @Test
+    public void testCustomAllowListAlwaysWinsOverAnyDefault() {
+        // A user-configured allow list must take precedence no matter which
+        // default is passed to getAllowList(List).
+        StrimziMetricsReporter metricsConfig = new StrimziMetricsReporterBuilder()
+                .withNewValues()
+                .withAllowList(List.of("kafka_log.*", "kafka_network.*"))
+                .endValues()
+                .build();
+        StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(
+                new KafkaClusterSpecBuilder()
+                        .withMetricsConfig(metricsConfig)
+                        .build(),
+                List.of("mixed.*"));
+
+        assertThat(metrics.getAllowList(List.of("broker.*")), is("kafka_log.*,kafka_network.*"));
+        assertThat(metrics.getAllowList(List.of("controller.*")), is("kafka_log.*,kafka_network.*"));
+    }
+
+    @Test
     public void testValidation() {
         assertDoesNotThrow(() -> StrimziMetricsReporterModel.validate(new StrimziMetricsReporterBuilder()
                 .withNewValues()


### PR DESCRIPTION
Fixes [#12181](https://github.com/strimzi/strimzi-kafka-operator/issues/12181)

## Description

This change splits the default Strimzi Metrics Reporter allow list by Kafka node role.

- broker-only nodes use broker-specific metrics together with shared metrics
- controller-only nodes use controller-specific metrics together with shared metrics
- mixed broker/controller nodes continue using the combined default allow list
- custom `values.allowList` continues to take precedence for all node roles

The node-role selection is handled in `KafkaCluster`, while `StrimziMetricsReporterModel` remains role-agnostic by accepting the appropriate default allow list from the caller.

## Testing

- Added unit tests for broker-only, controller-only and mixed-role default allow lists.
- Added tests verifying that custom allow lists override role-specific defaults.