### PR TITLE
Create connectors in their requested initial state (KIP-980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support templated (per-pod) additional volumes for Kafka, Kafka Connect and Kafka MirrorMaker 2 operands
 * The `ServerSideApplyPhase1` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
 * Support for configuring Maven mirrors for Kafka Connect Build
+* Connectors that request the `stopped` or `paused` state via `spec.state` are now created directly in that state instead of being started first and then stopped or paused.
 
 ### Major changes, deprecations, and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -391,9 +391,10 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     /**
-     * Try to get the current connector config. If the connector does not exist, or its config differs from the
-     * {@code connectorSpec}'s, then call
-     * {@link #createOrUpdateConnector(Reconciliation, String, KafkaConnectApi, String, KafkaConnectorSpec, KafkaConnectorConfiguration)}
+     * Try to get the current connector config. If the connector does not exist, call
+     * {@link #createConnector(Reconciliation, String, KafkaConnectApi, String, KafkaConnectorSpec, KafkaConnectorConfiguration)};
+     * if it exists but its config differs from the {@code connectorSpec}'s, call
+     * {@link #updateConnector(Reconciliation, String, KafkaConnectApi, String, KafkaConnectorSpec, KafkaConnectorConfiguration)};
      * otherwise, just return the connectors current state.
      * @param reconciliation The reconciliation.
      * @param host The REST API host.
@@ -423,7 +424,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         .compose(status -> updateConnectorTopics(reconciliation, host, apiClient, connectorName, status));
                 } else {
                     LOGGER.debugCr(reconciliation, "Connector {} exists but does not have desired config, {}!={}", connectorName, desiredConfig.asOrderedProperties().asMap(), currentConfig);
-                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec, desiredConfig)
+                    return updateConnector(reconciliation, host, apiClient, connectorName, connectorSpec, desiredConfig)
                         .compose(createConnectorStatusAndConditions())
                         .compose(status -> updateConnectorTopics(reconciliation, host, apiClient, connectorName, status));
                 }
@@ -432,7 +433,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 if (error instanceof ConnectRestException connectRestException
                         && connectRestException.getStatusCode() == 404) {
                     LOGGER.debugCr(reconciliation, "Connector {} does not exist", connectorName);
-                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec, desiredConfig)
+                    return createConnector(reconciliation, host, apiClient, connectorName, connectorSpec, desiredConfig)
                         .compose(createConnectorStatusAndConditions())
                         .compose(status -> autoRestartFailedConnectorAndTasks(reconciliation, host, apiClient, connectorName, connectorSpec, status, resource))
                         .compose(status -> updateConnectorTopics(reconciliation, host, apiClient, connectorName, status));
@@ -465,13 +466,46 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         return !desiredConfig.equals(actualConfig);
     }
 
-    private Future<Map<String, Object>> createOrUpdateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
-                                                                  String connectorName, KafkaConnectorSpec connectorSpec, KafkaConnectorConfiguration desiredConfig) {
+    /**
+     * Updates an existing connector's config via PUT, then reconciles its running/paused/stopped state to
+     * match {@code spec.state}. Used only when the connector already exists and its config has changed.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param host              Kafka Connect host
+     * @param apiClient         Kafka Connect REST API client
+     * @param connectorName     Name of the connector
+     * @param connectorSpec     Spec of the connector
+     * @param desiredConfig     Desired connector configuration
+     *
+     * @return  Future with the connector status which completes when the connector is updated
+     */
+    private Future<Map<String, Object>> updateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
+                                                         String connectorName, KafkaConnectorSpec connectorSpec, KafkaConnectorConfiguration desiredConfig) {
         return Future.fromCompletionStage(apiClient.createOrUpdatePutRequest(reconciliation, host, port, connectorName, asJson(connectorSpec, desiredConfig)))
             .compose(ignored -> Future.fromCompletionStage(apiClient.statusWithBackOff(reconciliation, new BackOff(200L, 2, 10), host, port,
                     connectorName)))
             .compose(status -> updateState(reconciliation, host, apiClient, connectorName, connectorSpec, status, new ArrayList<>()))
             .compose(ignored ->  Future.fromCompletionStage(apiClient.status(reconciliation, host, port, connectorName)));
+    }
+
+    /**
+     * Creates a brand-new connector via POST, in the state requested by {@code spec.state} (KIP-980),
+     * so a paused or stopped connector is never started first. Used only when the connector does not
+     * exist yet.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param host              Kafka Connect host
+     * @param apiClient         Kafka Connect REST API client
+     * @param connectorName     Name of the connector
+     * @param connectorSpec     Spec of the connector
+     * @param desiredConfig     Desired connector configuration
+     *
+     * @return  Future with the connector status which completes when the connector is created
+     */
+    private Future<Map<String, Object>> createConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
+                                                         String connectorName, KafkaConnectorSpec connectorSpec, KafkaConnectorConfiguration desiredConfig) {
+        return Future.fromCompletionStage(apiClient.createConnector(reconciliation, host, port, connectorName, asJson(connectorSpec, desiredConfig), connectorSpec.getState()))
+            .compose(ignored -> Future.fromCompletionStage(apiClient.statusWithBackOff(reconciliation, new BackOff(200L, 2, 10), host, port, connectorName)));
     }
 
     private Future<List<Condition>> updateState(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, KafkaConnectorSpec connectorSpec, Map<String, Object> status, List<Condition> conditions) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -33,9 +33,9 @@ public interface KafkaConnectApi {
     CompletionStage<Map<String, Object>> createOrUpdatePutRequest(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson);
 
     /**
-     * Make a {@code POST} request to {@code /connectors} to create a brand-new connector, optionally
-     * in a given initial state (KIP-980, Kafka 3.7+). Unlike {@link #createOrUpdatePutRequest}, this
-     * can create a connector directly {@code paused} or {@code stopped} instead of starting it first.
+     * Make a {@code POST} request to {@code /connectors}.
+     * Unlike {@link #createOrUpdatePutRequest}, this can create a connector directly in a
+     * {@code paused} or {@code stopped} state.
      *
      * @param reconciliation The reconciliation
      * @param host The host to make the request to.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.strimzi.api.kafka.model.common.ConnectorState;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
@@ -30,6 +31,23 @@ public interface KafkaConnectApi {
      * this returns information about the connector, including its name, config and tasks.
      */
     CompletionStage<Map<String, Object>> createOrUpdatePutRequest(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson);
+
+    /**
+     * Make a {@code POST} request to {@code /connectors} to create a brand-new connector, optionally
+     * in a given initial state (KIP-980, Kafka 3.7+). Unlike {@link #createOrUpdatePutRequest}, this
+     * can create a connector directly {@code paused} or {@code stopped} instead of starting it first.
+     *
+     * @param reconciliation The reconciliation
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to create.
+     * @param configJson The connector configuration.
+     * @param initialState The state the connector should be created in, or {@code null} to use the
+     *                     Kafka Connect default (running).
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns information about the connector, including its name, config and tasks.
+     */
+    CompletionStage<Map<String, Object>> createConnector(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson, ConnectorState initialState);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -99,9 +99,6 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .put("name", connectorName)
                 .put("config", configJson);
         if (initialState != null) {
-            // KIP-980: create the connector directly in the wanted state. Kafka Connect expects the
-            // upper-case form (STOPPED / PAUSED / RUNNING). The enum constant names already match
-            // those values, so name() gives the exact wire value with no conversion.
             request.put("initial_state", initialState.name());
         }
         String data = request.toString();
@@ -118,15 +115,12 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         return httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
                 .thenCompose(response -> {
                     int statusCode = response.statusCode();
-                    if (statusCode == 200 || statusCode == 201) {
+                    if (statusCode == 201) {
                         JsonNode json = parseToJsonNode(response);
                         Map<String, Object> t = OBJECT_MAPPER.convertValue(json, TREE_TYPE);
                         LOGGER.debugCr(reconciliation, "Got {} response to POST request to {}: {}", statusCode, path, t);
                         return CompletableFuture.completedFuture(t);
                     } else if (statusCode == 409) {
-                        // 409 means the Connect cluster is rebalancing, or a connector with this name already exists.
-                        // Retrying rides out a rebalance. An "already exists" 409 will not clear on retry, so it uses up
-                        // the back off and fails this reconcile; the connector is then reconciled on the next one.
                         return withBackoff(reconciliation, new BackOff(200L, 2, 10), connectorName, Collections.singleton(409),
                                 () -> createConnector(reconciliation, host, port, connectorName, configJson, initialState), "create");
                     } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import io.strimzi.api.kafka.model.common.ConnectorState;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
@@ -84,6 +85,52 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                 () -> createOrUpdatePutRequest(reconciliation, host, port, connectorName, configJson), "create/update");
                     } else {
                         LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}", statusCode, path);
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
+                    }
+                });
+    }
+
+    @Override
+    public CompletionStage<Map<String, Object>> createConnector(
+            Reconciliation reconciliation,
+            String host, int port,
+            String connectorName, JsonObject configJson, ConnectorState initialState) {
+        JsonObject request = new JsonObject()
+                .put("name", connectorName)
+                .put("config", configJson);
+        if (initialState != null) {
+            // KIP-980: create the connector directly in the wanted state. Kafka Connect expects the
+            // upper-case form (STOPPED / PAUSED / RUNNING). The enum constant names already match
+            // those values, so name() gives the exact wire value with no conversion.
+            request.put("initial_state", initialState.name());
+        }
+        String data = request.toString();
+        String path = "/connectors";
+        LOGGER.debugCr(reconciliation, "Making POST request to {} with body {}", path, request);
+
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, encodeURLString(path))))
+                .POST(HttpRequest.BodyPublishers.ofString(data))
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .build();
+
+        return httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200 || statusCode == 201) {
+                        JsonNode json = parseToJsonNode(response);
+                        Map<String, Object> t = OBJECT_MAPPER.convertValue(json, TREE_TYPE);
+                        LOGGER.debugCr(reconciliation, "Got {} response to POST request to {}: {}", statusCode, path, t);
+                        return CompletableFuture.completedFuture(t);
+                    } else if (statusCode == 409) {
+                        // 409 means the Connect cluster is rebalancing, or a connector with this name already exists.
+                        // Retrying rides out a rebalance. An "already exists" 409 will not clear on retry, so it uses up
+                        // the back off and fails this reconcile; the connector is then reconciled on the next one.
+                        return withBackoff(reconciliation, new BackOff(200L, 2, 10), connectorName, Collections.singleton(409),
+                                () -> createConnector(reconciliation, host, port, connectorName, configJson, initialState), "create");
+                    } else {
+                        LOGGER.debugCr(reconciliation, "Got {} response to POST request to {}", statusCode, path);
                         return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
                     }
                 });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -286,23 +286,21 @@ public class ConnectorMockTest {
                     "tasks", Map.of()));
         });
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
+            LOGGER.info((String) invocation.getArgument(1) + invocation.getArgument(2) + invocation.getArgument(3) + invocation.getArgument(4));
             String host = invocation.getArgument(1);
-            LOGGER.debug("Mock PUT create/update for connector on {}", host);
+            LOGGER.info("###### create " + host);
             String connectorName = invocation.getArgument(3);
             JsonObject connectorConfig = invocation.getArgument(4);
             ConnectorStatus existing = connectors.get(key(host, connectorName));
-            // PUT /config creates or updates the config, keeping the connector's current state
             connectors.put(key(host, connectorName), new ConnectorStatus(existing != null ? existing.state : "RUNNING", connectorConfig));
             return CompletableFuture.completedFuture(null);
         });
         when(api.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
-            LOGGER.debug("Mock POST create for connector on {}", host);
+            LOGGER.info("###### create " + host);
             String connectorName = invocation.getArgument(3);
             JsonObject connectorConfig = invocation.getArgument(4);
             ConnectorState initialState = invocation.getArgument(5);
-            // KIP-980: a connector created via POST starts in its initial state (running when not set).
-            // The enum constant name is the state string Kafka Connect uses (see KafkaConnectApiImpl.createConnector).
             connectors.putIfAbsent(key(host, connectorName), new ConnectorStatus(initialState != null ? initialState.name() : "RUNNING", connectorConfig));
             return CompletableFuture.completedFuture(null);
         });
@@ -783,7 +781,7 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        // createConnector runs on the 404 (connector missing); it may be attempted more than once if reconciles race, so at least once
+        // createConnector may be called more than once across reconciles depending on timing
         verify(api, atLeastOnce()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any(), any());
@@ -851,7 +849,7 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        // createConnector runs exactly once - the connector is created on the first reconcile that sees it missing
+        // createConnector is called exactly once, when the connector is first found missing
         verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any(), any());
@@ -923,7 +921,7 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        // Triggered once or twice (Connect creation, Connector Status update), depending on the timing
+        // createConnector may be called more than once across reconciles depending on timing
         verify(api, atLeastOnce()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any(), any());
@@ -1005,7 +1003,7 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
         waitForConnectorReady(connectorName);
 
-        // createConnector runs once for the first cluster - the connector is created on the first reconcile
+        // createConnector is called exactly once for the first cluster, when it is first found missing
         verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(oldConnectClusterName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any(), any());
@@ -1103,7 +1101,7 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        // Might be triggered multiple times depending on the timing
+        // createConnector may be called more than once across reconciles depending on timing
         verify(api, atLeastOnce()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any(), any());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -286,12 +286,24 @@ public class ConnectorMockTest {
                     "tasks", Map.of()));
         });
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
-            LOGGER.info((String) invocation.getArgument(1) + invocation.getArgument(2) + invocation.getArgument(3) + invocation.getArgument(4));
             String host = invocation.getArgument(1);
-            LOGGER.info("###### create " + host);
+            LOGGER.debug("Mock PUT create/update for connector on {}", host);
             String connectorName = invocation.getArgument(3);
             JsonObject connectorConfig = invocation.getArgument(4);
-            connectors.putIfAbsent(key(host, connectorName), new ConnectorStatus("RUNNING", connectorConfig));
+            ConnectorStatus existing = connectors.get(key(host, connectorName));
+            // PUT /config creates or updates the config, keeping the connector's current state
+            connectors.put(key(host, connectorName), new ConnectorStatus(existing != null ? existing.state : "RUNNING", connectorConfig));
+            return CompletableFuture.completedFuture(null);
+        });
+        when(api.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenAnswer(invocation -> {
+            String host = invocation.getArgument(1);
+            LOGGER.debug("Mock POST create for connector on {}", host);
+            String connectorName = invocation.getArgument(3);
+            JsonObject connectorConfig = invocation.getArgument(4);
+            ConnectorState initialState = invocation.getArgument(5);
+            // KIP-980: a connector created via POST starts in its initial state (running when not set).
+            // The enum constant name is the state string Kafka Connect uses (see KafkaConnectApiImpl.createConnector).
+            connectors.putIfAbsent(key(host, connectorName), new ConnectorStatus(initialState != null ? initialState.name() : "RUNNING", connectorConfig));
             return CompletableFuture.completedFuture(null);
         });
         when(api.delete(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
@@ -680,9 +692,9 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -701,9 +713,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectconnectorconnectorconnect.svc", connectorName))));
 
         List<StatusDetails> connectorDeleted = Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).delete();
@@ -743,9 +755,9 @@ public class ConnectorMockTest {
 
         verify(api, never()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(empty()));
 
         // Create KafkaConnect cluster and wait till it's ready
@@ -771,10 +783,10 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        // Might be triggered multiple times (Connect creation, Connector Status update, Connect Status update), depending on the timing
-        verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
+        // createConnector runs on the 404 (connector missing); it may be attempted more than once if reconciles race, so at least once
+        verify(api, atLeastOnce()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorconnectconnectorconnect.svc", connectorName))));
 
         List<StatusDetails> connectorDeleted = Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).delete();
@@ -817,9 +829,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -839,10 +851,10 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        // triggered twice (Connect creation, Connector Status update)
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        // createConnector runs exactly once - the connector is created on the first reconcile that sees it missing
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectconnectorconnectconnector.svc", connectorName))));
 
         List<StatusDetails> connectDeleted = Crds.kafkaConnectOperation(client).inNamespace(namespace).withName(connectName).delete();
@@ -883,9 +895,9 @@ public class ConnectorMockTest {
 
         verify(api, never()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(empty()));
 
         // Create KafkaConnect cluster and wait till it's ready
@@ -912,9 +924,9 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
         // Triggered once or twice (Connect creation, Connector Status update), depending on the timing
-        verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
+        verify(api, atLeastOnce()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorconnectconnectconnector.svc", connectorName))));
 
         List<StatusDetails> connectDeleted = Crds.kafkaConnectOperation(client).inNamespace(namespace).withName(connectName).delete();
@@ -993,14 +1005,14 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
         waitForConnectorReady(connectorName);
 
-        // triggered twice (Connect creation, Connector Status update) for the first cluster
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        // createConnector runs once for the first cluster - the connector is created on the first reconcile
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(oldConnectClusterName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         // never triggered for the second cluster as connector's Strimzi cluster label does not match cluster 2
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(newConnectClusterName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // patch connector with new Strimzi cluster label associated with cluster 2
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).patch(PatchContext.of(PatchType.JSON), new KafkaConnectorBuilder()
@@ -1020,9 +1032,9 @@ public class ConnectorMockTest {
         verify(api, never()).delete(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(oldConnectClusterName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(newConnectClusterName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Force reconciliation to assert connector deletion request occurs for first cluster
         Checkpoint async = context.checkpoint();
@@ -1041,7 +1053,7 @@ public class ConnectorMockTest {
         String connectName = "cluster";
         String connectorName = "connector";
 
-        when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any()))
+        when(api.createConnector(any(), any(), anyInt(), anyString(), any(), any()))
             .thenAnswer(invocation -> CompletableFuture.failedFuture(new ConnectRestException("GET", "/foo", 500, "Internal server error", "Bad stuff happened")));
         // NOTE: Clear runningConnectors as re-mocking it causes an entry to be added
         connectors.clear();
@@ -1069,9 +1081,9 @@ public class ConnectorMockTest {
         // triggered at least once (Connect creation)
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector, should not go ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -1092,9 +1104,9 @@ public class ConnectorMockTest {
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
         // Might be triggered multiple times depending on the timing
-        verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
+        verify(api, atLeastOnce()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(empty()));
     }
 
@@ -1126,9 +1138,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -1148,9 +1160,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorpauseresume.svc", connectorName))));
 
         verify(api, never()).pause(any(),
@@ -1219,9 +1231,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -1241,9 +1253,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorstopresume.svc", connectorName))));
 
         verify(api, never()).stop(any(),
@@ -1312,9 +1324,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -1334,9 +1346,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorstopresumebyunset.svc", connectorName))));
 
         verify(api, never()).stop(any(),
@@ -1405,9 +1417,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(new KafkaConnectorBuilder()
@@ -1427,9 +1439,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorrestart.svc", connectorName))));
 
         verify(api, never()).restart(
@@ -1493,9 +1505,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(new KafkaConnectorBuilder()
@@ -1515,9 +1527,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorrestartfail.svc", connectorName))));
 
         verify(api, never()).restart(
@@ -1579,9 +1591,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(new KafkaConnectorBuilder()
@@ -1601,9 +1613,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorrestarttask.svc", connectorName))));
 
         verify(api, never()).restart(
@@ -1666,9 +1678,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(new KafkaConnectorBuilder()
@@ -1688,9 +1700,9 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName), any());
+            eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorrestarttaskfail.svc", connectorName))));
 
         verify(api, never()).restart(
@@ -1753,9 +1765,9 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -1774,14 +1786,15 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectscaletozero.svc", connectorName))));
 
         when(api.list(any(), any(), anyInt())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnectorConfig(any(), any(), anyInt(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnector(any(), any(), anyInt(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
 
@@ -1824,9 +1837,9 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -1845,14 +1858,15 @@ public class ConnectorMockTest {
 
         verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectrestapiissues.svc", connectorName))));
 
         when(api.list(any(), any(), anyInt())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnectorConfig(any(), any(), any(), anyInt(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnector(any(), any(), anyInt(), any())).thenReturn(CompletableFuture.failedFuture(new ConnectTimeoutException("connection timed out")));
 
@@ -2591,9 +2605,9 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -2615,9 +2629,9 @@ public class ConnectorMockTest {
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
         ArgumentCaptor<JsonObject> connectorConfig =  ArgumentCaptor.forClass(JsonObject.class);
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), connectorConfig.capture());
+                eq(connectorName), connectorConfig.capture(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorversion.svc", connectorName))));
 
         assertThat(connectorConfig.getValue().getString("connector.plugin.version"), is("[0.1.0,)"));
@@ -2653,9 +2667,9 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
-        verify(api, never()).createOrUpdatePutRequest(any(),
+        verify(api, never()).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), any());
+                eq(connectorName), any(), any());
 
         // Create KafkaConnector and wait till it's ready
         KafkaConnector connector = new KafkaConnectorBuilder()
@@ -2677,9 +2691,9 @@ public class ConnectorMockTest {
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT));
 
         ArgumentCaptor<JsonObject> connectorConfig = ArgumentCaptor.forClass(JsonObject.class);
-        verify(api, times(1)).createOrUpdatePutRequest(any(),
+        verify(api, times(1)).createConnector(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
-                eq(connectorName), connectorConfig.capture());
+                eq(connectorName), connectorConfig.capture(), any());
         assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.testconnectorforbiddenversionconfig.svc", connectorName))));
 
         // There is no such configuration, as the `connector.plugin.version` config is forbidden and therefore ignored
@@ -2800,6 +2814,151 @@ public class ConnectorMockTest {
         verify(api, never()).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
+    }
+
+    /** Create a connector directly in the stopped state (KIP-980) - it must never be started first */
+    @Test
+    public void testConnectorCreatedInStoppedState() {
+        assertConnectorCreatedInInitialState(ConnectorState.STOPPED, "STOPPED");
+    }
+
+    /** Create a connector directly in the paused state (KIP-980) - it must never be started first */
+    @Test
+    public void testConnectorCreatedInPausedState() {
+        assertConnectorCreatedInInitialState(ConnectorState.PAUSED, "PAUSED");
+    }
+
+    /**
+     * Shared check for KIP-980: a connector whose spec asks for a non-running state must be created
+     * directly in that state via POST, and must never be started first. That means no PUT-config
+     * create and no separate stop or pause call.
+     *
+     * This is a helper called by one {@code @Test} per state rather than a {@code @ParameterizedTest}
+     * on purpose: the per-test namespace is derived from the test method name (see beforeEach), so a
+     * parameterized test would reuse one namespace across all invocations. Separate test methods keep
+     * separate namespaces.
+     *
+     * @param state          The state requested via {@code spec.state}
+     * @param expectedState  The connector state string expected in the status
+     */
+    private void assertConnectorCreatedInInitialState(ConnectorState state, String expectedState) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withNamespace(namespace)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-kafka:9092")
+                    .withGroupId("my-group")
+                    .withConfigStorageTopic("my-config-topic")
+                    .withOffsetStorageTopic("my-offset-topic")
+                    .withStatusStorageTopic("my-status-topic")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(namespace).resource(connect).create();
+        waitForConnectReady(connectName);
+
+        // Create a KafkaConnector that asks to start in the given non-running state
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .withNamespace(namespace)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
+                    .withState(state)
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, expectedState);
+
+        // The connector must be created via POST with the requested initial state
+        verify(api, times(1)).createConnector(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any(), eq(state));
+        // ... and never started first: no PUT-config create and no separate stop or pause call
+        verify(api, never()).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        verify(api, never()).stop(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).pause(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /** Changing an existing connector's config must use the PUT update path, not a POST create */
+    @Test
+    public void testConnectorConfigChangeUsesPut() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withNamespace(namespace)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withBootstrapServers("my-kafka:9092")
+                    .withGroupId("my-group")
+                    .withConfigStorageTopic("my-config-topic")
+                    .withOffsetStorageTopic("my-offset-topic")
+                    .withStatusStorageTopic("my-status-topic")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(namespace).resource(connect).create();
+        waitForConnectReady(connectName);
+
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .withNamespace(namespace)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
+                    .withConfig(Map.of("file", "/tmp/one"))
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
+        waitForConnectorReady(connectorName);
+
+        // The initial create used POST (createConnector), not PUT
+        verify(api, times(1)).createConnector(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any(), any());
+        verify(api, never()).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Change the connector's config -> triggers a reconfigure
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).edit(sp -> new KafkaConnectorBuilder(sp)
+                .editSpec()
+                .withConfig(Map.of("file", "/tmp/two"))
+                .endSpec()
+                .build());
+        waitForConnectorReady(connectorName);
+
+        // The update went through the PUT path, and no second connector was created via POST
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        verify(api, times(1)).createConnector(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, namespace)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any(), any());
     }
 
     // Utility record used during tests

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.strimzi.api.kafka.model.common.ConnectorState;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.json.JsonObject;
@@ -20,8 +21,14 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
@@ -174,4 +181,43 @@ public class KafkaConnectApiImplTest {
                         hasEntry("org.apache.kafka.connect", "WARN")))
                 ).toCompletableFuture().join();
     }
+
+    @Test
+    public void testCreateConnectorSendsInitialState() {
+        server.stubFor(post(urlPathEqualTo("/connectors"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withBody("{\"name\":\"my-connector\",\"config\":{},\"tasks\":[]}")));
+
+        KafkaConnectApi api = new KafkaConnectApiImpl();
+        JsonObject config = new JsonObject().put("connector.class", "Dummy");
+
+        api.createConnector(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(),
+                "my-connector", config, ConnectorState.STOPPED).toCompletableFuture().join();
+
+        // The POST body must carry name, config, and the upper-case initial_state
+        server.verify(postRequestedFor(urlPathEqualTo("/connectors"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("my-connector")))
+                .withRequestBody(matchingJsonPath("$.initial_state", equalTo("STOPPED")))
+                .withRequestBody(matchingJsonPath("$.config['connector.class']", equalTo("Dummy"))));
+    }
+
+    @Test
+    public void testCreateConnectorWithoutStateOmitsInitialState() {
+        server.stubFor(post(urlPathEqualTo("/connectors"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withBody("{\"name\":\"my-connector\",\"config\":{},\"tasks\":[]}")));
+
+        KafkaConnectApi api = new KafkaConnectApiImpl();
+
+        api.createConnector(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(),
+                "my-connector", new JsonObject(), null).toCompletableFuture().join();
+
+        // With no requested state, the initial_state field must be omitted (Connect defaults to running)
+        server.verify(postRequestedFor(urlPathEqualTo("/connectors"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("my-connector")))
+                .withRequestBody(notMatching("(?s).*initial_state.*")));
+    }
+
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.strimzi.api.kafka.model.common.ConnectorState;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.TestUtils;
@@ -218,6 +219,49 @@ public class KafkaConnectApiImplTest {
         server.verify(postRequestedFor(urlPathEqualTo("/connectors"))
                 .withRequestBody(matchingJsonPath("$.name", equalTo("my-connector")))
                 .withRequestBody(notMatching("(?s).*initial_state.*")));
+    }
+
+    @Test
+    public void testCreateConnectorFailsOnServerError() {
+        server.stubFor(post(urlPathEqualTo("/connectors"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withBody("{\"message\": \"Connect cluster error\"}")));
+
+        KafkaConnectApi api = new KafkaConnectApiImpl();
+
+        ExecutionException ex = assertThrows(ExecutionException.class,
+                () -> api.createConnector(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(),
+                        "my-connector", new JsonObject(), ConnectorState.STOPPED)
+                        .toCompletableFuture().get());
+        assertThat(ex.getCause(), instanceOf(ConnectRestException.class));
+        assertThat(ex.getCause().getMessage(), containsString("Connect cluster error"));
+    }
+
+    @Test
+    public void testCreateConnectorRetriesOn409() {
+        // A 409 means the Connect cluster is rebalancing; the request is retried with back off.
+        // The first POST returns 409, the second returns 201.
+        String scenario = "rebalance-then-created";
+        server.stubFor(post(urlPathEqualTo("/connectors"))
+                .inScenario(scenario)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(409).withBody("{\"message\": \"rebalancing\"}"))
+                .willSetStateTo("created"));
+        server.stubFor(post(urlPathEqualTo("/connectors"))
+                .inScenario(scenario)
+                .whenScenarioStateIs("created")
+                .willReturn(aResponse().withStatus(201)
+                        .withBody("{\"name\":\"my-connector\",\"config\":{},\"tasks\":[]}")));
+
+        KafkaConnectApi api = new KafkaConnectApiImpl();
+
+        Map<String, Object> result = api.createConnector(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.port(),
+                "my-connector", new JsonObject(), ConnectorState.STOPPED).toCompletableFuture().join();
+
+        assertThat(result, hasEntry("name", "my-connector"));
+        // It retried after the 409: the connector was POSTed twice.
+        server.verify(2, postRequestedFor(urlPathEqualTo("/connectors")));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -76,6 +76,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -565,7 +566,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         KafkaConnectApi connectApi = mock(KafkaConnectApi.class);
         when(connectApi.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         when(connectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.failedFuture(new ConnectRestException("maybeCreateOrUpdateConnector", "", 404, "error", "error")));
-        when(connectApi.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(connectApi.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenReturn(CompletableFuture.completedFuture(Map.of()));
         when(connectApi.status(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "RUNNING"))));
         when(connectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "RUNNING"))));
         when(connectApi.getConnectorTopics(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(List.of()));
@@ -575,7 +576,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         createMirrorMaker2Cluster(context, connectApi, false)
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     ArgumentCaptor<JsonObject> configJsonCaptor = ArgumentCaptor.forClass(JsonObject.class);
-                    verify(connectApi).createOrUpdatePutRequest(any(), any(), anyInt(), eq(connectorName), configJsonCaptor.capture());
+                    verify(connectApi).createConnector(any(), any(), anyInt(), eq(connectorName), configJsonCaptor.capture(), any());
                     assertThat(configJsonCaptor.getValue().getString("connector.plugin.version"), is("[0.1.0,)"));
 
                     async.flag();
@@ -619,7 +620,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         KafkaConnectApi connectApi = mock(KafkaConnectApi.class);
         when(connectApi.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         when(connectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.failedFuture(new ConnectRestException("maybeCreateOrUpdateConnector", "", 404, "error", "error")));
-        when(connectApi.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(connectApi.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenReturn(CompletableFuture.completedFuture(Map.of()));
         when(connectApi.status(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "RUNNING"))));
         when(connectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "RUNNING"))));
         when(connectApi.getConnectorTopics(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(List.of()));
@@ -629,9 +630,67 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         createMirrorMaker2Cluster(context, connectApi, false)
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     ArgumentCaptor<JsonObject> configJsonCaptor = ArgumentCaptor.forClass(JsonObject.class);
-                    verify(connectApi).createOrUpdatePutRequest(any(), any(), anyInt(), eq(connectorName), configJsonCaptor.capture());
+                    verify(connectApi).createConnector(any(), any(), anyInt(), eq(connectorName), configJsonCaptor.capture(), any());
                     // `connector.plugin.version` is forbidden, so the config JSON will not contain this key
                     assertThat(configJsonCaptor.getValue().containsKey("connector.plugin.version"), is(false));
+                    async.flag();
+                })));
+    }
+
+    /** A brand-new MirrorMaker2 connector asking for the stopped state (KIP-980) must never be started first */
+    @Test
+    public void testConnectorCreatedInStoppedState(VertxTestContext context) {
+        String connectorName = "source->target.MirrorSourceConnector";
+        Crds.kafkaMirrorMaker2Operation(client).resource(new KafkaMirrorMaker2Builder()
+                .withNewMetadata()
+                    .withName(CLUSTER_NAME)
+                    .withNamespace(namespace)
+                    .withLabels(Map.of("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(REPLICAS)
+                    .withNewTarget()
+                        .withAlias("target")
+                        .withGroupId("my-mm2-group")
+                        .withConfigStorageTopic("my-mm2-config")
+                        .withOffsetStorageTopic("my-mm2-offset")
+                        .withStatusStorageTopic("my-mm2-status")
+                        .withBootstrapServers("target:9092")
+                    .endTarget()
+                    .withMirrors(
+                            new KafkaMirrorMaker2MirrorSpecBuilder()
+                                    .withNewSource()
+                                        .withAlias("source")
+                                        .withBootstrapServers("source:9092")
+                                    .endSource()
+                                    .withNewSourceConnector()
+                                        .withTasksMax(1)
+                                        .withConfig(Map.of("replication.factor", -1))
+                                        .withState(ConnectorState.STOPPED)
+                                    .endSourceConnector()
+                                    .build()
+                    )
+                .endSpec()
+                .build()).create();
+
+        KafkaConnectApi connectApi = mock(KafkaConnectApi.class);
+        when(connectApi.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(connectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.failedFuture(new ConnectRestException("maybeCreateOrUpdateConnector", "", 404, "error", "error")));
+        when(connectApi.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(connectApi.status(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "STOPPED"))));
+        when(connectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "STOPPED"))));
+        when(connectApi.getConnectorTopics(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        Checkpoint async = context.checkpoint();
+
+        createMirrorMaker2Cluster(context, connectApi, false)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // The connector must be created via POST with the requested initial state
+                    verify(connectApi).createConnector(any(), any(), anyInt(), eq(connectorName), any(), eq(ConnectorState.STOPPED));
+                    // ... and never started first: no PUT-config create and no separate stop or pause call
+                    verify(connectApi, never()).createOrUpdatePutRequest(any(), any(), anyInt(), eq(connectorName), any());
+                    verify(connectApi, never()).stop(any(), any(), anyInt(), eq(connectorName));
+                    verify(connectApi, never()).pause(any(), any(), anyInt(), eq(connectorName));
                     async.flag();
                 })));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -637,9 +637,28 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 })));
     }
 
-    /** A brand-new MirrorMaker2 connector asking for the stopped state (KIP-980) must never be started first */
+    /** A brand-new MirrorMaker2 connector asking for the stopped state must never be started first */
     @Test
     public void testConnectorCreatedInStoppedState(VertxTestContext context) {
+        assertConnectorCreatedInInitialState(context, ConnectorState.STOPPED, "STOPPED");
+    }
+
+    /** A brand-new MirrorMaker2 connector asking for the paused state must never be started first */
+    @Test
+    public void testConnectorCreatedInPausedState(VertxTestContext context) {
+        assertConnectorCreatedInInitialState(context, ConnectorState.PAUSED, "PAUSED");
+    }
+
+    /**
+     * Shared check: a MirrorMaker2 source connector whose spec asks for a non-running state must be
+     * created directly in that state via POST, and never started first (no PUT-config create and no
+     * separate stop or pause call).
+     *
+     * @param context        The Vert.x test context
+     * @param state          The state requested via spec.state
+     * @param expectedState  The connector state string Kafka Connect reports back
+     */
+    private void assertConnectorCreatedInInitialState(VertxTestContext context, ConnectorState state, String expectedState) {
         String connectorName = "source->target.MirrorSourceConnector";
         Crds.kafkaMirrorMaker2Operation(client).resource(new KafkaMirrorMaker2Builder()
                 .withNewMetadata()
@@ -666,7 +685,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                                     .withNewSourceConnector()
                                         .withTasksMax(1)
                                         .withConfig(Map.of("replication.factor", -1))
-                                        .withState(ConnectorState.STOPPED)
+                                        .withState(state)
                                     .endSourceConnector()
                                     .build()
                     )
@@ -677,8 +696,8 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         when(connectApi.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         when(connectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.failedFuture(new ConnectRestException("maybeCreateOrUpdateConnector", "", 404, "error", "error")));
         when(connectApi.createConnector(any(), any(), anyInt(), anyString(), any(), any())).thenReturn(CompletableFuture.completedFuture(Map.of()));
-        when(connectApi.status(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "STOPPED"))));
-        when(connectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "STOPPED"))));
+        when(connectApi.status(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", expectedState))));
+        when(connectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", expectedState))));
         when(connectApi.getConnectorTopics(any(), any(), anyInt(), eq(connectorName))).thenReturn(CompletableFuture.completedFuture(List.of()));
 
         Checkpoint async = context.checkpoint();
@@ -686,7 +705,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         createMirrorMaker2Cluster(context, connectApi, false)
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     // The connector must be created via POST with the requested initial state
-                    verify(connectApi).createConnector(any(), any(), anyInt(), eq(connectorName), any(), eq(ConnectorState.STOPPED));
+                    verify(connectApi).createConnector(any(), any(), anyInt(), eq(connectorName), any(), eq(state));
                     // ... and never started first: no PUT-config create and no separate stop or pause call
                     verify(connectApi, never()).createOrUpdatePutRequest(any(), any(), anyInt(), eq(connectorName), any());
                     verify(connectApi, never()).stop(any(), any(), anyInt(), eq(connectorName));


### PR DESCRIPTION
Create stopped/paused connectors directly via POST /connectors with initial_state instead of creating them running and stopping them after.

Fixes #11754

### Type of change

- Enhancement / new feature

### Description

A `KafkaConnector` (or MirrorMaker2 connector) with `spec.state: stopped` or `paused` was first created running and then stopped or paused with a second call. This briefly started a connector that should never have run (for example, a MirrorHeartbeat connector created a `heartbeats` topic before being stopped).

This change uses the Kafka Connect `POST /connectors` endpoint with the `initial_state` field (KIP-980, Kafka 3.7+) to create the connector directly in the requested state, in a single step.

Main changes:
- Add `KafkaConnectApi.createConnector(...)`, which sends `POST /connectors` with `initial_state`, plus its implementation.
- `AbstractConnectOperator`: the create path (the 404 "connector does not exist" branch) now calls `createConnector` with `spec.state`. The old `createOrUpdateConnector` is renamed to `updateConnector` and is now only used to update an existing connector (still `PUT /connectors/{name}/config`).
- Reconfiguring an existing connector is unchanged.

All Kafka versions currently supported by Strimzi are well past 3.7, so no version guard is needed for `initial_state`.

No documentation change is needed: the `spec.state` field, its values, and its contract are unchanged. A `stopped` connector still ends up stopped; this only removes the unwanted transient start.

AI assistance (Claude Code) was used throughout this change to analyze the issue, write the code and tests, and run the local Kubernetes verification. I reviewed all changes before submitting.

### Checklist

- [ ] Update documentation
- [x] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))