### PR TITLE
`Util` and `PemAuthIdentity` clean-up

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -132,7 +132,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
     protected static HTTPHeader getAuthHttpHeader(boolean apiAuthEnabled, Secret apiSecret) {
         if (apiAuthEnabled) {
-            String password = Util.fromAsciiBytes(Util.decodeBase64FieldFromSecret(apiSecret, CruiseControlApiProperties.REBALANCE_OPERATOR_PASSWORD_KEY));
+            String password = Util.decodeStringFieldFromSecret(apiSecret, CruiseControlApiProperties.REBALANCE_OPERATOR_PASSWORD_KEY);
             return generateAuthHttpHeader(CruiseControlApiProperties.REBALANCE_OPERATOR_USERNAME, password);
         } else {
             return null;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -89,17 +89,19 @@ public class Util {
     }
 
     /**
-     * Decode binary item from Kubernetes Secret from base64 into byte array
+     * Decode an item from Kubernetes Secret (where it is stored in base64) to String. This method should be used only
+     * for things that are stored in the Secrets as Strings and not for binary data where entropy might be lost.
      *
      * @param secret    Kubernetes Secret
-     * @param field     Field which should be retrieved and decoded
-     * @return          Decoded bytes
+     * @param field     Field that should be retrieved and decoded
+     *
+     * @return          Decoded String
      */
-    public static byte[] decodeBase64FieldFromSecret(Secret secret, String field) {
+    public static String decodeStringFieldFromSecret(Secret secret, String field) {
         Objects.requireNonNull(secret);
         String data = secret.getData().get(field);
         if (data != null) {
-            return Base64.getDecoder().decode(data);
+            return decodeFromBase64(data);
         } else {
             throw new RuntimeException(String.format("The Secret %s/%s is missing the field %s",
                     secret.getMetadata().getNamespace(),
@@ -310,14 +312,5 @@ public class Util {
      */
     public static String decodeFromBase64(String data, Charset charset)  {
         return new String(decodeBytesFromBase64(data), charset);
-    }
-
-    /**
-     * Decodes the provided byte array using the charset StandardCharsets.US_ASCII
-     * @param bytes Byte array to convert to String
-     * @return New String object containing the provided byte array
-     */
-    public static String fromAsciiBytes(byte[] bytes) {
-        return new String(bytes, StandardCharsets.US_ASCII);
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/PemAuthIdentity.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/PemAuthIdentity.java
@@ -27,12 +27,8 @@ import java.util.Objects;
  * This consists of an X509 end-entity certificate, corresponding private key, and a (possibly empty) chain of X509 intermediate CA certificates, all in PEM format.
  */
 public class PemAuthIdentity {
-    /**
-     * Filename suffix for certificate chain as PEM
-     */
-    public static final String PEM_SUFFIX = "pem";
-    private final byte[] privateKeyAsPemBytes;
-    private final byte[] certificateChainAsPemBytes;
+    private final String privateKeyAsPem;
+    private final String certificateChainAsPem;
     private final String certificateName;
     private final String secretName;
     private final String secretNamespace;
@@ -48,8 +44,8 @@ public class PemAuthIdentity {
         this.certificateName = certificateName;
         this.secretName = secret.getMetadata().getName();
         this.secretNamespace = secret.getMetadata().getNamespace();
-        privateKeyAsPemBytes = Util.decodeBase64FieldFromSecret(secret, keyName);
-        certificateChainAsPemBytes = Util.decodeBase64FieldFromSecret(secret, certificateName);
+        this.privateKeyAsPem = Util.decodeStringFieldFromSecret(secret, keyName);
+        this.certificateChainAsPem = Util.decodeStringFieldFromSecret(secret, certificateName);
     }
 
     /**
@@ -81,28 +77,10 @@ public class PemAuthIdentity {
     /**
      * End-entity certificate and (possibly empty) chain of intermediate CA certificates for this authentication identity.
      *
-     * @return The certificate chain for this authentication identity as a byte array
-     */
-    public byte[] certificateChainAsPemBytes() {
-        return certificateChainAsPemBytes;
-    }
-
-    /**
-     * End-entity certificate and (possibly empty) chain of intermediate CA certificates for this authentication identity.
-     *
      * @return The certificate chain for this authentication identity as a String
      */
     public String certificateChainAsPem() {
-        return Util.fromAsciiBytes(certificateChainAsPemBytes);
-    }
-
-    /**
-     * Private key corresponding to the end-entity certificate for this authentication identity.
-     *
-     * @return The private key for this authentication identity as a byte array
-     */
-    public byte[] privateKeyAsPemBytes() {
-        return privateKeyAsPemBytes;
+        return certificateChainAsPem;
     }
 
     /**
@@ -111,15 +89,7 @@ public class PemAuthIdentity {
      * @return The private key for this authentication identity as a String
      */
     public String privateKeyAsPem() {
-        return Util.fromAsciiBytes(privateKeyAsPemBytes);
-    }
-
-    /**
-     * KeyStore to use for TLS connections.
-     * @return KeyStore file in PEM format
-     */
-    public byte[] pemKeyStore() {
-        return (privateKeyAsPem() + certificateChainAsPem()).getBytes(StandardCharsets.US_ASCII);
+        return privateKeyAsPem;
     }
 
     /**
@@ -156,7 +126,7 @@ public class PemAuthIdentity {
     private X509Certificate certificateChain() {
         try {
             final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-            return (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(certificateChainAsPemBytes));
+            return (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(certificateChainAsPem.getBytes(StandardCharsets.US_ASCII)));
         } catch (CertificateException e) {
             throw new RuntimeException("Bad/corrupt certificate found in data." + certificateName + " of Secret "
                     + secretName + " in namespace " + secretNamespace);


### PR DESCRIPTION
### Type of Change

- Refactoring

### Description

This PR does a minor cleanup of the `Util` and `PemAuthIdentity` classes.
* It removes some unused methods and fields from the `PemAuthIdentity` class
* It refactors how we read data from Secrets in `PemAuthIdentity` and in `CruiseControlApiImpl`
    * Instead of going through `byte[]` it goes directly to `String` as the fields are anyway always Base64 encoded strings
    * This change should also help to make it more clear to static code scanners that these fields are Strings in the first place and there is no entropy loss when converting `byte[]` to `String` as it might happen with an actual binary keys

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests