### PR TITLE
Integrate Gatekeeper plugins into the Cluster Operator config and main

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -140,6 +140,11 @@ public class ClusterOperatorConfig {
      */
     public static final String NO_PROXY = "NO_PROXY";
 
+    /**
+     * Enabled or disables the FIPS mode
+     */
+    public static final String FIPS_MODE = "FIPS_MODE";
+
     // Default values
     /**
      * Namespace in which the operator will run and create resources

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.common.model.Labels;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.strimzi.operator.common.config.ConfigParameterParser.BOOLEAN;
+import static io.strimzi.operator.common.config.ConfigParameterParser.COMMA_SEPARATED_LIST;
 import static io.strimzi.operator.common.config.ConfigParameterParser.INTEGER;
 import static io.strimzi.operator.common.config.ConfigParameterParser.LABEL_PREDICATE;
 import static io.strimzi.operator.common.config.ConfigParameterParser.LOCAL_OBJECT_REFERENCE_LIST;
@@ -67,6 +69,15 @@ public class ClusterOperatorConfig {
     private static final String STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE";
     private static final String STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE";
     private static final String STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
+
+    /**
+     * List of mandatory Gatekeeper plugins that are not user-configurable but are hardcoded by Strimzi
+     */
+    private static final List<String> MANDATORY_GATEKEEPER_PLUGINS = List.of();
+    /**
+     * List of default Gatekeeper plugins that are used by default, but users can change / reconfigure them.
+     */
+    private static final List<String> DEFAULT_GATEKEEPER_PLUGINS = List.of();
 
     /**
      * Configures the Kafka Exporter container image
@@ -128,11 +139,6 @@ public class ClusterOperatorConfig {
      * Server which should not use proxy to connect to
      */
     public static final String NO_PROXY = "NO_PROXY";
-
-    /**
-     * Enabled or disables the FIPS mode
-     */
-    public static final String FIPS_MODE = "FIPS_MODE";
 
     // Default values
     /**
@@ -258,6 +264,16 @@ public class ClusterOperatorConfig {
      * Set true to enable watched namespace feature for Entity Operators (Topic Operator and User Operator)
      */
     public static final ConfigParameter<Boolean> ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED = new ConfigParameter<>("STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED", BOOLEAN, "false", CONFIG_VALUES);
+
+    /**
+     * Comma-separated list of custom Gatekeeper plugins that should be enabled
+     */
+    public static final ConfigParameter<List<String>> GATEKEEPER_CUSTOM_PLUGINS = new ConfigParameter<>("STRIMZI_GATEKEEPER_CUSTOM_PLUGINS", COMMA_SEPARATED_LIST, "", CONFIG_VALUES);
+
+    /**
+     * Comma-separated list of default Gatekeeper plugins. If not set, the default list of default plugins is used.
+     */
+    public static final ConfigParameter<List<String>> GATEKEEPER_DEFAULT_PLUGINS = new ConfigParameter<>("STRIMZI_GATEKEEPER_DEFAULT_PLUGINS", COMMA_SEPARATED_LIST, "", CONFIG_VALUES);
 
     /**
      * The configured Kafka versions
@@ -656,6 +672,52 @@ public class ClusterOperatorConfig {
         return get(ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED);
     }
 
+    /**
+     * Gets the list of custom Gatekeeper plugins.
+     *
+     * @return List of custom Gatekeeper plugins
+     */
+    public List<String> getGatekeeperCustomPlugins() {
+        return get(GATEKEEPER_CUSTOM_PLUGINS);
+    }
+
+    /**
+     * Gets the list of default Gatekeeper plugins.
+     *
+     * @return List of default Gatekeeper plugins
+     */
+    public List<String> getGatekeeperDefaultPlugins() {
+        return get(GATEKEEPER_DEFAULT_PLUGINS);
+    }
+
+    /**
+     * Gets the full list of the Gatekeeper plugins that should be used. This is constructed from the partial lists:
+     *   - Custom
+     *   - Default
+     *   - Mandatory
+     *
+     * @return  List of all Gatekeeper plugins that should be used
+     */
+    public List<String> getGatekeeperPlugins() {
+        List<String> plugins = new ArrayList<>();
+
+        List<String> customPlugins = get(GATEKEEPER_CUSTOM_PLUGINS);
+        if (customPlugins != null) {
+            plugins.addAll(customPlugins);
+        }
+
+        List<String> defaultPlugins = get(GATEKEEPER_DEFAULT_PLUGINS);
+        if (defaultPlugins != null) {
+            plugins.addAll(defaultPlugins);
+        } else {
+            plugins.addAll(DEFAULT_GATEKEEPER_PLUGINS);
+        }
+
+        plugins.addAll(MANDATORY_GATEKEEPER_PLUGINS);
+
+        return plugins;
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig{" +
@@ -680,6 +742,9 @@ public class ClusterOperatorConfig {
                 "\n\tpodDisruptionBudgetGeneration=" + isPodDisruptionBudgetGeneration() + '\'' +
                 "\n\tisPkcs12KeystoreGeneration='" + isPkcs12KeystoreGeneration() +
                 "\n\tisEntityOperatorWatchedNamespaceEnabled='" + isEntityOperatorWatchedNamespaceEnabled() +
+                "\n\tgatekeeperCustomPlugins='" + getGatekeeperCustomPlugins() + "'" +
+                "\n\tgatekeeperDefaultPlugins='" + getGatekeeperDefaultPlugins() + "'" +
+                "\n\tgatekeeperPlugins='" + getGatekeeperPlugins() + "'" +
                 "}";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -22,6 +22,8 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.operator.common.gatekeeper.impl.GatekeeperPluginConfigurationContextImpl;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -170,6 +172,9 @@ public class Main {
 
         // Initialize the PodSecurityProvider factory to provide the user configured provider
         PodSecurityProviderFactory.initialize(config.getPodSecurityProviderClass(), pfa);
+
+        // Load and configure the Gatekeeper plugins
+        GatekeeperPluginFactory.initialize(config.getGatekeeperPlugins(), new GatekeeperPluginConfigurationContextImpl(client));
 
         KafkaAssemblyOperator kafkaClusterOperations = null;
         KafkaConnectAssemblyOperator kafkaConnectClusterOperations = null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvoker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvoker.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.gatekeeper;
+
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatusBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatusBuilder;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatusBuilder;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2StatusBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatusBuilder;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceBuilder;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatusBuilder;
+import io.strimzi.operator.common.gatekeeper.AbstractGatekeeperPluginInvoker;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2DeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2EntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2MutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.KafkaAndKafkaNodePools;
+import io.strimzi.plugin.gatekeeper.KafkaConnectAndKafkaConnectors;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Invokes the Strimzi Gatekeeper plugins for Kafka, KafkaConnect, KafkaMirrorMaker2, and KafkaRebalance reconciliations.
+ * It provides entry, exit, and deletion methods which invoke all the Kafka, KafkaConnect, KafkaMirrorMaker2,
+ * and KafkaRebalance plugins - both mutating and validating - as one ordered chain. The plugins (and their order) are
+ * provided by the {@link GatekeeperPluginFactory}.
+ */
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
+public class ClusterOperatorGatekeeperPluginInvoker extends AbstractGatekeeperPluginInvoker {
+    private ClusterOperatorGatekeeperPluginInvoker() { }
+
+    /**
+     * Invokes the entry of all the KafkaMirrorMaker2 plugins (mutating and validating) as a single ordered chain. Mutating plugins
+     * can modify the resource; validating plugins receive a copy of it and let the original pass through unchanged.
+     *
+     * @param context   The entry context passed to the plugins
+     * @param kafkaMirrorMaker2   The KafkaMirrorMaker2 custom resource being reconciled
+     *
+     * @return  A completion stage with the KafkaMirrorMaker2 resource after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaMirrorMaker2> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+        return chain(
+                GatekeeperKafkaMirrorMaker2MutatingPlugin.class,
+                GatekeeperKafkaMirrorMaker2ValidatingPlugin.class,
+                Phase.ENTRY,
+                kafkaMirrorMaker2,
+                (plugin, current) -> plugin.kafkaMirrorMaker2Entry(context, current),
+                (plugin, current) -> plugin.kafkaMirrorMaker2Entry(context, copy(current, item -> new KafkaMirrorMaker2Builder(item).build())));
+    }
+
+    /**
+     * Invokes the exit of all the KafkaMirrorMaker2 plugins (mutating and validating) as a single ordered chain, in the reverse of
+     * the configured order. Mutating plugins can modify the status; validating plugins receive copies of the resource and
+     * the status and let the original status pass through unchanged.
+     *
+     * @param context   The exit context passed to the plugins
+     * @param kafkaMirrorMaker2   The KafkaMirrorMaker2 custom resource being reconciled
+     * @param status    The status computed for the KafkaMirrorMaker2 resource
+     *
+     * @return  A completion stage with the KafkaMirrorMaker2 status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaMirrorMaker2Status> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status status) {
+        return chain(
+                GatekeeperKafkaMirrorMaker2MutatingPlugin.class,
+                GatekeeperKafkaMirrorMaker2ValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaMirrorMaker2Exit(context, kafkaMirrorMaker2, current),
+                (plugin, current) -> plugin.kafkaMirrorMaker2Exit(context, copy(kafkaMirrorMaker2, item -> new KafkaMirrorMaker2Builder(item).build()), copy(current, item -> new KafkaMirrorMaker2StatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the entry of all the KafkaBridge plugins (mutating and validating) as a single ordered chain. Mutating plugins
+     * can modify the resource; validating plugins receive a copy of it and let the original pass through unchanged.
+     *
+     * @param context   The entry context passed to the plugins
+     * @param kafkaBridge   The KafkaBridge custom resource being reconciled
+     *
+     * @return  A completion stage with the KafkaBridge resource after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaBridge> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+        return chain(
+                GatekeeperKafkaBridgeMutatingPlugin.class,
+                GatekeeperKafkaBridgeValidatingPlugin.class,
+                Phase.ENTRY,
+                kafkaBridge,
+                (plugin, current) -> plugin.kafkaBridgeEntry(context, current),
+                (plugin, current) -> plugin.kafkaBridgeEntry(context, copy(current, item -> new KafkaBridgeBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the exit of all the KafkaBridge plugins (mutating and validating) as a single ordered chain, in the reverse of
+     * the configured order. Mutating plugins can modify the status; validating plugins receive copies of the resource and
+     * the status and let the original status pass through unchanged.
+     *
+     * @param context   The exit context passed to the plugins
+     * @param kafkaBridge   The KafkaBridge custom resource being reconciled
+     * @param status    The status computed for the KafkaBridge resource
+     *
+     * @return  A completion stage with the KafkaBridge status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaBridgeStatus> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus status) {
+        return chain(
+                GatekeeperKafkaBridgeMutatingPlugin.class,
+                GatekeeperKafkaBridgeValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaBridgeExit(context, kafkaBridge, current),
+                (plugin, current) -> plugin.kafkaBridgeExit(context, copy(kafkaBridge, item -> new KafkaBridgeBuilder(item).build()), copy(current, item -> new KafkaBridgeStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the entry of all the KafkaRebalance plugins (mutating and validating) as a single ordered chain. Mutating plugins
+     * can modify the resource; validating plugins receive a copy of it and let the original pass through unchanged.
+     *
+     * @param context   The entry context passed to the plugins
+     * @param kafkaRebalance   The KafkaRebalance custom resource being reconciled
+     *
+     * @return  A completion stage with the KafkaRebalance resource after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaRebalance> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+        return chain(
+                GatekeeperKafkaRebalanceMutatingPlugin.class,
+                GatekeeperKafkaRebalanceValidatingPlugin.class,
+                Phase.ENTRY,
+                kafkaRebalance,
+                (plugin, current) -> plugin.kafkaRebalanceEntry(context, current),
+                (plugin, current) -> plugin.kafkaRebalanceEntry(context, copy(current, item -> new KafkaRebalanceBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the exit of all the KafkaRebalance plugins (mutating and validating) as a single ordered chain, in the reverse of
+     * the configured order. Mutating plugins can modify the status; validating plugins receive copies of the resource and
+     * the status and let the original status pass through unchanged.
+     *
+     * @param context   The exit context passed to the plugins
+     * @param kafkaRebalance   The KafkaRebalance custom resource being reconciled
+     * @param status    The status computed for the KafkaRebalance resource
+     *
+     * @return  A completion stage with the KafkaRebalance status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaRebalanceStatus> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus status) {
+        return chain(
+                GatekeeperKafkaRebalanceMutatingPlugin.class,
+                GatekeeperKafkaRebalanceValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaRebalanceExit(context, kafkaRebalance, current),
+                (plugin, current) -> plugin.kafkaRebalanceExit(context, copy(kafkaRebalance, item -> new KafkaRebalanceBuilder(item).build()), copy(current, item -> new KafkaRebalanceStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the entry of all the Kafka plugins (mutating and validating) as a single ordered chain. Mutating plugins
+     * can modify the Kafka resource and its KafkaNodePool resources; validating plugins receive copies of them and let the
+     * originals pass through unchanged.
+     *
+     * @param context           The entry context passed to the plugins
+     * @param kafka           The Kafka custom resource being reconciled
+     * @param kafkaNodePools   The KafkaNodePool resources belonging to the Kafka
+     *
+     * @return  A completion stage with the Kafka resource and its KafkaNodePool resources after they passed through all the plugins
+     */
+    public static CompletionStage<KafkaAndKafkaNodePools> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+        return chain(
+                GatekeeperKafkaMutatingPlugin.class,
+                GatekeeperKafkaValidatingPlugin.class,
+                Phase.ENTRY,
+                new KafkaAndKafkaNodePools(kafka, kafkaNodePools),
+                (plugin, current) -> plugin.kafkaEntry(context, current.kafka(), current.kafkaNodePools()),
+                (plugin, current) -> plugin.kafkaEntry(context, copy(current.kafka(), item -> new KafkaBuilder(item).build()), copyList(current.kafkaNodePools(), item -> new KafkaNodePoolBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the Kafka exit of all the Kafka plugins (mutating and validating) as a single ordered chain, in the
+     * reverse of the configured order. Mutating plugins can modify the status; validating plugins receive copies of the
+     * resources and the status and let the original status pass through unchanged.
+     *
+     * @param context           The exit context passed to the plugins
+     * @param kafka           The Kafka custom resource being reconciled
+     * @param kafkaNodePools   The KafkaNodePool resources belonging to the Kafka
+     * @param status            The status computed for the Kafka resource
+     *
+     * @return  A completion stage with the Kafka status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaStatus> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus status) {
+        return chain(
+                GatekeeperKafkaMutatingPlugin.class,
+                GatekeeperKafkaValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaExit(context, kafka, kafkaNodePools, current),
+                (plugin, current) -> plugin.kafkaExit(context, copy(kafka, item -> new KafkaBuilder(item).build()), copyList(kafkaNodePools, item -> new KafkaNodePoolBuilder(item).build()), copy(current, item -> new KafkaStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the KafkaNodePool exit of all the Kafka plugins (mutating and validating) as a single ordered chain for a single
+     * KafkaNodePool, in the reverse of the configured order. Mutating plugins can modify the status; validating plugins receive
+     * copies of the resources and the status and let the original status pass through unchanged.
+     *
+     * @param context           The exit context passed to the plugins
+     * @param kafka           The Kafka custom resource being reconciled
+     * @param kafkaNodePool     The KafkaNodePool resource whose status is being processed
+     * @param status            The status computed for the KafkaNodePool resource
+     *
+     * @return  A completion stage with the KafkaNodePool status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaNodePoolStatus> kafkaNodePoolExit(GatekeeperKafkaExitContext context, Kafka kafka, KafkaNodePool kafkaNodePool, KafkaNodePoolStatus status) {
+        return chain(
+                GatekeeperKafkaMutatingPlugin.class,
+                GatekeeperKafkaValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaNodePoolExit(context, kafka, kafkaNodePool, current),
+                (plugin, current) -> plugin.kafkaNodePoolExit(context, copy(kafka, item -> new KafkaBuilder(item).build()), copy(kafkaNodePool, item -> new KafkaNodePoolBuilder(item).build()), copy(current, item -> new KafkaNodePoolStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the entry of all the KafkaConnect plugins (mutating and validating) as a single ordered chain. Mutating plugins
+     * can modify the KafkaConnect resource and its KafkaConnector resources; validating plugins receive copies of them and let the
+     * originals pass through unchanged.
+     *
+     * @param context           The entry context passed to the plugins
+     * @param kafkaConnect           The KafkaConnect custom resource being reconciled
+     * @param kafkaConnectors   The KafkaConnector resources belonging to the KafkaConnect
+     *
+     * @return  A completion stage with the KafkaConnect resource and its KafkaConnector resources after they passed through all the plugins
+     */
+    public static CompletionStage<KafkaConnectAndKafkaConnectors> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+        return chain(
+                GatekeeperKafkaConnectMutatingPlugin.class,
+                GatekeeperKafkaConnectValidatingPlugin.class,
+                Phase.ENTRY,
+                new KafkaConnectAndKafkaConnectors(kafkaConnect, kafkaConnectors),
+                (plugin, current) -> plugin.kafkaConnectEntry(context, current.kafkaConnect(), current.kafkaConnectors()),
+                (plugin, current) -> plugin.kafkaConnectEntry(context, copy(current.kafkaConnect(), item -> new KafkaConnectBuilder(item).build()), copyList(current.kafkaConnectors(), item -> new KafkaConnectorBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the KafkaConnect exit of all the KafkaConnect plugins (mutating and validating) as a single ordered chain, in the
+     * reverse of the configured order. Mutating plugins can modify the status; validating plugins receive copies of the
+     * resources and the status and let the original status pass through unchanged.
+     *
+     * @param context           The exit context passed to the plugins
+     * @param kafkaConnect           The KafkaConnect custom resource being reconciled
+     * @param kafkaConnectors   The KafkaConnector resources belonging to the KafkaConnect
+     * @param status            The status computed for the KafkaConnect resource
+     *
+     * @return  A completion stage with the KafkaConnect status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaConnectStatus> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus status) {
+        return chain(
+                GatekeeperKafkaConnectMutatingPlugin.class,
+                GatekeeperKafkaConnectValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaConnectExit(context, kafkaConnect, kafkaConnectors, current),
+                (plugin, current) -> plugin.kafkaConnectExit(context, copy(kafkaConnect, item -> new KafkaConnectBuilder(item).build()), copyList(kafkaConnectors, item -> new KafkaConnectorBuilder(item).build()), copy(current, item -> new KafkaConnectStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the KafkaConnector exit of all the KafkaConnect plugins (mutating and validating) as a single ordered chain for a single
+     * KafkaConnector, in the reverse of the configured order. Mutating plugins can modify the status; validating plugins receive
+     * copies of the resources and the status and let the original status pass through unchanged.
+     *
+     * @param context           The exit context passed to the plugins
+     * @param kafkaConnect           The KafkaConnect custom resource being reconciled
+     * @param kafkaConnector     The KafkaConnector resource whose status is being processed
+     * @param status            The status computed for the KafkaConnector resource
+     *
+     * @return  A completion stage with the KafkaConnector status after it passed through all the plugins
+     */
+    public static CompletionStage<KafkaConnectorStatus> kafkaConnectorExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, KafkaConnector kafkaConnector, KafkaConnectorStatus status) {
+        return chain(
+                GatekeeperKafkaConnectMutatingPlugin.class,
+                GatekeeperKafkaConnectValidatingPlugin.class,
+                Phase.EXIT,
+                status,
+                (plugin, current) -> plugin.kafkaConnectorExit(context, kafkaConnect, kafkaConnector, current),
+                (plugin, current) -> plugin.kafkaConnectorExit(context, copy(kafkaConnect, item -> new KafkaConnectBuilder(item).build()), copy(kafkaConnector, item -> new KafkaConnectorBuilder(item).build()), copy(current, item -> new KafkaConnectorStatusBuilder(item).build())));
+    }
+
+    /**
+     * Invokes the deletion hook of all the Kafka plugins (both mutating and validating, since the deletion hook is
+     * defined on their common interface) as a single ordered chain. There is no resource to mutate during a deletion, so
+     * the hooks only react to the deletion; any of them can reject it by completing exceptionally, which stops the chain.
+     *
+     * @param context   The deletion context passed to the plugins
+     * @param namespace The namespace of the Kafka being deleted
+     * @param name      The name of the Kafka being deleted
+     *
+     * @return  A completion stage which completes when all the deletion hooks completed
+     */
+    public static CompletionStage<Void> kafkaDeletion(GatekeeperKafkaDeletionContext context, String namespace, String name) {
+        return deletion(
+                GatekeeperKafkaMutatingPlugin.class,
+                GatekeeperKafkaValidatingPlugin.class,
+                plugin -> plugin instanceof GatekeeperKafkaMutatingPlugin mutating
+                        ? mutating.kafkaDeletion(context, namespace, name)
+                        : ((GatekeeperKafkaValidatingPlugin) plugin).kafkaDeletion(context, namespace, name));
+    }
+
+    /**
+     * Invokes the deletion hook of all the KafkaConnect plugins as a single ordered chain. There is no resource to
+     * mutate during a deletion, so the hooks only react to the deletion; any of them can reject it by completing
+     * exceptionally, which stops the chain.
+     *
+     * @param context   The deletion context passed to the plugins
+     * @param namespace The namespace of the KafkaConnect being deleted
+     * @param name      The name of the KafkaConnect being deleted
+     *
+     * @return  A completion stage which completes when all the deletion hooks completed
+     */
+    public static CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+        return deletion(
+                GatekeeperKafkaConnectMutatingPlugin.class,
+                GatekeeperKafkaConnectValidatingPlugin.class,
+                plugin -> plugin instanceof GatekeeperKafkaConnectMutatingPlugin mutating
+                        ? mutating.kafkaConnectDeletion(context, namespace, name)
+                        : ((GatekeeperKafkaConnectValidatingPlugin) plugin).kafkaConnectDeletion(context, namespace, name));
+    }
+
+    /**
+     * Invokes the deletion hook of all the KafkaMirrorMaker2 plugins as a single ordered chain. There is no resource to
+     * mutate during a deletion, so the hooks only react to the deletion; any of them can reject it by completing
+     * exceptionally, which stops the chain.
+     *
+     * @param context   The deletion context passed to the plugins
+     * @param namespace The namespace of the KafkaMirrorMaker2 being deleted
+     * @param name      The name of the KafkaMirrorMaker2 being deleted
+     *
+     * @return  A completion stage which completes when all the deletion hooks completed
+     */
+    public static CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+        return deletion(
+                GatekeeperKafkaMirrorMaker2MutatingPlugin.class,
+                GatekeeperKafkaMirrorMaker2ValidatingPlugin.class,
+                plugin -> plugin instanceof GatekeeperKafkaMirrorMaker2MutatingPlugin mutating
+                        ? mutating.kafkaMirrorMaker2Deletion(context, namespace, name)
+                        : ((GatekeeperKafkaMirrorMaker2ValidatingPlugin) plugin).kafkaMirrorMaker2Deletion(context, namespace, name));
+    }
+
+    /**
+     * Invokes the deletion hook of all the KafkaBridge plugins as a single ordered chain. There is no resource to mutate
+     * during a deletion, so the hooks only react to the deletion; any of them can reject it by completing exceptionally,
+     * which stops the chain.
+     *
+     * @param context   The deletion context passed to the plugins
+     * @param namespace The namespace of the KafkaBridge being deleted
+     * @param name      The name of the KafkaBridge being deleted
+     *
+     * @return  A completion stage which completes when all the deletion hooks completed
+     */
+    public static CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+        return deletion(
+                GatekeeperKafkaBridgeMutatingPlugin.class,
+                GatekeeperKafkaBridgeValidatingPlugin.class,
+                plugin -> plugin instanceof GatekeeperKafkaBridgeMutatingPlugin mutating
+                        ? mutating.kafkaBridgeDeletion(context, namespace, name)
+                        : ((GatekeeperKafkaBridgeValidatingPlugin) plugin).kafkaBridgeDeletion(context, namespace, name));
+    }
+
+    /**
+     * Invokes the deletion hook of all the KafkaRebalance plugins as a single ordered chain. There is no resource to
+     * mutate during a deletion, so the hooks only react to the deletion; any of them can reject it by completing
+     * exceptionally, which stops the chain.
+     *
+     * @param context   The deletion context passed to the plugins
+     * @param namespace The namespace of the KafkaRebalance being deleted
+     * @param name      The name of the KafkaRebalance being deleted
+     *
+     * @return  A completion stage which completes when all the deletion hooks completed
+     */
+    public static CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+        return deletion(
+                GatekeeperKafkaRebalanceMutatingPlugin.class,
+                GatekeeperKafkaRebalanceValidatingPlugin.class,
+                plugin -> plugin instanceof GatekeeperKafkaRebalanceMutatingPlugin mutating
+                        ? mutating.kafkaRebalanceDeletion(context, namespace, name)
+                        : ((GatekeeperKafkaRebalanceValidatingPlugin) plugin).kafkaRebalanceDeletion(context, namespace, name));
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvoker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvoker.java
@@ -66,10 +66,10 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Invokes the Strimzi Gatekeeper plugins for Kafka, KafkaConnect, KafkaMirrorMaker2, and KafkaRebalance reconciliations.
- * It provides entry, exit, and deletion methods which invoke all the Kafka, KafkaConnect, KafkaMirrorMaker2,
- * and KafkaRebalance plugins - both mutating and validating - as one ordered chain. The plugins (and their order) are
- * provided by the {@link GatekeeperPluginFactory}.
+ * Invokes the Strimzi Gatekeeper plugins for Kafka (+KafkaNodePools), KafkaConnect (+KafkaConnectors),
+ * KafkaMirrorMaker2, KafkaBridge, and KafkaRebalance reconciliations. It provides entry, exit, and deletion methods
+ * which invoke all the Kafka, KafkaConnect, KafkaMirrorMaker2, KafkaBridge, and KafkaRebalance plugins (both mutating
+ * and validating) as one ordered chain. The plugins (and their order) are provided by the {@link GatekeeperPluginFactory}.
  */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class ClusterOperatorGatekeeperPluginInvoker extends AbstractGatekeeperPluginInvoker {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ClusterOperatorConfigTest {
-
     private static final Map<String, String> ENV_VARS = new HashMap<>(8);
     static {
         ENV_VARS.put(ClusterOperatorConfig.NAMESPACE.key(), "namespace");
@@ -50,6 +49,11 @@ public class ClusterOperatorConfigTest {
         ENV_VARS.put(ClusterOperatorConfig.PKCS12_KEYSTORE_GENERATION.key(), "false");
         ENV_VARS.put(ClusterOperatorConfig.ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED.key(), "true");
     }
+
+    private static final String CUSTOM_PLUGIN_1 = "io.strimzi.Custom1";
+    private static final String CUSTOM_PLUGIN_2 = "io.strimzi.Custom2";
+    private static final String DEFAULT_PLUGIN_1 = "io.strimzi.Default1";
+    private static final String DEFAULT_PLUGIN_2 = "io.strimzi.Default2";
 
     @Test
     public void testDefaultConfig() {
@@ -387,5 +391,32 @@ public class ClusterOperatorConfigTest {
 
         config.getLeaderElectionConfig();
         assertThat(ClusterOperatorConfig.buildFromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getLeaderElectionConfig(), is(notNullValue()));
+    }
+
+    // TODO: Once we have some mandatory and default default plugins (i.e. default plugins configured by default),
+    //       we should add dedicated tests for their handling as well. But as they are currently empty, it cannot be
+    //       checked right now
+
+    @Test
+    public void testGatekeeperPluginsDefaultToEmpty() {
+        ClusterOperatorConfig config = ClusterOperatorConfig.buildFromMap(ENV_VARS);
+
+        assertThat(config.getGatekeeperCustomPlugins(), is(nullValue()));
+        assertThat(config.getGatekeeperDefaultPlugins(), is(nullValue()));
+        assertThat(config.getGatekeeperPlugins(), is(List.of()));
+    }
+
+    @Test
+    public void testGatekeeperPluginsOrdering() {
+        // The custom plugins are invoked first, then the default plugins. The User Operator has no mandatory plugins.
+        Map<String, String> envVars = new HashMap<>(ENV_VARS);
+        envVars.put(ClusterOperatorConfig.GATEKEEPER_DEFAULT_PLUGINS.key(), DEFAULT_PLUGIN_2 + ", " + DEFAULT_PLUGIN_1);
+        envVars.put(ClusterOperatorConfig.GATEKEEPER_CUSTOM_PLUGINS.key(), CUSTOM_PLUGIN_1 + "," + CUSTOM_PLUGIN_2);
+
+        ClusterOperatorConfig config = ClusterOperatorConfig.buildFromMap(envVars);
+
+        assertThat(config.getGatekeeperCustomPlugins(), is(List.of(CUSTOM_PLUGIN_1, CUSTOM_PLUGIN_2)));
+        assertThat(config.getGatekeeperDefaultPlugins(), is(List.of(DEFAULT_PLUGIN_2, DEFAULT_PLUGIN_1)));
+        assertThat(config.getGatekeeperPlugins(), is(List.of(CUSTOM_PLUGIN_1, CUSTOM_PLUGIN_2, DEFAULT_PLUGIN_2, DEFAULT_PLUGIN_1)));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvokerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvokerTest.java
@@ -4,19 +4,55 @@
  */
 package io.strimzi.operator.cluster.gatekeeper;
 
+import io.strimzi.api.kafka.model.bridge.KafkaBridge;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
+import io.strimzi.api.kafka.model.bridge.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceBuilder;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
 import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaBridgeValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaConnectValidatingPlugin;
 import io.strimzi.plugin.gatekeeper.GatekeeperKafkaDeletionContext;
 import io.strimzi.plugin.gatekeeper.GatekeeperKafkaEntryContext;
 import io.strimzi.plugin.gatekeeper.GatekeeperKafkaExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2DeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2EntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2MutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMirrorMaker2ValidatingPlugin;
 import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaRebalanceValidatingPlugin;
 import io.strimzi.plugin.gatekeeper.GatekeeperKafkaValidatingPlugin;
 import io.strimzi.plugin.gatekeeper.KafkaAndKafkaNodePools;
+import io.strimzi.plugin.gatekeeper.KafkaConnectAndKafkaConnectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,9 +70,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the ClusterOperatorGatekeeperPluginInvoker. The invoker delegates to the same shared chaining logic
- * as the User and Topic Operator invokers, so these tests focus on the Kafka methods, which exercise the
- * Cluster-Operator-specific parts (the compound KafkaAndKafkaNodePools resource and the KafkaNodePool exit).
+ * as the User and Topic Operator invokers, so the Kafka tests focus on the Cluster-Operator-specific parts (the
+ * compound KafkaAndKafkaNodePools resource and the KafkaNodePool exit). The tests for the other operands
+ * (KafkaConnect, KafkaMirrorMaker2, KafkaBridge, and KafkaRebalance) exercise the entry, exit, and deletion methods
+ * of each so that every operand-specific invoker method is covered.
  */
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public class ClusterOperatorGatekeeperPluginInvokerTest {
     private final List<String> order = new ArrayList<>();
 
@@ -193,13 +232,313 @@ public class ClusterOperatorGatekeeperPluginInvokerTest {
         assertThat(order, contains("fail"));
     }
 
+    ///////////////////////////////////////////////////
+    // KafkaConnect
+    ///////////////////////////////////////////////////
+
+    @Test
+    public void testKafkaConnectEntryChainsPluginsAndMutatesResourceAndConnectors() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectMutator("A"), new ConnectValidator("B", false)));
+
+        KafkaConnectAndKafkaConnectors result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectEntry(null, kafkaConnect(""), List.of(kafkaConnector("c")))
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+        assertThat(result.kafkaConnect().getMetadata().getName(), is("A"));
+        assertThat(result.kafkaConnectors().get(0).getMetadata().getName(), is("cA"));
+    }
+
+    @Test
+    public void testKafkaConnectEntryValidatingPluginCannotModifyTheResource() {
+        KafkaConnect base = kafkaConnect("original");
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectResourceMutatingValidator()));
+
+        KafkaConnectAndKafkaConnectors result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectEntry(null, base, List.of())
+                .toCompletableFuture().join();
+
+        assertThat(result.kafkaConnect().getMetadata().getName(), is("original"));
+        assertThat(base.getMetadata().getName(), is("original"));
+    }
+
+    @Test
+    public void testKafkaConnectEntryStopsAtFirstValidationFailure() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectValidator("fail", true), new ConnectValidator("ok", false)));
+
+        CompletableFuture<KafkaConnectAndKafkaConnectors> result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectEntry(null, kafkaConnect(""), List.of())
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+        assertThat(order, contains("fail"));
+    }
+
+    @Test
+    public void testKafkaConnectExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectMutator("A")));
+
+        KafkaConnectStatus status = new KafkaConnectStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaConnectStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectExit(null, kafkaConnect("my-connect"), List.of(), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testKafkaConnectExitValidatingPluginCannotModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectValidator("A", false)));
+
+        KafkaConnectStatus status = new KafkaConnectStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaConnectStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectExit(null, kafkaConnect("my-connect"), List.of(), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1L));
+    }
+
+    @Test
+    public void testKafkaConnectorExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectMutator("A")));
+
+        KafkaConnectorStatus status = new KafkaConnectorStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaConnectorStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectorExit(null, kafkaConnect("my-connect"), kafkaConnector("c"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testKafkaConnectDeletionInvokesMutatingAndValidatingPluginsInOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectMutator("A"), new ConnectValidator("B", false)));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectDeletion(null, "my-namespace", "my-connect")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+    }
+
+    @Test
+    public void testKafkaConnectDeletionStopsAtFirstFailure() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new ConnectValidator("fail", true), new ConnectMutator("ok")));
+
+        CompletableFuture<Void> result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaConnectDeletion(null, "my-namespace", "my-connect")
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+        assertThat(order, contains("fail"));
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaMirrorMaker2
+    ///////////////////////////////////////////////////
+
+    @Test
+    public void testKafkaMirrorMaker2EntryChainsPluginsAndMutatesResource() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new MirrorMaker2Mutator("A"), new MirrorMaker2Validator("B", false)));
+
+        KafkaMirrorMaker2 result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaMirrorMaker2Entry(null, kafkaMirrorMaker2(""))
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+        assertThat(result.getMetadata().getName(), is("A"));
+    }
+
+    @Test
+    public void testKafkaMirrorMaker2ExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new MirrorMaker2Mutator("A")));
+
+        KafkaMirrorMaker2Status status = new KafkaMirrorMaker2Status();
+        status.setObservedGeneration(1L);
+
+        KafkaMirrorMaker2Status result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaMirrorMaker2Exit(null, kafkaMirrorMaker2("my-mm2"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testKafkaMirrorMaker2ExitValidatingPluginCannotModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new MirrorMaker2Validator("A", false)));
+
+        KafkaMirrorMaker2Status status = new KafkaMirrorMaker2Status();
+        status.setObservedGeneration(1L);
+
+        KafkaMirrorMaker2Status result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaMirrorMaker2Exit(null, kafkaMirrorMaker2("my-mm2"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1L));
+    }
+
+    @Test
+    public void testKafkaMirrorMaker2DeletionInvokesMutatingAndValidatingPluginsInOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new MirrorMaker2Mutator("A"), new MirrorMaker2Validator("B", false)));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaMirrorMaker2Deletion(null, "my-namespace", "my-mm2")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaBridge
+    ///////////////////////////////////////////////////
+
+    @Test
+    public void testKafkaBridgeEntryChainsPluginsAndMutatesResource() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new BridgeMutator("A"), new BridgeValidator("B", false)));
+
+        KafkaBridge result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaBridgeEntry(null, kafkaBridge(""))
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+        assertThat(result.getMetadata().getName(), is("A"));
+    }
+
+    @Test
+    public void testKafkaBridgeExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new BridgeMutator("A")));
+
+        KafkaBridgeStatus status = new KafkaBridgeStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaBridgeStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaBridgeExit(null, kafkaBridge("my-bridge"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testKafkaBridgeExitValidatingPluginCannotModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new BridgeValidator("A", false)));
+
+        KafkaBridgeStatus status = new KafkaBridgeStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaBridgeStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaBridgeExit(null, kafkaBridge("my-bridge"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1L));
+    }
+
+    @Test
+    public void testKafkaBridgeDeletionInvokesMutatingAndValidatingPluginsInOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new BridgeMutator("A"), new BridgeValidator("B", false)));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaBridgeDeletion(null, "my-namespace", "my-bridge")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaRebalance
+    ///////////////////////////////////////////////////
+
+    @Test
+    public void testKafkaRebalanceEntryChainsPluginsAndMutatesResource() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new RebalanceMutator("A"), new RebalanceValidator("B", false)));
+
+        KafkaRebalance result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaRebalanceEntry(null, kafkaRebalance(""))
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+        assertThat(result.getMetadata().getName(), is("A"));
+    }
+
+    @Test
+    public void testKafkaRebalanceExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new RebalanceMutator("A")));
+
+        KafkaRebalanceStatus status = new KafkaRebalanceStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaRebalanceStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaRebalanceExit(null, kafkaRebalance("my-rebalance"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testKafkaRebalanceExitValidatingPluginCannotModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new RebalanceValidator("A", false)));
+
+        KafkaRebalanceStatus status = new KafkaRebalanceStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaRebalanceStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaRebalanceExit(null, kafkaRebalance("my-rebalance"), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1L));
+    }
+
+    @Test
+    public void testKafkaRebalanceDeletionInvokesMutatingAndValidatingPluginsInOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new RebalanceMutator("A"), new RebalanceValidator("B", false)));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaRebalanceDeletion(null, "my-namespace", "my-rebalance")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+    }
+
+    ///////////////////////////////////////////////////
+    // Helper methods for creating the resources
+    ///////////////////////////////////////////////////
+
     private static Kafka kafka(String name) {
         return new KafkaBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static KafkaConnect kafkaConnect(String name) {
+        return new KafkaConnectBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static KafkaConnector kafkaConnector(String name) {
+        return new KafkaConnectorBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static KafkaMirrorMaker2 kafkaMirrorMaker2(String name) {
+        return new KafkaMirrorMaker2Builder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static KafkaBridge kafkaBridge(String name) {
+        return new KafkaBridgeBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static KafkaRebalance kafkaRebalance(String name) {
+        return new KafkaRebalanceBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
     }
 
     private static String append(String current, String tag) {
         return (current == null ? "" : current) + tag;
     }
+
+    ///////////////////////////////////////////////////
+    // Kafka plugins
+    ///////////////////////////////////////////////////
 
     private final class KafkaMutator implements GatekeeperKafkaMutatingPlugin {
         private final String tag;
@@ -295,6 +634,289 @@ public class ClusterOperatorGatekeeperPluginInvokerTest {
             return fail
                     ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
                     : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaConnect plugins
+    ///////////////////////////////////////////////////
+
+    private final class ConnectMutator implements GatekeeperKafkaConnectMutatingPlugin {
+        private final String tag;
+
+        private ConnectMutator(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public CompletionStage<KafkaConnectAndKafkaConnectors> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+            order.add(tag);
+            KafkaConnect mutated = new KafkaConnectBuilder(kafkaConnect)
+                    .editOrNewMetadata()
+                        .withName(append(kafkaConnect.getMetadata().getName(), tag))
+                    .endMetadata()
+                    .build();
+            List<KafkaConnector> mutatedConnectors = kafkaConnectors.stream()
+                    .map(connector -> new KafkaConnectorBuilder(connector)
+                            .editOrNewMetadata()
+                                .withName(append(connector.getMetadata().getName(), tag))
+                            .endMetadata()
+                            .build())
+                    .toList();
+            return CompletableFuture.completedFuture(new KafkaConnectAndKafkaConnectors(mutated, mutatedConnectors));
+        }
+
+        @Override
+        public CompletionStage<KafkaConnectStatus> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus newKafkaConnectStatus) {
+            newKafkaConnectStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaConnectStatus);
+        }
+
+        @Override
+        public CompletionStage<KafkaConnectorStatus> kafkaConnectorExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, KafkaConnector kafkaConnector, KafkaConnectorStatus newKafkaConnectorStatus) {
+            newKafkaConnectorStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaConnectorStatus);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private final class ConnectValidator implements GatekeeperKafkaConnectValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+
+        private ConnectValidator(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaConnectExit(GatekeeperKafkaConnectExitContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors, KafkaConnectStatus newKafkaConnectStatus) {
+            newKafkaConnectStatus.setObservedGeneration(1919L);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaConnectDeletion(GatekeeperKafkaConnectDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class ConnectResourceMutatingValidator implements GatekeeperKafkaConnectValidatingPlugin {
+        @Override
+        public CompletionStage<Void> kafkaConnectEntry(GatekeeperKafkaConnectEntryContext context, KafkaConnect kafkaConnect, List<KafkaConnector> kafkaConnectors) {
+            kafkaConnect.getMetadata().setName("HACKED");
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaMirrorMaker2 plugins
+    ///////////////////////////////////////////////////
+
+    private final class MirrorMaker2Mutator implements GatekeeperKafkaMirrorMaker2MutatingPlugin {
+        private final String tag;
+
+        private MirrorMaker2Mutator(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public CompletionStage<KafkaMirrorMaker2> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+            order.add(tag);
+            KafkaMirrorMaker2 mutated = new KafkaMirrorMaker2Builder(kafkaMirrorMaker2)
+                    .editOrNewMetadata()
+                        .withName(append(kafkaMirrorMaker2.getMetadata().getName(), tag))
+                    .endMetadata()
+                    .build();
+            return CompletableFuture.completedFuture(mutated);
+        }
+
+        @Override
+        public CompletionStage<KafkaMirrorMaker2Status> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status newKafkaMirrorMaker2Status) {
+            newKafkaMirrorMaker2Status.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaMirrorMaker2Status);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private final class MirrorMaker2Validator implements GatekeeperKafkaMirrorMaker2ValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+
+        private MirrorMaker2Validator(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaMirrorMaker2Entry(GatekeeperKafkaMirrorMaker2EntryContext context, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaMirrorMaker2Exit(GatekeeperKafkaMirrorMaker2ExitContext context, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Status newKafkaMirrorMaker2Status) {
+            newKafkaMirrorMaker2Status.setObservedGeneration(1919L);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaMirrorMaker2Deletion(GatekeeperKafkaMirrorMaker2DeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaBridge plugins
+    ///////////////////////////////////////////////////
+
+    private final class BridgeMutator implements GatekeeperKafkaBridgeMutatingPlugin {
+        private final String tag;
+
+        private BridgeMutator(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public CompletionStage<KafkaBridge> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+            order.add(tag);
+            KafkaBridge mutated = new KafkaBridgeBuilder(kafkaBridge)
+                    .editOrNewMetadata()
+                        .withName(append(kafkaBridge.getMetadata().getName(), tag))
+                    .endMetadata()
+                    .build();
+            return CompletableFuture.completedFuture(mutated);
+        }
+
+        @Override
+        public CompletionStage<KafkaBridgeStatus> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus newKafkaBridgeStatus) {
+            newKafkaBridgeStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaBridgeStatus);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private final class BridgeValidator implements GatekeeperKafkaBridgeValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+
+        private BridgeValidator(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaBridgeEntry(GatekeeperKafkaBridgeEntryContext context, KafkaBridge kafkaBridge) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaBridgeExit(GatekeeperKafkaBridgeExitContext context, KafkaBridge kafkaBridge, KafkaBridgeStatus newKafkaBridgeStatus) {
+            newKafkaBridgeStatus.setObservedGeneration(1919L);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaBridgeDeletion(GatekeeperKafkaBridgeDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    ///////////////////////////////////////////////////
+    // KafkaRebalance plugins
+    ///////////////////////////////////////////////////
+
+    private final class RebalanceMutator implements GatekeeperKafkaRebalanceMutatingPlugin {
+        private final String tag;
+
+        private RebalanceMutator(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public CompletionStage<KafkaRebalance> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+            order.add(tag);
+            KafkaRebalance mutated = new KafkaRebalanceBuilder(kafkaRebalance)
+                    .editOrNewMetadata()
+                        .withName(append(kafkaRebalance.getMetadata().getName(), tag))
+                    .endMetadata()
+                    .build();
+            return CompletableFuture.completedFuture(mutated);
+        }
+
+        @Override
+        public CompletionStage<KafkaRebalanceStatus> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus newKafkaRebalanceStatus) {
+            newKafkaRebalanceStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaRebalanceStatus);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private final class RebalanceValidator implements GatekeeperKafkaRebalanceValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+
+        private RebalanceValidator(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaRebalanceEntry(GatekeeperKafkaRebalanceEntryContext context, KafkaRebalance kafkaRebalance) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaRebalanceExit(GatekeeperKafkaRebalanceExitContext context, KafkaRebalance kafkaRebalance, KafkaRebalanceStatus newKafkaRebalanceStatus) {
+            newKafkaRebalanceStatus.setObservedGeneration(1919L);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaRebalanceDeletion(GatekeeperKafkaRebalanceDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(null);
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvokerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/gatekeeper/ClusterOperatorGatekeeperPluginInvokerTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.gatekeeper;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolStatus;
+import io.strimzi.operator.common.gatekeeper.GatekeeperPluginFactory;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaDeletionContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaEntryContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaExitContext;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaMutatingPlugin;
+import io.strimzi.plugin.gatekeeper.GatekeeperKafkaValidatingPlugin;
+import io.strimzi.plugin.gatekeeper.KafkaAndKafkaNodePools;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for the ClusterOperatorGatekeeperPluginInvoker. The invoker delegates to the same shared chaining logic
+ * as the User and Topic Operator invokers, so these tests focus on the Kafka methods, which exercise the
+ * Cluster-Operator-specific parts (the compound KafkaAndKafkaNodePools resource and the KafkaNodePool exit).
+ */
+public class ClusterOperatorGatekeeperPluginInvokerTest {
+    private final List<String> order = new ArrayList<>();
+
+    @AfterEach
+    public void cleanup() {
+        GatekeeperPluginFactory.clearTestPlugins();
+    }
+
+    @Test
+    public void testEntryChainsMutatingPluginsInRequestedOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaMutator("A"), new KafkaMutator("B")));
+
+        KafkaAndKafkaNodePools result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaEntry(null, kafka(""), List.of())
+                .toCompletableFuture().join();
+
+        assertThat(result.kafka().getMetadata().getName(), is("AB"));
+        assertThat(order, contains("A", "B"));
+    }
+
+    @Test
+    public void testExitChainsPluginsInReverseOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaMutator("A"), new KafkaMutator("B")));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaExit(null, kafka(""), List.of(), new KafkaStatus())
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("B", "A"));
+    }
+
+    @Test
+    public void testMutatingAndValidatingPluginsRunInOneOrderedChain() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaMutator("A"), new KafkaValidator("B", false)));
+
+        KafkaAndKafkaNodePools result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaEntry(null, kafka(""), List.of())
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+        assertThat(result.kafka().getMetadata().getName(), is("A"));
+    }
+
+    @Test
+    public void testEntryWithNoPluginsReturnsResourceUnchanged() {
+        GatekeeperPluginFactory.initializeForTests(List.of());
+
+        KafkaAndKafkaNodePools result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaEntry(null, kafka("unchanged"), List.of())
+                .toCompletableFuture().join();
+
+        assertThat(result.kafka().getMetadata().getName(), is("unchanged"));
+        assertThat(order, is(empty()));
+    }
+
+    @Test
+    public void testChainStopsAtFirstValidationFailure() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaValidator("fail", true), new KafkaValidator("ok", false)));
+
+        CompletableFuture<KafkaAndKafkaNodePools> result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaEntry(null, kafka(""), List.of())
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+        assertThat(order, contains("fail"));
+    }
+
+    @Test
+    public void testValidatingPluginCannotModifyTheResource() {
+        Kafka base = kafka("original");
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaResourceMutatingValidator()));
+
+        KafkaAndKafkaNodePools result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaEntry(null, base, List.of())
+                .toCompletableFuture().join();
+
+        assertThat(result.kafka().getMetadata().getName(), is("original"));
+        assertThat(base.getMetadata().getName(), is("original"));
+    }
+
+    @Test
+    public void testExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new StatusMutator()));
+
+        KafkaStatus status = new KafkaStatusBuilder().withObservedGeneration(1L).build();
+
+        KafkaStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaExit(null, kafka("my-kafka"), List.of(), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testExitValidatingPluginCannotModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new StatusMutatingValidator()));
+
+        KafkaStatus status = new KafkaStatusBuilder().withObservedGeneration(1L).build();
+
+        KafkaStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaExit(null, kafka("my-kafka"), List.of(), status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1L));
+    }
+
+    @Test
+    public void testNodePoolExitMutatingPluginCanModifyStatus() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new NodePoolStatusMutator()));
+
+        KafkaNodePoolStatus status = new KafkaNodePoolStatus();
+        status.setObservedGeneration(1L);
+
+        KafkaNodePoolStatus result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaNodePoolExit(null, kafka("my-kafka"), null, status)
+                .toCompletableFuture().join();
+
+        assertThat(result.getObservedGeneration(), is(1874L));
+    }
+
+    @Test
+    public void testDeletionInvokesAllPluginsInRequestedOrder() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaDeletionPlugin("A", false), new KafkaDeletionPlugin("B", false)));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaDeletion(null, "my-namespace", "my-kafka")
+                .toCompletableFuture().join();
+
+        assertThat(order, contains("A", "B"));
+    }
+
+    @Test
+    public void testDeletionPassesNamespaceAndName() {
+        KafkaDeletionPlugin plugin = new KafkaDeletionPlugin("A", false);
+        GatekeeperPluginFactory.initializeForTests(List.of(plugin));
+
+        ClusterOperatorGatekeeperPluginInvoker
+                .kafkaDeletion(null, "my-namespace", "my-kafka")
+                .toCompletableFuture().join();
+
+        assertThat(plugin.namespace, is("my-namespace"));
+        assertThat(plugin.name, is("my-kafka"));
+    }
+
+    @Test
+    public void testDeletionStopsAtFirstFailure() {
+        GatekeeperPluginFactory.initializeForTests(List.of(new KafkaDeletionPlugin("fail", true), new KafkaDeletionPlugin("ok", false)));
+
+        CompletableFuture<Void> result = ClusterOperatorGatekeeperPluginInvoker
+                .kafkaDeletion(null, "my-namespace", "my-kafka")
+                .toCompletableFuture();
+
+        assertThrows(CompletionException.class, result::join);
+        assertThat(order, contains("fail"));
+    }
+
+    private static Kafka kafka(String name) {
+        return new KafkaBuilder().withNewMetadata().withName(name).endMetadata().withNewSpec().endSpec().build();
+    }
+
+    private static String append(String current, String tag) {
+        return (current == null ? "" : current) + tag;
+    }
+
+    private final class KafkaMutator implements GatekeeperKafkaMutatingPlugin {
+        private final String tag;
+
+        private KafkaMutator(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public CompletionStage<KafkaAndKafkaNodePools> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+            order.add(tag);
+            Kafka mutated = new KafkaBuilder(kafka)
+                    .editOrNewMetadata()
+                        .withName(append(kafka.getMetadata().getName(), tag))
+                    .endMetadata()
+                    .build();
+            return CompletableFuture.completedFuture(new KafkaAndKafkaNodePools(mutated, kafkaNodePools));
+        }
+
+        @Override
+        public CompletionStage<KafkaStatus> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+            order.add(tag);
+            return CompletableFuture.completedFuture(newKafkaStatus);
+        }
+    }
+
+    private final class KafkaValidator implements GatekeeperKafkaValidatingPlugin {
+        private final String tag;
+        private final boolean fail;
+
+        private KafkaValidator(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+            order.add(tag);
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class KafkaResourceMutatingValidator implements GatekeeperKafkaValidatingPlugin {
+        @Override
+        public CompletionStage<Void> kafkaEntry(GatekeeperKafkaEntryContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools) {
+            kafka.getMetadata().setName("HACKED");
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class StatusMutator implements GatekeeperKafkaMutatingPlugin {
+        @Override
+        public CompletionStage<KafkaStatus> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+            newKafkaStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaStatus);
+        }
+    }
+
+    private static final class StatusMutatingValidator implements GatekeeperKafkaValidatingPlugin {
+        @Override
+        public CompletionStage<Void> kafkaExit(GatekeeperKafkaExitContext context, Kafka kafka, List<KafkaNodePool> kafkaNodePools, KafkaStatus newKafkaStatus) {
+            newKafkaStatus.setObservedGeneration(1919L);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static final class NodePoolStatusMutator implements GatekeeperKafkaMutatingPlugin {
+        @Override
+        public CompletionStage<KafkaNodePoolStatus> kafkaNodePoolExit(GatekeeperKafkaExitContext context, Kafka kafka, KafkaNodePool kafkaNodePool, KafkaNodePoolStatus newKafkaNodePoolStatus) {
+            newKafkaNodePoolStatus.setObservedGeneration(1874L);
+            return CompletableFuture.completedFuture(newKafkaNodePoolStatus);
+        }
+    }
+
+    private final class KafkaDeletionPlugin implements GatekeeperKafkaMutatingPlugin {
+        private final String tag;
+        private final boolean fail;
+        private String namespace;
+        private String name;
+
+        private KafkaDeletionPlugin(String tag, boolean fail) {
+            this.tag = tag;
+            this.fail = fail;
+        }
+
+        @Override
+        public CompletionStage<Void> kafkaDeletion(GatekeeperKafkaDeletionContext context, String namespace, String name) {
+            order.add(tag);
+            this.namespace = namespace;
+            this.name = name;
+            return fail
+                    ? CompletableFuture.failedFuture(new RuntimeException("rejected by " + tag))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+}


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR delivers the next part of the Gatekeeper plugin integration. It adds the Gatekeeper configuration options into the Cluster Operator configuration and initializes the Gatekeeper plugin factory from the `Main` class. It also adds the CO Gatekeeper invoker with the methods for invoking the Gatekeeper plugins from the different reconciliation with its tests. The invocations will be added in the future PRs.

This should resolve #12812.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
