### PR TITLE
Use more secure and modern TLS version in internal communication

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -95,7 +95,7 @@ public class KafkaAgentClient {
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(keyManagerFactoryAlgorithm);
             keyManagerFactory.init(tlsPemIdentity.pemAuthIdentity().keyStore(KEYSTORE_PASSWORD), KEYSTORE_PASSWORD);
 
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
             sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 
             return HttpClient.newBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -147,7 +147,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm);
                 trustManagerFactory.init(pemTrustSet.trustStore());
 
-                SSLContext sslContext = SSLContext.getInstance("TLS");
+                SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
                 sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
 
                 builder.sslContext(sslContext);

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -104,7 +104,7 @@ public class KafkaAgentTest {
         String password = Base64.getUrlEncoder().withoutPadding().encodeToString(random).substring(0, 32);
         kmf.init(KafkaAgentUtils.keyStore(nodeCertSecret, password.toCharArray()), password.toCharArray());
 
-        SSLContext sslContext = SSLContext.getInstance("TLS");
+        SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), RANDOM);
         return sslContext;
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
@@ -250,7 +250,7 @@ public class CruiseControlClientImpl implements CruiseControlClient {
                 tmf.init(keyStore);
 
                 // create an SSL context that uses our trust manager
-                SSLContext sslContext = SSLContext.getInstance("TLS");
+                SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
                 sslContext.init(null, tmf.getTrustManagers(), null);
                 builder.sslContext(sslContext);
             }


### PR DESCRIPTION
### Type of Change

- Task

### Description

Currently, we have several places where we use just the `TLS` `SSLContext` algorithms. That is not great as it allows TLs versions that are nto considered secure anymore such as TLSv1 or TLSv1.1. This PR updates this to use TLSv1.3 which is more modern and secure.

As this changes the configuration for the internal TLS clients - in the Kafka Agent and Cruise Control clients - these connections are internal only. So they do not connect anywhere outside and we do not need to be worried about impact on users.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass