### PR TITLE
Avoid using passwords in `KafkaAgent` and `KafkaAgentClient`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -34,7 +34,6 @@ public class KafkaAgentClient {
 
     private static final String BROKER_STATE_REST_PATH = "/v1/broker-state/";
     private static final int KAFKA_AGENT_HTTPS_PORT = 8443;
-    private static final char[] KEYSTORE_PASSWORD = "changeit".toCharArray();
     // Bounds the connect and full HTTP request lifecycle so that a broker which accepts the TCP connection but
     // never produces a response (e.g. alive but stuck on IO) cannot block the KafkaRoller's single-threaded
     // executor indefinitely. The Kafka Agent only serves a small broker-state JSON, so 10 seconds is well above
@@ -93,7 +92,7 @@ public class KafkaAgentClient {
             }
             String keyManagerFactoryAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(keyManagerFactoryAlgorithm);
-            keyManagerFactory.init(tlsPemIdentity.pemAuthIdentity().keyStore(KEYSTORE_PASSWORD), KEYSTORE_PASSWORD);
+            keyManagerFactory.init(tlsPemIdentity.pemAuthIdentity().keyStore(), null);
 
             SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
             sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -241,12 +240,7 @@ public class KafkaAgent {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setTrustStore(KafkaAgentUtils.trustStore(caCertSecret));
 
-        byte[] random = new byte[24];
-        RANDOM.nextBytes(random);
-        String password = Base64.getUrlEncoder().withoutPadding().encodeToString(random).substring(0, 32);
-
-        sslContextFactory.setKeyStore(KafkaAgentUtils.keyStore(nodeCertSecret, password.toCharArray()));
-        sslContextFactory.setKeyStorePassword(password);
+        sslContextFactory.setKeyStore(KafkaAgentUtils.keyStore(nodeCertSecret));
         sslContextFactory.setNeedClientAuth(true);
         return  sslContextFactory;
     }

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgentUtils.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgentUtils.java
@@ -59,7 +59,7 @@ public class KafkaAgentUtils {
      * @throws GeneralSecurityException if something goes wrong when creating the truststore
      * @throws IOException if there is an I/O or format problem with the data used to load the truststore.
      */
-    static KeyStore keyStore(Secret secret, char[] password) throws GeneralSecurityException, IOException {
+    static KeyStore keyStore(Secret secret) throws GeneralSecurityException, IOException {
         String secretName = secret.getMetadata().getName();
         String strippedPrivateKey = new String(decodeBase64FieldFromSecret(secret, secretName + ".key"), StandardCharsets.US_ASCII)
                 .replace("-----BEGIN PRIVATE KEY-----", "")
@@ -73,7 +73,7 @@ public class KafkaAgentUtils {
         X509Certificate certificateChain = x509Certificate(decodeBase64FieldFromSecret(secret, secretName + ".crt"));
         KeyStore nodeKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         nodeKeyStore.load(null);
-        nodeKeyStore.setKeyEntry(secret.getMetadata().getName(), key, password, new Certificate[]{certificateChain});
+        nodeKeyStore.setKeyEntry(secret.getMetadata().getName(), key, null, new Certificate[]{certificateChain});
         return nodeKeyStore;
     }
 

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -31,7 +31,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.Map;
 
 import static io.strimzi.kafka.agent.KafkaAgent.RANDOM;
@@ -99,10 +98,7 @@ public class KafkaAgentTest {
         tmf.init(KafkaAgentUtils.trustStore(caCertSecret));
 
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        byte[] random = new byte[24];
-        RANDOM.nextBytes(random);
-        String password = Base64.getUrlEncoder().withoutPadding().encodeToString(random).substring(0, 32);
-        kmf.init(KafkaAgentUtils.keyStore(nodeCertSecret, password.toCharArray()), password.toCharArray());
+        kmf.init(KafkaAgentUtils.keyStore(nodeCertSecret), null);
 
         SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), RANDOM);

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/PemAuthIdentity.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/PemAuthIdentity.java
@@ -95,13 +95,11 @@ public class PemAuthIdentity {
     /**
      * KeyStore to use for TLS connections.
      *
-     * @param password to use to secure the KeyStore
-     *
      * @return In-memory KeyStore using the JVM's default keystore type
      * @throws GeneralSecurityException if something goes wrong when creating the truststore
      * @throws IOException if there is an I/O or format problem with the data used to load the truststore.
      */
-    public KeyStore keyStore(char[] password) throws GeneralSecurityException, IOException {
+    public KeyStore keyStore() throws GeneralSecurityException, IOException {
         String strippedPrivateKey = privateKeyAsPem()
                 .replace("-----BEGIN PRIVATE KEY-----", "")
                 .replaceAll(System.lineSeparator(), "")
@@ -113,7 +111,7 @@ public class PemAuthIdentity {
 
         KeyStore coKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         coKeyStore.load(null);
-        coKeyStore.setKeyEntry("cluster-operator", key, password, new Certificate[]{certificateChain()});
+        coKeyStore.setKeyEntry("cluster-operator", key, null, new Certificate[]{certificateChain()});
         return coKeyStore;
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/auth/PemAuthIdentityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/auth/PemAuthIdentityTest.java
@@ -60,7 +60,7 @@ public class PemAuthIdentityTest {
                         "cluster-operator.password", "bm90YXBhc3N3b3Jk")) //notapassword
                 .build();
         PemAuthIdentity pemAuthIdentity = PemAuthIdentity.clusterOperator(secretWithBadCertificate);
-        Exception e = assertThrows(RuntimeException.class, () -> pemAuthIdentity.keyStore(new char[]{}));
+        Exception e = assertThrows(RuntimeException.class, pemAuthIdentity::keyStore);
         assertThat(e.getMessage(), is("Bad/corrupt certificate found in data.cluster-operator.crt of Secret testcluster-cluster-operator-certs in namespace testns"));
     }
 


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR removes the password from the in-memory keystores in the `KafkaAgent` and `KafkaAgentClient` classes. This should resolve #12985.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests