### PR TITLE
Add attestation job to operators workflows

### DIFF
--- a/.github/actions/build/integration-test-strimzi/action.yml
+++ b/.github/actions/build/integration-test-strimzi/action.yml
@@ -10,20 +10,20 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         javaVersion: "21"
 
     - name: Install Docker
-      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         version: "v4.6.3"
 
     - name: Install Helm
-      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         helmVersion: "v3.16.0"
 
@@ -36,7 +36,7 @@ runs:
           maven-
 
     - name: Setup Kind cluster
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         controlNodes: 1
         workerNodes: 3

--- a/.github/actions/build/unit-test-strimzi/action.yml
+++ b/.github/actions/build/unit-test-strimzi/action.yml
@@ -5,20 +5,20 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         javaVersion: "21"
 
     - name: Install Docker
-      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         version: "v4.6.3"
 
     - name: Install Helm
-      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         helmVersion: "v3.16.0"
 

--- a/.github/actions/systemtests/generate-matrix/action.yml
+++ b/.github/actions/systemtests/generate-matrix/action.yml
@@ -46,7 +46,7 @@ runs:
   steps:
     # yq is required for generate-matrix action
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         version: 'v4.6.3'
         architecture: ${{ inputs.runnerArch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Build workflow trigger via pull_request will have merge commit sha in github.sha
       - name: Store build commit sha
@@ -44,22 +44,22 @@ jobs:
           rm -rf commit-sha.txt
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           helmVersion: "v3.16.0"
 
@@ -72,7 +72,7 @@ jobs:
             kafka-binaries-
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           mainJavaBuild: "true"
           artifactSuffix: "operators"
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build/unit-test-strimzi
 
   # Runs Strimzi integration tests (Failsafe only) against multiple Kubernetes versions
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build/integration-test-strimzi
         with:
           kindNodeImage: ${{ matrix.kindNodeImage }}
@@ -129,15 +129,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install AsciiDoctor
-        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           rubyVersion: "3.2"
 
@@ -160,22 +160,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           architecture: ${{ matrix.architecture }}
           imagesLocation: "./docker-images/container-archives"
@@ -193,28 +193,32 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      images: ${{ steps.push-containers.outputs.images }}
+      sbomsArtifact: ${{ steps.push-containers.outputs.sbomsArtifact }}
     permissions:
       contents: read
       # Required for keyless signing with GitHub OIDC
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        id: push-containers
+        uses: strimzi/github-actions/.github/actions/build/push-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -223,6 +227,20 @@ jobs:
           containerTag: "latest"
           architectures: "amd64,arm64,ppc64le,s390x"
           artifactSuffix: "operators"
+
+  # Attest Strimzi container images - run only on main branch after push
+  attest:
+    name: Attestation
+    needs:
+      - push-containers
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: strimzi/github-actions/.github/workflows/reusable-attest.yml@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
+    with:
+      containerImages: ${{ needs.push-containers.outputs.images }}
+      sbomsArtifact: ${{ needs.push-containers.outputs.sbomsArtifact }}
 
   # Publish Strimzi docs to the website - run only on main branch
   publish-docs:
@@ -237,7 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build/publish-docs
         with:
           artifactName: "documentation.tar"
@@ -256,20 +274,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Deploy to Maven Central
-        uses: strimzi/github-actions/.github/actions/build/deploy-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/build/deploy-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           modules: "./,crd-annotations,crd-generator,test,api"
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,15 +42,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup Java and Maven
-      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         javaVersion: "21"
 
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       with:
         version: "v4.6.3"
 
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -80,4 +80,4 @@ jobs:
 
     # Analyze the code
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       packages: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
@@ -66,22 +66,22 @@ jobs:
           - ppc64le
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           architecture: ${{ matrix.architecture }}
           imagesLocation: "./docker-images/container-archives"
@@ -94,27 +94,31 @@ jobs:
       - build-containers
     if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
     runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.push-containers.outputs.images }}
+      sbomsArtifact: ${{ steps.push-containers.outputs.sbomsArtifact }}
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        id: push-containers
+        uses: strimzi/github-actions/.github/actions/build/push-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -123,6 +127,20 @@ jobs:
           containerTag: "${{ inputs.releaseVersion }}-${{ inputs.releaseSuffix }}"
           architectures: "amd64,arm64,ppc64le,s390x"
           artifactSuffix: "operators"
+
+  # Attest containers with suffix
+  attest-with-suffix:
+    name: Attestation (${{ inputs.releaseVersion }}-${{ inputs.releaseSuffix }})
+    needs:
+      - push-containers-with-suffix
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: strimzi/github-actions/.github/workflows/reusable-attest.yml@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
+    with:
+      containerImages: ${{ needs.push-containers-with-suffix.outputs.images }}
+      sbomsArtifact: ${{ needs.push-containers-with-suffix.outputs.sbomsArtifact }}
 
   # Manual validation step - waits for approval before pushing without suffix
   manual-validation:
@@ -147,27 +165,31 @@ jobs:
       - manual-validation
     if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
     runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.push-containers.outputs.images }}
+      sbomsArtifact: ${{ steps.push-containers.outputs.sbomsArtifact }}
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        id: push-containers
+        uses: strimzi/github-actions/.github/actions/build/push-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -176,3 +198,17 @@ jobs:
           containerTag: "${{ inputs.releaseVersion }}"
           architectures: "amd64,arm64,ppc64le,s390x"
           artifactSuffix: "operators"
+
+  # Attest containers without suffix
+  attest:
+    name: Attestation (${{ inputs.releaseVersion }})
+    needs:
+      - push-containers
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: strimzi/github-actions/.github/workflows/reusable-attest.yml@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
+    with:
+      containerImages: ${{ needs.push-containers.outputs.images }}
+      sbomsArtifact: ${{ needs.push-containers.outputs.sbomsArtifact }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -46,15 +46,15 @@ jobs:
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
@@ -62,7 +62,7 @@ jobs:
         run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
 
       - name: Run FOSSA Maven scan
-        uses: strimzi/github-actions/.github/actions/security/fossa-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/security/fossa-maven-scan@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           scanName: operators
           fossaTest: "true"
@@ -128,10 +128,10 @@ jobs:
         run: tar -xvf "$CONTAINERS_ARCHIVE"
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Run FOSSA container scan
-        uses: strimzi/github-actions/.github/actions/security/fossa-container-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/security/fossa-container-scan@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           imageFile: docker-images/container-archives/${{ matrix.image }}.tar.gz
           image: ${{ matrix.image }}

--- a/.github/workflows/github-actions-integration.yml
+++ b/.github/workflows/github-actions-integration.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  attestations: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,7 +29,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
         with:
           args: -color
@@ -38,7 +39,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install dependencies
       - name: Install act
@@ -48,7 +49,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
@@ -124,7 +125,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install dependencies
       - name: Install act
@@ -134,7 +135,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
@@ -211,7 +212,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install dependencies
       - name: Install act
@@ -221,7 +222,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
@@ -308,7 +309,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install dependencies
       - name: Install act
@@ -318,7 +319,7 @@ jobs:
           sudo install -m 0755 ./bin/act /usr/local/bin/act
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
@@ -399,7 +400,7 @@ jobs:
           echo "🎉 All $TOTAL perf-report scenarios passed!"
 
   test-github-actions-integration:
-    uses: strimzi/github-actions/.github/workflows/reusable-test-integrations.yml@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+    uses: strimzi/github-actions/.github/workflows/reusable-test-integrations.yml@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
     with:
       repo: ${{ github.repository }}
       ref: ${{ github.sha }}
@@ -414,5 +415,5 @@ jobs:
       imagesLocation: "./docker-images/container-archives"
       clusterOperatorBuild: true
       checkTests: false
-      githubActionsRef: "v2"
+      githubActionsRef: "v2.2"
     secrets: inherit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,36 +34,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           helmVersion: "v3.16.0"
 
       - name: Install AsciiDoctor
-        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-ascii-doctor@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           rubyVersion: "3.2"
 
       - name: Prepare release artifacts
-        uses: strimzi/github-actions/.github/actions/build/release-artifacts@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/build/release-artifacts@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "operators"
 
       - name: Deploy to Maven Central
-        uses: strimzi/github-actions/.github/actions/build/deploy-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/build/deploy-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           modules: "./,crd-annotations,crd-generator,test,api"
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -86,7 +86,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
@@ -117,27 +117,31 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/heads/release-') && inputs.useSuffix == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      images: ${{ steps.push-containers.outputs.images }}
+      sbomsArtifact: ${{ steps.push-containers.outputs.sbomsArtifact }}
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        id: push-containers
+        uses: strimzi/github-actions/.github/actions/build/push-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -147,6 +151,20 @@ jobs:
           architectures: "amd64,arm64,ppc64le,s390x"
           artifactSuffix: "operators"
           buildRunId: ${{ inputs.sourceBuildRunId }}
+
+  # Attest containers with suffix
+  attest-with-suffix:
+    name: Attestation (with suffix)
+    needs:
+      - push-containers-with-suffix
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: strimzi/github-actions/.github/workflows/reusable-attest.yml@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
+    with:
+      containerImages: ${{ needs.push-containers-with-suffix.outputs.images }}
+      sbomsArtifact: ${{ needs.push-containers-with-suffix.outputs.sbomsArtifact }}
 
   # Push containers without suffix (e.g., 0.49.0)
   push-containers:
@@ -165,27 +183,31 @@ jobs:
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      images: ${{ steps.push-containers.outputs.images }}
+      sbomsArtifact: ${{ steps.push-containers.outputs.sbomsArtifact }}
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Syft
-        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-syft@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "1.20.0"
 
       - name: Push containers using push-containers action
-        uses: strimzi/github-actions/.github/actions/build/push-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        id: push-containers
+        uses: strimzi/github-actions/.github/actions/build/push-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           registryUser: ${{ secrets.QUAY_USER }}
           registryPassword: ${{ secrets.QUAY_PASS }}
@@ -204,21 +226,24 @@ jobs:
       - push-java-artifacts-to-ghcr
       - push-containers
     if: |-
-      ${{ always() && startsWith(github.ref, 'refs/heads/release-') && 
+      ${{ always() && startsWith(github.ref, 'refs/heads/release-') &&
         needs.push-containers.result == 'success'
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      image: ${{ steps.publish-helm-chart.outputs.image }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           helmVersion: "v3.16.0"
 
       - name: Publish Helm charts using publish-helm action
-        uses: strimzi/github-actions/.github/actions/build/publish-helm-chart@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        id: publish-helm-chart
+        uses: strimzi/github-actions/.github/actions/build/publish-helm-chart@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           registryUser: ${{ secrets.QUAY_HELM_USER }}
           registryPassword: ${{ secrets.QUAY_HELM_PASS }}
@@ -227,6 +252,30 @@ jobs:
           helmChartName: "strimzi-kafka-operator-helm-3-chart"
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "operators"
+
+  # Attest release archives, Helm chart, and container images
+  attest:
+    name: Attestation
+    needs:
+      - push-containers
+      - prepare-release-artifacts
+      - publish-helm-chart
+    if: |-
+      ${{ always() && startsWith(github.ref, 'refs/heads/release-') &&
+        needs.push-containers.result == 'success'
+      }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: strimzi/github-actions/.github/workflows/reusable-attest.yml@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
+    with:
+      containerImages: ${{ needs.push-containers.outputs.images }}
+      sbomsArtifact: ${{ needs.push-containers.outputs.sbomsArtifact }}
+      artifactSuffix: "operators"
+      releaseVersion: ${{ inputs.releaseVersion }}
+      helmChartName: "strimzi-kafka-operator-helm-3-chart"
+      helmChartImage: ${{ needs.publish-helm-chart.outputs.image }}
 
   # Run Snyk security scans on Maven dependencies and container images
   snyk-scan:

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -81,7 +81,7 @@ jobs:
       KUBE_VERSION: ${{ inputs.kubeVersion }}
     # Job steps
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
 
@@ -94,28 +94,28 @@ jobs:
           checkDescription: "Test run for ${{ matrix.config.jobName }}"
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
           architecture: ${{ matrix.config.arch }}
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           helmVersion: "v3.16.0"
 
       - name: Setup Kind cluster
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-kind@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           architecture: ${{ matrix.config.arch }}
           controlNodes: 1

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -58,6 +58,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -47,15 +47,15 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
@@ -84,7 +84,7 @@ jobs:
           MAVEN_TEST_MODULES: "systemtest,mockkube,test"
 
       - name: Run Snyk Maven scan (prod)
-        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           scanName: operators-prod
           snykMonitor: "true"
@@ -93,7 +93,7 @@ jobs:
           exclude: "${{ steps.compute-excludes.outputs.maven-test-modules }},docker-images"
 
       - name: Run Snyk Maven scan (test)
-        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           scanName: operators-test
           snykMonitor: "true"
@@ -102,7 +102,7 @@ jobs:
           exclude: "${{ steps.compute-excludes.outputs.maven-prod-modules }},docker-images"
 
       - name: Run Snyk Maven scan (3rd-party)
-        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/security/snyk-maven-scan@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           scanName: kafka-3rd-party
           snykMonitor: "true"
@@ -171,10 +171,10 @@ jobs:
         run: tar -xvf "$CONTAINERS_ARCHIVE"
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Run Snyk container scan
-        uses: strimzi/github-actions/.github/actions/security/snyk-container-scan@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/security/snyk-container-scan@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           imageFile: docker-images/container-archives/${{ matrix.image }}.tar.gz
           image: ${{ matrix.image }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -46,11 +46,11 @@ jobs:
     steps:
       - name: Should Run
         id: should_run
-        uses: strimzi/github-actions/.github/actions/utils/should-run@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/utils/should-run@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
       - name: Determine checkout ref
         id: determine_ref
         if: steps.should_run.outputs.shouldRun == 'true'
-        uses: strimzi/github-actions/.github/actions/utils/determine-ref@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/utils/determine-ref@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
   check-rights:
     needs:
@@ -63,7 +63,7 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: strimzi/github-actions/.github/actions/utils/check-permissions@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      - uses: strimzi/github-actions/.github/actions/utils/check-permissions@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
   check-build:
     needs:
@@ -84,7 +84,7 @@ jobs:
       buildMetadataSha: ${{ steps.verify.outputs.buildMetadataSha }}
       commentId: ${{ steps.initial-comment.outputs.commentId }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - name: Add initial comment
@@ -145,7 +145,7 @@ jobs:
       message: ${{ steps.validate.outputs.message }}
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - name: Parse Comment
@@ -216,32 +216,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           javaVersion: "21"
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "0.11.0"
 
       - name: Install Helm
-        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-helm@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           helmVersion: "v3.16.0"
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           mainJavaBuild: "true"
           artifactSuffix: "operators"
@@ -273,24 +273,24 @@ jobs:
     runs-on: cncf-ubuntu-2-8-arm
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
 
       - name: Install Docker
-        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-docker@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
 
       - name: Install yq
-        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-yq@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "v4.6.3"
 
       - name: Install Shellcheck
-        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+        uses: strimzi/github-actions/.github/actions/dependencies/install-shellcheck@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           version: "0.11.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@0b7212d193ac3ab199e0dfef2a9cbd0229a15820 # v2.1
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@af789b85722d00ba9de34ad8b3a32292e4e628e3 # v2.2
         with:
           architecture: ${{ matrix.architecture }}
           imagesLocation: "./docker-images/container-archives"
@@ -355,7 +355,7 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - name: Add comment
@@ -397,7 +397,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.parse-params.outputs.ref }}
       - uses: ./.github/actions/systemtests/run-perf-report


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds job that use attestation reusable workflow from https://github.com/strimzi/github-actions/pull/67 . It will generate attestation for images, helm chart + oci image, and release artifacts that can be then verified against GitHub API. As part of release artifacts it will also add provenance in `.intoto.jsonl` format.

`github-actions` version bump to `v2.2` was needed as it contains required changes. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
