### PR TITLE
Allow configuring Maven Mirror for System Tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -117,6 +117,12 @@ public class Environment {
     public static final String ST_FILE_PLUGIN_URL_ENV = "ST_FILE_SINK_PLUGIN_URL";
 
     /**
+     * User-specific Maven mirror for tests using Connect build with Maven artifacts. Should end without a trailing
+     * slash ("/"). E.g. "https://repo.maven.apache.org/maven2".
+     */
+    public static final String ST_MAVEN_MIRROR_URL_ENV = "ST_MAVEN_MIRROR_URL";
+
+    /**
      * Resource allocation strategy
      */
     public static final String RESOURCE_ALLOCATION_STRATEGY_ENV = "RESOURCE_ALLOCATION_STRATEGY";
@@ -166,7 +172,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_KAFKA_MAVEN_VERSION_DEFAULT = TestKafkaVersion.getSpecificVersion(ST_KAFKA_VERSION_DEFAULT).mavenVersion();
-    public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_MAVEN_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_MAVEN_VERSION_DEFAULT + ".jar";
+    public static final String ST_FILE_PLUGIN_URL_DEFAULT = (Environment.ST_MAVEN_MIRROR_URL != null ? Environment.ST_MAVEN_MIRROR_URL : "https://repo.maven.apache.org/maven2") + "/org/apache/kafka/connect-file/" + ST_KAFKA_MAVEN_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_MAVEN_VERSION_DEFAULT + ".jar";
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";
     public static final String IP_FAMILY_VERSION_6 = "ipv6";
@@ -220,8 +226,9 @@ public class Environment {
     public static final boolean LB_FINALIZERS = ENVIRONMENT_VARIABLES.getOrDefault(LB_FINALIZERS_ENV, Boolean::parseBoolean, LB_FINALIZERS_DEFAULT);
     public static final String RESOURCE_ALLOCATION_STRATEGY = ENVIRONMENT_VARIABLES.getOrDefault(RESOURCE_ALLOCATION_STRATEGY_ENV, RESOURCE_ALLOCATION_STRATEGY_DEFAULT);
 
-    // Connect build related variables
+    // Connect build-related variables
     public static final String ST_FILE_PLUGIN_URL = ENVIRONMENT_VARIABLES.getOrDefault(ST_FILE_PLUGIN_URL_ENV, ST_FILE_PLUGIN_URL_DEFAULT);
+    public static final String ST_MAVEN_MIRROR_URL = ENVIRONMENT_VARIABLES.getOrDefault(ST_MAVEN_MIRROR_URL_ENV, null);
 
     public static final String CONNECT_BUILD_IMAGE_PATH = ENVIRONMENT_VARIABLES.getOrDefault(CONNECT_BUILD_IMAGE_PATH_ENV, "");
     public static final String CONNECT_BUILD_REGISTRY_SECRET = ENVIRONMENT_VARIABLES.getOrDefault(CONNECT_BUILD_REGISTRY_SECRET_ENV, "");

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -19,7 +19,9 @@ import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
 import io.strimzi.api.kafka.model.connect.MountedPluginBuilder;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
+import io.strimzi.api.kafka.model.connect.build.MavenArtifact;
 import io.strimzi.api.kafka.model.connect.build.MavenArtifactBuilder;
+import io.strimzi.api.kafka.model.connect.build.MavenMirrorBuilder;
 import io.strimzi.api.kafka.model.connect.build.OtherArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.Plugin;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
@@ -65,6 +67,7 @@ import org.junit.jupiter.api.Tag;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -99,9 +102,9 @@ class ConnectBuilderST extends AbstractST {
 
     private static final String CAMEL_CONNECTOR_HTTP_SINK_CLASS_NAME = "org.apache.camel.kafkaconnector.http.CamelHttpSinkConnector";
     private static final String CAMEL_CONNECTOR_TIMER_CLASS_NAME = "org.apache.camel.kafkaconnector.timer.CamelTimerSourceConnector";
-    private static final String CAMEL_CONNECTOR_TGZ_URL = "https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.tar.gz";
+    private static final String CAMEL_CONNECTOR_TGZ_URL = (Environment.ST_MAVEN_MIRROR_URL != null ? Environment.ST_MAVEN_MIRROR_URL : "https://repo.maven.apache.org/maven2") + "/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.tar.gz";
     private static final String CAMEL_CONNECTOR_TGZ_CHECKSUM = "d0bb8c6a9e50b68eee3e4d70b6b7e5ae361373883ed3156bc11771330095b66195ac1c12480a0669712da4e5f38e64f004ffecabca4bf70d312f3f7ae0ad51b5";
-    private static final String CAMEL_CONNECTOR_ZIP_URL = "https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.zip";
+    private static final String CAMEL_CONNECTOR_ZIP_URL = (Environment.ST_MAVEN_MIRROR_URL != null ? Environment.ST_MAVEN_MIRROR_URL : "https://repo.maven.apache.org/maven2") + "/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.zip";
     private static final String CAMEL_CONNECTOR_ZIP_CHECKSUM = "bc15135b8ef7faccd073508da0510c023c0f6fa3ec7e48c98ad880dd112b53bf106ad0a47bcb353eed3ec03bb3d273da7de356f3f7f1766a13a234a6bc28d602";
     private static final String CAMEL_CONNECTOR_MAVEN_GROUP_ID = "org.apache.camel.kafkaconnector";
     private static final String CAMEL_CONNECTOR_MAVEN_ARTIFACT_ID = "camel-timer-kafka-connector";
@@ -149,16 +152,23 @@ class ConnectBuilderST extends AbstractST {
         )
         .build();
 
-    private static final Plugin PLUGIN_WITH_MAVEN_TYPE = new PluginBuilder()
-        .withName(PLUGIN_WITH_MAVEN_NAME)
-        .withArtifacts(
-            new MavenArtifactBuilder()
+    private static final Plugin PLUGIN_WITH_MAVEN_TYPE;
+    static {
+        MavenArtifact mavenArtifact = new MavenArtifactBuilder()
                 .withVersion(CAMEL_CONNECTOR_MAVEN_VERSION)
                 .withArtifact(CAMEL_CONNECTOR_MAVEN_ARTIFACT_ID)
                 .withGroup(CAMEL_CONNECTOR_MAVEN_GROUP_ID)
-                .build()
-        )
-        .build();
+                .build();
+
+        if (Environment.ST_MAVEN_MIRROR_URL != null)    {
+            mavenArtifact.setMirrors(List.of(new MavenMirrorBuilder().withUrl(Environment.ST_MAVEN_MIRROR_URL).build()));
+        }
+
+        PLUGIN_WITH_MAVEN_TYPE = new PluginBuilder()
+                .withName(PLUGIN_WITH_MAVEN_NAME)
+                .withArtifacts(mavenArtifact)
+                .build();
+    }
 
     @ParallelTest
     @TestDoc(

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -77,7 +77,7 @@ public class FeatureGatesST extends AbstractST {
 
         TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
         final String camelChecksum = "6d1f9311fe10521a5de3262574ad7c21073cd45089fc67245f04a303562b0ea54869c8cd0375ee76de8b5c24d454a0545688018ccdae0563bd5f254aceb98b5e";
-        final String camelConnectorUrl = "https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-timer-kafka-connector/0.9.0/camel-timer-kafka-connector-0.9.0-package.tar.gz";
+        final String camelConnectorUrl = (Environment.ST_MAVEN_MIRROR_URL != null ? Environment.ST_MAVEN_MIRROR_URL : "https://repo.maven.apache.org/maven2") + "/org/apache/camel/kafkaconnector/camel-timer-kafka-connector/0.9.0/camel-timer-kafka-connector-0.9.0-package.tar.gz";
         int randomNum = new Random().nextInt(Integer.MAX_VALUE);
         final String imageName = Environment.getImageOutputRegistry(testStorage.getNamespaceName(), testStorage.getNamespaceName(), String.valueOf(randomNum));
 


### PR DESCRIPTION
### Type of Change

- Task

### Description

When running System Tests, there are several places where we download things from Maven Central. That often leads to issues during executions due to rate limiting, etc. https://github.com/strimzi/strimzi-kafka-operator/pull/12984 allowed configuring Maven Mirrors for Maven artifacts. This PR allows setting Maven mirror for System Tests as well:

* For tests using the Maven Artifact itself
* For archive artifacts downloaded from Maven Central directly

This should allow configuring your own Maven mirror centrally for all downloads from Maven Central.

### Checklist

- [ ] Make sure all tests pass