### PR TITLE
Use reconciliation logger in `StatusDiff`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -1243,7 +1243,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                     } else {
                         V currentStatus = fetchedResource.getStatus();
 
-                        StatusDiff ksDiff = new StatusDiff(currentStatus, desiredStatus);
+                        StatusDiff ksDiff = new StatusDiff(reconciliation, currentStatus, desiredStatus);
 
                         if (!ksDiff.isEmpty()) {
                             U resourceWithNewStatus = copyWithStatus.apply(fetchedResource, desiredStatus);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -338,7 +338,7 @@ public abstract class AbstractOperator<
                 .compose(res -> {
                     if (res != null) {
                         S currentStatus = res.getStatus();
-                        StatusDiff sDiff = new StatusDiff(currentStatus, desiredStatus);
+                        StatusDiff sDiff = new StatusDiff(reconciliation, currentStatus, desiredStatus);
 
                         if (!sDiff.isEmpty()) {
                             res.setStatus(desiredStatus);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -302,7 +302,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     if (kafka != null) {
                         KafkaStatus currentStatus = kafka.getStatus();
 
-                        StatusDiff ksDiff = new StatusDiff(currentStatus, desiredStatus);
+                        StatusDiff ksDiff = new StatusDiff(reconciliation, currentStatus, desiredStatus);
 
                         if (!ksDiff.isEmpty()) {
                             Kafka resourceWithNewStatus = new KafkaBuilder(kafka).withStatus(desiredStatus).build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -815,7 +815,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     private static void updateStatus(Reconciliation reconciliation, Throwable error, KafkaConnector kafkaConnector2, CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperations) {
         KafkaConnectorStatus status = new KafkaConnectorStatus();
         StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnector2, status, error);
-        StatusDiff diff = new StatusDiff(kafkaConnector2.getStatus(), status);
+        StatusDiff diff = new StatusDiff(reconciliation, kafkaConnector2.getStatus(), status);
         if (!diff.isEmpty()) {
             KafkaConnector copy = new KafkaConnectorBuilder(kafkaConnector2).build();
             copy.setStatus(status);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1265,7 +1265,7 @@ public class KafkaReconciler {
                                     .build())
                     .build();
 
-            StatusDiff diff = new StatusDiff(nodePool.getStatus(), updatedNodePool.getStatus());
+            StatusDiff diff = new StatusDiff(reconciliation, nodePool.getStatus(), updatedNodePool.getStatus());
 
             if (!diff.isEmpty()) {
                 // Status changed => we will update it

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -402,7 +402,7 @@ public class StrimziPodSetController implements Runnable {
      * @param desiredStatus     The desired status which should be set if it differs
      */
     private void maybeUpdateStatus(Reconciliation reconciliation, StrimziPodSet podSet, StrimziPodSetStatus desiredStatus) {
-        if (!new StatusDiff(podSet.getStatus(), desiredStatus).isEmpty())  {
+        if (!new StatusDiff(reconciliation, podSet.getStatus(), desiredStatus).isEmpty())  {
             try {
                 LOGGER.debugCr(reconciliation, "Updating status of StrimziPodSet {} in namespace {}", reconciliation.name(), reconciliation.namespace());
                 StrimziPodSet latestPodSet = strimziPodSetInformer.get(reconciliation.namespace(), reconciliation.name());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatusBuilder;
+import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.StatusDiff;
 import io.strimzi.operator.common.model.StatusUtils;
 import org.junit.jupiter.api.Test;
@@ -90,28 +91,28 @@ public class StatusDiffTest {
                 .withListeners(ls3, ls1)
                 .build();
 
-        StatusDiff diff = new StatusDiff(null, status1);
+        StatusDiff diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, null, status1);
         assertThat(diff.isEmpty(), is(false));
 
-        diff = new StatusDiff(new KafkaStatus(), status1);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, new KafkaStatus(), status1);
         assertThat(diff.isEmpty(), is(false));
 
-        diff = new StatusDiff(status1, status2);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status1, status2);
         assertThat(diff.isEmpty(), is(true));
 
-        diff = new StatusDiff(status1, status3);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status1, status3);
         assertThat(diff.isEmpty(), is(false));
 
-        diff = new StatusDiff(status1, status4);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status1, status4);
         assertThat(diff.isEmpty(), is(false));
 
-        diff = new StatusDiff(status3, status4);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status3, status4);
         assertThat(diff.isEmpty(), is(false));
 
-        diff = new StatusDiff(status3, status5);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status3, status5);
         assertThat(diff.isEmpty(), is(false));
 
-        diff = new StatusDiff(status5, status6);
+        diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status5, status6);
         assertThat(diff.isEmpty(), is(false));
     }
 
@@ -155,7 +156,7 @@ public class StatusDiffTest {
                 .withListeners(ls1, ls2)
                 .build();
 
-        StatusDiff diff = new StatusDiff(status1, status2);
+        StatusDiff diff = new StatusDiff(Reconciliation.DUMMY_RECONCILIATION, status1, status2);
         assertThat(diff.isEmpty(), is(true));
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/StatusDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/StatusDiff.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.common.model;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.zjsonpatch.JsonDiff;
 import io.strimzi.api.kafka.model.kafka.Status;
+import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 
 import java.util.regex.Pattern;
@@ -24,10 +25,11 @@ public class StatusDiff extends AbstractJsonDiff {
     /**
      * Constructs the status diff
      *
-     * @param current   Current status
-     * @param desired   Desired status
+     * @param reconciliation    Reconciliation marker
+     * @param current           Current status
+     * @param desired           Desired status
      */
-    public StatusDiff(Status current, Status desired) {
+    public StatusDiff(Reconciliation reconciliation,  Status current, Status desired) {
         JsonNode source = PATCH_MAPPER.valueToTree(current == null ? "{}" : current);
         JsonNode target = PATCH_MAPPER.valueToTree(desired == null ? "{}" : desired);
         JsonNode diff = JsonDiff.asJson(source, target);
@@ -38,14 +40,14 @@ public class StatusDiff extends AbstractJsonDiff {
             String pathValue = d.get("path").asText();
 
             if (IGNORABLE_PATHS.matcher(pathValue).matches()) {
-                LOGGER.debugOp("Ignoring Status diff {}", d);
+                LOGGER.debugCr(reconciliation, "Ignoring Status diff {}", d);
                 continue;
             }
 
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debugOp("Status differs: {}", d);
-                LOGGER.debugOp("Current Status path {} has value {}", pathValue, lookupPath(source, pathValue));
-                LOGGER.debugOp("Desired Status path {} has value {}", pathValue, lookupPath(target, pathValue));
+                LOGGER.debugCr(reconciliation, "Status differs: {}", d);
+                LOGGER.debugCr(reconciliation, "Current Status path {} has value {}", pathValue, lookupPath(source, pathValue));
+                LOGGER.debugCr(reconciliation, "Desired Status path {} has value {}", pathValue, lookupPath(target, pathValue));
             }
 
             num++;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KubernetesHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KubernetesHandler.java
@@ -94,7 +94,7 @@ public class KubernetesHandler {
         // and that it saw the last update to the resource
         reconcilableTopic.kt().getStatus().setObservedGeneration(reconcilableTopic.kt().getMetadata().getGeneration());
 
-        StatusDiff statusDiff = new StatusDiff(oldStatus, reconcilableTopic.kt().getStatus());
+        StatusDiff statusDiff = new StatusDiff(reconcilableTopic.reconciliation(), oldStatus, reconcilableTopic.kt().getStatus());
         if (!statusDiff.isEmpty()) {
             var updatedTopic = new KafkaTopicBuilder(reconcilableTopic.kt())
                 .editOrNewMetadata()

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserControllerLoop.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserControllerLoop.java
@@ -153,7 +153,7 @@ public class UserControllerLoop extends AbstractControllerLoop {
      */
     private void maybeUpdateStatus(Reconciliation reconciliation, KafkaUser kafkaUser, KafkaUserStatus desiredStatus) {
         // KafkaUser or desiredStatus being null means deletion => no status to update
-        if (kafkaUser != null && desiredStatus != null && !new StatusDiff(kafkaUser.getStatus(), desiredStatus).isEmpty()) {
+        if (kafkaUser != null && desiredStatus != null && !new StatusDiff(reconciliation, kafkaUser.getStatus(), desiredStatus).isEmpty()) {
             LOGGER.debugCr(reconciliation, "Updating status of {} {} in namespace {}", reconciliation.kind(), reconciliation.name(), reconciliation.namespace());
             KafkaUser latestKafkaUser = userInformer.get(reconciliation.namespace(), reconciliation.name());
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `StatusDiff` class does not log the reconciliation when logging the `.status` diff. That makes it pretty hard to filter the logs when debugging problems. This PR passes the reconciliation marker to it and uses it in the logging.

### Checklist

- [x] Make sure all tests pass