### PR TITLE
docs(deploying): fix inconsistent KafkaConnect cluster name in KafkaConnector procedure

### DIFF
--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -93,7 +93,7 @@ kind: KafkaConnector
 metadata:
   name: my-sink-connector
   labels:
-    strimzi.io/cluster: my-connect
+    strimzi.io/cluster: my-connect-cluster
 spec:
   class: org.apache.kafka.connect.file.FileStreamSinkConnector # <1>
   tasksMax: 2


### PR DESCRIPTION
Fixes #12977

The sink connector example in the KafkaConnector deploying procedure referenced
`strimzi.io/cluster: my-connect`, while the KafkaConnect resource defined in the
same procedure is named `my-connect-cluster`.

This inconsistency means a user following the tutorial step by step would create
a sink connector pointing to a non-existent cluster, causing the connector to
never be reconciled by the Cluster Operator.

Changed `strimzi.io/cluster: my-connect` to `strimzi.io/cluster: my-connect-cluster`
in `proc-deploying-kafkaconnector.adoc` to match:
- the KafkaConnect resource name defined in step 2 of the same procedure
- the source connector example (`snip-example-source-connector-config.adoc`)
- the example file (`examples/connect/source-connector.yaml`)