### PR TITLE
Remove some leftover debug messages

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStorageTest.java
@@ -576,7 +576,6 @@ public class KafkaClusterStorageTest {
         assertThat(kc.getStorageByPoolName().get("brokers"), is(ephemeral));
 
         // Warning status condition is set
-        System.out.println(kc.getWarningConditions());
         assertThat(kc.getWarningConditions().size(), is(1));
         assertThat(kc.getWarningConditions().get(0).getReason(), is("KafkaStorage"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -91,7 +91,6 @@ public class KafkaConnectApiIT {
                     if ("RUNNING".equals(((Map<String, Object>) status.getOrDefault("connector", emptyMap())).get("state"))) {
                         completableFuture.complete(status);
                     } else {
-                        System.err.println(status);
                         checkStatusWithDelay(statusSupplier, singleExecutor, completableFuture, delay);
                     }
                 } else {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -804,7 +804,6 @@ class CrdGenerator {
         if (propertyType.getGenericType() instanceof ParameterizedType
                 && ((ParameterizedType) propertyType.getGenericType()).getRawType().equals(Map.class)
                 && ((ParameterizedType) propertyType.getGenericType()).getActualTypeArguments()[0].equals(Integer.class)) {
-            System.err.println("It's OK");
             schema = nf.objectNode();
             schema.put("type", "object");
             schema.putObject("patternProperties").set("-?[0-9]+", buildArraySchema(crApiVersion, property, new PropertyType(null, ((ParameterizedType) propertyType.getGenericType()).getActualTypeArguments()[1]), description));

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -511,6 +511,7 @@ class DocGenerator {
                         classes.add(cls);
                     } else {
                         System.err.println(arg + " is not a subclass of " + CustomResource.class.getName());
+                        System.exit(1);
                     }
                 }
             }


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR tries to remove some leftover debug messages that I run into in our code. (Debug messages as in `System.out.println` and `System.err.println()`, not as logger based debug messages). It also adds `System.exit` to one of the messages that seemed to have been an intentional error message but was just ignored.

### Checklist

- [ ] Make sure all tests pass