### PR TITLE
Add initial Cluster Security to Kafka CR `.status` section

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.KafkaAutoRebalanceStatus;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -25,7 +26,7 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "listeners", "kafkaNodePools", "clusterId",
-    "operatorLastSuccessfulVersion", "kafkaVersion", "kafkaMetadataVersion", "autoRebalance" })
+    "operatorLastSuccessfulVersion", "kafkaVersion", "kafkaMetadataVersion", "autoRebalance", "clusterSecurity" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaStatus extends Status {
@@ -36,6 +37,7 @@ public class KafkaStatus extends Status {
     private String kafkaVersion;
     private String kafkaMetadataVersion;
     private KafkaAutoRebalanceStatus autoRebalance;
+    private Object clusterSecurity;
 
     @Description("Addresses of the internal and external listeners")
     public List<ListenerStatus> getListeners() {
@@ -98,5 +100,15 @@ public class KafkaStatus extends Status {
 
     public void setAutoRebalance(KafkaAutoRebalanceStatus autoRebalance) {
         this.autoRebalance = autoRebalance;
+    }
+
+    @Description("The current security configuration of the Kafka cluster.")
+    @PreserveUnknownFields
+    public Object getClusterSecurity() {
+        return clusterSecurity;
+    }
+
+    public void setClusterSecurity(Object clusterSecurity) {
+        this.clusterSecurity = clusterSecurity;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
@@ -32,7 +32,9 @@ public class ClusterSecurityAuthenticationStatus implements UnknownPropertyPrese
     private ClusterSecurityAuthenticationType type;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of authentication used for this cluster")
+    @Description("The type of authentication currently used for this cluster's internal communication. " +
+            "Supported types are:" +
+            "* `strimzi-mtls` for Strimzi-based mTLS encryption")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityAuthenticationType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.clustersecurity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the Cluster Security authentication status.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type"})
+@EqualsAndHashCode
+@ToString
+public class ClusterSecurityAuthenticationStatus implements UnknownPropertyPreserving {
+    private ClusterSecurityAuthenticationType type;
+    private Map<String, Object> additionalProperties;
+
+    @Description("The type of authentication used for this cluster")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @RequiredInVersions("v1+")
+    public ClusterSecurityAuthenticationType getType() {
+        return type;
+    }
+
+    public void setType(ClusterSecurityAuthenticationType type) {
+        this.type = type;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.clustersecurity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents supported authentication types for ClusterSecurity
+ */
+public enum ClusterSecurityAuthenticationType {
+    STRIMZI_MTLS;
+
+    @JsonCreator
+    public static ClusterSecurityAuthenticationType forValue(String value) {
+        return switch (value) {
+            case "strimzi-mtls" -> STRIMZI_MTLS;
+            default -> null;
+        };
+    }
+
+    @JsonValue
+    public String toValue() {
+        return switch (this) {
+            case STRIMZI_MTLS -> "strimzi-mtls";
+        };
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
@@ -32,7 +32,9 @@ public class ClusterSecurityEncryptionStatus implements UnknownPropertyPreservin
     private ClusterSecurityEncryptionType type;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of encryption used for this cluster")
+    @Description("The type of encryption currently used for this cluster's internal communication. " +
+            "Supported types are:" +
+            "* `strimzi-tls` for Strimzi-based TLS encryption")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityEncryptionType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.clustersecurity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the Cluster Security encryption status.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type"})
+@EqualsAndHashCode
+@ToString
+public class ClusterSecurityEncryptionStatus implements UnknownPropertyPreserving {
+    private ClusterSecurityEncryptionType type;
+    private Map<String, Object> additionalProperties;
+
+    @Description("The type of encryption used for this cluster")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @RequiredInVersions("v1+")
+    public ClusterSecurityEncryptionType getType() {
+        return type;
+    }
+
+    public void setType(ClusterSecurityEncryptionType type) {
+        this.type = type;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.clustersecurity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents supported encryption types for ClusterSecurity
+ */
+public enum ClusterSecurityEncryptionType {
+    STRIMZI_TLS;
+
+    @JsonCreator
+    public static ClusterSecurityEncryptionType forValue(String value) {
+        return switch (value) {
+            case "strimzi-tls" -> STRIMZI_TLS;
+            default -> null;
+        };
+    }
+
+    @JsonValue
+    public String toValue() {
+        return switch (this) {
+            case STRIMZI_TLS -> "strimzi-tls";
+        };
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityStatus.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.clustersecurity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.RequiredInVersions;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the Cluster Security status.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"authentication", "encryption"})
+@EqualsAndHashCode
+@ToString
+public class ClusterSecurityStatus implements UnknownPropertyPreserving {
+    private ClusterSecurityEncryptionStatus encryption;
+    private ClusterSecurityAuthenticationStatus authentication;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Encryption configuration of the Kafka cluster's internal communication")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @RequiredInVersions("v1+")
+    public ClusterSecurityEncryptionStatus getEncryption() {
+        return encryption;
+    }
+
+    public void setEncryption(ClusterSecurityEncryptionStatus encryption) {
+        this.encryption = encryption;
+    }
+
+    @Description("Authentication configuration of the Kafka cluster's internal communication")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @RequiredInVersions("v1+")
+    public ClusterSecurityAuthenticationStatus getAuthentication() {
+        return authentication;
+    }
+
+    public void setAuthentication(ClusterSecurityAuthenticationStatus authentication) {
+        this.authentication = authentication;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityStatus.java
@@ -33,7 +33,7 @@ public class ClusterSecurityStatus implements UnknownPropertyPreserving {
     private ClusterSecurityAuthenticationStatus authentication;
     private Map<String, Object> additionalProperties;
 
-    @Description("Encryption configuration of the Kafka cluster's internal communication")
+    @Description("Current encryption configuration of the Kafka cluster's internal communication.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityEncryptionStatus getEncryption() {
@@ -44,7 +44,7 @@ public class ClusterSecurityStatus implements UnknownPropertyPreserving {
         this.encryption = encryption;
     }
 
-    @Description("Authentication configuration of the Kafka cluster's internal communication")
+    @Description("Current authentication configuration of the Kafka cluster's internal communication.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityAuthenticationStatus getAuthentication() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContext.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityAuthenticationType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptionType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityStatus;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityStatusBuilder;
+import io.strimzi.operator.common.model.InvalidResourceException;
+
+/**
+ * Class that holds the security configuration of the Kafka cluster.
+ */
+public class KafkaClusterSecurityContext {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ClusterSecurityEncryptionType encryptionType;
+    private final ClusterSecurityAuthenticationType authenticationType;
+
+    private KafkaClusterSecurityContext(ClusterSecurityEncryptionType encryptionType, ClusterSecurityAuthenticationType authenticationType) {
+        this.encryptionType = encryptionType;
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+     * Creates an instance of this class from the Kafka CR.
+     *
+     * @param kafka     The Kafka CR
+     *
+     * @return  KafkaClusterSecurityContext instance corresponding to the Kafka CR
+     */
+    public static KafkaClusterSecurityContext fromCrd(Kafka kafka) {
+        if (kafka.getStatus() != null && kafka.getStatus().getClusterSecurity() != null) {
+            // Cluster Security already exists in status. Today we just validate it and re-use it. In the future, this
+            // will be used to validate the user-configured security from the CR and ensure that the security configuration
+            // is not changed in a way that is not supported.
+            ClusterSecurityStatus clusterSecurityStatus = deserializeStatus(kafka.getStatus().getClusterSecurity());
+            return new KafkaClusterSecurityContext(clusterSecurityStatus.getEncryption().getType(), clusterSecurityStatus.getAuthentication().getType());
+        } else {
+            // Cluster Security does not exist in status. This is a new cluster or a cluster that follows the migration
+            // procedure. Today we just create the context with the default configuration. In the future, this will take
+            // over the user-configured settings.
+            return new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        }
+    }
+
+    /**
+     * Deserializes the ClusterSecurityStatus from the untyped object to the typed object.
+     *
+     * @param untypedClusterSecurityStatus  Untyped Cluster Security Status
+     *
+     * @return  Typed Cluster Security Status
+     */
+    public static ClusterSecurityStatus deserializeStatus(Object untypedClusterSecurityStatus) {
+        if (untypedClusterSecurityStatus == null) {
+            throw new InvalidResourceException("ClusterSecurityStatus is null and cannot be deserialized.");
+        } else {
+            try {
+                ClusterSecurityStatus status = OBJECT_MAPPER.convertValue(untypedClusterSecurityStatus, ClusterSecurityStatus.class);
+
+                if (status.getEncryption() == null || status.getEncryption().getType() == null || status.getAuthentication() == null || status.getAuthentication().getType() == null) {
+                    throw new InvalidResourceException("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set");
+                }
+
+                return status;
+            } catch (IllegalArgumentException e) {
+                throw new InvalidResourceException("Failed to deserialize ClusterSecurityStatus", e);
+            }
+        }
+    }
+
+    /**
+     * Exports the Cluster Security Context for storing it in the `.status` section of the Kafka CR.
+     *
+     * @return  ClusterSecurityStatus instance corresponding to this context
+     */
+    public ClusterSecurityStatus toStatus() {
+        return new ClusterSecurityStatusBuilder()
+                .withNewEncryption()
+                    .withType(encryptionType)
+                .endEncryption()
+                .withNewAuthentication()
+                    .withType(authenticationType)
+                .endAuthentication()
+                .build();
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -26,6 +26,7 @@ import io.strimzi.certs.CertIssuer;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.model.KafkaClusterSecurityContext;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NodeRef;
@@ -39,6 +40,7 @@ import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.ca.Ca;
 import io.strimzi.operator.common.config.ConfigParameter;
+import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.PasswordGenerator;
@@ -197,6 +199,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     // the auto-rebalance is enabled otherwise I could reset it to null if needed
                     status.setAutoRebalance(kafkaAssembly.getStatus().getAutoRebalance());
                 }
+
+                if (status.getClusterSecurity() == null)    {
+                    // Copy the cluster security state if needed
+                    status.setClusterSecurity(kafkaAssembly.getStatus().getClusterSecurity());
+                }
             }
 
             if (reconcileResult.succeeded())    {
@@ -230,7 +237,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     Future<Void> reconcile(ReconciliationState reconcileState)  {
         Promise<Void> chainPromise = Promise.promise();
 
-        reconcileState.initialStatus()
+        reconcileState.initialize()
+                .compose(state -> state.initialStatus())
                 // Preparation steps => prepare cluster descriptions, handle CA creation or changes
                 .compose(state -> state.reconcileCas(clock))
                 .compose(state -> state.emitCertificateSecretMetrics())
@@ -274,6 +282,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Map<String, ResourceRequirements> kafkaBrokerResources;
         // needed to take information for the auto-rebalancing on scaling via Cruise Control
         private Set<Integer> scalingDownBlockedNodes;
+        private KafkaClusterSecurityContext securityContext;
 
         /* test */ KafkaStatus kafkaStatus = new KafkaStatus();
 
@@ -282,6 +291,25 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             this.kafkaAssembly = kafkaAssembly;
             this.namespace = kafkaAssembly.getMetadata().getNamespace();
             this.name = kafkaAssembly.getMetadata().getName();
+        }
+
+        /**
+         * Initializes the reconciliation state.
+         *
+         * @return  Future that returns when the reconciliation state has been initialized
+         */
+        Future<ReconciliationState> initialize() {
+            // Initialize the security context from the Kafka CR and set it in the status.
+            try {
+                this.securityContext = KafkaClusterSecurityContext.fromCrd(kafkaAssembly);
+                this.kafkaStatus.setClusterSecurity(securityContext.toStatus());
+
+                // NOTE: To correctly propagate any possible errors into the Kafka CR, we have to make sure to fail
+                // the Future in case of any errors.
+                return Future.succeededFuture(this);
+            } catch (InvalidResourceException e) {
+                return Future.failedFuture(e);
+            }
         }
 
         /**
@@ -686,6 +714,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         // We copy the cluster ID if set
         if (kafka.getStatus() != null && kafka.getStatus().getClusterId() != null)  {
             status.setClusterId(kafka.getStatus().getClusterId());
+        }
+
+        // We copy the cluster security if set
+        if (kafka.getStatus() != null && kafka.getStatus().getClusterSecurity() != null)  {
+            status.setClusterSecurity(kafka.getStatus().getClusterSecurity());
         }
 
         return status;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityAuthenticationType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptionType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityStatus;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityStatusBuilder;
+import io.strimzi.operator.common.model.InvalidResourceException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KafkaClusterSecurityContextTest {
+    private static final String NAMESPACE = "my-namespace";
+    private static final String CLUSTER_NAME = "my-cluster";
+
+    private static final Map<String, Object> VALID_STATUS = Map.of(
+            "encryption", Map.of("type", "strimzi-tls"),
+            "authentication", Map.of("type", "strimzi-mtls")
+    );
+
+    private static final Kafka KAFKA = new KafkaBuilder()
+            .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .build();
+
+    //////////////////////////////////////////////////
+    // Tests for the fromCrd method
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testFromCrdWithoutStatus()  {
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(KAFKA).toStatus();
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+    }
+
+    @Test
+    public void testFromCrdWithStatusWithoutClusterSecurity()  {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewStatus()
+                    .withObservedGeneration(1L)
+                .endStatus()
+                .build();
+
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(kafka).toStatus();
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+    }
+
+    @Test
+    public void testFromCrdWithUntypedClusterSecurityInStatus()  {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewStatus()
+                    .withClusterSecurity(VALID_STATUS)
+                .endStatus()
+                .build();
+
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(kafka).toStatus();
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+    }
+
+    @Test
+    public void testFromCrdWithTypedClusterSecurityInStatus()  {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewStatus()
+                    .withClusterSecurity(new ClusterSecurityStatusBuilder()
+                            .withNewEncryption()
+                                .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                            .endEncryption()
+                            .withNewAuthentication()
+                                .withType(ClusterSecurityAuthenticationType.STRIMZI_MTLS)
+                            .endAuthentication()
+                            .build())
+                .endStatus()
+                .build();
+
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(kafka).toStatus();
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+    }
+
+    @Test
+    public void testFromCrdWithInvalidClusterSecurityInStatus()  {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewStatus()
+                    .withClusterSecurity(Map.of("encryption", Map.of("type", "strimzi-tls")))
+                .endStatus()
+                .build();
+
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.fromCrd(kafka));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for the deserializeStatus method
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testDeserializeStatus()  {
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.deserializeStatus(VALID_STATUS);
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+    }
+
+    @Test
+    public void testDeserializeStatusWithUnknownFields()  {
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.deserializeStatus(Map.of(
+                "encryption", Map.of("type", "strimzi-tls", "someEncryptionField", "someEncryptionValue"),
+                "authentication", Map.of("type", "strimzi-mtls"),
+                "someField", "someValue"
+        ));
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getAdditionalProperties(), is(Map.of("someField", "someValue")));
+        assertThat(status.getEncryption().getAdditionalProperties(), is(Map.of("someEncryptionField", "someEncryptionValue")));
+    }
+
+    @Test
+    public void testDeserializeNullStatus()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(null));
+        assertThat(e.getMessage(), is("ClusterSecurityStatus is null and cannot be deserialized."));
+    }
+
+    @Test
+    public void testDeserializeEmptyStatus()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of()));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusWithMissingEncryption()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of("authentication", Map.of("type", "strimzi-mtls"))));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusWithMissingAuthentication()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of("encryption", Map.of("type", "strimzi-tls"))));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusWithMissingEncryptionType()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
+                "encryption", Map.of(),
+                "authentication", Map.of("type", "strimzi-mtls")
+        )));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusWithMissingAuthenticationType()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
+                "encryption", Map.of("type", "strimzi-tls"),
+                "authentication", Map.of()
+        )));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusWithUnsupportedEncryptionType()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
+                "encryption", Map.of("type", "some-other-tls"),
+                "authentication", Map.of("type", "strimzi-mtls")
+        )));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusWithUnsupportedAuthenticationType()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
+                "encryption", Map.of("type", "strimzi-tls"),
+                "authentication", Map.of("type", "some-other-mtls")
+        )));
+        assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+    }
+
+    @Test
+    public void testDeserializeStatusFromUnsupportedType()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus("strimzi-tls"));
+        assertThat(e.getMessage(), is("Failed to deserialize ClusterSecurityStatus"));
+        assertThat(e.getCause(), is(notNullValue()));
+        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
+    }
+
+    @Test
+    public void testDeserializeStatusFromList()  {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(List.of(VALID_STATUS)));
+        assertThat(e.getMessage(), is("Failed to deserialize ClusterSecurityStatus"));
+        assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for the toStatus method
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testToStatus()  {
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(KAFKA).toStatus();
+
+        assertThat(status, is(new ClusterSecurityStatusBuilder()
+                .withNewEncryption()
+                    .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                .endEncryption()
+                .withNewAuthentication()
+                    .withType(ClusterSecurityAuthenticationType.STRIMZI_MTLS)
+                .endAuthentication()
+                .build()));
+    }
+
+    @Test
+    public void testStatusRoundTrip()  {
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(KAFKA).toStatus();
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewStatus()
+                    .withClusterSecurity(status)
+                .endStatus()
+                .build();
+
+        assertThat(KafkaClusterSecurityContext.fromCrd(kafka).toStatus(), is(status));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -10,6 +10,10 @@ import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaList;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityAuthenticationType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptionType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityStatus;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityStatusBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerAddressBuilder;
@@ -20,6 +24,7 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaClusterSecurityContext;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
@@ -101,6 +106,14 @@ public class KafkaStatusTest {
                             .withStatus("True")
                             .build())
                     .withClusterId("my-cluster-id")
+                    .withClusterSecurity(new ClusterSecurityStatusBuilder()
+                            .withNewEncryption()
+                                .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                            .endEncryption()
+                            .withNewAuthentication()
+                                .withType(ClusterSecurityAuthenticationType.STRIMZI_MTLS)
+                            .endAuthentication()
+                            .build())
                 .endStatus()
                 .build();
     }
@@ -150,6 +163,14 @@ public class KafkaStatusTest {
             assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
             assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
 
+            // Test ClusterSecurity status
+            assertThat(status.getClusterSecurity(), is(notNullValue()));
+            ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
+            assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+
             async.flag();
         })));
     }
@@ -189,6 +210,14 @@ public class KafkaStatusTest {
 
                 assertThat(status.getOperatorLastSuccessfulVersion(), is(nullValue()));
                 assertThat(status.getKafkaVersion(), is(nullValue()));
+
+                // Test ClusterSecurity status
+                assertThat(status.getClusterSecurity(), is(notNullValue()));
+                ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
+                assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
+                assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+                assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
+                assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
 
                 async.flag();
             })));
@@ -243,6 +272,14 @@ public class KafkaStatusTest {
 
             assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
             assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+
+            // Test ClusterSecurity status
+            assertThat(status.getClusterSecurity(), is(notNullValue()));
+            ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
+            assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
 
             async.flag();
         })));
@@ -302,6 +339,14 @@ public class KafkaStatusTest {
 
             assertThat(status.getOperatorLastSuccessfulVersion(), is(nullValue()));
             assertThat(status.getKafkaVersion(), is(nullValue()));
+
+            // Test ClusterSecurity status
+            assertThat(status.getClusterSecurity(), is(notNullValue()));
+            ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
+            assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
 
             async.flag();
         })));
@@ -380,6 +425,63 @@ public class KafkaStatusTest {
             assertThat(status.getOperatorLastSuccessfulVersion(), is("old-operator"));
             assertThat(status.getKafkaMetadataVersion(), is("old-metadata-version"));
 
+            // Test ClusterSecurity status
+            assertThat(status.getClusterSecurity(), is(notNullValue()));
+            ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
+            assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+
+            async.flag();
+        })));
+    }
+
+    @Test
+    public void testStatusAfterClusterSecurityDecodingFailure(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the Kafka Operator
+        CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
+
+        Kafka readyKafka = new KafkaBuilder(getKafkaCrd())
+                .editStatus()
+                    .withClusterSecurity(new ClusterSecurityStatusBuilder()
+                            .withNewEncryption()
+                                .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                            .endEncryption()
+                            .build())
+                .endStatus()
+                .build();
+
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(CompletableFuture.completedFuture(readyKafka));
+        when(mockKafkaOps.get(eq(namespace), eq(clusterName))).thenReturn(readyKafka);
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(any(), kafkaCaptor.capture())).thenReturn(CompletableFuture.completedFuture(null));
+
+        KafkaAssemblyOperator kao = new KafkaAssemblyOperator(
+                vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certIssuer,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName)).onComplete(context.failing(v -> context.verify(() -> {
+            assertThat(kafkaCaptor.getValue(), is(notNullValue()));
+            assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
+            KafkaStatus status = kafkaCaptor.getValue().getStatus();
+
+            assertThat(status.getConditions().size(), is(1));
+            assertThat(status.getConditions().get(0).getType(), is("NotReady"));
+            assertThat(status.getConditions().get(0).getStatus(), is("True"));
+            assertThat(status.getConditions().get(0).getReason(), is("InvalidResourceException"));
+            assertThat(status.getConditions().get(0).getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
+
+            // Test ClusterSecurity status
+            assertThat(status.getClusterSecurity(), is(notNullValue()));
+
             async.flag();
         })));
     }
@@ -413,6 +515,7 @@ public class KafkaStatusTest {
             KafkaStatus status = kafkaCaptor.getAllValues().get(0).getStatus();
 
             assertThat(status.getListeners(), is(nullValue()));
+            assertThat(status.getClusterSecurity(), is(nullValue()));
 
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));

--- a/crd-annotations/src/main/java/io/strimzi/crdgenerator/annotations/PreserveUnknownFields.java
+++ b/crd-annotations/src/main/java/io/strimzi/crdgenerator/annotations/PreserveUnknownFields.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to preserve unknown fields in the CR
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface PreserveUnknownFields {
+}

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -28,6 +28,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 import io.strimzi.crdgenerator.annotations.Type;
 
@@ -819,6 +820,10 @@ class CrdGenerator {
             schema = buildArraySchema(crApiVersion, property, property.getType(), description);
         } else {
             schema = buildObjectSchema(crApiVersion, returnType, description);
+        }
+
+        if (property.isAnnotationPresent(PreserveUnknownFields.class))  {
+            preserveUnknownFields(schema);
         }
 
         if (description) {

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -25,6 +25,7 @@ import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
+import io.strimzi.crdgenerator.annotations.PreserveUnknownFields;
 import io.strimzi.crdgenerator.annotations.RequiredInVersions;
 
 import java.util.List;
@@ -65,7 +66,7 @@ import java.util.Map;
     "objectProperty", "mapStringObject", "mapStringString", "mapStringQuantity", "polymorphicProperty", "affinity", "fieldProperty",
     "arrayProperty", "arrayProperty2", "listOfInts", "listOfInts2", "listOfObjects", "listOfPolymorphic", "polymorphicWithOptionalType",
     "rawList", "listOfRawList", "arrayOfList", "arrayOfRawList", "listOfArray", "arrayOfTypeVar", "listOfTypeVar",
-    "arrayOfBoundTypeVar", "listOfBoundTypeVar", "arrayOfBoundTypeVar2", "listOfBoundTypeVar2",
+    "arrayOfBoundTypeVar", "listOfBoundTypeVar", "arrayOfBoundTypeVar2", "listOfBoundTypeVar2", "unstructured",
     "listOfWildcardTypeVar1", "listOfWildcardTypeVar2", "listOfWildcardTypeVar3", "listOfWildcardTypeVar4",
     "listOfCustomizedEnum", "listOfNormalEnum", "listOfMaps", "either", "or", "status", "spec", "external"})
 public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource {
@@ -139,6 +140,9 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     public List<NormalEnum> listOfNormalEnum;
 
     public List<Map<String, Object>> listOfMaps;
+
+    @PreserveUnknownFields
+    public Object unstructured;
 
     public String either;
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -98,6 +98,9 @@
 |listOfBoundTypeVar2
 |xref:type-Number-{context}[`Number`] array
 |
+|unstructured
+|object
+|
 |listOfWildcardTypeVar1
 |string array
 |

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -573,6 +573,10 @@ spec:
             items:
               type: object
               properties: {}
+          unstructured:
+            type: object
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
             items:
@@ -1194,6 +1198,10 @@ spec:
             items:
               type: object
               properties: {}
+          unstructured:
+            type: object
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
             items:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -579,6 +579,10 @@ spec:
             items:
               type: object
               properties: {}
+          unstructured:
+            type: object
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
             items:
@@ -1200,6 +1204,10 @@ spec:
             items:
               type: object
               properties: {}
+          unstructured:
+            type: object
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
             items:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -564,6 +564,10 @@ spec:
             items:
               type: object
               properties: {}
+          unstructured:
+            type: object
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
             items:
@@ -1179,6 +1183,10 @@ spec:
             items:
               type: object
               properties: {}
+          unstructured:
+            type: object
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
             items:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1793,6 +1793,9 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |autoRebalance
 |xref:type-KafkaAutoRebalanceStatus-{context}[`KafkaAutoRebalanceStatus`]
 |The status of an auto-rebalancing triggered by a cluster scaling request.
+|clusterSecurity
+|object
+|The current security configuration of the Kafka cluster.
 |====
 
 [id='type-Condition-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5699,6 +5699,11 @@ spec:
                             description: "List of broker IDs involved in an auto-rebalancing operation related to the current mode. \nThe list contains one of the following: \n\n* Broker IDs for a current auto-rebalance. \n* Broker IDs for a queued auto-rebalance (if a previous auto-rebalance is still in progress). \n"
                       description: "List of modes where an auto-rebalancing operation is either running or queued. \nEach mode entry (`add-brokers` or `remove-brokers`) includes one of the following: \n\n* Broker IDs for a current auto-rebalance. \n* Broker IDs for a queued auto-rebalance (if a previous rebalance is still in progress)."
                   description: The status of an auto-rebalancing triggered by a cluster scaling request.
+                clusterSecurity:
+                  type: object
+                  properties: {}
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: The current security configuration of the Kafka cluster.
               description: The status of the Kafka cluster.
           required:
             - spec

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -5698,6 +5698,11 @@ spec:
                           description: "List of broker IDs involved in an auto-rebalancing operation related to the current mode. \nThe list contains one of the following: \n\n* Broker IDs for a current auto-rebalance. \n* Broker IDs for a queued auto-rebalance (if a previous auto-rebalance is still in progress). \n"
                     description: "List of modes where an auto-rebalancing operation is either running or queued. \nEach mode entry (`add-brokers` or `remove-brokers`) includes one of the following: \n\n* Broker IDs for a current auto-rebalance. \n* Broker IDs for a queued auto-rebalance (if a previous rebalance is still in progress)."
                 description: The status of an auto-rebalancing triggered by a cluster scaling request.
+              clusterSecurity:
+                type: object
+                properties: {}
+                x-kubernetes-preserve-unknown-fields: true
+                description: The current security configuration of the Kafka cluster.
             description: The status of the Kafka cluster.
         required:
         - spec


### PR DESCRIPTION
### Type of change

- Task

### Description

This is the first PR towards the implementation of [SEP-150 (Configurable Cluster Security)](https://github.com/strimzi/proposals/blob/main/150-configurable-security-of-internal-communication.md).

It creates the new `KafkaClusterSecurityContext` class that will be used within the Cluster Operator models and reconciliations to configure the cluster security. It also creates the new `ClusterSecurityStatus` API that is used to store the current security configuration in the `.status` section of the Kafka CR.

In this PR, it only supports the existing TLS/mTLS security. So there is nothing really configurable yet. This just tracks the current settings. The next PRs will add support for the new security configurations on top of this.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
