### PR TITLE
Fixed asserts in KafkaAgent tests and minor refactoring

### DIFF
--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -49,9 +49,9 @@ import java.util.Properties;
  * <dl>
  *     <dt>{@code GET /v1/broker-state}</dt>
  *     <dd>Reflects the BrokerState metric, returning a JSON response e.g. {"brokerState": 3}.
- *      If broker state is RECOVERY(2), it includes remainingLogsToRecover and remainingLogsToRecover in the response e.g.
+ *      If broker state is RECOVERY(2), it includes remainingLogsToRecover and remainingSegmentsToRecover in the response e.g.
  *      {"brokerState": 2,
- *       "recovery": {
+ *       "recoveryState": {
  *          "remainingLogsToRecover": 123,
  *          "remainingSegmentsToRecover": 456
  *        }
@@ -260,7 +260,7 @@ public class KafkaAgent {
                     byte observedState = (byte) brokerState.value();
                     boolean stateIsRunning = BROKER_RUNNING_STATE <= observedState && BROKER_UNKNOWN_STATE != observedState;
                     if (stateIsRunning) {
-                        LOGGER.trace("Broker is in running according to {}. The current state is {}", brokerStateName, observedState);
+                        LOGGER.trace("Broker is running according to {}. The current state is {}", brokerStateName, observedState);
                         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
                         response.write(true, null, callback);
                     } else {
@@ -298,7 +298,7 @@ public class KafkaAgent {
                     agentConfigs.put(key, agentProperties.getProperty(key));
                 }
             } catch (IOException e) {
-                LOGGER.error("Could not read and parse properties file {}", args[0]);
+                LOGGER.error("Could not read and parse properties file {}", args[0], e);
                 System.exit(1);
             }
 

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -149,10 +149,10 @@ public class KafkaAgentTest {
         server.start();
 
         HttpResponse<String> response = httpsClient.send(httpsReq, HttpResponse.BodyHandlers.ofString());
-        assertThat(HttpServletResponse.SC_OK, is(response.statusCode()));
+        assertThat(response.statusCode(), is(HttpServletResponse.SC_OK));
 
         String expectedResponse = "{\"brokerState\":2,\"recoveryState\":{\"remainingLogsToRecover\":10,\"remainingSegmentsToRecover\":100}}";
-        assertThat(expectedResponse, is(response.body()));
+        assertThat(response.body(), is(expectedResponse));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class KafkaAgentTest {
         server.start();
 
         HttpResponse<String> response = httpsClient.send(httpsReq, HttpResponse.BodyHandlers.ofString());
-        assertThat(HttpServletResponse.SC_NOT_FOUND, is(response.statusCode()));
+        assertThat(response.statusCode(), is(HttpServletResponse.SC_NOT_FOUND));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class KafkaAgentTest {
                 .build()
                 .send(httpReq, HttpResponse.BodyHandlers.ofString());
 
-        assertThat(HttpServletResponse.SC_NO_CONTENT, is(response.statusCode()));
+        assertThat(response.statusCode(), is(HttpServletResponse.SC_NO_CONTENT));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class KafkaAgentTest {
                 .build()
                 .send(httpReq, HttpResponse.BodyHandlers.ofString());
 
-        assertThat(HttpServletResponse.SC_SERVICE_UNAVAILABLE, is(response.statusCode()));
+        assertThat(response.statusCode(), is(HttpServletResponse.SC_SERVICE_UNAVAILABLE));
     }
 
     @Test
@@ -217,6 +217,6 @@ public class KafkaAgentTest {
                 .build()
                 .send(httpReq, HttpResponse.BodyHandlers.ofString());
 
-        assertThat(HttpServletResponse.SC_SERVICE_UNAVAILABLE, is(response.statusCode()));
+        assertThat(response.statusCode(), is(HttpServletResponse.SC_SERVICE_UNAVAILABLE));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixes all the flipped `assertThat` statements within the KafkaAgent tests.
They are supposed to be something like `assertThat(actual, is(expected))` while the are the other way around `assertThat(expected, is(actual))`.
There are also some other minor fixes within the KafkaAgent itself.

### Checklist

- [x] Make sure all tests pass