### PR TITLE
Update README to reflect strimzi-dev channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The roadmap of the Strimzi Operator project is maintained as [GitHub Project](ht
 
 If you encounter any issues while using Strimzi, you can get help using:
 
-- [#strimzi channel on CNCF Slack](https://slack.cncf.io/)
+- [#strimzi channel on CNCF Slack](https://cloud-native.slack.com/archives/CMH3Q3SNP)
 - [Strimzi Users mailing list](https://lists.cncf.io/g/cncf-strimzi-users/topics)
 - [GitHub Discussions](https://github.com/strimzi/strimzi-kafka-operator/discussions)
 
@@ -56,9 +56,8 @@ You can contribute by:
 - Improving Strimzi documentation
 - Talking about Strimzi
 
-All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/strimzi/strimzi-kafka-operator/issues). Issues which 
-might be a good start for new contributors are marked with ["good-start"](https://github.com/strimzi/strimzi-kafka-operator/labels/good-start)
-label.
+All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/strimzi/strimzi-kafka-operator/issues). 
+Issues which might be a good start for new contributors are marked with ["good-start"](https://github.com/strimzi/strimzi-kafka-operator/labels/good-start) label.
 
 The [development guide](development-docs/DEV_GUIDE.md) describes how to quickly get set up to build Strimzi from source.
 Before submitting a patch, make sure you understand how to test your changes by reading the [Test guide](development-docs/TESTING.md).
@@ -88,9 +87,11 @@ If you have already made a commit and forgot to include the sign-off, you can am
 git commit --amend -s
 ```
 
+### Getting help with your contributions
+
 If you want to get in touch with us first before contributing, you can use:
 
-- [#strimzi channel on CNCF Slack](https://slack.cncf.io/)
+- [#strimzi-dev channel on CNCF Slack](https://cloud-native.slack.com/archives/C018247K8T0)
 - [Strimzi Dev mailing list](https://lists.cncf.io/g/cncf-strimzi-dev/topics)
 
 ## License


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This small PR changes the README a bit to reflect the `strimzi-dev` channel used for discussion around development of Strimzi - so in case that contributor needs to help with some issue they are working on, with something during build of the project, or really anything that they might hit during the work on some task.

Also it adds direct link to `#strimzi` channel.

### Checklist

- [x] Update README.md