### PR TITLE
Remove unnecessary `.spec` null checks

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -11,7 +11,6 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.common.Condition;
-import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.api.kafka.model.common.Spec;
 import io.strimzi.api.kafka.model.kafka.Status;
 import io.strimzi.operator.cluster.operator.VertxUtil;
@@ -24,7 +23,6 @@ import io.strimzi.operator.common.StrimziTimeoutException;
 import io.strimzi.operator.common.metrics.MetricsHolder;
 import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
 import io.strimzi.operator.common.model.InvalidConfigParameterException;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.StatusDiff;
@@ -239,24 +237,6 @@ public abstract class AbstractOperator<
             });
             metrics().pausedResourceCounter(namespace).getAndIncrement();
             LOGGER.infoCr(reconciliation, "Reconciliation of {} {} is paused", kind, name);
-            return createOrUpdate.future();
-        } else if (cr.getSpec() == null) {
-            InvalidResourceException exception = new InvalidResourceException("Spec cannot be null");
-
-            S status = createStatus(cr);
-            Condition errorCondition = new ConditionBuilder()
-                    .withLastTransitionTime(StatusUtils.iso8601Now())
-                    .withType("NotReady")
-                    .withStatus("True")
-                    .withReason(exception.getClass().getSimpleName())
-                    .withMessage(exception.getMessage())
-                    .build();
-            status.setObservedGeneration(cr.getMetadata().getGeneration());
-            status.addCondition(errorCondition);
-
-            LOGGER.errorCr(reconciliation, "{} spec cannot be null", cr.getMetadata().getName());
-            updateStatus(reconciliation, status).onComplete(notUsed -> createOrUpdate.fail(exception));
-
             return createOrUpdate.future();
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -443,10 +443,6 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         } else {
             LOGGER.infoCr(reconciliation, "creating/updating connector: {}", connectorName);
 
-            if (connector.getSpec() == null) {
-                return Future.failedFuture(new InvalidResourceException("spec property is required"));
-            }
-
             if (!useResources) {
                 return Future.failedFuture(new NoSuchResourceException(reconciliation.kind() + " " + reconciliation.name() + " is not configured with annotation " + Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES));
             } else {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -683,8 +683,7 @@ public class BatchingTopicController {
     private static Either<TopicOperatorException, NewPartitions> partitionChanges(
         Reconciliation reconciliation, KafkaTopic kafkaTopic, int currentNumPartitions
     ) {
-        var requested = kafkaTopic.getSpec() == null || kafkaTopic.getSpec().getPartitions() == null
-            ? KafkaHandler.DEFAULT_PARTITIONS : kafkaTopic.getSpec().getPartitions();
+        var requested = kafkaTopic.getSpec().getPartitions() == null ? KafkaHandler.DEFAULT_PARTITIONS : kafkaTopic.getSpec().getPartitions();
         if (requested > currentNumPartitions) {
             LOGGER.debugCr(reconciliation, "Partition increase from {} to {}", currentNumPartitions, requested);
             return Either.ofRight(NewPartitions.increaseTo(requested));


### PR DESCRIPTION
### Type of change

- Task

### Description

As discussed in https://cloud-native.slack.com/archives/C018247K8T0/p1785185874464989, this PR removes some unnecessary `.spec` null checks. The `.spec` section is now required in our CRs/CRDs, so the null checks are not needed.

While it is possible to override the CRD validations and create a resource without the `.spec` section that way, that is something we do not need to take care in our code and users doing it should expect NPEs.

### Checklist

- [ ] Make sure all tests pass