### PR TITLE
Use `createPodDisruptionBudget` for Deployment-based components

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -586,13 +586,12 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
      * @return The PodDisruptionBudget for Cruise Control
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
-        return PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(
+        return PodDisruptionBudgetUtils.createPodDisruptionBudget(
                 componentName,
                 namespace,
                 labels,
                 ownerReference,
-                templatePodDisruptionBudget,
-                1
+                templatePodDisruptionBudget
         );
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -375,13 +375,12 @@ public class EntityOperator extends AbstractModel {
      * @return The PodDisruptionBudget for the Entity Operator
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
-        return PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(
+        return PodDisruptionBudgetUtils.createPodDisruptionBudget(
                 componentName,
                 namespace,
                 labels,
                 ownerReference,
-                templatePodDisruptionBudget,
-                1
+                templatePodDisruptionBudget
         );
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -342,13 +342,12 @@ public class KafkaExporter extends AbstractModel {
      * @return The PodDisruptionBudget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
-        return PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(
+        return PodDisruptionBudgetUtils.createPodDisruptionBudget(
                 componentName,
                 namespace,
                 labels,
                 ownerReference,
-                templatePodDisruptionBudget,
-                1
+                templatePodDisruptionBudget
         );
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -548,7 +548,7 @@ public class CruiseControlTest {
         PodDisruptionBudget pbd = cc.generatePodDisruptionBudget();
         assertThat(pbd.getMetadata().getLabels().entrySet().containsAll(pbdLabels.entrySet()), is(true));
         assertThat(pbd.getMetadata().getAnnotations().entrySet().containsAll(pbdAnnotations.entrySet()), is(true));
-        assertThat(pbd.getSpec().getMinAvailable(), is(new IntOrString(0)));
+        assertThat(pbd.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -360,7 +360,7 @@ public class EntityOperatorTest {
         PodDisruptionBudget pdb = entityOperator.generatePodDisruptionBudget();
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
-        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(0)));
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -438,7 +438,7 @@ public class KafkaExporterTest {
         PodDisruptionBudget pdb = ke.generatePodDisruptionBudget();
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
-        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(0)));
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -262,7 +262,7 @@ public class CruiseControlReconcilerTest {
                     verify(mockPodDisruptionBudget, times(1)).reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.componentName(NAME)), pdbCaptor.capture());
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
                     assertThat(pdbCaptor.getValue().getMetadata().getName(), is(CruiseControlResources.componentName(NAME)));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
@@ -203,7 +203,7 @@ public class EntityOperatorReconcilerTest {
 
                     assertThat(pdbCaptor.getAllValues().size(), is(1));
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));
@@ -327,7 +327,7 @@ public class EntityOperatorReconcilerTest {
 
                     assertThat(pdbCaptor.getAllValues().size(), is(1));
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));
@@ -445,7 +445,7 @@ public class EntityOperatorReconcilerTest {
 
                     assertThat(pdbCaptor.getAllValues().size(), is(1));
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));
@@ -548,7 +548,7 @@ public class EntityOperatorReconcilerTest {
 
                     assertThat(pdbCaptor.getAllValues().size(), is(1));
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconcilerTest.java
@@ -163,7 +163,7 @@ public class KafkaExporterReconcilerTest {
                     ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
                     verify(mockPodDisruptionBudgetOps, times(1)).reconcile(any(), eq(NAMESPACE), eq(KafkaExporterResources.componentName(NAME)), pdbCaptor.capture());
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));
@@ -231,7 +231,7 @@ public class KafkaExporterReconcilerTest {
                     ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
                     verify(mockPodDisruptionBudgetOps, times(1)).reconcile(any(), eq(NAMESPACE), eq(KafkaExporterResources.componentName(NAME)), pdbCaptor.capture());
                     assertThat(pdbCaptor.getValue(), is(notNullValue()));
-                    assertThat(pdbCaptor.getValue().getSpec().getMinAvailable(), is(new IntOrString(0)));
+                    assertThat(pdbCaptor.getValue().getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
                     async.flag();
                 })));

--- a/documentation/api/io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate.adoc
@@ -30,7 +30,8 @@ For example:
 * If there are three broker pods and the `maxUnavailable` property is set to `1` in the `Kafka` resource, the `minAvailable` setting is `2`, allowing one pod to be unavailable.
 * If there are three broker pods and the `maxUnavailable` property is set to `0` (zero), the `minAvailable` setting is `3`, requiring all three broker pods to be available and allowing zero pods to be unavailable.
 
-The above examples also applies for the `EntityOperator`, `Cruise Control`, `KafkaExporter` deployments.
+The Entity Operator, Cruise Control, and Kafka Exporter run as `Deployment` resources, which support `maxUnavailable` directly.
+For these components, the value is used as is and no conversion takes place.
 
 .Example `PodDisruptionBudget` template configuration
 [source,yaml,subs=attributes+]


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As identified by @scholzj in https://github.com/strimzi/strimzi-kafka-operator/issues/12892#issuecomment-5128597800, the Entity Operator, Cruise Control and Kafka Exporter are `Deployment`-based but generated their `PodDisruptionBudget` with `createCustomControllerPodDisruptionBudget`, which always produced `minAvailable: 0` for these single-replica components.

This PR switches them to `createPodDisruptionBudget`, matching what the HTTP Bridge already does. `Kafka`, `KafkaConnect` and `KafkaMirrorMaker2` are unchanged. Documentation is updated to match.

**Scope:** this does not address the drain-blocking behaviour discussed in #12892, which is still under maintainer review.

### Verification

Built the operator from this branch and deployed it on Minikube with a 2-node Kafka cluster and the Entity Operator, Cruise Control and Kafka Exporter enabled:

```
$ kubectl get pdb -n kafka -o custom-columns=NAME:.metadata.name,MIN:.spec.minAvailable,MAX:.spec.maxUnavailable
NAME                         MIN      MAX
my-cluster-cruise-control    <none>   1
my-cluster-entity-operator   <none>   1
my-cluster-kafka             1        <none>
my-cluster-kafka-exporter    <none>   1
```

### Checklist

- [x] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
