### PR TITLE
Improved `Identity` record Javadoc

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/Identity.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/Identity.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.common.auth;
 
 /**
- * Represents the operator's identity, including trust material and authentication credentials,
+ * Represents the operator's identity configuration, including trust material and authentication credentials,
  * used when connecting to operands.
  *
  * @param trustSet      Trust set for esablishing the trust with the operand

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/Identity.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/Identity.java
@@ -5,7 +5,8 @@
 package io.strimzi.operator.common.auth;
 
 /**
- * Represents the configuration of the operator when connecting to operands
+ * Represents the operator's identity, including trust material and authentication credentials,
+ * used when connecting to operands.
  *
  * @param trustSet      Trust set for esablishing the trust with the operand
  * @param authIdentity  Authentication identify for authenticating the operator


### PR DESCRIPTION
I missed the review of https://github.com/strimzi/strimzi-kafka-operator/pull/13008. While I agree on that, I would improve the Javadoc for the `Identity` record. This is the purpose of the current PR.