### PR TITLE
Remove deprecated resource state metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support for configuring Maven mirrors for Kafka Connect Build
 * Connectors that request the `stopped` or `paused` state via `spec.state` are now created directly in that state instead of being started first and then stopped or paused.
 * Added support for broker cordoning [KIP-1066](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/311627566/KIP-1066+Mechanism+to+cordon+brokers+and+log+directories) during auto-rebalancing on scale down for Kafka 4.3+.
+* Removed deprecated resource state metrics - the KSM (kube-state-metrics) should be used instead.
 
 ### Major changes, deprecations, and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -7,8 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.Watcher;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.Spec;
@@ -20,7 +18,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.StrimziTimeoutException;
-import io.strimzi.operator.common.metrics.MetricsHolder;
 import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
 import io.strimzi.operator.common.model.InvalidConfigParameterException;
 import io.strimzi.operator.common.model.Labels;
@@ -518,86 +515,26 @@ public abstract class AbstractOperator<
      * Log the reconciliation outcome.
      */
     private Future<Void> handleResult(Reconciliation reconciliation, AsyncResult<Void> result, Timer.Sample reconciliationTimerSample) {
-        Promise<Void> handlingResult = Promise.promise();
-
         if (result.succeeded()) {
-            updateResourceState(reconciliation, true, null).onComplete(stateUpdateResult -> {
-                metrics().successfulReconciliationsCounter(reconciliation.namespace()).increment();
-                reconciliationTimerSample.stop(metrics().reconciliationsTimer(reconciliation.namespace()));
-                LOGGER.infoCr(reconciliation, "reconciled");
-                handlingResult.handle(stateUpdateResult);
-            });
+            metrics().successfulReconciliationsCounter(reconciliation.namespace()).increment();
+            reconciliationTimerSample.stop(metrics().reconciliationsTimer(reconciliation.namespace()));
+            LOGGER.infoCr(reconciliation, "reconciled");
         } else {
             Throwable cause = result.cause();
 
             if (cause instanceof InvalidConfigParameterException) {
-                updateResourceState(reconciliation, false, cause).onComplete(stateUpdateResult -> {
-                    metrics().failedReconciliationsCounter(reconciliation.namespace()).increment();
-                    reconciliationTimerSample.stop(metrics().reconciliationsTimer(reconciliation.namespace()));
-                    LOGGER.warnCr(reconciliation, "Failed to reconcile {}", cause.getMessage());
-                    handlingResult.handle(stateUpdateResult);
-                });
+                metrics().failedReconciliationsCounter(reconciliation.namespace()).increment();
+                reconciliationTimerSample.stop(metrics().reconciliationsTimer(reconciliation.namespace()));
+                LOGGER.warnCr(reconciliation, "Failed to reconcile {}", cause.getMessage());
             } else if (cause instanceof UnableToAcquireLockException) {
                 metrics().lockedReconciliationsCounter(reconciliation.namespace()).increment();
-                handlingResult.complete();
             } else {
-                updateResourceState(reconciliation, false, cause).onComplete(stateUpdateResult -> {
-                    metrics().failedReconciliationsCounter(reconciliation.namespace()).increment();
-                    reconciliationTimerSample.stop(metrics().reconciliationsTimer(reconciliation.namespace()));
-                    LOGGER.warnCr(reconciliation, "Failed to reconcile", cause);
-                    handlingResult.handle(stateUpdateResult);
-                });
+                metrics().failedReconciliationsCounter(reconciliation.namespace()).increment();
+                reconciliationTimerSample.stop(metrics().reconciliationsTimer(reconciliation.namespace()));
+                LOGGER.warnCr(reconciliation, "Failed to reconcile", cause);
             }
         }
 
-        return handlingResult.future();
-    }
-
-    /**
-     * Updates the resource state metric for the provided reconciliation which brings kind, name and namespace
-     * of the custom resource.
-     *
-     * @param reconciliation reconciliation to use to update the resource state metric
-     * @param ready if reconcile was successful and the resource is ready
-     */
-    private Future<Void> updateResourceState(Reconciliation reconciliation, boolean ready, Throwable cause) {
-        String key = reconciliation.namespace() + ":" + reconciliation.kind() + "/" + reconciliation.name();
-
-        String errorReason = "none";
-        if (cause != null) {
-            if (cause.getMessage() != null) {
-                errorReason = cause.getMessage();
-            } else {
-                errorReason = "unknown error";
-            }
-        }
-
-        Tags metricTags = Tags.of(
-                Tag.of("kind", reconciliation.kind()),
-                Tag.of("name", reconciliation.name()),
-                Tag.of("resource-namespace", reconciliation.namespace()),
-                Tag.of("reason", errorReason));
-
-        boolean removed = metrics().removeMetric(MetricsHolder.METRICS_RESOURCE_STATE,
-                Tags.of(Tag.of("kind", reconciliation.kind()),
-                        Tag.of("name", reconciliation.name()),
-                        Tag.of("resource-namespace", reconciliation.namespace())));
-
-        if (removed) {
-            resourcesStateCounter.remove(key);
-            LOGGER.debugCr(reconciliation, "Removed metric " + MetricsHolder.METRICS_PREFIX + "resource.state{}", key);
-        }
-
-        return VertxUtil.toFuture(resourceOperator.getAsync(reconciliation.namespace(), reconciliation.name())).map(cr -> {
-            if (cr != null && ReconcilerUtils.matchesSelector(selector(), cr)) {
-                resourcesStateCounter.computeIfAbsent(key, tags ->
-                        metrics().metricsProvider().gauge(MetricsHolder.METRICS_RESOURCE_STATE, "Current state of the resource: 1 ready, 0 fail", metricTags)
-                );
-                resourcesStateCounter.get(key).set(ready ? 1 : 0);
-                LOGGER.debugCr(reconciliation, "Updated metric " + MetricsHolder.METRICS_PREFIX + "resource.state{} = {}", metricTags, ready ? 1 : 0);
-            }
-
-            return null;
-        });
+        return Future.succeededFuture();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.strimzi.api.kafka.model.common.Spec;
 import io.strimzi.api.kafka.model.kafka.Status;
 import io.strimzi.operator.common.MetricsProvider;
@@ -50,7 +49,6 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(VertxExtension.class)
 @Group("strimzi")
@@ -110,12 +108,6 @@ public class OperatorMetricsTest {
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
-                    assertThat(registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                            .tag("kind", "TestResource")
-                            .tag("name", "my-resource")
-                            .tag("resource-namespace", "my-namespace")
-                            .gauge().value(), is(1.0));
-
                     async.flag();
                 })));
     }
@@ -171,13 +163,6 @@ public class OperatorMetricsTest {
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
-
-                    assertThat(registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                            .tag("kind", "TestResource")
-                            .tag("name", "my-resource")
-                            .tag("resource-namespace", "my-namespace")
-                            .tag("reason", "Test error")
-                            .gauge().value(), is(0.0));
 
                     async.flag();
                 })));
@@ -237,12 +222,6 @@ public class OperatorMetricsTest {
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
-
-                    assertThat(registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                            .tag("kind", "TestResource")
-                            .tag("name", "my-resource")
-                            .tag("resource-namespace", "my-namespace")
-                            .gauge().value(), is(1.0));
 
                     async.flag();
                 })));
@@ -343,12 +322,6 @@ public class OperatorMetricsTest {
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(MetricsHolder.METRICS_RECONCILIATIONS_DURATION).tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
-                    assertThrows(MeterNotFoundException.class, () -> registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                            .tag("kind", "TestResource")
-                            .tag("name", "my-resource")
-                            .tag("resource-namespace", "my-namespace")
-                            .gauge());
-
                     async.flag();
                 })));
     }
@@ -387,14 +360,6 @@ public class OperatorMetricsTest {
 
             assertThat(registry.get(MetricsHolder.METRICS_RESOURCES).meter().getId().getTags().get(2), is(selectorTag));
             assertThat(registry.get(MetricsHolder.METRICS_RESOURCES).tag("kind", "TestResource").tag("namespace", "my-namespace").gauge().value(), is(3.0));
-
-            for (NamespaceAndName resource : resources) {
-                assertThat(registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                        .tag("kind", "TestResource")
-                        .tag("name", resource.getName())
-                        .tag("resource-namespace", resource.getNamespace())
-                        .gauge().value(), is(1.0));
-            }
 
             async.flag();
         })));
@@ -439,14 +404,6 @@ public class OperatorMetricsTest {
 
                     assertThat(registry.get(MetricsHolder.METRICS_RESOURCES).tag("kind", "TestResource").tag("namespace", "my-namespace").gauge().value(), is(2.0));
                     assertThat(registry.get(MetricsHolder.METRICS_RESOURCES).tag("kind", "TestResource").tag("namespace", "my-namespace2").gauge().value(), is(1.0));
-
-                    for (NamespaceAndName resource : resources) {
-                        assertThat(registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                                .tag("kind", "TestResource")
-                                .tag("name", resource.getName())
-                                .tag("resource-namespace", resource.getNamespace())
-                                .gauge().value(), is(1.0));
-                    }
                 })))
                 .compose(ignore -> {
                     // Reconcile again with resource in my-namespace2 deleted
@@ -472,14 +429,6 @@ public class OperatorMetricsTest {
 
                     assertThat(registry.get(MetricsHolder.METRICS_RESOURCES).tag("kind", "TestResource").tag("namespace", "my-namespace").gauge().value(), is(2.0));
                     assertThat(registry.get(MetricsHolder.METRICS_RESOURCES).tag("kind", "TestResource").tag("namespace", "my-namespace2").gauge().value(), is(0.0));
-
-                    for (NamespaceAndName resource : updatedResources) {
-                        assertThat(registry.get(MetricsHolder.METRICS_RESOURCE_STATE)
-                                .tag("kind", "TestResource")
-                                .tag("name", resource.getName())
-                                .tag("resource-namespace", resource.getNamespace())
-                                .gauge().value(), is(1.0));
-                    }
 
                     async.flag();
                 })));

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
@@ -59,10 +59,6 @@ public abstract class MetricsHolder {
      */
     public static final String METRICS_RESOURCES = METRICS_PREFIX + "resources";
     /**
-     * Metric name for the resource state.
-     */
-    public static final String METRICS_RESOURCE_STATE = METRICS_PREFIX + "resource.state";
-    /**
      * Metric name for number of paused resources.
      */
     public static final String METRICS_RESOURCES_PAUSED = METRICS_RESOURCES + ".paused";

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -83,21 +83,6 @@ public class MetricsUtils {
         assertMetricValueNotNull(collector, metrics);
     }
 
-    public static void assertCoMetricResourceStateNotExists(String namespaceName, String kind, String name, BaseMetricsCollector collector) {
-        String metric = "strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",resource_namespace=\"" + namespaceName + "\"}";
-        List<Double> values = createPatternAndCollectWithoutWait(collector, metric);
-        assertThat(values.isEmpty(), is(true));
-    }
-
-    public static void assertCoMetricResourceState(String namespaceName, String kind, String name, BaseMetricsCollector collector, double value, String reason) {
-        assertMetricResourceState(namespaceName, kind, name, collector, value, reason);
-    }
-
-    public static void assertMetricResourceState(String namespaceName, String kind, String name, BaseMetricsCollector collector, double value, String reason) {
-        String metric = "strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",reason=\"" + reason + ".*\",resource_namespace=\"" + namespaceName + "\"}";
-        assertMetricValue(collector, metric, value);
-    }
-
     public static void assertCoMetricResources(String namespaceName, String kind, BaseMetricsCollector collector, double value) {
         assertMetricResources(namespaceName, kind, collector, value);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -90,8 +90,6 @@ import static io.strimzi.systemtest.TestTags.MIRROR_MAKER2;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static io.strimzi.systemtest.TestTags.SANITY;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertCoMetricResourceNotNull;
-import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertCoMetricResourceState;
-import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertCoMetricResourceStateNotExists;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertCoMetricResources;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertCoMetricResourcesNullOrZero;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricCountHigherThan;
@@ -220,7 +218,6 @@ public class MetricsST extends AbstractST {
         clusterOperatorCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
         assertCoMetricResources(namespaceFirst, KafkaConnect.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaConnect.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceState(namespaceFirst, KafkaConnect.RESOURCE_KIND, kafkaClusterFirstName, clusterOperatorCollector, 1.0, "none");
 
         assertCoMetricResources(namespaceFirst, KafkaConnector.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaConnector.RESOURCE_KIND, clusterOperatorCollector);
@@ -349,12 +346,9 @@ public class MetricsST extends AbstractST {
 
         assertCoMetricResources(namespaceFirst, Kafka.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResources(namespaceSecond, Kafka.RESOURCE_KIND, clusterOperatorCollector, 1.0);
-        assertCoMetricResourceState(namespaceFirst, Kafka.RESOURCE_KIND, kafkaClusterFirstName, clusterOperatorCollector, 1.0, "none");
-        assertCoMetricResourceState(namespaceSecond, Kafka.RESOURCE_KIND, kafkaClusterSecondName, clusterOperatorCollector, 1.0, "none");
 
         assertCoMetricResourcesNullOrZero(namespaceFirst, KafkaRebalance.RESOURCE_KIND, clusterOperatorCollector);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaRebalance.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceStateNotExists(kafkaClusterFirstName, KafkaRebalance.RESOURCE_KIND, namespaceFirst, clusterOperatorCollector);
 
         // check StrimziPodSet metrics in CO
         assertMetricCountHigherThan(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 0.0);
@@ -430,7 +424,6 @@ public class MetricsST extends AbstractST {
         clusterOperatorCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
         assertCoMetricResources(namespaceFirst, KafkaMirrorMaker2.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaMirrorMaker2.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceState(namespaceFirst, KafkaMirrorMaker2.RESOURCE_KIND, mm2ClusterName, clusterOperatorCollector, 1.0, "none");
         assertMetricValueHigherThanOrEqualTo(clusterOperatorCollector, getResourceMetricPattern(namespaceFirst, StrimziPodSet.RESOURCE_KIND), 1.0);
     }
 
@@ -503,7 +496,6 @@ public class MetricsST extends AbstractST {
         clusterOperatorCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
         assertCoMetricResources(namespaceFirst, KafkaBridge.RESOURCE_KIND, clusterOperatorCollector, 1.0);
         assertCoMetricResourcesNullOrZero(namespaceSecond, KafkaBridge.RESOURCE_KIND, clusterOperatorCollector);
-        assertCoMetricResourceState(namespaceFirst, KafkaBridge.RESOURCE_KIND, bridgeClusterName, clusterOperatorCollector, 1.0, "none");
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the deprecated resource state metrics, together with all related tests.

Closes #11696 

### Checklist

- [X] Update CHANGELOG.md (if present)
- [X] Reference relevant issue(s) and close them after merging
- [x] Make sure all tests pass
- [X] Try your changes inside a Kubernetes cluster, not just from unit tests