### PR TITLE
Added dynamic heap percentage and max configuration to the KafkaBridge

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -455,7 +455,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
-        JvmOptionUtils.heapOptions(varList, 50, 0L, jvmOptions, resources);
+        JvmOptionUtils.heapOptions(varList, 75, 0L, jvmOptions, resources);
         JvmOptionUtils.jvmPerformanceOptions(varList, jvmOptions);
         JvmOptionUtils.jvmSystemProperties(varList, jvmOptions);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -454,7 +454,10 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
-        JvmOptionUtils.javaOptions(varList, jvmOptions);
+
+        JvmOptionUtils.heapOptions(varList, 50, 0L, jvmOptions, resources);
+        JvmOptionUtils.jvmPerformanceOptions(varList, jvmOptions);
+        JvmOptionUtils.jvmSystemProperties(varList, jvmOptions);
 
         // Add shared environment variables used for all containers
         varList.addAll(sharedEnvironmentProvider.variables());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -137,6 +137,7 @@ public class KafkaBridgeClusterTest {
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(String.valueOf(JvmOptions.DEFAULT_GC_LOGGING_ENABLED)).build());
+        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS).withValue("-Xms" + JvmOptionUtils.DEFAULT_JVM_XMS).build());
         return expected;
     }
 
@@ -1212,11 +1213,14 @@ public class KafkaBridgeClusterTest {
         assertThat(systemProps.getValue(), containsString("-DmyProperty1=myValue1"));
         assertThat(systemProps.getValue(), containsString("-DmyProperty2=myValue2"));
 
-        EnvVar javaOpts = kb.getEnvVars().stream().filter(envVar -> AbstractModel.ENV_VAR_STRIMZI_JAVA_OPTS.equals(envVar.getName())).findFirst().orElse(null);
-        assertThat(javaOpts, is(notNullValue()));
-        assertThat(javaOpts.getValue(), containsString("-Xms128m"));
-        assertThat(javaOpts.getValue(), containsString("-Xmx256m"));
-        assertThat(javaOpts.getValue(), containsString("-XX:InitiatingHeapOccupancyPercent=36"));
+        EnvVar heapOpts = kb.getEnvVars().stream().filter(envVar -> AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS.equals(envVar.getName())).findFirst().orElse(null);
+        assertThat(heapOpts, is(notNullValue()));
+        assertThat(heapOpts.getValue(), containsString("-Xms128m"));
+        assertThat(heapOpts.getValue(), containsString("-Xmx256m"));
+
+        EnvVar perfOptions = kb.getEnvVars().stream().filter(envVar -> AbstractModel.ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS.equals(envVar.getName())).findFirst().orElse(null);
+        assertThat(perfOptions, is(notNullValue()));
+        assertThat(perfOptions.getValue(), containsString("-XX:InitiatingHeapOccupancyPercent=36"));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR fixes #13024 passing `STRIMZI_DYNAMIC_HEAP_PERCENTAGE` and `STRIMZI_DYNAMIC_HEAP_MAX` env vars to the underlying HTTP bridge dynamic heap script to configure dynamic heap percentage and max.
The corresponding part on the HTTP bridge is done via https://github.com/strimzi/strimzi-kafka-bridge/pull/1150 in the bridge repository.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests