### PR TITLE
Allow a configurable ISR safety margin when rolling Kafka nodes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -189,6 +189,12 @@ public class ClusterOperatorConfig {
     public static final ConfigParameter<Integer> OPERATIONS_THREAD_POOL_SIZE = new ConfigParameter<>("STRIMZI_OPERATIONS_THREAD_POOL_SIZE", INTEGER, "10", CONFIG_VALUES);
 
     /**
+     * Number of in-sync replicas that must remain above min.insync.replicas after rolling a broker.
+     * 0 (default) keeps the historical behaviour of allowing a roll down to exactly min.insync.replicas.
+     */
+    public static final ConfigParameter<Integer> ROLL_ISR_SAFETY_MARGIN = new ConfigParameter<>("STRIMZI_ROLL_ISR_SAFETY_MARGIN", INTEGER, "0", CONFIG_VALUES);
+
+    /**
      * Number of seconds to cache a successful DNS name lookup
      */
     /* test */ static final ConfigParameter<Integer> DNS_CACHE_TTL = new ConfigParameter<>("STRIMZI_DNS_CACHE_TTL", INTEGER, "30", CONFIG_VALUES);
@@ -551,6 +557,15 @@ public class ClusterOperatorConfig {
      */
     public int getOperationsThreadPoolSize() {
         return get(OPERATIONS_THREAD_POOL_SIZE);
+    }
+
+    /**
+     * Returns the configured ISR safety margin used when deciding whether a Kafka node can be rolled.
+     *
+     * @return  The number of in-sync replicas that must remain above min.insync.replicas after a broker is rolled
+     */
+    public int getRollIsrSafetyMargin() {
+        return get(ROLL_ISR_SAFETY_MARGIN);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -64,6 +64,7 @@ public class CaReconciler {
 
     /* test */ final Reconciliation reconciliation;
     private final long operationTimeoutMs;
+    private final int isrSafetyMargin;
 
     /* test */ final DeploymentOperator deploymentOperator;
     private final StrimziPodSetOperator strimziPodSetOperator;
@@ -110,6 +111,7 @@ public class CaReconciler {
     ) {
         this.reconciliation = reconciliation;
         this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.isrSafetyMargin = config.getRollIsrSafetyMargin();
 
         this.deploymentOperator = supplier.deploymentOperations;
         this.strimziPodSetOperator = supplier.strimziPodSetOperator;
@@ -437,7 +439,8 @@ public class CaReconciler {
                 brokerId -> null,
                 null,
                 false,
-                eventPublisher);
+                eventPublisher,
+                isrSafetyMargin);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -116,6 +116,7 @@ public class KafkaReconciler {
 
     // Various settings
     private final long operationTimeoutMs;
+    private final int isrSafetyMargin;
     private final boolean isNetworkPolicyGeneration;
     private final boolean isPodDisruptionBudgetGeneration;
     private final List<String> maintenanceWindows;
@@ -200,6 +201,7 @@ public class KafkaReconciler {
         this.reconciliation = reconciliation;
         this.vertx = vertx;
         this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.isrSafetyMargin = config.getRollIsrSafetyMargin();
         this.kafkaNodePoolCrs = nodePools;
         this.kafka = kafka;
 
@@ -485,7 +487,8 @@ public class KafkaReconciler {
                     brokerId -> kafka.generatePerBrokerConfiguration(brokerId, kafkaAdvertisedHostnames, kafkaAdvertisedPorts, scalingDownBlockedNodes.contains(brokerId)),
                     kafka.getKafkaVersion(),
                     allowReconfiguration,
-                    eventsPublisher
+                    eventsPublisher,
+                    isrSafetyMargin
             ).rollingRestart(podNeedsRestart));
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -42,9 +42,21 @@ class KafkaAvailability {
 
     private final CompletionStage<Collection<TopicDescription>> descriptions;
 
+    /**
+     * Number of in-sync replicas that must remain <em>above</em> {@code min.insync.replicas} after a
+     * broker is rolled. {@code 0} means a roll may take a partition down to exactly
+     * {@code min.insync.replicas}, which is the historical behaviour.
+     */
+    private final int isrSafetyMargin;
+
     KafkaAvailability(Reconciliation reconciliation, Admin ac) {
+        this(reconciliation, ac, 0);
+    }
+
+    KafkaAvailability(Reconciliation reconciliation, Admin ac, int isrSafetyMargin) {
         this.ac = ac;
         this.reconciliation = reconciliation;
+        this.isrSafetyMargin = isrSafetyMargin;
         // 1. Get all topic names
         CompletionStage<Set<String>> topicNames = topicNames();
         // 2. Get topic descriptions
@@ -111,13 +123,28 @@ class KafkaAvailability {
         for (TopicPartitionInfo pi : td.partitions()) {
             List<Node> isr = pi.isr();
             if (minIsr >= 0) {
-                if (pi.replicas().size() <= minIsr) {
+                // The ISR size this partition must retain after the restart. With a safety margin
+                // configured we require the ISR to stay above min.insync.replicas rather than merely
+                // at it, so that a further unrelated failure during the restart window does not
+                // immediately stall acks=all producers.
+                //
+                // A partition that does not have enough replicas to satisfy the margin falls back to
+                // the plain min.insync.replicas behaviour; otherwise such partitions could never be
+                // rolled at all.
+                int effectiveMinIsr = minIsr;
+                if (isrSafetyMargin > 0 && pi.replicas().size() > minIsr + isrSafetyMargin) {
+                    effectiveMinIsr = minIsr + isrSafetyMargin;
+                    LOGGER.traceCr(reconciliation, "{}/{} requires ISR >= {} after restart ({}={} plus safety margin {}).",
+                            td.name(), pi.partition(), effectiveMinIsr, TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minIsr, isrSafetyMargin);
+                }
+
+                if (pi.replicas().size() <= effectiveMinIsr) {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debugCr(reconciliation, "{}/{} will be under-replicated (ISR={{}}, replicas=[{}], {}={}) if broker {} is restarted, but there are only {} replicas.",
                                 td.name(), pi.partition(), nodeList(isr), nodeList(pi.replicas()), TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minIsr, broker,
                                 pi.replicas().size());
                     }
-                } else if (isr.size() < minIsr
+                } else if (isr.size() < effectiveMinIsr
                         && contains(pi.replicas(), broker)) {
                     if (LOGGER.isInfoEnabled()) {
                         String msg;
@@ -132,9 +159,9 @@ class KafkaAvailability {
                                 td.name(), pi.partition(), nodeList(isr), nodeList(pi.replicas()), TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minIsr, broker);
                     }
                     return true;
-                } else if (isr.size() == minIsr
+                } else if (isr.size() == effectiveMinIsr
                         && contains(isr, broker)) {
-                    if (minIsr < pi.replicas().size()) {
+                    if (effectiveMinIsr < pi.replicas().size()) {
                         if (LOGGER.isInfoEnabled()) {
                             LOGGER.infoCr(reconciliation, "{}/{} will be under-replicated (ISR={{}}, replicas=[{}], {}={}) if broker {} is restarted.",
                                     td.name(), pi.partition(), nodeList(isr), nodeList(pi.replicas()), TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minIsr, broker);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -120,6 +120,7 @@ public class KafkaRoller {
     private final KafkaVersion kafkaVersion;
     private final Reconciliation reconciliation;
     private final boolean allowReconfiguration;
+    private final int isrSafetyMargin;
     /**
      * Admin client used to send requests that are only relevant for the brokers. It is bootstrapped with broker nodes that might be rolled.
      */
@@ -147,11 +148,13 @@ public class KafkaRoller {
      * @param kafkaVersion              Kafka version
      * @param allowReconfiguration      Flag indicting whether reconfiguration is allowed or not
      * @param eventsPublisher           Kubernetes Events publisher for publishing events about pod restarts
+     * @param isrSafetyMargin           Number of in-sync replicas that must remain above min.insync.replicas after a node is rolled
      */
     public KafkaRoller(Reconciliation reconciliation, PodOperator podOperations,
                        long pollingIntervalMs, long operationTimeoutMs, Supplier<BackOff> backOffSupplier, Set<NodeRef> nodes,
                        Identity coIdentity, AdminClientProvider adminClientProvider, KafkaAgentClientProvider kafkaAgentClientProvider,
-                       Function<Integer, String> kafkaConfigProvider, KafkaVersion kafkaVersion, boolean allowReconfiguration, KubernetesRestartEventPublisher eventsPublisher) {
+                       Function<Integer, String> kafkaConfigProvider, KafkaVersion kafkaVersion, boolean allowReconfiguration, KubernetesRestartEventPublisher eventsPublisher,
+                       int isrSafetyMargin) {
         this.namespace = reconciliation.namespace();
         this.cluster = reconciliation.name();
         this.nodes = nodes;
@@ -170,6 +173,7 @@ public class KafkaRoller {
         this.kafkaVersion = kafkaVersion;
         this.reconciliation = reconciliation;
         this.allowReconfiguration = allowReconfiguration;
+        this.isrSafetyMargin = isrSafetyMargin;
     }
 
     private final ScheduledExecutorService singleExecutor = Executors.newSingleThreadScheduledExecutor(
@@ -897,7 +901,7 @@ public class KafkaRoller {
 
 
     /* test */ KafkaAvailability availability(Admin ac) {
-        return new KafkaAvailability(reconciliation, ac);
+        return new KafkaAvailability(reconciliation, ac, isrSafetyMargin);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -587,4 +587,103 @@ public class KafkaAvailabilityTest {
             }
         }
     }
+
+    @Test
+    public void testSafetyMarginBlocksRollThatWouldLandOnMinIsr() {
+        // RF=4, min.insync.replicas=2, ISR=3 (broker 3 is not in sync).
+        // Without a margin this is rollable: ISR would become 2, which is exactly min.insync.replicas.
+        // With a margin of 1 the ISR must stay at 3, so brokers in the ISR must not be rolled.
+        KSB ksb = new KSB()
+                .addNewTopic("A", false)
+                    .addToConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+                    .addNewPartition(0)
+                        .replicaOn(0, 1, 2, 3)
+                        .leader(0)
+                        .isr(0, 1, 2)
+                    .endPartition()
+                .endTopic();
+
+        KafkaAvailability noMargin = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac(), 0);
+        KafkaAvailability withMargin = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac(), 1);
+
+        for (int brokerId = 0; brokerId <= 2; brokerId++) {
+            int id = brokerId;
+            noMargin.canRoll(id).whenComplete((canRoll, err) ->
+                    assertTrue(canRoll, "broker " + id + " should be rollable with no safety margin")
+            ).toCompletableFuture().join();
+
+            withMargin.canRoll(id).whenComplete((canRoll, err) ->
+                    assertFalse(canRoll, "broker " + id + " should not be rollable with a safety margin of 1")
+            ).toCompletableFuture().join();
+        }
+    }
+
+    @Test
+    public void testSafetyMarginIgnoredWhenMarginUnsatisfiable() {
+        // RF=3, min.insync.replicas=2, margin 1. Satisfying the margin would need at least 4 replicas,
+        // so it must fall back to the plain min.insync.replicas behaviour instead of blocking forever.
+        KSB ksb = new KSB()
+                .addNewTopic("A", false)
+                    .addToConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+                    .addNewPartition(0)
+                        .replicaOn(0, 1, 2)
+                        .leader(0)
+                        .isr(0, 1, 2)
+                    .endPartition()
+                .endTopic();
+
+        KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac(), 1);
+
+        for (Integer brokerId : ksb.brokers.keySet()) {
+            kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) ->
+                    assertTrue(canRoll, "broker " + brokerId + " should be rollable; a margin of 1 needs RF >= 4")
+            ).toCompletableFuture().join();
+        }
+    }
+
+    @Test
+    public void testSafetyMarginSatisfiedWhenEnoughReplicas() {
+        // RF=4, min.insync.replicas=2, ISR=4. Rolling leaves ISR=3, one above the floor, so a
+        // margin of 1 is satisfied and the roll is allowed.
+        KSB ksb = new KSB()
+                .addNewTopic("A", false)
+                    .addToConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+                    .addNewPartition(0)
+                        .replicaOn(0, 1, 2, 3)
+                        .leader(0)
+                        .isr(0, 1, 2, 3)
+                    .endPartition()
+                .endTopic();
+
+        KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac(), 1);
+
+        for (Integer brokerId : ksb.brokers.keySet()) {
+            kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) ->
+                    assertTrue(canRoll, "broker " + brokerId + " should be rollable, ISR would still be above min.insync.replicas")
+            ).toCompletableFuture().join();
+        }
+    }
+
+    @Test
+    public void testSafetyMarginIgnoredWhenNotEnoughReplicas() {
+        // RF=2, min.insync.replicas=1. A margin of 1 cannot be satisfied by any roll, so it must fall
+        // back to the plain min.insync.replicas behaviour rather than blocking the broker forever.
+        KSB ksb = new KSB()
+                .addNewTopic("A", false)
+                    .addToConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "1")
+                    .addNewPartition(0)
+                        .replicaOn(0, 1)
+                        .leader(0)
+                        .isr(0, 1)
+                    .endPartition()
+                .endTopic();
+
+        KafkaAvailability kafkaAvailability = new KafkaAvailability(new Reconciliation("dummy", "kind", "namespace", "A"), ksb.ac(), 1);
+
+        for (Integer brokerId : ksb.brokers.keySet()) {
+            kafkaAvailability.canRoll(brokerId).whenComplete((canRoll, err) ->
+                    assertTrue(canRoll, "broker " + brokerId + " should be rollable; the margin is unsatisfiable with only 2 replicas")
+            ).toCompletableFuture().join();
+        }
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -952,7 +952,8 @@ public class KafkaRollerTest {
                     brokerId -> "compression.type=gzip",
                     KafkaVersionTestUtils.getLatestVersion(),
                     true,
-                    mock(KubernetesRestartEventPublisher.class));
+                    mock(KubernetesRestartEventPublisher.class),
+                    0);
             this.delegateAdminClientCall = delegateAdminClientCall;
             this.activeController = activeController;
             this.controllerCall = 0;

--- a/documentation/modules/operators/con-configuring-cluster-operator.adoc
+++ b/documentation/modules/operators/con-configuring-cluster-operator.adoc
@@ -47,6 +47,12 @@ The timeout for internal operations, in milliseconds. Increase this value when u
 `STRIMZI_OPERATIONS_THREAD_POOL_SIZE`:: Optional, default 10.
 The worker thread pool size, which is used for various asynchronous and blocking operations that are run by the Cluster Operator.
 
+`STRIMZI_ROLL_ISR_SAFETY_MARGIN`:: Optional, default 0.
+The number of in-sync replicas that must remain _above_ `min.insync.replicas` after a Kafka node is rolled.
+With the default of `0`, a node is rolled if doing so leaves each of its partitions with at least `min.insync.replicas` in-sync replicas, which means a partition can sit exactly on the minimum for the duration of the restart.
+Setting this to `1` requires one spare in-sync replica beyond the minimum, so that an unrelated failure during the restart does not immediately stall producers using `acks=all`.
+Partitions without enough replicas to satisfy the margin fall back to the `min.insync.replicas` behavior, so topics with a low replication factor are not blocked from rolling.
+
 `STRIMZI_OPERATOR_NAME`:: Optional, defaults to the pod's hostname.
 The operator name identifies the Strimzi instance when xref:proc-operator-restart-events-str[emitting Kubernetes events].
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #13031.

Today a broker is rollable as long as the restart doesn't take a partition **below** `min.insync.replicas`. Landing **exactly on** it is allowed.

So with `RF=3` / `minISR=2`, every partition on the rolling node sits on the minimum for the whole restart. One more failure in that window — another broker, a disk, a NotReady node — and `acks=all` producers start failing.

This adds an opt-in margin so you can require the ISR to stay *above* `min.insync.replicas` instead of merely at it:

```
STRIMZI_ROLL_ISR_SAFETY_MARGIN   default 0
```

`0` keeps today's behaviour exactly. With `1` and `RF=4` / `minISR=2`:

| | ISR |
| -- | -- |
| before roll | 4 |
| during roll | 3 — one to spare |
| after a further failure | 2 — still writable |

**Partitions that can't satisfy the margin fall back to the current behaviour.** A margin of 1 needs `replicas > minISR + 1`; where that doesn't hold (e.g. `RF=3`/`minISR=2`) nothing changes. That's what makes the flag safe to enable cluster-wide with mixed replication factors.

Raising `min.insync.replicas` instead doesn't achieve this — it moves the floor rather than adding headroom, since producers then require the higher value too.

### Changes

| File | Change |
| -- | -- |
| `ClusterOperatorConfig` | new parameter + getter |
| `KafkaAvailability` | compare against an effective threshold; new ctor overload, old one delegates with `0` |
| `KafkaRoller` | pass the margin through |
| `KafkaReconciler`, `CaReconciler` | read it from config |
| `KafkaAvailabilityTest` | 3 tests: blocks, allows, falls back |
| docs | `con-configuring-cluster-operator.adoc` |

The branch structure in `wouldAffectAvailability()` is unchanged — only the value it compares against.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md — happy to add an entry if you'd like one
- [ ] Supply screenshots for visual changes (n/a)

### Testing

```
KafkaAvailabilityTest     15/15 pass
ClusterOperatorConfigTest 30/30 pass
```

Checkstyle clean.

`KafkaRollerTest` shows 5 failures / 2 errors here — but the **same 5 and 2 on unmodified `main`** at `ee17c65ce`, so they look pre-existing. Happy to look into it if that's unexpected.

### Note

Glad to write this up in `strimzi/proposals` first if you'd prefer that for a change in the rolling path.
