### PR TITLE
Fixes to Javadoc related to generalized Identity classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheck.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/BrokersInUseCheck.java
@@ -41,7 +41,7 @@ public class BrokersInUseCheck {
      * Checks if broker contains any partition replicas when scaling down
      *
      * @param reconciliation        Reconciliation marker
-     * @param coIdentity      Trust set and identity for TLS client authentication for connecting to the Kafka cluster
+     * @param coIdentity            Trust set and identity for authentication for connecting to the Kafka cluster
      * @param adminClientProvider   Used to create the Admin client instance
      *
      * @return returns CompletionStage with set of node ids containing partition replicas based on the outcome of the check

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
@@ -90,8 +90,8 @@ public class DefaultKafkaQuotasManager {
      *
      * @param reconciliation            Reconciliation marker
      * @param adminClientProvider       Kafka Admin client provider
-     * @param kafkaTrustSet             Trust set for TLS authentication
-     * @param authIdentity              Identity for TLS client authentication
+     * @param kafkaTrustSet             Trust set for connecting to Kafka
+     * @param authIdentity              Identity for authentication for connecting to Kafka
      * @param quotasPlugin              Configuration of Kafka quotas plugin
      *
      * @return  CompletionStage that completes when the default user quota configuration is completed

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -52,7 +52,7 @@ public class KRaftMetadataManager {
      * manually.
      *
      * @param reconciliation            Reconciliation marker
-     * @param coIdentity          Trust set and identity for TLS client authentication for connecting to the Kafka cluster
+     * @param coIdentity                Trust set and identity for authentication for connecting to the Kafka cluster
      * @param adminClientProvider       Kafka Admin client provider
      * @param desiredMetadataVersion    Desired metadata version
      * @param status                    Kafka status

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -124,7 +124,7 @@ public class ReconcilerUtils {
      * @param reconciliation Reconciliation Marker
      * @param secretOperator Secret operator for working with Kubernetes Secrets that store certificates
      *
-     * @return  Future containing the TlsPemIdentity to use for client authentication.
+     * @return  Future containing the PemTrustSet and PemAuthIdentity to use for client authentication.
      */
     public static Future<Identity> coTlsPemIdentity(Reconciliation reconciliation, SecretOperator secretOperator) {
         return Future.join(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -53,7 +53,7 @@ public class KafkaAgentClient {
      * @param reconciliation    Reconciliation marker
      * @param cluster   Cluster name
      * @param namespace Cluster namespace
-     * @param identity Trust set and identity for TLS client authentication for connecting to the Kafka cluster
+     * @param identity Trust set and identity for authentication for connecting to the Kafka cluster
      */
     public KafkaAgentClient(Reconciliation reconciliation, String cluster, String namespace, Identity identity) {
         this.reconciliation = reconciliation;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientProvider.java
@@ -16,7 +16,7 @@ public interface KafkaAgentClientProvider {
      * Creates an instance of KafkaAgentClient
      *
      * @param reconciliation    Reconciliation information
-     * @param identity    Trust set and identity for TLS client authentication for connecting to the Kafka cluster
+     * @param identity    Trust set and identity for authentication for connecting to the Kafka cluster
      *
      * @return  KafkaAgentClient instance
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -140,7 +140,7 @@ public class KafkaRoller {
      * @param operationTimeoutMs        Operation timeout in milliseconds
      * @param backOffSupplier           Backoff supplier
      * @param nodes                     List of Kafka node references to consider rolling
-     * @param coIdentity          Trust set and identity for TLS client authentication for connecting to the Kafka cluster
+     * @param coIdentity                Trust set and identity for authentication for connecting to the Kafka cluster
      * @param adminClientProvider       Kafka Admin client provider
      * @param kafkaAgentClientProvider  Kafka Agent client provider
      * @param kafkaConfigProvider       Kafka configuration provider

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -69,8 +69,8 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
     /**
      * Utility method for preparing the Admin client configuration
      *
-     * @param kafkaTrustSet       Trust set for connecting to Kafka
-     * @param authIdentity          Identity for TLS client authentication for connecting to Kafka
+     * @param kafkaTrustSet         Trust set for connecting to Kafka
+     * @param authIdentity          Identity for authentication for connecting to Kafka
      * @param config                Custom Admin client configuration or empty properties instance
      *
      * @return  Admin client configuration

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/Identity.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/Identity.java
@@ -8,7 +8,7 @@ package io.strimzi.operator.common.auth;
  * Represents the operator's identity configuration, including trust material and authentication credentials,
  * used when connecting to operands.
  *
- * @param trustSet      Trust set for esablishing the trust with the operand
+ * @param trustSet      Trust set for establishing the trust with the operand
  * @param authIdentity  Authentication identify for authenticating the operator
  */
 public record Identity(TrustSet trustSet, AuthIdentity authIdentity) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/auth/TrustSet.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/auth/TrustSet.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.common.auth;
 
 /**
- * Interface representing the different ways how a trust can be extablished for an operand. This is used when connecting
+ * Interface representing the different ways that trust can be established for an operand. This is used when connecting
  * from the operators to the operands.
  */
 public interface TrustSet { }


### PR DESCRIPTION
### Type of change

_Select the type of your PR and delete the other items_

- Documentation

### Description

I didn't see the PR for adding the generic Identity classes until after it was merged and on review there seemed to be some typos in the Javadoc, but also areas where it still references TLS specifically rather than being general. This PR addresses those

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
