### PR TITLE
[ST] Make Connect Build tests configurable using file

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -210,7 +210,7 @@ public class KafkaConnectTemplates {
 
             return kafkaConnectBuilder
                 .editOrNewSpec()
-                    .editBuild()
+                    .editOrNewBuild()
                         .withPlugins(fileSinkPlugin)
                     .endBuild()
                 .endSpec();
@@ -221,7 +221,9 @@ public class KafkaConnectTemplates {
 
             LOGGER.info("Using {} image from {} env variable", Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN, Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV);
 
-            kafkaConnectBuilder.getSpec().setBuild(null);
+            if (kafkaConnectBuilder.getSpec() != null) {
+                kafkaConnectBuilder.getSpec().setBuild(null);
+            }
 
             return kafkaConnectBuilder
                 .editOrNewSpec()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -7,7 +7,9 @@ package io.strimzi.systemtest.templates.crd;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.skodjob.kubetest4j.utils.KubeTestUtils;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
 import io.strimzi.api.kafka.model.connect.build.DockerOutput;
@@ -19,10 +21,13 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.utils.FileUtils;
+import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Random;
 
 public class KafkaConnectTemplates {
@@ -31,6 +36,7 @@ public class KafkaConnectTemplates {
 
     private static final String METRICS_CONNECT_CONFIG_MAP_SUFFIX = "-connect-metrics";
     private static final String CONFIG_MAP_KEY = "metrics-config.yml";
+    private static final String PATH_TO_CONNECT_BUILD_YAML = TestUtils.USER_PATH + "/../systemtest/src/test/resources/connect-build/connect-build-template.yaml";
 
     private KafkaConnectTemplates() {}
 
@@ -80,14 +86,65 @@ public class KafkaConnectTemplates {
         return kafkaConnectClusterName + METRICS_CONNECT_CONFIG_MAP_SUFFIX;
     }
 
+    public static KafkaConnectBuilder kafkaConnectBuild(
+        final String namespaceName,
+        String kafkaConnectClusterName,
+        String kafkaClusterName,
+        int kafkaConnectReplicas
+    ) {
+        final String imageName = Environment.getImageOutputRegistry(namespaceName, TestConstants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
+        return kafkaConnectBuild(namespaceName, kafkaConnectClusterName, kafkaClusterName, kafkaConnectReplicas, imageName);
+    }
+
+    public static KafkaConnectBuilder kafkaConnectBuild(
+        final String namespaceName,
+        String kafkaConnectClusterName,
+        String kafkaClusterName,
+        int kafkaConnectReplicas,
+        String imageName
+    ) {
+        try {
+            String connectFromResourcesYaml = Files.readString(Paths.get(PATH_TO_CONNECT_BUILD_YAML));
+            KafkaConnect connectFromResources = KubeTestUtils.configFromYaml(connectFromResourcesYaml, KafkaConnect.class);
+            DockerOutputBuilder dockerOutputBuilder = new DockerOutputBuilder();
+
+            if (connectFromResources.getSpec() != null
+                && connectFromResources.getSpec().getBuild() != null
+                && connectFromResources.getSpec().getBuild().getOutput() instanceof DockerOutput dockerOutput
+            ) {
+                dockerOutputBuilder = new DockerOutputBuilder(dockerOutput);
+            }
+
+            return configureKafkaConnectBuilderWithDefaults(namespaceName, kafkaConnectClusterName, kafkaClusterName, kafkaConnectReplicas, new KafkaConnectBuilder(connectFromResources))
+                .editSpec()
+                    .editOrNewBuild()
+                        .withOutput(dockerOutput(imageName, dockerOutputBuilder))
+                    .endBuild()
+                .endSpec();
+        } catch (Exception e) {
+            LOGGER.error("Failed to read Connect Build template from: {}, due to: {}", PATH_TO_CONNECT_BUILD_YAML, e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
     private static KafkaConnectBuilder defaultKafkaConnect(
         final String namespaceName,
         String kafkaConnectClusterName,
         String kafkaClusterName,
         int kafkaConnectReplicas
     ) {
-        return new KafkaConnectBuilder()
-            .withNewMetadata()
+        return configureKafkaConnectBuilderWithDefaults(namespaceName, kafkaConnectClusterName, kafkaClusterName, kafkaConnectReplicas, new KafkaConnectBuilder());
+    }
+
+    private static KafkaConnectBuilder configureKafkaConnectBuilderWithDefaults(
+        final String namespaceName,
+        String kafkaConnectClusterName,
+        String kafkaClusterName,
+        int kafkaConnectReplicas,
+        KafkaConnectBuilder connectBuilder
+    ) {
+        return connectBuilder
+            .editOrNewMetadata()
                 .withName(kafkaConnectClusterName)
                 .withNamespace(namespaceName)
             .endMetadata()
@@ -129,18 +186,17 @@ public class KafkaConnectTemplates {
      * @return KafkaConnect builder with File plugin
      */
     public static KafkaConnectBuilder kafkaConnectWithFilePlugin(String namespaceName, String kafkaConnectClusterName, String kafkaClusterName, int replicas) {
-        return addFileSinkPluginOrImage(namespaceName, kafkaConnect(namespaceName, kafkaConnectClusterName, kafkaClusterName, replicas));
+        return addFileSinkPluginOrImage(kafkaConnectBuild(namespaceName, kafkaConnectClusterName, kafkaClusterName, replicas));
     }
 
     /**
      * Method for adding Connect Build with file-sink plugin to the Connect spec or set Connect's image in case that
      * the image is set in `CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN` env. variable
-     * @param namespaceName namespace for output registry
      * @param kafkaConnectBuilder builder of the Connect resource
      * @return updated Connect resource in builder
      */
     @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
-    public static KafkaConnectBuilder addFileSinkPluginOrImage(String namespaceName, KafkaConnectBuilder kafkaConnectBuilder) {
+    public static KafkaConnectBuilder addFileSinkPluginOrImage(KafkaConnectBuilder kafkaConnectBuilder) {
         if (!KubeClusterResource.getInstance().isMicroShift() && Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN.isEmpty()) {
             final Plugin fileSinkPlugin = new PluginBuilder()
                 .withName("file-plugin")
@@ -151,13 +207,11 @@ public class KafkaConnectTemplates {
                 )
                 .build();
 
-            final String imageFullPath = Environment.getImageOutputRegistry(namespaceName, TestConstants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
 
             return kafkaConnectBuilder
                 .editOrNewSpec()
-                    .editOrNewBuild()
+                    .editBuild()
                         .withPlugins(fileSinkPlugin)
-                        .withOutput(dockerOutput(imageFullPath))
                     .endBuild()
                 .endSpec();
         } else {
@@ -167,6 +221,8 @@ public class KafkaConnectTemplates {
 
             LOGGER.info("Using {} image from {} env variable", Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN, Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV);
 
+            kafkaConnectBuilder.getSpec().setBuild(null);
+
             return kafkaConnectBuilder
                 .editOrNewSpec()
                     .withImage(Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)
@@ -174,19 +230,24 @@ public class KafkaConnectTemplates {
         }
     }
 
-    public static DockerOutput dockerOutput(String imageName) {
-        DockerOutputBuilder dockerOutputBuilder = new DockerOutputBuilder().withImage(imageName);
+    public static DockerOutput dockerOutput(String imageName, DockerOutputBuilder dockerOutputBuilder) {
+        dockerOutputBuilder.withImage(imageName);
+
         if (Environment.CONNECT_BUILD_REGISTRY_SECRET != null && !Environment.CONNECT_BUILD_REGISTRY_SECRET.isEmpty()) {
             dockerOutputBuilder.withPushSecret(Environment.CONNECT_BUILD_REGISTRY_SECRET);
         }
 
         if (Environment.isConnectBuildWithBuildahEnabled() && !KubeClusterResource.getInstance().isOpenShiftLikeCluster()) {
-            // for Buildah on minikube or Kind, we need to add `--tls-verify=false` in order to push via HTTP
-            dockerOutputBuilder.withAdditionalBuildOptions("--tls-verify=false");
-            dockerOutputBuilder.withAdditionalPushOptions("--tls-verify=false");
+            if (dockerOutputBuilder.getAdditionalBuildOptions() == null || !dockerOutputBuilder.getAdditionalBuildOptions().contains("--tls-verify=false")) {
+                // for Buildah on minikube or Kind, we need to add `--tls-verify=false` in order to push via HTTP
+                dockerOutputBuilder.addToAdditionalBuildOptions("--tls-verify=false");
+            }
+            if (dockerOutputBuilder.getAdditionalPushOptions() == null || !dockerOutputBuilder.getAdditionalPushOptions().contains("--tls-verify=false")) {
+                dockerOutputBuilder.addToAdditionalPushOptions("--tls-verify=false");
+            }
         } else if (!Environment.isConnectBuildWithBuildahEnabled() && KubeClusterResource.getInstance().isKind()) {
             // if we use Kind we add insecure option
-            dockerOutputBuilder.withAdditionalBuildOptions(
+            dockerOutputBuilder.addToAdditionalBuildOptions(
                 // --insecure for PUSH via HTTP instead of HTTPS
                 "--insecure");
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -86,6 +86,7 @@ public class KafkaConnectTemplates {
         return kafkaConnectClusterName + METRICS_CONNECT_CONFIG_MAP_SUFFIX;
     }
 
+    @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
     public static KafkaConnectBuilder kafkaConnectBuild(
         final String namespaceName,
         String kafkaConnectClusterName,
@@ -195,7 +196,6 @@ public class KafkaConnectTemplates {
      * @param kafkaConnectBuilder builder of the Connect resource
      * @return updated Connect resource in builder
      */
-    @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
     public static KafkaConnectBuilder addFileSinkPluginOrImage(KafkaConnectBuilder kafkaConnectBuilder) {
         if (!KubeClusterResource.getInstance().isMicroShift() && Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN.isEmpty()) {
             final Plugin fileSinkPlugin = new PluginBuilder()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -221,12 +221,9 @@ public class KafkaConnectTemplates {
 
             LOGGER.info("Using {} image from {} env variable", Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN, Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV);
 
-            if (kafkaConnectBuilder.getSpec() != null) {
-                kafkaConnectBuilder.getSpec().setBuild(null);
-            }
-
             return kafkaConnectBuilder
                 .editOrNewSpec()
+                    .withBuild(null)
                     .withImage(Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)
                 .endSpec();
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -203,14 +203,13 @@ class ConnectBuilderST extends AbstractST {
 
         KubeResourceManager.get().createResourceWithWait(ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build());
 
-        KubeResourceManager.get().createResourceWithoutWait(KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1)
+        KubeResourceManager.get().createResourceWithoutWait(KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1, imageName)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
             .endMetadata()
             .editOrNewSpec()
-                .withNewBuild()
+                .editBuild()
                     .withPlugins(pluginWithWrongChecksum)
-                    .withOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
             .endSpec()
             .build());
@@ -281,7 +280,7 @@ class ConnectBuilderST extends AbstractST {
         final String imageName = getImageNameForTestCase();
 
         KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), suiteTestStorage.getClusterName()).build());
-        KubeResourceManager.get().createResourceWithWait(KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1)
+        KubeResourceManager.get().createResourceWithWait(KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1, imageName)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
             .endMetadata()
@@ -290,9 +289,8 @@ class ConnectBuilderST extends AbstractST {
                 .addToConfig("value.converter.schemas.enable", false)
                 .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                .withNewBuild()
+                .editBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR, PLUGIN_WITH_ZIP)
-                    .withOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
                 .withNewInlineLogging()
                     .addToLoggers("rootLogger.level", "INFO")
@@ -488,7 +486,7 @@ class ConnectBuilderST extends AbstractST {
 
         KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), suiteTestStorage.getClusterName()).build());
 
-        KafkaConnect connect = KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1)
+        KafkaConnect connect = KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1, imageName)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
             .endMetadata()
@@ -497,9 +495,8 @@ class ConnectBuilderST extends AbstractST {
                 .addToConfig("value.converter.schemas.enable", false)
                 .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                .withNewBuild()
+                .editBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR)
-                    .withOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
             .endSpec()
             .build();
@@ -583,7 +580,7 @@ class ConnectBuilderST extends AbstractST {
 
         KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getNamespaceName(), topicName, suiteTestStorage.getClusterName()).build());
 
-        KubeResourceManager.get().createResourceWithWait(KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1)
+        KubeResourceManager.get().createResourceWithWait(KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1, imageName)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
             .endMetadata()
@@ -592,9 +589,8 @@ class ConnectBuilderST extends AbstractST {
                 .addToConfig("value.converter.schemas.enable", false)
                 .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                    .withNewBuild()
+                    .editBuild()
                         .withPlugins(PLUGIN_WITH_OTHER_TYPE)
-                        .withOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
             .endSpec()
             .build());
@@ -657,7 +653,7 @@ class ConnectBuilderST extends AbstractST {
 
         KubeResourceManager.get().createResourceWithWait(
             KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), suiteTestStorage.getClusterName()).build(),
-            KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1)
+            KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), suiteTestStorage.getClusterName(), 1, imageName)
                 .editMetadata()
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
@@ -666,9 +662,8 @@ class ConnectBuilderST extends AbstractST {
                     .addToConfig("value.converter.schemas.enable", false)
                     .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                     .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                    .withNewBuild()
+                    .editBuild()
                         .withPlugins(PLUGIN_WITH_MAVEN_TYPE)
-                        .withOutput(KafkaConnectTemplates.dockerOutput(imageName))
                     .endBuild()
                 .endSpec()
                 .build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -94,7 +94,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.function.Consumer;
 
 import static io.strimzi.systemtest.TestTags.ACCEPTANCE;
@@ -771,8 +770,6 @@ class ConnectST extends AbstractST {
         );
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3).build());
 
-        final String imageFullPath = Environment.getImageOutputRegistry(testStorage.getNamespaceName(), TestConstants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
-
         KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3).build());
 
         final Plugin echoSinkPlugin = new PluginBuilder()
@@ -784,7 +781,7 @@ class ConnectST extends AbstractST {
                     .build())
             .build();
 
-        KafkaConnect connect = KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), 1)
+        KafkaConnect connect = KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getClusterName(), 1)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
             .endMetadata()
@@ -793,9 +790,8 @@ class ConnectST extends AbstractST {
                 .addToConfig("value.converter.schemas.enable", false)
                 .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                .withNewBuild()
+                .editBuild()
                     .withPlugins(echoSinkPlugin)
-                    .withOutput(KafkaConnectTemplates.dockerOutput(imageFullPath))
                 .endBuild()
             .endSpec()
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -86,7 +86,7 @@ public class FeatureGatesST extends AbstractST {
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3).build());
         KubeResourceManager.get().createResourceWithWait(
             KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName()).build(),
-            KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getClusterName(), 1)
+            KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getClusterName(), 1)
                 .editMetadata()
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
@@ -95,7 +95,7 @@ public class FeatureGatesST extends AbstractST {
                     .addToConfig("value.converter.schemas.enable", false)
                     .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                     .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                    .withNewBuild()
+                    .editBuild()
                         .addNewPlugin()
                             .withName("camel-connector")
                             .withArtifacts(
@@ -105,10 +105,6 @@ public class FeatureGatesST extends AbstractST {
                                     .build()
                             )
                         .endPlugin()
-                        .withNewDockerOutputLike(KafkaConnectTemplates.dockerOutput(imageName))
-                            .withAdditionalPushOptions("--tls-verify=false")
-                            .withAdditionalBuildOptions("--tls-verify=false")
-                        .endDockerOutput()
                     .endBuild()
                 .endSpec()
                 .build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
@@ -247,11 +247,11 @@ public class OpenTelemetryST extends AbstractST {
         configOfKafkaConnect.put("key.converter.schemas.enable", "false");
         configOfKafkaConnect.put("value.converter.schemas.enable", "false");
 
-        KafkaConnectBuilder connectBuilder = KafkaConnectTemplates.kafkaConnect(testStorage.getNamespaceName(), testStorage.getClusterName(), 1)
+        KafkaConnectBuilder connectBuilder = KafkaConnectTemplates.kafkaConnectBuild(testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getClusterName(), 1)
             .editMetadata()
                 .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
             .endMetadata()
-            .withNewSpec()
+            .editOrNewSpec()
                 .withGroupId(KafkaConnectResources.componentName(testStorage.getClusterName()))
                 .withConfigStorageTopic(KafkaConnectResources.configMapName(testStorage.getClusterName()))
                 .withOffsetStorageTopic(KafkaConnectResources.configStorageTopicOffsets(testStorage.getClusterName()))
@@ -261,7 +261,8 @@ public class OpenTelemetryST extends AbstractST {
                 .endOpenTelemetryTracing()
                 .withBootstrapServers(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
                 .withReplicas(1)
-                .withNewTemplate()
+                .withTls(null)
+                .editOrNewTemplate()
                     .withNewConnectContainer()
                         .addNewEnv()
                             .withName(TracingConstants.OTEL_SERVICE_ENV)
@@ -275,7 +276,7 @@ public class OpenTelemetryST extends AbstractST {
                 .endTemplate()
             .endSpec();
 
-        KubeResourceManager.get().createResourceWithWait(KafkaConnectTemplates.addFileSinkPluginOrImage(testStorage.getNamespaceName(), connectBuilder).build());
+        KubeResourceManager.get().createResourceWithWait(KafkaConnectTemplates.addFileSinkPluginOrImage(connectBuilder).build());
 
         KubeResourceManager.get().createResourceWithWait(KafkaConnectorTemplates.kafkaConnector(testStorage.getNamespaceName(), testStorage.getClusterName())
             .editSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
 import io.strimzi.api.kafka.model.connect.build.Build;
 import io.strimzi.api.kafka.model.connect.build.BuildBuilder;
+import io.strimzi.api.kafka.model.connect.build.DockerOutputBuilder;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -445,7 +446,7 @@ public class AbstractKRaftUpgradeST extends AbstractST {
                 final String imageFullPath = Environment.getImageOutputRegistry(testStorage.getNamespaceName(), TestConstants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
 
                 final Build connectBuild = new BuildBuilder()
-                    .withOutput(KafkaConnectTemplates.dockerOutput(imageFullPath))
+                    .withOutput(KafkaConnectTemplates.dockerOutput(imageFullPath, new DockerOutputBuilder()))
                     .withPlugins(new PluginBuilder()
                         .withName("file-plugin")
                         .withArtifacts(

--- a/systemtest/src/test/resources/connect-build/connect-build-template.yaml
+++ b/systemtest/src/test/resources/connect-build/connect-build-template.yaml
@@ -1,0 +1,48 @@
+# Template for KafkaConnect with build support.
+# Values like name, version, replicas, and bootstrapServers are placeholders
+# overridden at runtime by KafkaConnectTemplates.kafkaConnectBuild().
+# Use this file to configure things like spec.template (e.g. security context)
+# or spec.build.output that should apply to all Connect build tests.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.3.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  groupId: my-connect-group
+  configStorageTopic: my-connect-configs
+  statusStorageTopic: my-connect-status
+  offsetStorageTopic: my-connect-offsets
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        pattern: "*.crt"
+#  build:
+#    output:
+#      type: docker
+#      # ...
+#      additionalBuildOptions:
+#        - --log-format=json
+#        - --ignore-path=/usr/bin/newuidmap
+#        - --ignore-path=/usr/bin/newgidmap
+  config:
+    # -1 means it will use the default replication factor configured in the broker
+    config.storage.replication.factor: -1
+    offset.storage.replication.factor: -1
+    status.storage.replication.factor: -1
+#  template:
+#    buildContainer:
+#      securityContext:
+#        runAsUser: 1000
+#        runAsGroup: 1000
+#        allowPrivilegeEscalation: true
+#        capabilities:
+#          add:
+#            - SETUID
+#            - SETGID
+#            - DAC_OVERRIDE
+#            - SYS_ADMIN


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds possibility to configure KafkaConnect resource used for Connect Build - during the tests that are focused on Connect Build feature or that are using Connect Build for building image with FileSink plugin.
This will make sure that even with more restricted environment, users running the tests will be able to run these without changing anything in the code - just update the resource.

Closes #12880 

### Checklist

- [X] Reference relevant issue(s) and close them after merging
- [X] Make sure all tests pass
- [X] Try your changes inside a Kubernetes cluster, not just from unit tests
