### PR TITLE
Bump Vert.x and Netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <fasterxml.jackson-annotations.version>2.22</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.22.1</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.22.1</fasterxml.jackson-jaxrs.version>
-        <vertx.version>5.1.5</vertx.version>
-        <vertx-junit5.version>5.1.5</vertx-junit5.version>
+        <vertx.version>5.1.6</vertx.version>
+        <vertx-junit5.version>5.1.6</vertx-junit5.version>
         <kafka.version>4.3.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>
@@ -93,7 +93,7 @@
         <opentelemetry.version>1.63.0</opentelemetry.version>
         <jetty.version>12.0.36</jetty.version>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
-        <netty.version>4.2.16.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <micrometer.version>1.16.6</micrometer.version>
         <commons-codec.version>1.13</commons-codec.version>
         <snakeyaml.version>2.5</snakeyaml.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This trivial PR bumps Vert.x 5.1.6 and corresponding Netty 4.2.17.Final with bug and vulnerabilities fixes.