### PR TITLE
Add support for disabling encryption and authentication - Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.3.0
 
-* _Nothing here yet, but we will surely develop something new pretty soon_ 😉
+* (Early Access) Configurable internal cluster security allows users to configure encryption and authentication on the internal connections within the Apache Kafka cluster.
 
 ### Major changes, deprecations, and removals
 

--- a/documentation/assemblies/security/assembly-internal-cluster-security.adoc
+++ b/documentation/assemblies/security/assembly-internal-cluster-security.adoc
@@ -5,11 +5,15 @@
 // security/assembly-security.adoc
 
 [id='assembly-internal-cluster-security-{context}']
-= Internal cluster security
+= (Early Access) Internal cluster security
 
 [role="_abstract"]
 Configure the encryption and authentication used for communication between components of a Kafka cluster.
-The default TLS encryption and mTLS authentication provide secure internal communication, but you can disable mTLS or both options when your environment provides equivalent protection or has other requirements.
+The default TLS encryption and mTLS authentication provide secure internal communication.
+But you can disable mTLS or both options when your environment provides equivalent protection or has other requirements.
+
+IMPORTANT: Changing the internal cluster security configuration requires downtime of the Kafka cluster.
+Make sure to carefully follow the xref:proc-changing-internal-cluster-security[Changing the internal cluster security configuration] procedure to avoid leaving the cluster in an invalid state.
 
 include::../../modules/security/con-internal-cluster-security.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/security/assembly-internal-cluster-security.adoc
+++ b/documentation/assemblies/security/assembly-internal-cluster-security.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+
+// This assembly is included in the following assemblies:
+//
+// security/assembly-security.adoc
+
+[id='assembly-internal-cluster-security-{context}']
+= Internal cluster security
+
+[role="_abstract"]
+Configure the encryption and authentication used for communication between components of a Kafka cluster.
+The default TLS encryption and mTLS authentication provide secure internal communication, but you can disable mTLS or both options when your environment provides equivalent protection or has other requirements.
+
+include::../../modules/security/con-internal-cluster-security.adoc[leveloffset=+1]
+
+include::../../modules/security/proc-changing-internal-cluster-security.adoc[leveloffset=+1]

--- a/documentation/assemblies/security/assembly-security.adoc
+++ b/documentation/assemblies/security/assembly-security.adoc
@@ -5,12 +5,12 @@
 // configuring/configuring.adoc
 
 [id='security-{context}']
-= Managing TLS certificates
+= Managing internal cluster security and TLS certificates
 
 [role="_abstract"]
-Strimzi supports TLS for encrypted communication between Kafka and Strimzi components.
+By default, Strimzi uses TLS for encrypted communication between Kafka and Strimzi components.
 
-Strimzi establishes encrypted TLS connections for communication between the following components when using Kafka in KRaft mode:
+With the default internal cluster security configuration, Strimzi establishes encrypted TLS connections for communication between the following components when using Kafka in KRaft mode:
 
 * Kafka brokers
 * Kafka controllers
@@ -26,7 +26,7 @@ For more information, see xref:deploy-client-access-str[].
  
 The following diagram shows the connections for secure communication.   
 
-.Kafka communication secured by TLS encryption
+.Kafka communication secured by the default TLS encryption
 image::secure_communication_kraft.png[Secure Communication]
 
 The ports shown in the diagram are used as follows:
@@ -45,9 +45,12 @@ The listeners cannot be configured to use the ports reserved for interbroker com
 
 .Node status monitoring using the `KafkaAgent` (8443)
 
-Strimzi includes a component called `KafkaAgent` that runs inside each Kafka node. 
+Strimzi includes a component called `KafkaAgent` that runs inside each Kafka node.
 The agent is responsible for collecting and providing node-specific information, such as current state and readiness, to the Cluster Operator. 
-It listens on port 8443 for secure HTTPS connections and exposes this information through a REST API, which the Cluster Operator uses to retrieve data from the nodes.
+By default, it listens on port 8443 for HTTPS connections secured by TLS encryption and mTLS authentication.
+The security of this interface follows the internal cluster security configuration.
+
+include::assembly-internal-cluster-security.adoc[leveloffset=+1]
 
 include::../../modules/security/con-certificate-authorities.adoc[leveloffset=+1]
 
@@ -69,4 +72,3 @@ include::../../modules/security/proc-configuring-external-clients-to-trust-clust
 
 //user-supplied certs
 include::assembly-using-your-own-certificates.adoc[leveloffset=+1]
-

--- a/documentation/modules/security/con-internal-cluster-security.adoc
+++ b/documentation/modules/security/con-internal-cluster-security.adoc
@@ -72,29 +72,6 @@ Disable authentication only if other controls, such as network isolation or a se
 If the `strimzi.io/internal-cluster-security` annotation is not present, Strimzi uses `strimzi-tls` encryption with `strimzi-mtls` authentication.
 This behavior is unchanged from previous releases.
 
-The following explicit configuration is equivalent to omitting the annotation:
-
-.Default TLS encryption with mTLS authentication
-[source,yaml,subs="+quotes,attributes"]
-----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
-metadata:
-  name: my-cluster
-  annotations:
-    strimzi.io/internal-cluster-security: |
-      {
-        "encryption": {
-          "type": "strimzi-tls"
-        },
-        "authentication": {
-          "type": "strimzi-mtls"
-        }
-      }
-spec:
-  # ...
-----
-
 == (Early Access) Disabling mTLS authentication
 
 Set the authentication type to `none` to disable mTLS authentication while retaining TLS encryption.

--- a/documentation/modules/security/con-internal-cluster-security.adoc
+++ b/documentation/modules/security/con-internal-cluster-security.adoc
@@ -5,7 +5,7 @@
 // assembly-internal-cluster-security.adoc
 
 [id='con-internal-cluster-security-{context}']
-= Internal cluster encryption and authentication
+= (Early Access) Internal cluster encryption and authentication
 
 [role="_abstract"]
 Use the `strimzi.io/internal-cluster-security` annotation on the `Kafka` resource to configure encryption and authentication for internal cluster communication.
@@ -57,7 +57,11 @@ The annotation is a temporary configuration interface and might also change.
 
 The `strimzi-mtls` authentication type requires `strimzi-tls` encryption.
 Consequently, disabling TLS encryption also requires authentication to be disabled.
-The supported combinations are TLS with mTLS, TLS without authentication, and no TLS with no authentication.
+The supported combinations are:
+
+* TLS encryption with mTLS authentication
+* TLS encryption without authentication
+* And no encryption with no authentication
 
 WARNING: When the authentication type is `none` and Kafka authorization is configured, Strimzi automatically makes the `ANONYMOUS` user a super user so that internal components can operate.
 This gives unrestricted access to any connection that Kafka identifies as `ANONYMOUS`, including connections through an unauthenticated client listener.
@@ -91,7 +95,7 @@ spec:
   # ...
 ----
 
-== Disabling mTLS authentication
+== (Early Access) Disabling mTLS authentication
 
 Set the authentication type to `none` to disable mTLS authentication while retaining TLS encryption.
 Connections governed by the internal cluster authentication setting remain encrypted, but connecting components are not authenticated with mTLS.
@@ -118,7 +122,7 @@ spec:
   # ...
 ----
 
-== Disabling TLS encryption and mTLS authentication
+== (Early Access) Disabling TLS encryption and mTLS authentication
 
 Set both types to `none` to disable TLS encryption and mTLS authentication.
 Kafka protocol communication and communication with Kafka Agent are then unencrypted and unauthenticated.

--- a/documentation/modules/security/con-internal-cluster-security.adoc
+++ b/documentation/modules/security/con-internal-cluster-security.adoc
@@ -1,0 +1,153 @@
+:_mod-docs-content-type: CONCEPT
+
+// Module included in the following assemblies:
+//
+// assembly-internal-cluster-security.adoc
+
+[id='con-internal-cluster-security-{context}']
+= Internal cluster encryption and authentication
+
+[role="_abstract"]
+Use the `strimzi.io/internal-cluster-security` annotation on the `Kafka` resource to configure encryption and authentication for internal cluster communication.
+
+The annotation controls security for the internal control plane and replication listeners and for communication involving the following components:
+
+* Kafka brokers and controllers
+* Cluster Operator
+* Topic Operator and User Operator deployed as part of the Entity Operator
+* Cruise Control
+* Kafka Exporter
+* Kafka Agent
+
+The setting also controls TLS encryption for the Cruise Control REST API.
+It does not change the HTTP Basic authentication configured separately for the Cruise Control REST API.
+
+Standalone deployments of the Topic Operator and User Operator are not affected by the annotation.
+Configure their Kafka connections separately.
+
+The annotation does not configure client listener security, which remains defined by the listener configuration in the `Kafka` resource.
+It also does not disable management of the cluster or clients CAs.
+
+NOTE: Internal cluster security is currently an *Early Access* feature and might be subject to change in future releases.
+The annotation is a temporary configuration interface and might also change.
+
+.Supported internal cluster security types
+[cols="1,1,3",options="header"]
+|===
+|Layer
+|Type
+|Description
+
+|Encryption
+|`strimzi-tls`
+|Encrypts internal communication by using Strimzi-managed TLS certificates.
+
+|Encryption
+|`none`
+|Disables TLS encryption for internal communication.
+
+|Authentication
+|`strimzi-mtls`
+|Authenticates internal components by using Strimzi-managed mTLS certificates.
+
+|Authentication
+|`none`
+|Disables mTLS authentication governed by the internal cluster security configuration.
+|===
+
+The `strimzi-mtls` authentication type requires `strimzi-tls` encryption.
+Consequently, disabling TLS encryption also requires authentication to be disabled.
+The supported combinations are TLS with mTLS, TLS without authentication, and no TLS with no authentication.
+
+WARNING: When the authentication type is `none` and Kafka authorization is configured, Strimzi automatically makes the `ANONYMOUS` user a super user so that internal components can operate.
+This gives unrestricted access to any connection that Kafka identifies as `ANONYMOUS`, including connections through an unauthenticated client listener.
+Disable authentication only if other controls, such as network isolation or a service mesh, prevent unauthorized access.
+
+== Default internal cluster security
+
+If the `strimzi.io/internal-cluster-security` annotation is not present, Strimzi uses `strimzi-tls` encryption with `strimzi-mtls` authentication.
+This behavior is unchanged from previous releases.
+
+The following explicit configuration is equivalent to omitting the annotation:
+
+.Default TLS encryption with mTLS authentication
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+      {
+        "encryption": {
+          "type": "strimzi-tls"
+        },
+        "authentication": {
+          "type": "strimzi-mtls"
+        }
+      }
+spec:
+  # ...
+----
+
+== Disabling mTLS authentication
+
+Set the authentication type to `none` to disable mTLS authentication while retaining TLS encryption.
+Connections governed by the internal cluster authentication setting remain encrypted, but connecting components are not authenticated with mTLS.
+Separately configured authentication, such as HTTP Basic authentication for the Cruise Control REST API, is unchanged.
+
+.TLS encryption without authentication
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+      {
+        "encryption": {
+          "type": "strimzi-tls"
+        },
+        "authentication": {
+          "type": "none"
+        }
+      }
+spec:
+  # ...
+----
+
+== Disabling TLS encryption and mTLS authentication
+
+Set both types to `none` to disable TLS encryption and mTLS authentication.
+Kafka protocol communication and communication with Kafka Agent are then unencrypted and unauthenticated.
+Authentication for the Cruise Control REST API remains configured separately.
+
+.Internal communication without encryption or authentication
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+      {
+        "encryption": {
+          "type": "none"
+        },
+        "authentication": {
+          "type": "none"
+        }
+      }
+spec:
+  # ...
+----
+
+During reconciliation, the Cluster Operator records the selected configuration in `.status.clusterSecurity` of the `Kafka` resource.
+If a subsequent annotation change does not match the recorded configuration, reconciliation fails to protect the running cluster from an incompatible change.
+To change the configuration of an existing cluster, use the required downtime procedure.
+
+Additional authentication types are planned for future releases so that internal components can authenticate without mTLS.
+These authentication types are not currently available.

--- a/documentation/modules/security/proc-changing-internal-cluster-security.adoc
+++ b/documentation/modules/security/proc-changing-internal-cluster-security.adoc
@@ -5,17 +5,18 @@
 // assembly-internal-cluster-security.adoc
 
 [id='proc-changing-internal-cluster-security-{context}']
-= Changing the internal cluster security configuration
+= (Early Access) Changing the internal cluster security configuration
 
 [role="_abstract"]
 Change the encryption or authentication configuration for an existing Kafka cluster by stopping the cluster and resetting its recorded security status.
-This procedure causes a complete outage of the Kafka cluster.
+
+WARNING: This procedure requires downtime of the Kafka cluster.
 
 The Cluster Operator compares the `strimzi.io/internal-cluster-security` annotation with `.status.clusterSecurity` in the `Kafka` resource.
 Changing only the annotation causes reconciliation to fail and does not migrate the cluster.
 
 WARNING: Follow the steps in the specified order.
-Removing `.status.clusterSecurity` while cluster Pods are running can apply an incompatible security configuration and leave the cluster unavailable.
+Removing `.status.clusterSecurity` while cluster Pods are running can apply an incompatible security configuration and leave the cluster in an invalid state.
 
 .Prerequisites
 

--- a/documentation/modules/security/proc-changing-internal-cluster-security.adoc
+++ b/documentation/modules/security/proc-changing-internal-cluster-security.adoc
@@ -1,0 +1,112 @@
+:_mod-docs-content-type: PROCEDURE
+
+// Module included in the following assemblies:
+//
+// assembly-internal-cluster-security.adoc
+
+[id='proc-changing-internal-cluster-security-{context}']
+= Changing the internal cluster security configuration
+
+[role="_abstract"]
+Change the encryption or authentication configuration for an existing Kafka cluster by stopping the cluster and resetting its recorded security status.
+This procedure causes a complete outage of the Kafka cluster.
+
+The Cluster Operator compares the `strimzi.io/internal-cluster-security` annotation with `.status.clusterSecurity` in the `Kafka` resource.
+Changing only the annotation causes reconciliation to fail and does not migrate the cluster.
+
+WARNING: Follow the steps in the specified order.
+Removing `.status.clusterSecurity` while cluster Pods are running can apply an incompatible security configuration and leave the cluster unavailable.
+
+.Prerequisites
+
+* The Cluster Operator is running.
+* A maintenance window allows a complete outage of the Kafka cluster.
+* You have permission to update the `Kafka` status subresource and to delete `StrimziPodSet`, `Deployment`, and `Pod` resources.
+* You have selected a supported encryption and authentication combination.
+
+.Procedure
+
+. Pause reconciliation of the `Kafka` resource:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafka <cluster_name> \
+  strimzi.io/pause-reconciliation="true" --overwrite
+----
+
+. Check that the status conditions of the `Kafka` resource show a change to `ReconciliationPaused`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl describe kafka <cluster_name>
+----
++
+Continue only after the `ReconciliationPaused` condition has a status of `True`.
+
+. Stop the cluster by deleting its `StrimziPodSet` and `Deployment` resources and their Pods:
++
+[source,shell,subs="+quotes"]
+----
+kubectl delete strimzipodsets,deployments \
+  -l 'strimzi.io/cluster=<cluster_name>,strimzi.io/kind=Kafka' \
+  --cascade=foreground
+----
+
+. Verify that all Pods belonging to the cluster have stopped:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get pods \
+  -l 'strimzi.io/cluster=<cluster_name>,strimzi.io/kind=Kafka'
+----
++
+Continue only when the command returns no Pods.
+
+. Edit the status subresource of the `Kafka` resource:
++
+[source,shell,subs="+quotes"]
+----
+kubectl edit kafka <cluster_name> --subresource status
+----
++
+Remove the complete `.status.clusterSecurity` section, including its `encryption` and `authentication` fields.
+Do not change other status fields.
+
+. Set the `strimzi.io/internal-cluster-security` annotation to the new configuration.
+For example, set both types to `none` to disable TLS encryption and mTLS authentication:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafka <cluster_name> \
+  strimzi.io/internal-cluster-security='{"encryption":{"type":"none"},"authentication":{"type":"none"}}' \
+  --overwrite
+----
++
+Use one of the combinations described in xref:con-internal-cluster-security-{context}[Internal cluster encryption and authentication].
+
+. Unpause reconciliation of the `Kafka` resource:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafka <cluster_name> \
+  strimzi.io/pause-reconciliation="false" --overwrite
+----
++
+The Cluster Operator recreates the `StrimziPodSet`, `Deployment`, and `Pod` resources with the new security configuration.
+
+. Verify that the Kafka cluster is ready and that `.status.clusterSecurity` contains the new configuration:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafka <cluster_name> -o yaml
+----
+
+. Verify that the cluster Pods are running:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get pods \
+  -l 'strimzi.io/cluster=<cluster_name>,strimzi.io/kind=Kafka'
+----
+
+. Verify that Kafka clients can connect to the cluster.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR continues the work on disabling TLS encryption and mTLS authentication in the Kafka clusters and adds the related documentation and CHANGELOG.md changes.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md (if present)
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
