### PR TITLE
Add support for disabling encryption and authentication - System Tests

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.security.ClusterSecurityST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.security.ClusterSecurityST.md
@@ -1,0 +1,51 @@
+# ClusterSecurityST
+
+**Description:** Test suite for verifying configurable security of the Kafka cluster's internal communication.
+
+**Labels:**
+
+* [security](labels/security.md)
+* [kafka](labels/kafka.md)
+
+<hr style="border:1px solid">
+
+## testClusterSecurityConfiguration
+
+**Description:** Test a Kafka cluster that uses different combinations of authentication and encryption for internal communication.
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Kafka with specified encryption and authentication (including Entity Operator and Cruise Control). | The cluster is ready with the requested security configuration. |
+| 2. | Send and consume messages over mTLS. | The messages are sent and consumed successfully. |
+| 3. | Change dynamic Kafka configuration. | The configuration is applied without rolling the Kafka pods. |
+| 4. | Change read-only Kafka configuration. | The Kafka controllers and brokers roll and remain functional. |
+| 5. | Run a Kafka rebalance. | Cruise Control completes the rebalance. |
+
+**Labels:**
+
+* [security](labels/security.md)
+* [kafka](labels/kafka.md)
+* [cruise-control](labels/cruise-control.md)
+
+
+## testClusterSecurityMigration
+
+**Description:** Test migrating internal cluster security from the default TLS and mTLS configuration to no security and back.
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy a persistent Kafka cluster with the default internal security and send and consume messages over mTLS. | The cluster is ready and the messages are available. |
+| 2. | Pause reconciliation, stop all cluster workloads, remove status.clusterSecurity, disable TLS and mTLS, and unpause. | The cluster restarts without internal encryption or authentication. |
+| 3. | Consume the existing messages and send and consume new messages. | Both the existing and new messages are available. |
+| 4. | Repeat the stopped migration and remove the internal security annotation. | The cluster restarts with the default TLS and mTLS configuration. |
+| 5. | Consume all existing messages and send and consume more messages. | All existing and new messages are available after the round-trip migration. |
+
+**Labels:**
+
+* [security](labels/security.md)
+* [kafka](labels/kafka.md)
+

--- a/development-docs/systemtests/io.strimzi.systemtest.security.ClusterSecurityST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.security.ClusterSecurityST.md
@@ -18,7 +18,7 @@
 | Step | Action | Result |
 | - | - | - |
 | 1. | Deploy Kafka with specified encryption and authentication (including Entity Operator and Cruise Control). | The cluster is ready with the requested security configuration. |
-| 2. | Send and consume messages over mTLS. | The messages are sent and consumed successfully. |
+| 2. | Create a TLS user with ACLs and send and consume messages over mTLS. | The messages are authorized, sent, and consumed successfully. |
 | 3. | Change dynamic Kafka configuration. | The configuration is applied without rolling the Kafka pods. |
 | 4. | Change read-only Kafka configuration. | The Kafka controllers and brokers roll and remain functional. |
 | 5. | Run a Kafka rebalance. | Cruise Control completes the rebalance. |
@@ -38,7 +38,7 @@
 
 | Step | Action | Result |
 | - | - | - |
-| 1. | Deploy a persistent Kafka cluster with the default internal security and send and consume messages over mTLS. | The cluster is ready and the messages are available. |
+| 1. | Deploy a persistent Kafka cluster with authorization and send and consume messages using a TLS user with ACLs. | The cluster is ready and the messages are authorized and available. |
 | 2. | Pause reconciliation, stop all cluster workloads, remove status.clusterSecurity, disable TLS and mTLS, and unpause. | The cluster restarts without internal encryption or authentication. |
 | 3. | Consume the existing messages and send and consume new messages. | Both the existing and new messages are available. |
 | 4. | Repeat the stopped migration and remove the internal security annotation. | The cluster restarts with the default TLS and mTLS configuration. |

--- a/development-docs/systemtests/labels/cruise-control.md
+++ b/development-docs/systemtests/labels/cruise-control.md
@@ -11,6 +11,7 @@ Ensuring the correctness of Cruise Control behavior under different configuratio
 **Tests:**
 - [testAutoCreationOfCruiseControlTopicsWithResources](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)
 - [testAutoKafkaRebalanceScaleUpScaleDown](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)
+- [testClusterSecurityConfiguration](../io.strimzi.systemtest.security.ClusterSecurityST.md)
 - [testConfigurationUpdate](../io.strimzi.systemtest.cruisecontrol.CruiseControlConfigurationST.md)
 - [testCruiseControlAPIUsers](../io.strimzi.systemtest.cruisecontrol.CruiseControlApiST.md)
 - [testCruiseControlBasicAPIRequestsWithSecurityDisabled](../io.strimzi.systemtest.cruisecontrol.CruiseControlApiST.md)

--- a/development-docs/systemtests/labels/kafka.md
+++ b/development-docs/systemtests/labels/kafka.md
@@ -16,6 +16,8 @@ These tests are crucial to ensure that Kafka clusters can handle production work
 - [testClusterIp](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testClusterIpTls](../io.strimzi.systemtest.kafka.listeners.ListenersST.md)
 - [testClusterOperatorMetrics](../io.strimzi.systemtest.metrics.MetricsST.md)
+- [testClusterSecurityConfiguration](../io.strimzi.systemtest.security.ClusterSecurityST.md)
+- [testClusterSecurityMigration](../io.strimzi.systemtest.security.ClusterSecurityST.md)
 - [testClusterWideDynamicConfiguration](../io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfST.md)
 - [testCombinationOfEveryKindOfListener](../io.strimzi.systemtest.kafka.listeners.MultipleListenersST.md)
 - [testCombinationOfInternalAndExternalListeners](../io.strimzi.systemtest.kafka.listeners.MultipleListenersST.md)

--- a/development-docs/systemtests/labels/security.md
+++ b/development-docs/systemtests/labels/security.md
@@ -23,6 +23,8 @@ They cover authentication and authorization mechanisms (OAuth, ACLs, OPA integra
 - [testCertRenewalInMaintenanceTimeWindow](../io.strimzi.systemtest.security.SecurityST.md)
 - [testClientsCACertRenew](../io.strimzi.systemtest.security.SecurityST.md)
 - [testClusterCACertRenew](../io.strimzi.systemtest.security.SecurityST.md)
+- [testClusterSecurityConfiguration](../io.strimzi.systemtest.security.ClusterSecurityST.md)
+- [testClusterSecurityMigration](../io.strimzi.systemtest.security.ClusterSecurityST.md)
 - [testCustomCaTrustChainOnInternalPort](../io.strimzi.systemtest.security.custom.CustomCaChainST.md)
 - [testCustomClusterCaAndClientsCaCertificates](../io.strimzi.systemtest.security.custom.CustomCaST.md)
 - [testDisabledPKCS12Stores](../io.strimzi.systemtest.security.DisablingPkcs12StoresST.md)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.templates.crd;
 
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import io.strimzi.api.kafka.model.user.acl.StrimziAclOperation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.storage.TestStorage;
 
@@ -64,5 +65,33 @@ public class KafkaUserTemplates {
                         .withControllerMutationRate(mutRate)
                     .endQuotas()
                 .endSpec();
+    }
+
+    /**
+     * Returns KafkaUser resource builder with authorization rules for consuming and producing to a topic.
+     *
+     * @param testStorage   TestStorage instances used to gather the username, namespace, cluster name, and topic name from.
+     *
+     * @return  KafkaUserBuilder instance with authorization rules for consuming and producing to a topic.
+     */
+    public static KafkaUserBuilder tlsUserWithAuthorization(TestStorage testStorage) {
+        return tlsUser(testStorage)
+            .editSpec()
+                .withNewKafkaUserAuthorizationSimple()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(testStorage.getTopicName())
+                        .endAclRuleTopicResource()
+                        .withOperations(StrimziAclOperation.READ, StrimziAclOperation.WRITE,
+                            StrimziAclOperation.DESCRIBE, StrimziAclOperation.CREATE)
+                    .endAcl()
+                    .addNewAcl()
+                        .withNewAclRuleGroupResource()
+                            .withName("*")
+                        .endAclRuleGroupResource()
+                        .withOperations(StrimziAclOperation.READ)
+                    .endAcl()
+                .endKafkaUserAuthorizationSimple()
+            .endSpec();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ClusterSecuritySTUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ClusterSecuritySTUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.specific;
+
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityAuthenticationType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptionType;
+import io.strimzi.systemtest.resources.CrdClients;
+import io.strimzi.systemtest.storage.TestStorage;
+import org.hamcrest.CoreMatchers;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ *  Provides auxiliary methods for working with Cluster Security configurations.
+ */
+public class ClusterSecuritySTUtils {
+    private ClusterSecuritySTUtils() { }
+
+    /**
+     * Generates the Cluster Security annotation for the given encryption and authentication types
+     *
+     * @param encryption        Encryption type
+     * @param authentication    Authentication type
+     *
+     * @return  Cluster Security annotation as a JSON string
+     */
+    public static String clusterSecurityAnnotation(ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
+        return "{\"encryption\":{\"type\":\"" + encryption.toValue() + "\"},\"authentication\":{\"type\":\"" + authentication.toValue() + "\"}}";
+    }
+
+    /**
+     * Checks that the cluster security status corresponds to the desired encryption and authentication types.
+     *
+     * @param testStorage       Test storage containing cluster information
+     * @param encryption        Expected encryption type
+     * @param authentication    Expected authentication type
+     */
+    public static void assertClusterSecurityStatus(TestStorage testStorage, ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
+        assertThat(CrdClients.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName())
+                        .get().getStatus().getClusterSecurity(),
+                CoreMatchers.is(Map.of(
+                        "encryption", Map.of("type", encryption.toValue()),
+                        "authentication", Map.of("type", authentication.toValue())
+                )));
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
@@ -21,6 +21,8 @@ import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptio
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceState;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.acl.StrimziAclOperation;
 import io.strimzi.kafka.config.model.Scope;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
@@ -75,30 +77,6 @@ class ClusterSecurityST extends AbstractST {
     private static final int CONTROLLER_REPLICAS = 3;
     private static final String INTERNAL_CLUSTER_SECURITY_ANNOTATION = "strimzi.io/internal-cluster-security";
 
-    /**
-     * Generates the combinations of encryption and authentication types for testing.
-     *
-     * @return  A stream of arguments containing encryption and authentication type combinations.
-     */
-    private Stream<Arguments> securityConfigurationCombos() {
-        return Stream.of(
-                Arguments.of(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE),
-                Arguments.of(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)
-        );
-    }
-
-    /**
-     * Generates the Cluster Security annotation for the given encryption and authentication types
-     *
-     * @param encryption        Encryption type
-     * @param authentication    Authentication type
-     *
-     * @return  Cluster Security annotation as a JSON string
-     */
-    private String clusterSecurityAnnotation(ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
-        return "{\"encryption\":{\"type\":\"" + encryption.toValue() + "\"},\"authentication\":{\"type\":\"" + authentication.toValue() + "\"}}";
-    }
-
     @Tag(CRUISE_CONTROL)
     @Tag(DYNAMIC_CONFIGURATION)
     @Tag(ROLLING_UPDATE)
@@ -106,7 +84,7 @@ class ClusterSecurityST extends AbstractST {
         description = @Desc("Test a Kafka cluster that uses different combinations of authentication and encryption for internal communication."),
         steps = {
             @Step(value = "Deploy Kafka with specified encryption and authentication (including Entity Operator and Cruise Control).", expected = "The cluster is ready with the requested security configuration."),
-            @Step(value = "Send and consume messages over mTLS.", expected = "The messages are sent and consumed successfully."),
+            @Step(value = "Create a TLS user with ACLs and send and consume messages over mTLS.", expected = "The messages are authorized, sent, and consumed successfully."),
             @Step(value = "Change dynamic Kafka configuration.", expected = "The configuration is applied without rolling the Kafka pods."),
             @Step(value = "Change read-only Kafka configuration.", expected = "The Kafka controllers and brokers roll and remain functional."),
             @Step(value = "Run a Kafka rebalance.", expected = "Cruise Control completes the rebalance.")
@@ -134,6 +112,8 @@ class ClusterSecurityST extends AbstractST {
                         .endMetadata()
                         .editSpec()
                             .editKafka()
+                                .withNewKafkaAuthorizationSimple()
+                                .endKafkaAuthorizationSimple()
                                 .withListeners(
                                     new GenericKafkaListenerBuilder()
                                         .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
@@ -155,7 +135,7 @@ class ClusterSecurityST extends AbstractST {
                 ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build()
         );
         KubeResourceManager.get().createResourceWithWait(
-                KafkaUserTemplates.tlsUser(testStorage).build(),
+                authorizedTlsUser(testStorage),
                 KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
         );
 
@@ -205,7 +185,7 @@ class ClusterSecurityST extends AbstractST {
     @TestDoc(
         description = @Desc("Test migrating internal cluster security from the default TLS and mTLS configuration to no security and back."),
         steps = {
-            @Step(value = "Deploy a persistent Kafka cluster with the default internal security and send and consume messages over mTLS.", expected = "The cluster is ready and the messages are available."),
+            @Step(value = "Deploy a persistent Kafka cluster with authorization and send and consume messages using a TLS user with ACLs.", expected = "The cluster is ready and the messages are authorized and available."),
             @Step(value = "Pause reconciliation, stop all cluster workloads, remove status.clusterSecurity, disable TLS and mTLS, and unpause.", expected = "The cluster restarts without internal encryption or authentication."),
             @Step(value = "Consume the existing messages and send and consume new messages.", expected = "Both the existing and new messages are available."),
             @Step(value = "Repeat the stopped migration and remove the internal security annotation.", expected = "The cluster restarts with the default TLS and mTLS configuration."),
@@ -228,6 +208,8 @@ class ClusterSecurityST extends AbstractST {
             KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), BROKER_REPLICAS)
                     .editSpec()
                         .editKafka()
+                            .withNewKafkaAuthorizationSimple()
+                            .endKafkaAuthorizationSimple()
                             .withListeners(
                                 new GenericKafkaListenerBuilder()
                                     .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
@@ -248,7 +230,7 @@ class ClusterSecurityST extends AbstractST {
                     .build()
         );
         KubeResourceManager.get().createResourceWithWait(
-            KafkaUserTemplates.tlsUser(testStorage).build(),
+            authorizedTlsUser(testStorage),
             KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
         );
 
@@ -322,6 +304,28 @@ class ClusterSecurityST extends AbstractST {
             .build();
     }
 
+    private KafkaUser authorizedTlsUser(TestStorage testStorage) {
+        return KafkaUserTemplates.tlsUser(testStorage)
+            .editSpec()
+                .withNewKafkaUserAuthorizationSimple()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(testStorage.getTopicName())
+                        .endAclRuleTopicResource()
+                        .withOperations(StrimziAclOperation.READ, StrimziAclOperation.WRITE,
+                            StrimziAclOperation.DESCRIBE, StrimziAclOperation.CREATE)
+                    .endAcl()
+                    .addNewAcl()
+                        .withNewAclRuleGroupResource()
+                            .withName("*")
+                        .endAclRuleGroupResource()
+                        .withOperations(StrimziAclOperation.READ)
+                    .endAcl()
+                .endKafkaUserAuthorizationSimple()
+            .endSpec()
+            .build();
+    }
+
     private void sendAndReceiveMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
         clients.setMessageCount(messageCount);
         clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
@@ -342,6 +346,38 @@ class ClusterSecurityST extends AbstractST {
         ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), messageCount);
     }
 
+
+    /**
+     * Generates the combinations of encryption and authentication types for testing.
+     *
+     * @return  A stream of arguments containing encryption and authentication type combinations.
+     */
+    private Stream<Arguments> securityConfigurationCombos() {
+        return Stream.of(
+                Arguments.of(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE),
+                Arguments.of(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)
+        );
+    }
+
+    /**
+     * Generates the Cluster Security annotation for the given encryption and authentication types
+     *
+     * @param encryption        Encryption type
+     * @param authentication    Authentication type
+     *
+     * @return  Cluster Security annotation as a JSON string
+     */
+    private String clusterSecurityAnnotation(ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
+        return "{\"encryption\":{\"type\":\"" + encryption.toValue() + "\"},\"authentication\":{\"type\":\"" + authentication.toValue() + "\"}}";
+    }
+
+    /**
+     * Checks that the cluster security status corresponds to the desired encryption and authentication types.
+     *
+     * @param testStorage       Test storage containing cluster information
+     * @param encryption        Expected encryption type
+     * @param authentication    Expected authentication type
+     */
     private void assertClusterSecurityStatus(TestStorage testStorage, ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
         assertThat(CrdClients.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName())
                 .get().getStatus().getClusterSecurity(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
@@ -165,8 +165,6 @@ class ClusterSecurityST extends AbstractST {
                 .withAuthentication(ClientsAuthentication.configureTls(testStorage.getClusterName(), testStorage.getUsername()))
                 .build();
 
-        clients.setMessageCount(testStorage.getMessageCount());
-        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
         KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob(), clients.getConsumer().getJob());
         ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getProducerName(), testStorage.getMessageCount());
 
@@ -194,7 +192,6 @@ class ClusterSecurityST extends AbstractST {
                 BROKER_REPLICAS, brokerPods);
 
         // Test message consumption
-        clients.setMessageCount(testStorage.getMessageCount());
         clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
         KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
         ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getMessageCount());
@@ -275,12 +272,9 @@ class ClusterSecurityST extends AbstractST {
                 .withAuthentication(ClientsAuthentication.configureTls(testStorage.getClusterName(), testStorage.getUsername()))
                 .build();
 
-        clients.setMessageCount(testStorage.getMessageCount());
-        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
         KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob(), clients.getConsumer().getJob());
         ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getProducerName(), testStorage.getMessageCount());
 
-        clients.setMessageCount(testStorage.getMessageCount());
         clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
         KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
         ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getMessageCount());
@@ -290,7 +284,6 @@ class ClusterSecurityST extends AbstractST {
         ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE);
 
         // Test sending and consuming messages still works
-        clients.setMessageCount(testStorage.getMessageCount());
         KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob());
         ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getProducerName(), testStorage.getMessageCount());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.security;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Label;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
+import io.skodjob.kubetest4j.resources.KubeResourceManager;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityAuthenticationType;
+import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptionType;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceState;
+import io.strimzi.kafka.config.model.Scope;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
+import io.strimzi.systemtest.enums.CustomResourceStatus;
+import io.strimzi.systemtest.kafkaclients.ClientsAuthentication;
+import io.strimzi.systemtest.resources.CrdClients;
+import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaRebalanceTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.testclients.clients.kafka.KafkaProducerConsumer;
+import io.strimzi.testclients.clients.kafka.KafkaProducerConsumerBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.strimzi.systemtest.TestTags.CRUISE_CONTROL;
+import static io.strimzi.systemtest.TestTags.DYNAMIC_CONFIGURATION;
+import static io.strimzi.systemtest.TestTags.REGRESSION;
+import static io.strimzi.systemtest.TestTags.ROLLING_UPDATE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Tag(REGRESSION)
+@SuiteDoc(
+    description = @Desc("Test suite for verifying configurable security of the Kafka cluster's internal communication."),
+    labels = {
+        @Label(value = TestDocsLabels.SECURITY),
+        @Label(value = TestDocsLabels.KAFKA)
+    }
+)
+class ClusterSecurityST extends AbstractST {
+    private static final int BROKER_REPLICAS = 3;
+    private static final int CONTROLLER_REPLICAS = 3;
+    private static final String INTERNAL_CLUSTER_SECURITY_ANNOTATION = "strimzi.io/internal-cluster-security";
+
+    /**
+     * Generates the combinations of encryption and authentication types for testing.
+     *
+     * @return  A stream of arguments containing encryption and authentication type combinations.
+     */
+    private Stream<Arguments> securityConfigurationCombos() {
+        return Stream.of(
+                Arguments.of(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE),
+                Arguments.of(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)
+        );
+    }
+
+    /**
+     * Generates the Cluster Security annotation for the given encryption and authentication types
+     *
+     * @param encryption        Encryption type
+     * @param authentication    Authentication type
+     *
+     * @return  Cluster Security annotation as a JSON string
+     */
+    private String clusterSecurityAnnotation(ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
+        return "{\"encryption\":{\"type\":\"" + encryption.toValue() + "\"},\"authentication\":{\"type\":\"" + authentication.toValue() + "\"}}";
+    }
+
+    @Tag(CRUISE_CONTROL)
+    @Tag(DYNAMIC_CONFIGURATION)
+    @Tag(ROLLING_UPDATE)
+    @TestDoc(
+        description = @Desc("Test a Kafka cluster that uses different combinations of authentication and encryption for internal communication."),
+        steps = {
+            @Step(value = "Deploy Kafka with specified encryption and authentication (including Entity Operator and Cruise Control).", expected = "The cluster is ready with the requested security configuration."),
+            @Step(value = "Send and consume messages over mTLS.", expected = "The messages are sent and consumed successfully."),
+            @Step(value = "Change dynamic Kafka configuration.", expected = "The configuration is applied without rolling the Kafka pods."),
+            @Step(value = "Change read-only Kafka configuration.", expected = "The Kafka controllers and brokers roll and remain functional."),
+            @Step(value = "Run a Kafka rebalance.", expected = "Cruise Control completes the rebalance.")
+        },
+        labels = {
+            @Label(value = TestDocsLabels.SECURITY),
+            @Label(value = TestDocsLabels.KAFKA),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL)
+        }
+    )
+    @ParameterizedTest(name = "Encryption: {0}; Authentication: {1}")
+    @MethodSource("securityConfigurationCombos")
+    void testClusterSecurityConfiguration(ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+
+        KubeResourceManager.get().createResourceWithWait(
+                KafkaNodePoolTemplates.brokerPool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(),
+                        testStorage.getClusterName(), BROKER_REPLICAS).build(),
+                KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(),
+                        testStorage.getClusterName(), CONTROLLER_REPLICAS).build()
+        );
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafkaWithCruiseControlTunedForFastModelGeneration(testStorage.getNamespaceName(), testStorage.getClusterName(), BROKER_REPLICAS)
+                        .editMetadata()
+                            .addToAnnotations(INTERNAL_CLUSTER_SECURITY_ANNOTATION, clusterSecurityAnnotation(encryption, authentication))
+                        .endMetadata()
+                        .editSpec()
+                            .editKafka()
+                                .withListeners(
+                                    new GenericKafkaListenerBuilder()
+                                        .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                                        .withPort(9092)
+                                        .withType(KafkaListenerType.INTERNAL)
+                                        .withTls(false)
+                                        .build(),
+                                    new GenericKafkaListenerBuilder()
+                                        .withName(TestConstants.TLS_LISTENER_DEFAULT_NAME)
+                                        .withPort(9093)
+                                        .withType(KafkaListenerType.INTERNAL)
+                                        .withTls(true)
+                                        .withNewKafkaListenerAuthenticationTlsAuth()
+                                        .endKafkaListenerAuthenticationTlsAuth()
+                                        .build())
+                            .endKafka()
+                        .endSpec()
+                        .build(),
+                ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build()
+        );
+        KubeResourceManager.get().createResourceWithWait(
+                KafkaUserTemplates.tlsUser(testStorage).build(),
+                KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
+        );
+
+        // Assert security status
+        assertClusterSecurityStatus(testStorage, encryption, authentication);
+
+        // Test message producing and consuming
+        KafkaProducerConsumer clients = kafkaClients(testStorage);
+        sendAndReceiveMessages(testStorage, clients, testStorage.getMessageCount());
+
+        // Check dynamic configuration update
+        Map<String, String> controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getControllerSelector());
+        Map<String, String> brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
+
+        KafkaUtils.updateConfigurationWithStabilityWait(testStorage.getNamespaceName(), testStorage.getClusterName(),
+                "log.message.timestamp.type", "LogAppendTime");
+        assertThat(KafkaUtils.verifyCrDynamicConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(),
+                "log.message.timestamp.type", "LogAppendTime"), is(true));
+        assertThat(KafkaUtils.verifyPodDynamicConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(),
+                PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), testStorage.getScraperName()), Scope.CLUSTER_WIDE.toString(),
+                "log.message.timestamp.type", "LogAppendTime"), is(true));
+        assertThat("Controller pods rolled after a dynamic configuration update",
+                PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getControllerSelector()), is(controllerPods));
+        assertThat("Broker pods rolled after a dynamic configuration update",
+                PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector()), is(brokerPods));
+
+        // Check configuration updates through rolling updates
+        KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "auto.create.topics.enable", false);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getControllerSelector(),
+                CONTROLLER_REPLICAS, controllerPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(),
+                BROKER_REPLICAS, brokerPods);
+
+        // Test message consumption
+        consumeMessages(testStorage, clients, testStorage.getMessageCount());
+
+        // Test CRuise Control
+        KubeResourceManager.get().createResourceWithWait(
+                KafkaRebalanceTemplates.kafkaRebalance(testStorage.getNamespaceName(), testStorage.getClusterName()).build()
+        );
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(testStorage.getNamespaceName(), testStorage.getClusterName(),
+                KafkaRebalanceState.ProposalReady);
+        KafkaRebalanceUtils.doRebalancingProcess(testStorage.getNamespaceName(), testStorage.getClusterName());
+    }
+
+    @ParallelNamespaceTest
+    @TestDoc(
+        description = @Desc("Test migrating internal cluster security from the default TLS and mTLS configuration to no security and back."),
+        steps = {
+            @Step(value = "Deploy a persistent Kafka cluster with the default internal security and send and consume messages over mTLS.", expected = "The cluster is ready and the messages are available."),
+            @Step(value = "Pause reconciliation, stop all cluster workloads, remove status.clusterSecurity, disable TLS and mTLS, and unpause.", expected = "The cluster restarts without internal encryption or authentication."),
+            @Step(value = "Consume the existing messages and send and consume new messages.", expected = "Both the existing and new messages are available."),
+            @Step(value = "Repeat the stopped migration and remove the internal security annotation.", expected = "The cluster restarts with the default TLS and mTLS configuration."),
+            @Step(value = "Consume all existing messages and send and consume more messages.", expected = "All existing and new messages are available after the round-trip migration.")
+        },
+        labels = {
+            @Label(value = TestDocsLabels.SECURITY),
+            @Label(value = TestDocsLabels.KAFKA)
+        }
+    )
+    void testClusterSecurityMigration() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+
+        // Deploy the initial cluster
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(),
+                testStorage.getClusterName(), BROKER_REPLICAS).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(),
+                testStorage.getClusterName(), CONTROLLER_REPLICAS).build(),
+            KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), BROKER_REPLICAS)
+                    .editSpec()
+                        .editKafka()
+                            .withListeners(
+                                new GenericKafkaListenerBuilder()
+                                    .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                                    .withPort(9092)
+                                    .withType(KafkaListenerType.INTERNAL)
+                                    .withTls(false)
+                                    .build(),
+                                new GenericKafkaListenerBuilder()
+                                    .withName(TestConstants.TLS_LISTENER_DEFAULT_NAME)
+                                    .withPort(9093)
+                                    .withType(KafkaListenerType.INTERNAL)
+                                    .withTls(true)
+                                    .withNewKafkaListenerAuthenticationTlsAuth()
+                                    .endKafkaListenerAuthenticationTlsAuth()
+                                    .build())
+                        .endKafka()
+                    .endSpec()
+                    .build()
+        );
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaUserTemplates.tlsUser(testStorage).build(),
+            KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
+        );
+
+        assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+
+        KafkaProducerConsumer clients = kafkaClients(testStorage);
+        sendAndReceiveMessages(testStorage, clients, testStorage.getMessageCount());
+
+        // Migrate to different security settings
+        migrateClusterSecurity(testStorage, clusterSecurityAnnotation(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE));
+        assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE);
+        consumeMessages(testStorage, clients, testStorage.getMessageCount());
+        sendMessages(testStorage, clients, testStorage.getMessageCount());
+        consumeMessages(testStorage, clients, 2 * testStorage.getMessageCount());
+
+        // Migrate back to the original to close the round trip
+        migrateClusterSecurity(testStorage, clusterSecurityAnnotation(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        consumeMessages(testStorage, clients, 2 * testStorage.getMessageCount());
+        sendMessages(testStorage, clients, testStorage.getMessageCount());
+        consumeMessages(testStorage, clients, 3 * testStorage.getMessageCount());
+    }
+
+    private void migrateClusterSecurity(TestStorage testStorage, String clusterSecurity) {
+        String namespaceName = testStorage.getNamespaceName();
+        String clusterName = testStorage.getClusterName();
+
+        KafkaUtils.annotateKafka(namespaceName, clusterName,
+            Map.of(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true"));
+        KafkaUtils.waitForKafkaStatus(namespaceName, clusterName, CustomResourceStatus.ReconciliationPaused);
+
+        String selector = Labels.STRIMZI_CLUSTER_LABEL + "=" + clusterName + "," + Labels.STRIMZI_KIND_LABEL + "=" + Kafka.RESOURCE_KIND;
+        KubeResourceManager.get().kubeCmdClient().inNamespace(namespaceName).exec(
+            "delete", "strimzipodsets,deployments", "-l", selector, "--cascade=foreground");
+
+        LabelSelector clusterPodSelector = new LabelSelectorBuilder()
+            .addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, clusterName)
+            .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND)
+            .build();
+        PodUtils.waitForPodsReady(namespaceName, clusterPodSelector, 0, true);
+
+        CrdClients.kafkaClient()
+            .inNamespace(namespaceName)
+            .withName(clusterName)
+            .subresource("status")
+            .patch(PatchContext.of(PatchType.JSON_MERGE), "{\"status\":{\"clusterSecurity\":null}}");
+
+        if (clusterSecurity == null) {
+            KafkaUtils.removeAnnotation(namespaceName, clusterName, INTERNAL_CLUSTER_SECURITY_ANNOTATION);
+        } else {
+            KafkaUtils.annotateKafka(namespaceName, clusterName, Map.of(INTERNAL_CLUSTER_SECURITY_ANNOTATION, clusterSecurity));
+        }
+        KafkaUtils.annotateKafka(namespaceName, clusterName,
+            Map.of(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "false"));
+
+        PodUtils.waitForPodsReady(namespaceName, testStorage.getControllerSelector(), CONTROLLER_REPLICAS, true);
+        PodUtils.waitForPodsReady(namespaceName, testStorage.getBrokerSelector(), BROKER_REPLICAS, true);
+        KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
+    }
+
+    private KafkaProducerConsumer kafkaClients(TestStorage testStorage) {
+        return new KafkaProducerConsumerBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withMessageCount(testStorage.getMessageCount())
+            .withAuthentication(ClientsAuthentication.configureTls(testStorage.getClusterName(), testStorage.getUsername()))
+            .build();
+    }
+
+    private void sendAndReceiveMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
+        clients.setMessageCount(messageCount);
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob(), clients.getConsumer().getJob());
+        ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getProducerName(), messageCount);
+    }
+
+    private void sendMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
+        clients.setMessageCount(messageCount);
+        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getProducerName(), messageCount);
+    }
+
+    private void consumeMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
+        clients.setMessageCount(messageCount);
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), messageCount);
+    }
+
+    private void assertClusterSecurityStatus(TestStorage testStorage, ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
+        assertThat(CrdClients.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName())
+                .get().getStatus().getClusterSecurity(),
+            is(Map.of(
+                "encryption", Map.of("type", encryption.toValue()),
+                "authentication", Map.of("type", authentication.toValue())
+            )));
+    }
+
+    @BeforeAll
+    void setup() {
+        SetupClusterOperator
+            .getInstance()
+            .withDefaultConfiguration()
+            .install();
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
@@ -21,8 +21,6 @@ import io.strimzi.api.kafka.model.kafka.clustersecurity.ClusterSecurityEncryptio
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceState;
-import io.strimzi.api.kafka.model.user.KafkaUser;
-import io.strimzi.api.kafka.model.user.acl.StrimziAclOperation;
 import io.strimzi.kafka.config.model.Scope;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
@@ -46,6 +44,7 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.systemtest.utils.specific.ClusterSecuritySTUtils;
 import io.strimzi.testclients.clients.kafka.KafkaProducerConsumer;
 import io.strimzi.testclients.clients.kafka.KafkaProducerConsumerBuilder;
 import org.junit.jupiter.api.BeforeAll;
@@ -76,6 +75,18 @@ class ClusterSecurityST extends AbstractST {
     private static final int BROKER_REPLICAS = 3;
     private static final int CONTROLLER_REPLICAS = 3;
     private static final String INTERNAL_CLUSTER_SECURITY_ANNOTATION = "strimzi.io/internal-cluster-security";
+
+    /**
+     * Generates the combinations of encryption and authentication types for testing.
+     *
+     * @return  A stream of arguments containing encryption and authentication type combinations.
+     */
+    private Stream<Arguments> securityConfigurationCombos() {
+        return Stream.of(
+                Arguments.of(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE),
+                Arguments.of(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)
+        );
+    }
 
     @Tag(CRUISE_CONTROL)
     @Tag(DYNAMIC_CONFIGURATION)
@@ -108,7 +119,7 @@ class ClusterSecurityST extends AbstractST {
         );
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafkaWithCruiseControlTunedForFastModelGeneration(testStorage.getNamespaceName(), testStorage.getClusterName(), BROKER_REPLICAS)
                         .editMetadata()
-                            .addToAnnotations(INTERNAL_CLUSTER_SECURITY_ANNOTATION, clusterSecurityAnnotation(encryption, authentication))
+                            .addToAnnotations(INTERNAL_CLUSTER_SECURITY_ANNOTATION, ClusterSecuritySTUtils.clusterSecurityAnnotation(encryption, authentication))
                         .endMetadata()
                         .editSpec()
                             .editKafka()
@@ -135,16 +146,29 @@ class ClusterSecurityST extends AbstractST {
                 ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build()
         );
         KubeResourceManager.get().createResourceWithWait(
-                authorizedTlsUser(testStorage),
+                KafkaUserTemplates.tlsUserWithAuthorization(testStorage).build(),
                 KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
         );
 
         // Assert security status
-        assertClusterSecurityStatus(testStorage, encryption, authentication);
+        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, encryption, authentication);
 
         // Test message producing and consuming
-        KafkaProducerConsumer clients = kafkaClients(testStorage);
-        sendAndReceiveMessages(testStorage, clients, testStorage.getMessageCount());
+        KafkaProducerConsumer clients = new KafkaProducerConsumerBuilder()
+                .withProducerName(testStorage.getProducerName())
+                .withConsumerName(testStorage.getConsumerName())
+                .withNamespaceName(testStorage.getNamespaceName())
+                .withTopicName(testStorage.getTopicName())
+                .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
+                .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+                .withMessageCount(testStorage.getMessageCount())
+                .withAuthentication(ClientsAuthentication.configureTls(testStorage.getClusterName(), testStorage.getUsername()))
+                .build();
+
+        clients.setMessageCount(testStorage.getMessageCount());
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob(), clients.getConsumer().getJob());
+        ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getProducerName(), testStorage.getMessageCount());
 
         // Check dynamic configuration update
         Map<String, String> controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getControllerSelector());
@@ -170,9 +194,12 @@ class ClusterSecurityST extends AbstractST {
                 BROKER_REPLICAS, brokerPods);
 
         // Test message consumption
-        consumeMessages(testStorage, clients, testStorage.getMessageCount());
+        clients.setMessageCount(testStorage.getMessageCount());
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getMessageCount());
 
-        // Test CRuise Control
+        // Test Cruise Control
         KubeResourceManager.get().createResourceWithWait(
                 KafkaRebalanceTemplates.kafkaRebalance(testStorage.getNamespaceName(), testStorage.getClusterName()).build()
         );
@@ -230,28 +257,61 @@ class ClusterSecurityST extends AbstractST {
                     .build()
         );
         KubeResourceManager.get().createResourceWithWait(
-            authorizedTlsUser(testStorage),
-            KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
+                KafkaUserTemplates.tlsUserWithAuthorization(testStorage).build(),
+                KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
         );
 
-        assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
 
-        KafkaProducerConsumer clients = kafkaClients(testStorage);
-        sendAndReceiveMessages(testStorage, clients, testStorage.getMessageCount());
+        // Test sending and consuming messages works
+        KafkaProducerConsumer clients = new KafkaProducerConsumerBuilder()
+                .withProducerName(testStorage.getProducerName())
+                .withConsumerName(testStorage.getConsumerName())
+                .withNamespaceName(testStorage.getNamespaceName())
+                .withTopicName(testStorage.getTopicName())
+                .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
+                .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+                .withMessageCount(testStorage.getMessageCount())
+                .withAuthentication(ClientsAuthentication.configureTls(testStorage.getClusterName(), testStorage.getUsername()))
+                .build();
+
+        clients.setMessageCount(testStorage.getMessageCount());
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob(), clients.getConsumer().getJob());
+        ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getProducerName(), testStorage.getMessageCount());
+
+        clients.setMessageCount(testStorage.getMessageCount());
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getMessageCount());
 
         // Migrate to different security settings
-        migrateClusterSecurity(testStorage, clusterSecurityAnnotation(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE));
-        assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE);
-        consumeMessages(testStorage, clients, testStorage.getMessageCount());
-        sendMessages(testStorage, clients, testStorage.getMessageCount());
-        consumeMessages(testStorage, clients, 2 * testStorage.getMessageCount());
+        migrateClusterSecurity(testStorage, ClusterSecuritySTUtils.clusterSecurityAnnotation(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE));
+        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE);
+
+        // Test sending and consuming messages still works
+        clients.setMessageCount(testStorage.getMessageCount());
+        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getProducerName(), testStorage.getMessageCount());
+
+        clients.setMessageCount(2 * testStorage.getMessageCount());
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), 2 * testStorage.getMessageCount());
 
         // Migrate back to the original to close the round trip
-        migrateClusterSecurity(testStorage, clusterSecurityAnnotation(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS));
-        assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
-        consumeMessages(testStorage, clients, 2 * testStorage.getMessageCount());
-        sendMessages(testStorage, clients, testStorage.getMessageCount());
-        consumeMessages(testStorage, clients, 3 * testStorage.getMessageCount());
+        migrateClusterSecurity(testStorage, ClusterSecuritySTUtils.clusterSecurityAnnotation(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+
+        // Test sending and consuming messages still works
+        clients.setMessageCount(testStorage.getMessageCount());
+        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getProducerName(), testStorage.getMessageCount());
+
+        clients.setMessageCount(3 * testStorage.getMessageCount());
+        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
+        KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), 3 * testStorage.getMessageCount());
     }
 
     private void migrateClusterSecurity(TestStorage testStorage, String clusterSecurity) {
@@ -289,102 +349,6 @@ class ClusterSecurityST extends AbstractST {
         PodUtils.waitForPodsReady(namespaceName, testStorage.getControllerSelector(), CONTROLLER_REPLICAS, true);
         PodUtils.waitForPodsReady(namespaceName, testStorage.getBrokerSelector(), BROKER_REPLICAS, true);
         KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
-    }
-
-    private KafkaProducerConsumer kafkaClients(TestStorage testStorage) {
-        return new KafkaProducerConsumerBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withMessageCount(testStorage.getMessageCount())
-            .withAuthentication(ClientsAuthentication.configureTls(testStorage.getClusterName(), testStorage.getUsername()))
-            .build();
-    }
-
-    private KafkaUser authorizedTlsUser(TestStorage testStorage) {
-        return KafkaUserTemplates.tlsUser(testStorage)
-            .editSpec()
-                .withNewKafkaUserAuthorizationSimple()
-                    .addNewAcl()
-                        .withNewAclRuleTopicResource()
-                            .withName(testStorage.getTopicName())
-                        .endAclRuleTopicResource()
-                        .withOperations(StrimziAclOperation.READ, StrimziAclOperation.WRITE,
-                            StrimziAclOperation.DESCRIBE, StrimziAclOperation.CREATE)
-                    .endAcl()
-                    .addNewAcl()
-                        .withNewAclRuleGroupResource()
-                            .withName("*")
-                        .endAclRuleGroupResource()
-                        .withOperations(StrimziAclOperation.READ)
-                    .endAcl()
-                .endKafkaUserAuthorizationSimple()
-            .endSpec()
-            .build();
-    }
-
-    private void sendAndReceiveMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
-        clients.setMessageCount(messageCount);
-        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
-        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob(), clients.getConsumer().getJob());
-        ClientUtils.waitForClientsSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), testStorage.getProducerName(), messageCount);
-    }
-
-    private void sendMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
-        clients.setMessageCount(messageCount);
-        KubeResourceManager.get().createResourceWithWait(clients.getProducer().getJob());
-        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getProducerName(), messageCount);
-    }
-
-    private void consumeMessages(TestStorage testStorage, KafkaProducerConsumer clients, int messageCount) {
-        clients.setMessageCount(messageCount);
-        clients.setConsumerGroup(ClientUtils.generateRandomConsumerGroup());
-        KubeResourceManager.get().createResourceWithWait(clients.getConsumer().getJob());
-        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), messageCount);
-    }
-
-
-    /**
-     * Generates the combinations of encryption and authentication types for testing.
-     *
-     * @return  A stream of arguments containing encryption and authentication type combinations.
-     */
-    private Stream<Arguments> securityConfigurationCombos() {
-        return Stream.of(
-                Arguments.of(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE),
-                Arguments.of(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)
-        );
-    }
-
-    /**
-     * Generates the Cluster Security annotation for the given encryption and authentication types
-     *
-     * @param encryption        Encryption type
-     * @param authentication    Authentication type
-     *
-     * @return  Cluster Security annotation as a JSON string
-     */
-    private String clusterSecurityAnnotation(ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
-        return "{\"encryption\":{\"type\":\"" + encryption.toValue() + "\"},\"authentication\":{\"type\":\"" + authentication.toValue() + "\"}}";
-    }
-
-    /**
-     * Checks that the cluster security status corresponds to the desired encryption and authentication types.
-     *
-     * @param testStorage       Test storage containing cluster information
-     * @param encryption        Expected encryption type
-     * @param authentication    Expected authentication type
-     */
-    private void assertClusterSecurityStatus(TestStorage testStorage, ClusterSecurityEncryptionType encryption, ClusterSecurityAuthenticationType authentication) {
-        assertThat(CrdClients.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName())
-                .get().getStatus().getClusterSecurity(),
-            is(Map.of(
-                "encryption", Map.of("type", encryption.toValue()),
-                "authentication", Map.of("type", authentication.toValue())
-            )));
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR adds the system tests covering the disabling of encryption and authentication. It adds two tests:
*  Basic smoke test for the new configurations that will check the basic functionality (producing and consuming messages, reconfiguration, rebalancing)
* A migration tests that checks a round-robin migration with message producing / consumption

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
