### PR TITLE
Bump strimzi-kafka-oauth to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added support for broker cordoning [KIP-1066](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/311627566/KIP-1066+Mechanism+to+cordon+brokers+and+log+directories) during auto-rebalancing on scale down for Kafka 4.3+.
 * Removed deprecated resource state metrics - the KSM (kube-state-metrics) should be used instead.
 * Update Strimzi metrics-reporter to 0.4.0
+* Update strimzi-kafka-oauth to 0.18.0
 
 ### Major changes, deprecations, and removals
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0.RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.18.0.RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.0/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
@@ -20,7 +20,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
@@ -20,7 +20,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0.RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.2.1/pom.xml
@@ -20,7 +20,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.18.0.RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.17.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0.RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.18.0.RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/4.3.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.18.0</strimzi-oauth.version>
         <strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
         <prometheus.version>1.3.6</prometheus.version>
         <cruise-control.version>2.5.146</cruise-control.version>


### PR DESCRIPTION
### Type of change

- Documentation
- Dependency update

### Description

Bump strimzi-kafka-oauth version to 0.18.0

### Checklist

- [] Update documentation
- [x] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
