### PR TITLE
Check the certificate of every Kafka node in `CustomCaST` and `CustomCaChainST`, not only the first broker.

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.security.custom.CustomCaChainST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.security.custom.CustomCaChainST.md
@@ -61,7 +61,7 @@
 | 1. | Generate a custom CA chain: Root -> Intermediate -> Leaf. | CA chain is generated. |
 | 2. | Deploy the full chain as Cluster CA and Clients CA secrets. | CA secrets are deployed. |
 | 3. | Deploy Kafka cluster with custom CAs. | Kafka cluster is ready. |
-| 4. | Verify the broker certificate chain contains 4 certificates and validate the issuer chain: broker cert -> Leaf CA -> Intermediate CA -> Root CA (self-signed). | Chain contains 4 certs with correct issuer relationships and CA basic constraints. |
+| 4. | Verify the certificate chain of every Kafka node contains 4 certificates and validate the issuer chain: node cert -> Leaf CA -> Intermediate CA -> Root CA (self-signed). | Chain of every node contains 4 certs with correct issuer relationships and CA basic constraints. |
 | 5. | Create five trust secrets with different levels: Root + Intermediate + Leaf, Root + Intermediate, Root only, Intermediate only, Leaf only. | Trust secrets are created. |
 | 6. | For each trust secret, verify that clients can successfully produce and consume messages. | All five trust configurations succeed. |
 | 7. | Create a trust secret with only a foreign Root CA. | Foreign trust secret is created. |

--- a/development-docs/systemtests/io.strimzi.systemtest.security.custom.CustomCaST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.security.custom.CustomCaST.md
@@ -18,7 +18,7 @@
 | - | - | - |
 | 1. | Create custom cluster and clients CAs and deploy them as secrets. | Both CA secrets are created. |
 | 2. | Deploy Kafka cluster configured to use custom CAs. | Kafka cluster is deployed using the custom CAs. |
-| 3. | Verify that Kafka broker certificates are signed by the custom cluster CA. | Broker certificates have the correct issuer. |
+| 3. | Verify that the certificates of all Kafka nodes are signed by the custom cluster CA. | Certificates of all Kafka nodes have the correct issuer. |
 | 4. | Create a KafkaUser and verify that its certificate is signed by the custom clients CA. | User certificate has the correct issuer. |
 | 5. | Send and receive messages over TLS. | Messages are successfully produced and consumed. |
 
@@ -56,11 +56,11 @@
 | Step | Action | Result |
 | - | - | - |
 | 1. | Create a custom cluster CA and deploy Kafka cluster with it. | Kafka cluster is deployed with custom cluster CA. |
-| 2. | Record initial CA and broker certificate dates. | Certificate dates are captured. |
+| 2. | Record initial CA and certificate dates of all Kafka nodes. | Certificate dates are captured. |
 | 3. | Pause Kafka reconciliation and update validity and renewal days for cluster CA. | CA configuration is updated. |
 | 4. | Resume reconciliation and wait for components to roll. | Controllers, brokers, and Entity Operator roll. |
 | 5. | Verify CA certificate dates remain unchanged. | Cluster CA was not renewed. |
-| 6. | Verify broker certificates have been renewed with new dates. | Broker certificates have updated validity dates. |
+| 6. | Verify certificates of all Kafka nodes have been renewed with new dates. | Certificates of all Kafka nodes have updated validity dates. |
 
 **Labels:**
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.utils.kubeUtils.objects;
 
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.skodjob.kubetest4j.enums.LogLevel;
@@ -14,6 +15,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.labels.LabelSelectors;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.security.SystemTestCertGenerator;
 import io.strimzi.test.TestUtils;
@@ -35,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class SecretUtils {
 
@@ -219,6 +222,47 @@ public class SecretUtils {
         } catch (CertificateException e) {
             e.printStackTrace();
         }
+        return certificates;
+    }
+
+    /**
+     * Returns the certificate chain of every Kafka node, keyed by Pod name. Each node keeps its certificate
+     * chain in a Secret named after the Pod, under the {@code <podName>.crt} key.
+     *
+     * @param namespaceName     name of the Namespace where the Kafka cluster is deployed
+     * @param clusterName       name of the Kafka cluster
+     *
+     * @return  Map of Pod name to the certificate chain of that node
+     */
+    public static Map<String, List<X509Certificate>> getKafkaNodeCertificateChains(String namespaceName, String clusterName) {
+        Map<String, List<X509Certificate>> chains = new TreeMap<>();
+
+        for (Pod pod : KubeResourceManager.get().kubeClient().listPods(namespaceName, LabelSelectors.allKafkaPodsLabelSelector(clusterName))) {
+            String podName = pod.getMetadata().getName();
+            Secret nodeSecret = KubeResourceManager.get().kubeClient().getClient().secrets().inNamespace(namespaceName).withName(podName).get();
+
+            chains.put(podName, getCertificatesFromSecret(nodeSecret, podName + ".crt"));
+        }
+
+        LOGGER.info("Found certificates of Kafka nodes: {}", chains.keySet());
+
+        return chains;
+    }
+
+    /**
+     * Returns the certificate of every Kafka node, keyed by Pod name. When the CA is a chain, the first
+     * certificate of the chain is the certificate of the node itself.
+     *
+     * @param namespaceName     name of the Namespace where the Kafka cluster is deployed
+     * @param clusterName       name of the Kafka cluster
+     *
+     * @return  Map of Pod name to the certificate of that node
+     */
+    public static Map<String, X509Certificate> getKafkaNodeCertificates(String namespaceName, String clusterName) {
+        Map<String, X509Certificate> certificates = new TreeMap<>();
+
+        getKafkaNodeCertificateChains(namespaceName, clusterName).forEach((podName, chain) -> certificates.put(podName, chain.getFirst()));
+
         return certificates;
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaChainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaChainST.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Tag;
 
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Map;
 
 import static io.strimzi.systemtest.TestTags.CONNECT;
 import static io.strimzi.systemtest.TestTags.CONNECT_COMPONENTS;
@@ -187,7 +188,7 @@ public class CustomCaChainST extends AbstractST {
             @Step(value = "Generate a custom CA chain: Root -> Intermediate -> Leaf.", expected = "CA chain is generated."),
             @Step(value = "Deploy the full chain as Cluster CA and Clients CA secrets.", expected = "CA secrets are deployed."),
             @Step(value = "Deploy Kafka cluster with custom CAs.", expected = "Kafka cluster is ready."),
-            @Step(value = "Verify the broker certificate chain contains 4 certificates and validate the issuer chain: broker cert -> Leaf CA -> Intermediate CA -> Root CA (self-signed).", expected = "Chain contains 4 certs with correct issuer relationships and CA basic constraints."),
+            @Step(value = "Verify the certificate chain of every Kafka node contains 4 certificates and validate the issuer chain: node cert -> Leaf CA -> Intermediate CA -> Root CA (self-signed).", expected = "Chain of every node contains 4 certs with correct issuer relationships and CA basic constraints."),
             @Step(value = "Create five trust secrets with different levels: Root + Intermediate + Leaf, Root + Intermediate, Root only, Intermediate only, Leaf only.", expected = "Trust secrets are created."),
             @Step(value = "For each trust secret, verify that clients can successfully produce and consume messages.", expected = "All five trust configurations succeed."),
             @Step(value = "Create a trust secret with only a foreign Root CA.", expected = "Foreign trust secret is created."),
@@ -199,6 +200,8 @@ public class CustomCaChainST extends AbstractST {
     )
     void testMultistageCustomCaTrustChainEstablishment() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        final int brokerReplicas = 3;
+        final int controllerReplicas = 1;
 
         final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
 
@@ -208,8 +211,8 @@ public class CustomCaChainST extends AbstractST {
         clientsCa.createCustomSecretsFromBundles(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         KubeResourceManager.get().createResourceWithWait(
-            KafkaNodePoolTemplates.brokerPool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3).build(),
-            KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 1).build()
+            KafkaNodePoolTemplates.brokerPool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), brokerReplicas).build(),
+            KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), controllerReplicas).build()
         );
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)
             .editSpec()
@@ -222,28 +225,28 @@ public class CustomCaChainST extends AbstractST {
             .endSpec()
             .build());
 
-        //  Verify broker certificate chain: broker cert -> Leaf CA -> Intermediate CA -> Root CA
-        LOGGER.info("Verifying broker certificate chain contains all certificates");
-        final String brokerPodName = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
-        final List<X509Certificate> brokerChain = SecretUtils.getCertificatesFromSecret(
-            KubeResourceManager.get().kubeClient().getClient().secrets().inNamespace(testStorage.getNamespaceName()).withName(brokerPodName).get(),
-            brokerPodName + ".crt");
-        LOGGER.info("Broker certificate chain contains {} certificates", brokerChain.size());
-        assertThat("Broker certificate chain should contain 4 certs: broker cert, Leaf CA, Intermediate CA, Root CA",
-            brokerChain.size(), is(4));
+        //  Verify certificate chain of every Kafka node: node cert -> Leaf CA -> Intermediate CA -> Root CA
+        LOGGER.info("Verifying certificate chain of every Kafka node contains all certificates");
+        final Map<String, List<X509Certificate>> nodeChains = SecretUtils.getKafkaNodeCertificateChains(testStorage.getNamespaceName(), testStorage.getClusterName());
 
-        final X509Certificate brokerCert = brokerChain.get(0);
-        final X509Certificate leafCaCert = brokerChain.get(1);
-        final X509Certificate intermediateCaCert = brokerChain.get(2);
-        final X509Certificate rootCaCert = brokerChain.get(3);
+        assertThat("Certificate chain of every Kafka node should be found.", nodeChains.size(), is(brokerReplicas + controllerReplicas));
+        nodeChains.forEach((podName, nodeChain) -> {
+            assertThat("Certificate chain of " + podName + " should contain 4 certs: node cert, Leaf CA, Intermediate CA, Root CA",
+                nodeChain.size(), is(4));
 
-        assertThat("Broker cert should be issued by Leaf CA", brokerCert.getIssuerX500Principal(), is(leafCaCert.getSubjectX500Principal()));
-        assertThat("Leaf CA cert should be issued by Intermediate CA", leafCaCert.getIssuerX500Principal(), is(intermediateCaCert.getSubjectX500Principal()));
-        assertThat("Leaf CA cert should be a CA", leafCaCert.getBasicConstraints(), is(greaterThanOrEqualTo(0)));
-        assertThat("Intermediate CA cert should be issued by Root CA", intermediateCaCert.getIssuerX500Principal(), is(rootCaCert.getSubjectX500Principal()));
-        assertThat("Intermediate CA cert should be a CA", intermediateCaCert.getBasicConstraints(), is(greaterThanOrEqualTo(0)));
-        assertThat("Root CA cert should be self-signed", rootCaCert.getIssuerX500Principal(), is(rootCaCert.getSubjectX500Principal()));
-        assertThat("Root CA cert should be a CA", rootCaCert.getBasicConstraints(), is(greaterThanOrEqualTo(0)));
+            final X509Certificate nodeCert = nodeChain.get(0);
+            final X509Certificate leafCaCert = nodeChain.get(1);
+            final X509Certificate intermediateCaCert = nodeChain.get(2);
+            final X509Certificate rootCaCert = nodeChain.get(3);
+
+            assertThat("Node cert of " + podName + " should be issued by Leaf CA", nodeCert.getIssuerX500Principal(), is(leafCaCert.getSubjectX500Principal()));
+            assertThat("Leaf CA cert of " + podName + " should be issued by Intermediate CA", leafCaCert.getIssuerX500Principal(), is(intermediateCaCert.getSubjectX500Principal()));
+            assertThat("Leaf CA cert of " + podName + " should be a CA", leafCaCert.getBasicConstraints(), is(greaterThanOrEqualTo(0)));
+            assertThat("Intermediate CA cert of " + podName + " should be issued by Root CA", intermediateCaCert.getIssuerX500Principal(), is(rootCaCert.getSubjectX500Principal()));
+            assertThat("Intermediate CA cert of " + podName + " should be a CA", intermediateCaCert.getBasicConstraints(), is(greaterThanOrEqualTo(0)));
+            assertThat("Root CA cert of " + podName + " should be self-signed", rootCaCert.getIssuerX500Principal(), is(rootCaCert.getSubjectX500Principal()));
+            assertThat("Root CA cert of " + podName + " should be a CA", rootCaCert.getBasicConstraints(), is(greaterThanOrEqualTo(0)));
+        });
 
         //  Create KafkaUser and Topic
         KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -391,15 +391,15 @@ public class CustomCaST extends AbstractST {
         // Print out certificate dates for debug
         LOGGER.info("Initial ClusterCA cert dates: {} --> {}", initialCertStartTime, initialCertEndTime);
         LOGGER.info("Changed ClusterCA cert dates: {} --> {}", changedCertStartTime, changedCertEndTime);
-        initialNodeCerts.forEach((podName, initialCert) -> {
-            LOGGER.info("{} cert creation dates: {} --> {}", podName, initialCert.getNotBefore(), initialCert.getNotAfter());
-            LOGGER.info("{} cert changed dates:  {} --> {}", podName, changedNodeCerts.get(podName).getNotBefore(), changedNodeCerts.get(podName).getNotAfter());
-        });
 
         // Verify renewal result
         assertThat("ClusterCA cert should not have changed start date.", initialCertEndTime.compareTo(changedCertEndTime) == 0);
         initialNodeCerts.forEach((podName, initialCert) -> {
             final X509Certificate changedCert = changedNodeCerts.get(podName);
+
+            LOGGER.info("{} cert creation dates: {} --> {}", podName, initialCert.getNotBefore(), initialCert.getNotAfter());
+            LOGGER.info("{} cert changed dates:  {} --> {}", podName, changedCert.getNotBefore(), changedCert.getNotAfter());
+
             assertThat("Certificate start date of " + podName + " should have been renewed.",
                     initialCert.getNotBefore().compareTo(changedCert.getNotBefore()) < 0);
             assertThat("Certificate end date of " + podName + " should have been renewed.",

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -60,6 +60,7 @@ import java.util.Date;
 import java.util.Map;
 
 import static io.strimzi.systemtest.TestTags.REGRESSION;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -74,6 +75,8 @@ public class CustomCaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CustomCaST.class);
     private static final String STRIMZI_INTERMEDIATE_CA = "C=CZ, L=Prague, O=Strimzi, CN=StrimziIntermediateCA";
+    private static final int BROKER_REPLICAS = 3;
+    private static final int CONTROLLER_REPLICAS = 3;
 
     @ParallelNamespaceTest
     @TestDoc(
@@ -230,7 +233,7 @@ public class CustomCaST extends AbstractST {
         steps = {
             @Step(value = "Create custom cluster and clients CAs and deploy them as secrets.", expected = "Both CA secrets are created."),
             @Step(value = "Deploy Kafka cluster configured to use custom CAs.", expected = "Kafka cluster is deployed using the custom CAs."),
-            @Step(value = "Verify that Kafka broker certificates are signed by the custom cluster CA.", expected = "Broker certificates have the correct issuer."),
+            @Step(value = "Verify that the certificates of all Kafka nodes are signed by the custom cluster CA.", expected = "Certificates of all Kafka nodes have the correct issuer."),
             @Step(value = "Create a KafkaUser and verify that its certificate is signed by the custom clients CA.", expected = "User certificate has the correct issuer."),
             @Step(value = "Send and receive messages over TLS.", expected = "Messages are successfully produced and consumed.")
         },
@@ -240,6 +243,8 @@ public class CustomCaST extends AbstractST {
     )
     void testCustomClusterCaAndClientsCaCertificates() {
         final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+        final int brokerReplicas = 3;
+        final int controllerReplicas = 1;
 
         final SystemTestCertBundle clientsCa = SystemTestCertBundle.forClientsCa(testStorage);
         final SystemTestCertBundle clusterCa = SystemTestCertBundle.forClusterCa(testStorage);
@@ -256,8 +261,8 @@ public class CustomCaST extends AbstractST {
 
         LOGGER.info("Deploying Kafka with new certs, Secrets");
         KubeResourceManager.get().createResourceWithWait(
-            KafkaNodePoolTemplates.brokerPool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3).build(),
-            KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 1).build()
+            KafkaNodePoolTemplates.brokerPool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), brokerReplicas).build(),
+            KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), controllerReplicas).build()
         );
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)
             .editSpec()
@@ -272,10 +277,12 @@ public class CustomCaST extends AbstractST {
         );
 
         LOGGER.info("Check Kafka(s) certificates");
-        String brokerPodName = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
-        final X509Certificate kafkaCert = SecretUtils.getCertificateFromSecret(KubeResourceManager.get().kubeClient().getClient().secrets().inNamespace(testStorage.getNamespaceName()).withName(brokerPodName).get(), brokerPodName + ".crt");
-        assertThat("KafkaCert does not have expected test Issuer: " + kafkaCert.getIssuerX500Principal().getName(),
-                SystemTestCertGenerator.containsAllDN(kafkaCert.getIssuerX500Principal().getName(), clusterCa.getSubjectDn()));
+        final Map<String, X509Certificate> nodeCerts = SecretUtils.getKafkaNodeCertificates(testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        assertThat("Certificate of every Kafka node should be found.", nodeCerts.size(), is(brokerReplicas + controllerReplicas));
+        nodeCerts.forEach((podName, kafkaCert) ->
+            assertThat("Certificate of " + podName + " does not have expected test Issuer: " + kafkaCert.getIssuerX500Principal().getName(),
+                    SystemTestCertGenerator.containsAllDN(kafkaCert.getIssuerX500Principal().getName(), clusterCa.getSubjectDn())));
 
         KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
@@ -311,11 +318,11 @@ public class CustomCaST extends AbstractST {
         description = @Desc("This test verifies that changing certificate validity and renewal days triggers renewal of cluster certificates without renewing the cluster CA itself."),
         steps = {
             @Step(value = "Create a custom cluster CA and deploy Kafka cluster with it.", expected = "Kafka cluster is deployed with custom cluster CA."),
-            @Step(value = "Record initial CA and broker certificate dates.", expected = "Certificate dates are captured."),
+            @Step(value = "Record initial CA and certificate dates of all Kafka nodes.", expected = "Certificate dates are captured."),
             @Step(value = "Pause Kafka reconciliation and update validity and renewal days for cluster CA.", expected = "CA configuration is updated."),
             @Step(value = "Resume reconciliation and wait for components to roll.", expected = "Controllers, brokers, and Entity Operator roll."),
             @Step(value = "Verify CA certificate dates remain unchanged.", expected = "Cluster CA was not renewed."),
-            @Step(value = "Verify broker certificates have been renewed with new dates.", expected = "Broker certificates have updated validity dates.")
+            @Step(value = "Verify certificates of all Kafka nodes have been renewed with new dates.", expected = "Certificates of all Kafka nodes have updated validity dates.")
         },
         labels = {
             @Label(value = TestDocsLabels.SECURITY)
@@ -342,12 +349,8 @@ public class CustomCaST extends AbstractST {
         final Date initialCertStartTime = cacert.getNotBefore();
         final Date initialCertEndTime = cacert.getNotAfter();
 
-        // Check Broker kafka certificate dates
-        String brokerPodName = KubeResourceManager.get().kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
-        Secret brokerCertCreationSecret = KubeResourceManager.get().kubeClient().getClient().secrets().inNamespace(testStorage.getNamespaceName()).withName(brokerPodName).get();
-        X509Certificate kafkaBrokerCert = SecretUtils.getCertificateFromSecret(brokerCertCreationSecret, brokerPodName + ".crt");
-        final Date initialKafkaBrokerCertStartTime = kafkaBrokerCert.getNotBefore();
-        final Date initialKafkaBrokerCertEndTime = kafkaBrokerCert.getNotAfter();
+        final Map<String, X509Certificate> initialNodeCerts = SecretUtils.getKafkaNodeCertificates(testStorage.getNamespaceName(), testStorage.getClusterName());
+        assertThat("Certificate of every Kafka node should be found.", initialNodeCerts.size(), is(BROKER_REPLICAS + CONTROLLER_REPLICAS));
 
         // Pause Kafka reconciliation
         LOGGER.info("Pause the reconciliation of the Kafka CustomResource ({})", KafkaComponents.getBrokerPodSetName(testStorage.getClusterName()));
@@ -382,22 +385,26 @@ public class CustomCaST extends AbstractST {
         final Date changedCertStartTime = cacert.getNotBefore();
         final Date changedCertEndTime = cacert.getNotAfter();
 
-        // Check renewed Broker kafka certificate dates
-        brokerCertCreationSecret = KubeResourceManager.get().kubeClient().getClient().secrets().inNamespace(testStorage.getNamespaceName()).withName(brokerPodName).get();
-        kafkaBrokerCert = SecretUtils.getCertificateFromSecret(brokerCertCreationSecret, brokerPodName + ".crt");
-        final Date changedKafkaBrokerCertStartTime = kafkaBrokerCert.getNotBefore();
-        final Date changedKafkaBrokerCertEndTime = kafkaBrokerCert.getNotAfter();
+        final Map<String, X509Certificate> changedNodeCerts = SecretUtils.getKafkaNodeCertificates(testStorage.getNamespaceName(), testStorage.getClusterName());
+        assertThat("Every Kafka node should still have a certificate after the renewal.", changedNodeCerts.keySet(), is(initialNodeCerts.keySet()));
 
         // Print out certificate dates for debug
         LOGGER.info("Initial ClusterCA cert dates: {} --> {}", initialCertStartTime, initialCertEndTime);
         LOGGER.info("Changed ClusterCA cert dates: {} --> {}", changedCertStartTime, changedCertEndTime);
-        LOGGER.info("Kafka Broker cert creation dates: {} --> {}", initialKafkaBrokerCertStartTime, initialKafkaBrokerCertEndTime);
-        LOGGER.info("Kafka Broker cert changed dates:  {} --> {}", changedKafkaBrokerCertStartTime, changedKafkaBrokerCertEndTime);
+        initialNodeCerts.forEach((podName, initialCert) -> {
+            LOGGER.info("{} cert creation dates: {} --> {}", podName, initialCert.getNotBefore(), initialCert.getNotAfter());
+            LOGGER.info("{} cert changed dates:  {} --> {}", podName, changedNodeCerts.get(podName).getNotBefore(), changedNodeCerts.get(podName).getNotAfter());
+        });
 
         // Verify renewal result
         assertThat("ClusterCA cert should not have changed start date.", initialCertEndTime.compareTo(changedCertEndTime) == 0);
-        assertThat("Broker certificates start dates should have been renewed.", initialKafkaBrokerCertStartTime.compareTo(changedKafkaBrokerCertStartTime) < 0);
-        assertThat("Broker certificates end dates should have been renewed.", initialKafkaBrokerCertEndTime.compareTo(changedKafkaBrokerCertEndTime) < 0);
+        initialNodeCerts.forEach((podName, initialCert) -> {
+            final X509Certificate changedCert = changedNodeCerts.get(podName);
+            assertThat("Certificate start date of " + podName + " should have been renewed.",
+                    initialCert.getNotBefore().compareTo(changedCert.getNotBefore()) < 0);
+            assertThat("Certificate end date of " + podName + " should have been renewed.",
+                    initialCert.getNotAfter().compareTo(changedCert.getNotAfter()) < 0);
+        });
     }
 
     @ParallelNamespaceTest
@@ -587,8 +594,8 @@ public class CustomCaST extends AbstractST {
         }
 
         KubeResourceManager.get().createResourceWithWait(
-            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3).build(),
-            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), BROKER_REPLICAS).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), CONTROLLER_REPLICAS).build()
         );
         // 2. Create a Kafka cluster without implicit generation of CA and paused reconciliation
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -75,8 +75,8 @@ public class CustomCaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CustomCaST.class);
     private static final String STRIMZI_INTERMEDIATE_CA = "C=CZ, L=Prague, O=Strimzi, CN=StrimziIntermediateCA";
-    private static final int DEFAULT_BROKER_REPLICAS = 3;
-    private static final int DEFAULT_CONTROLLER_REPLICAS = 3;
+    private static final int RENEWAL_TEST_BROKER_REPLICAS = 3;
+    private static final int RENEWAL_TEST_CONTROLLER_REPLICAS = 3;
 
     @ParallelNamespaceTest
     @TestDoc(
@@ -350,7 +350,7 @@ public class CustomCaST extends AbstractST {
         final Date initialCertEndTime = cacert.getNotAfter();
 
         final Map<String, X509Certificate> initialNodeCerts = SecretUtils.getKafkaNodeCertificates(testStorage.getNamespaceName(), testStorage.getClusterName());
-        assertThat("Certificate of every Kafka node should be found.", initialNodeCerts.size(), is(DEFAULT_BROKER_REPLICAS + DEFAULT_CONTROLLER_REPLICAS));
+        assertThat("Certificate of every Kafka node should be found.", initialNodeCerts.size(), is(RENEWAL_TEST_BROKER_REPLICAS + RENEWAL_TEST_CONTROLLER_REPLICAS));
 
         // Pause Kafka reconciliation
         LOGGER.info("Pause the reconciliation of the Kafka CustomResource ({})", KafkaComponents.getBrokerPodSetName(testStorage.getClusterName()));
@@ -594,8 +594,8 @@ public class CustomCaST extends AbstractST {
         }
 
         KubeResourceManager.get().createResourceWithWait(
-            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), DEFAULT_BROKER_REPLICAS).build(),
-            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), DEFAULT_CONTROLLER_REPLICAS).build()
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), RENEWAL_TEST_BROKER_REPLICAS).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), RENEWAL_TEST_CONTROLLER_REPLICAS).build()
         );
         // 2. Create a Kafka cluster without implicit generation of CA and paused reconciliation
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -75,8 +75,8 @@ public class CustomCaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CustomCaST.class);
     private static final String STRIMZI_INTERMEDIATE_CA = "C=CZ, L=Prague, O=Strimzi, CN=StrimziIntermediateCA";
-    private static final int BROKER_REPLICAS = 3;
-    private static final int CONTROLLER_REPLICAS = 3;
+    private static final int DEFAULT_BROKER_REPLICAS = 3;
+    private static final int DEFAULT_CONTROLLER_REPLICAS = 3;
 
     @ParallelNamespaceTest
     @TestDoc(
@@ -350,7 +350,7 @@ public class CustomCaST extends AbstractST {
         final Date initialCertEndTime = cacert.getNotAfter();
 
         final Map<String, X509Certificate> initialNodeCerts = SecretUtils.getKafkaNodeCertificates(testStorage.getNamespaceName(), testStorage.getClusterName());
-        assertThat("Certificate of every Kafka node should be found.", initialNodeCerts.size(), is(BROKER_REPLICAS + CONTROLLER_REPLICAS));
+        assertThat("Certificate of every Kafka node should be found.", initialNodeCerts.size(), is(DEFAULT_BROKER_REPLICAS + DEFAULT_CONTROLLER_REPLICAS));
 
         // Pause Kafka reconciliation
         LOGGER.info("Pause the reconciliation of the Kafka CustomResource ({})", KafkaComponents.getBrokerPodSetName(testStorage.getClusterName()));
@@ -594,8 +594,8 @@ public class CustomCaST extends AbstractST {
         }
 
         KubeResourceManager.get().createResourceWithWait(
-            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), BROKER_REPLICAS).build(),
-            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), CONTROLLER_REPLICAS).build()
+            KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), DEFAULT_BROKER_REPLICAS).build(),
+            KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), DEFAULT_CONTROLLER_REPLICAS).build()
         );
         // 2. Create a Kafka cluster without implicit generation of CA and paused reconciliation
         KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)


### PR DESCRIPTION
Check the certificate of every Kafka node in `CustomCaST` and `CustomCaChainST`, not only the first broker.

Fixes #11028

### Type of change

- Refactoring

### Description

These tests read one certificate, taken from `listPods(...).get(0)`, the first broker Pod. So most nodes were never checked, and controllers were never checked at all, even though their certificates come from the same Cluster CA.

Now the three affected tests check every Kafka node, brokers and controllers. Every failure message starts with the Pod name, so a failing run tells you which node is wrong.

The nodes are collected by two new helpers in `SecretUtils`. They use the existing `LabelSelectors.allKafkaPodsLabelSelector`, which `KafkaRollerST` and `RecoveryST` already use. It matches the Pods of every node pool, so mixed role pools are covered too.

The other tests in `CustomCaST` are unchanged, because they read `ca.crt` from the CA Secret, which is one certificate for the whole cluster. `SecurityST.testClusterCACertRenew` has the same single node pattern, but it tests the CA that Strimzi generates itself, not a custom CA, so I left it out of this change and can open a follow-up issue for it.

#### Testing

The three tests pass on a local kind cluster. They now check 4, 6 and 4 nodes where they checked 1 before, and the helper logs the Pod names it found on every run.

A loop over an empty collection passes every assertion, so I also inverted one assertion to prove the loop really runs. It failed, and the Pod it named was a controller, one the old test never touched.

AI assistance (Claude Code) was used for this change, to explore the tests, write it and run it locally against a real Kubernetes cluster. I reviewed everything before submitting and can explain and defend all of it.

### Checklist

- [x] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))