### PR TITLE
Fix incorrect logging of Ca

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/ca/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/ca/Ca.java
@@ -628,4 +628,9 @@ public abstract class Ca {
             this.caCertsRemoved = true;
         }
     }
+
+    @Override
+    public String toString() {
+        return caRole.caName();
+    }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR and delete the other items_

- Bugfix

### Description

Ca is logged incorrectly:
```
2026-08-18 09:32:40 INFO  KafkaRoller:446 - Reconciliation #124(timer) Kafka(default/my-cluster): Rolling Pod my-cluster-dual-role-0/0 due to [Pod has old io.strimzi.operator.common.ca.InternalCa@55880336 certificate generation, io.strimzi.operator.common.ca.InternalCa@55880336 certificate renewal, Pod has old revision, Kafka broker TLS certificates updated]
```
Add `toString()` on Ca to return caRole.caName(), so that when Ca gets logged, we should see "Cluster CA" or "Clients CA" rather than raw object reference. 

```
2026-08-18 10:02:20 INFO  KafkaRoller:446 - Reconciliation #4(timer) Kafka(default/my-cluster): Rolling Pod my-cluster-dual-role-0/0 due to [Pod has old Cluster CA certificate generation, Cluster CA certificate renewal, Pod has old revision, Kafka broker TLS certificates updated]
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
