### PR TITLE
Remove Vert.x from MetricsAndLoggingUtils

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -350,7 +350,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @return Future for tracking the asynchronous result of getting the metrics and logging config map
      */
     protected Future<ConfigMap> generateMetricsAndLoggingConfigMap(Reconciliation reconciliation, KafkaConnectCluster kafkaConnectCluster) {
-        return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, kafkaConnectCluster.logging(), kafkaConnectCluster.metrics())
+        return VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, kafkaConnectCluster.logging(), kafkaConnectCluster.metrics()))
                 .compose(metricsAndLoggingCm -> Future.succeededFuture(kafkaConnectCluster.generateConnectConfigMap(metricsAndLoggingCm)));
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -209,7 +209,7 @@ public class CruiseControlReconciler {
      */
     protected Future<Void> configMap() {
         if (cruiseControl != null) {
-            return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, cruiseControl.logging(), cruiseControl.metrics())
+            return VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, cruiseControl.logging(), cruiseControl.metrics()))
                     .compose(metricsAndLogging -> {
                         ConfigMap configMap = cruiseControl.generateConfigMap(metricsAndLogging);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -387,7 +387,7 @@ public class EntityOperatorReconciler {
      */
     protected Future<Void> topicOperatorConfigMap() {
         if (shouldInstallEntityOperator() && entityOperator.topicOperator() != null) {
-            return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.topicOperator().logging(), null)
+            return VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.topicOperator().logging(), null))
                     .compose(logging ->
                             VertxUtil.toFuture(configMapOperator.reconcile(
                                     reconciliation,
@@ -411,7 +411,7 @@ public class EntityOperatorReconciler {
      */
     protected Future<Void> userOperatorConfigMap() {
         if (shouldInstallEntityOperator() && entityOperator.userOperator() != null) {
-            return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.userOperator().logging(), null)
+            return VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.userOperator().logging(), null))
                     .compose(logging ->
                             VertxUtil.toFuture(configMapOperator.reconcile(
                                     reconciliation,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -116,7 +116,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 podAnnotations.put(Annotations.ANNO_STRIMZI_AUTH_HASH, Integer.toString(authTlsHash));
                 return Future.succeededFuture();
             })
-            .compose(i -> MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, bridge.logging(), bridge.metrics()))
+            .compose(i -> VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, bridge.logging(), bridge.metrics())))
             .compose(metricsAndLogging -> {
                 ConfigMap configMap = bridge.generateBridgeConfigMap(metricsAndLogging);
                 podAnnotations.put(Annotations.ANNO_STRIMZI_IO_CONFIGURATION_HASH, Util.hashStub(configMap.getData().get(KafkaBridgeCluster.BRIDGE_CONFIGURATION_FILENAME)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -750,7 +750,7 @@ public class KafkaReconciler {
      * @return  Future which completes when the Config Map(s) with configuration are created or updated
      */
     protected Future<Void> brokerConfigurationConfigMaps() {
-        return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, kafka.logging(), kafka.metrics())
+        return VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, kafka.logging(), kafka.metrics()))
                 .compose(metricsAndLoggingCm -> perBrokerKafkaConfiguration(metricsAndLoggingCm));
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtils.java
@@ -41,27 +41,27 @@ public class MetricsAndLoggingUtils {
                                                                        ConfigMapOperator configMapOperations,
                                                                        LoggingModel logging,
                                                                        MetricsModel metrics) {
-        CompletableFuture<ConfigMap> metricsFuture = metricsConfigMap(reconciliation, configMapOperations, metrics);
-        CompletableFuture<ConfigMap> loggingFuture = loggingConfigMap(reconciliation, configMapOperations, logging);
+        CompletableFuture<ConfigMap> metricsFuture = metricsConfigMap(reconciliation, configMapOperations, metrics).toCompletableFuture();
+        CompletableFuture<ConfigMap> loggingFuture = loggingConfigMap(reconciliation, configMapOperations, logging).toCompletableFuture();
         return CompletableFuture.allOf(metricsFuture, loggingFuture)
                 .thenApply(v -> new MetricsAndLogging(metricsFuture.join(), loggingFuture.join()));
     }
 
-    private static CompletableFuture<ConfigMap> metricsConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, MetricsModel metrics) {
+    private static CompletionStage<ConfigMap> metricsConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, MetricsModel metrics) {
         // this is only for JMX Prometheus Exporter, because the Strimzi Metrics Reporter configuration is in the Kafka configuration file
         if (metrics instanceof JmxPrometheusExporterModel model && model.getConfigMapName() != null) {
-            return configMapOperations.getAsync(reconciliation.namespace(), model.getConfigMapName()).toCompletableFuture();
+            return configMapOperations.getAsync(reconciliation.namespace(), model.getConfigMapName());
         } else {
             return CompletableFuture.completedFuture(null);
         }
     }
 
-    private static CompletableFuture<ConfigMap> loggingConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, LoggingModel logging) {
+    private static CompletionStage<ConfigMap> loggingConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, LoggingModel logging) {
         if (logging != null && logging.getLogging() instanceof ExternalLogging externalLogging) {
             if (externalLogging.getValueFrom() != null
                     && externalLogging.getValueFrom().getConfigMapKeyRef() != null
                     && externalLogging.getValueFrom().getConfigMapKeyRef().getName() != null) {
-                return configMapOperations.getAsync(reconciliation.namespace(), externalLogging.getValueFrom().getConfigMapKeyRef().getName()).toCompletableFuture();
+                return configMapOperations.getAsync(reconciliation.namespace(), externalLogging.getValueFrom().getConfigMapKeyRef().getName());
             } else {
                 LOGGER.warnCr(reconciliation, "External logging configuration does not specify logging ConfigMap");
                 throw new InvalidResourceException("External logging configuration does not specify logging ConfigMap");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtils.java
@@ -10,12 +10,13 @@ import io.strimzi.operator.cluster.model.MetricsAndLogging;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.InvalidResourceException;
-import io.vertx.core.Future;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Shared methods for working with Metrics and Logging configurations. These methods are bundled because we store both
@@ -34,38 +35,39 @@ public class MetricsAndLoggingUtils {
      * @param logging               Logging configuration
      * @param metrics               Metrics configuration
      *
-     * @return Future with the metrics and logging configuration holder
+     * @return CompletionStage with the metrics and logging configuration holder
      */
-    public static Future<MetricsAndLogging> metricsAndLogging(Reconciliation reconciliation,
-                                                              ConfigMapOperator configMapOperations,
-                                                              LoggingModel logging,
-                                                              MetricsModel metrics) {
-        return Future
-                .join(metricsConfigMap(reconciliation, configMapOperations, metrics), loggingConfigMap(reconciliation, configMapOperations, logging))
-                .map(result -> new MetricsAndLogging(result.resultAt(0), result.resultAt(1)));
+    public static CompletionStage<MetricsAndLogging> metricsAndLogging(Reconciliation reconciliation,
+                                                                       ConfigMapOperator configMapOperations,
+                                                                       LoggingModel logging,
+                                                                       MetricsModel metrics) {
+        CompletableFuture<ConfigMap> metricsFuture = metricsConfigMap(reconciliation, configMapOperations, metrics);
+        CompletableFuture<ConfigMap> loggingFuture = loggingConfigMap(reconciliation, configMapOperations, logging);
+        return CompletableFuture.allOf(metricsFuture, loggingFuture)
+                .thenApply(v -> new MetricsAndLogging(metricsFuture.join(), loggingFuture.join()));
     }
 
-    private static Future<ConfigMap> metricsConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, MetricsModel metrics) {
+    private static CompletableFuture<ConfigMap> metricsConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, MetricsModel metrics) {
         // this is only for JMX Prometheus Exporter, because the Strimzi Metrics Reporter configuration is in the Kafka configuration file
         if (metrics instanceof JmxPrometheusExporterModel model && model.getConfigMapName() != null) {
-            return VertxUtil.toFuture(configMapOperations.getAsync(reconciliation.namespace(), model.getConfigMapName()));
+            return configMapOperations.getAsync(reconciliation.namespace(), model.getConfigMapName()).toCompletableFuture();
         } else {
-            return Future.succeededFuture(null);
+            return CompletableFuture.completedFuture(null);
         }
     }
 
-    private static Future<ConfigMap> loggingConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, LoggingModel logging) {
+    private static CompletableFuture<ConfigMap> loggingConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, LoggingModel logging) {
         if (logging != null && logging.getLogging() instanceof ExternalLogging externalLogging) {
             if (externalLogging.getValueFrom() != null
                     && externalLogging.getValueFrom().getConfigMapKeyRef() != null
                     && externalLogging.getValueFrom().getConfigMapKeyRef().getName() != null) {
-                return VertxUtil.toFuture(configMapOperations.getAsync(reconciliation.namespace(), externalLogging.getValueFrom().getConfigMapKeyRef().getName()));
+                return configMapOperations.getAsync(reconciliation.namespace(), externalLogging.getValueFrom().getConfigMapKeyRef().getName()).toCompletableFuture();
             } else {
                 LOGGER.warnCr(reconciliation, "External logging configuration does not specify logging ConfigMap");
                 throw new InvalidResourceException("External logging configuration does not specify logging ConfigMap");
             }
         } else {
-            return Future.succeededFuture(null);
+            return CompletableFuture.completedFuture(null);
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.cluster.model.KafkaBridgeCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.MockSharedEnvironmentProvider;
 import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
+import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ClusterRoleBindingOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
@@ -759,7 +760,7 @@ public class KafkaBridgeAssemblyOperatorTest {
         Reconciliation reconciliation = new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, NAMESPACE, NAME);
 
         Checkpoint async = context.checkpoint();
-        MetricsAndLoggingUtils.metricsAndLogging(reconciliation, mockCmOps, originalBridgeCluster.logging(), originalBridgeCluster.metrics())
+        VertxUtil.toFuture(MetricsAndLoggingUtils.metricsAndLogging(reconciliation, mockCmOps, originalBridgeCluster.logging(), originalBridgeCluster.metrics()))
                 .compose(metricsAndLogging -> {
                     ConfigMap originalConfigMap = originalBridgeCluster.generateBridgeConfigMap(metricsAndLogging);
                     String originalHash = Util.hashStub(originalConfigMap.getData().get(KafkaBridgeCluster.BRIDGE_CONFIGURATION_FILENAME));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtilsTest.java
@@ -16,9 +16,11 @@ import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
 import io.strimzi.operator.common.Reconciliation;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class MetricsAndLoggingUtilsTest {
     @Test
     public void testNoMetricsAndNoExternalLogging()   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtilsTest.java
@@ -10,15 +10,12 @@ import io.strimzi.api.kafka.model.common.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpec;
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpecBuilder;
+import io.strimzi.operator.cluster.model.MetricsAndLogging;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
 import io.strimzi.operator.common.Reconciliation;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -35,28 +32,24 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(VertxExtension.class)
 public class MetricsAndLoggingUtilsTest {
     @Test
-    public void testNoMetricsAndNoExternalLogging(VertxTestContext context)   {
+    public void testNoMetricsAndNoExternalLogging()   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpec(), "KafkaConnectCluster");
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
 
-        Checkpoint async = context.checkpoint();
-        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, null)
-                .onComplete(context.succeeding(v -> context.verify(() -> {
-                    assertThat(v.loggingCm(), is(nullValue()));
-                    assertThat(v.metricsCm(), is(nullValue()));
+        MetricsAndLogging v = MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, null)
+                .toCompletableFuture().join();
 
-                    verify(mockCmOps, never()).getAsync(any(), any());
+        assertThat(v.loggingCm(), is(nullValue()));
+        assertThat(v.metricsCm(), is(nullValue()));
 
-                    async.flag();
-                })));
+        verify(mockCmOps, never()).getAsync(any(), any());
     }
 
     @Test
-    public void testMetricsAndExternalLogging(VertxTestContext context)   {
+    public void testMetricsAndExternalLogging()   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster");
         JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
 
@@ -64,61 +57,52 @@ public class MetricsAndLoggingUtilsTest {
         when(mockCmOps.getAsync(any(), eq("logging-cm"))).thenReturn(CompletableFuture.completedFuture(new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of()).build()));
         when(mockCmOps.getAsync(any(), eq("metrics-cm"))).thenReturn(CompletableFuture.completedFuture(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of()).build()));
 
-        Checkpoint async = context.checkpoint();
-        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
-                .onComplete(context.succeeding(v -> context.verify(() -> {
-                    assertThat(v.loggingCm(), is(notNullValue()));
-                    assertThat(v.loggingCm().getMetadata().getName(), is("logging-cm"));
+        MetricsAndLogging v = MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
+                .toCompletableFuture().join();
 
-                    assertThat(v.metricsCm(), is(notNullValue()));
-                    assertThat(v.metricsCm().getMetadata().getName(), is("metrics-cm"));
+        assertThat(v.loggingCm(), is(notNullValue()));
+        assertThat(v.loggingCm().getMetadata().getName(), is("logging-cm"));
 
-                    verify(mockCmOps, times(2)).getAsync(any(), any());
+        assertThat(v.metricsCm(), is(notNullValue()));
+        assertThat(v.metricsCm().getMetadata().getName(), is("metrics-cm"));
 
-                    async.flag();
-                })));
+        verify(mockCmOps, times(2)).getAsync(any(), any());
     }
 
     @Test
-    public void testNoMetricsAndExternalLogging(VertxTestContext context)   {
+    public void testNoMetricsAndExternalLogging()   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster");
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
         when(mockCmOps.getAsync(any(), eq("logging-cm"))).thenReturn(CompletableFuture.completedFuture(new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of()).build()));
 
-        Checkpoint async = context.checkpoint();
-        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, null)
-                .onComplete(context.succeeding(v -> context.verify(() -> {
-                    assertThat(v.loggingCm(), is(notNullValue()));
-                    assertThat(v.loggingCm().getMetadata().getName(), is("logging-cm"));
+        MetricsAndLogging v = MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, null)
+                .toCompletableFuture().join();
 
-                    assertThat(v.metricsCm(), is(nullValue()));
+        assertThat(v.loggingCm(), is(notNullValue()));
+        assertThat(v.loggingCm().getMetadata().getName(), is("logging-cm"));
 
-                    verify(mockCmOps, times(1)).getAsync(any(), any());
+        assertThat(v.metricsCm(), is(nullValue()));
 
-                    async.flag();
-                })));
+        verify(mockCmOps, times(1)).getAsync(any(), any());
     }
 
     @Test
-    public void testMetricsAndNoExternalLogging(VertxTestContext context)   {
+    public void testMetricsAndNoExternalLogging()   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpec(), "KafkaConnectCluster");
         JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
         when(mockCmOps.getAsync(any(), eq("metrics-cm"))).thenReturn(CompletableFuture.completedFuture(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of()).build()));
 
-        Checkpoint async = context.checkpoint();
-        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
-                .onComplete(context.succeeding(v -> context.verify(() -> {
-                    assertThat(v.loggingCm(), is(nullValue()));
+        MetricsAndLogging v = MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
+                .toCompletableFuture().join();
 
-                    assertThat(v.metricsCm(), is(notNullValue()));
-                    assertThat(v.metricsCm().getMetadata().getName(), is("metrics-cm"));
+        assertThat(v.loggingCm(), is(nullValue()));
 
-                    verify(mockCmOps, times(1)).getAsync(any(), any());
+        assertThat(v.metricsCm(), is(notNullValue()));
+        assertThat(v.metricsCm().getMetadata().getName(), is("metrics-cm"));
 
-                    async.flag();
-                })));
+        verify(mockCmOps, times(1)).getAsync(any(), any());
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring
- 
### Description

Remove Vert.x from MetricsAndLoggingUtils and update the related classes. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
