### PR TITLE
Avoid adding empty `properties` objects in the CRDs

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -571,7 +571,12 @@ class CrdGenerator {
 
         result.put("type", "object");
 
-        result.set("properties", buildSchemaProperties(crApiVersion, crdClass, description));
+        ObjectNode properties = buildSchemaProperties(crApiVersion, crdClass, description);
+        if (!properties.isEmpty())   {
+            // We set the proeprties only if not empty because otherwise it causes problems with diffing in Argo
+            result.set("properties", properties);
+        }
+
         ArrayNode oneOf = buildSchemaOneOf(crdClass);
         if (oneOf != null) {
             result.set("oneOf", oneOf);

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -516,14 +516,12 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfRawList:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           arrayOfList:
             type: array
             items:
@@ -536,7 +534,6 @@ spec:
               type: array
               items:
                 type: object
-                properties: {}
           listOfArray:
             type: array
             items:
@@ -547,35 +544,28 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           unstructured:
             type: object
-            properties: {}
             x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
@@ -585,19 +575,16 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar3:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar4:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           listOfCustomizedEnum:
             type: array
             items:
@@ -623,10 +610,8 @@ spec:
             type: string
           status:
             type: object
-            properties: {}
           spec:
             type: object
-            properties: {}
           external:
             type: string
         oneOf:
@@ -1141,14 +1126,12 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfRawList:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           arrayOfList:
             type: array
             items:
@@ -1161,7 +1144,6 @@ spec:
               type: array
               items:
                 type: object
-                properties: {}
           listOfArray:
             type: array
             items:
@@ -1172,35 +1154,28 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           unstructured:
             type: object
-            properties: {}
             x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
@@ -1210,19 +1185,16 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar3:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar4:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           listOfCustomizedEnum:
             type: array
             items:
@@ -1248,10 +1220,8 @@ spec:
             type: string
           status:
             type: object
-            properties: {}
           spec:
             type: object
-            properties: {}
           external:
             type: string
         oneOf:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -522,14 +522,12 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfRawList:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           arrayOfList:
             type: array
             items:
@@ -542,7 +540,6 @@ spec:
               type: array
               items:
                 type: object
-                properties: {}
           listOfArray:
             type: array
             items:
@@ -553,35 +550,28 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           unstructured:
             type: object
-            properties: {}
             x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
@@ -591,19 +581,16 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar3:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar4:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           listOfCustomizedEnum:
             type: array
             items:
@@ -629,10 +616,8 @@ spec:
             type: string
           status:
             type: object
-            properties: {}
           spec:
             type: object
-            properties: {}
           external:
             type: string
         oneOf:
@@ -1147,14 +1132,12 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfRawList:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           arrayOfList:
             type: array
             items:
@@ -1167,7 +1150,6 @@ spec:
               type: array
               items:
                 type: object
-                properties: {}
           listOfArray:
             type: array
             items:
@@ -1178,35 +1160,28 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           unstructured:
             type: object
-            properties: {}
             x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
@@ -1216,19 +1191,16 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar3:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar4:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           listOfCustomizedEnum:
             type: array
             items:
@@ -1254,10 +1226,8 @@ spec:
             type: string
           status:
             type: object
-            properties: {}
           spec:
             type: object
-            properties: {}
           external:
             type: string
         oneOf:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithSubresources.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithSubresources.yaml
@@ -45,10 +45,8 @@ spec:
             type: string
           spec:
             type: object
-            properties: {}
           status:
             type: object
-            properties: {}
   - name: v1beta1
     served: true
     storage: false
@@ -79,7 +77,5 @@ spec:
             type: string
           spec:
             type: object
-            properties: {}
           status:
             type: object
-            properties: {}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -507,14 +507,12 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfRawList:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           arrayOfList:
             type: array
             items:
@@ -527,7 +525,6 @@ spec:
               type: array
               items:
                 type: object
-                properties: {}
           listOfArray:
             type: array
             items:
@@ -538,35 +535,28 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           unstructured:
             type: object
-            properties: {}
             x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
@@ -576,19 +566,16 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar3:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar4:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           listOfCustomizedEnum:
             type: array
             items:
@@ -614,10 +601,8 @@ spec:
             type: string
           status:
             type: object
-            properties: {}
           spec:
             type: object
-            properties: {}
           external:
             type: string
         oneOf:
@@ -1126,14 +1111,12 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfRawList:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           arrayOfList:
             type: array
             items:
@@ -1146,7 +1129,6 @@ spec:
               type: array
               items:
                 type: object
-                properties: {}
           listOfArray:
             type: array
             items:
@@ -1157,35 +1139,28 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar:
             type: array
             items:
               type: object
-              properties: {}
           arrayOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           listOfBoundTypeVar2:
             type: array
             items:
               type: object
-              properties: {}
           unstructured:
             type: object
-            properties: {}
             x-kubernetes-preserve-unknown-fields: true
           listOfWildcardTypeVar1:
             type: array
@@ -1195,19 +1170,16 @@ spec:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar3:
             type: array
             items:
               type: object
-              properties: {}
           listOfWildcardTypeVar4:
             type: array
             items:
               type: array
               items:
                 type: object
-                properties: {}
           listOfCustomizedEnum:
             type: array
             items:
@@ -1233,10 +1205,8 @@ spec:
             type: string
           status:
             type: object
-            properties: {}
           spec:
             type: object
-            properties: {}
           external:
             type: string
         oneOf:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
@@ -43,10 +43,8 @@ spec:
             type: object
           spec:
             type: object
-            properties: {}
           status:
             type: object
-            properties: {}
           someInt:
             type: integer
             minimum: 0
@@ -88,10 +86,8 @@ spec:
             type: object
           spec:
             type: object
-            properties: {}
           status:
             type: object
-            properties: {}
           someInt:
             type: integer
             minimum: 4

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5701,7 +5701,6 @@ spec:
                   description: The status of an auto-rebalancing triggered by a cluster scaling request.
                 clusterSecurity:
                   type: object
-                  properties: {}
                   x-kubernetes-preserve-unknown-fields: true
                   description: The current security configuration of the Kafka cluster.
               description: The status of the Kafka cluster.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -5700,7 +5700,6 @@ spec:
                 description: The status of an auto-rebalancing triggered by a cluster scaling request.
               clusterSecurity:
                 type: object
-                properties: {}
                 x-kubernetes-preserve-unknown-fields: true
                 description: The current security configuration of the Kafka cluster.
             description: The status of the Kafka cluster.


### PR DESCRIPTION
### Type of Change

- Bugfix

### Description

Empty objects in CRDs seem to be causing issues to Argo. This PR removes the empty `properties` objects that showed up in 1.2.0 release.

This should resolve #13074.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass