### PR TITLE
Run GHA integration tests after merge to main only when specific changes are made

### DIFF
--- a/.github/workflows/github-actions-integration.yml
+++ b/.github/workflows/github-actions-integration.yml
@@ -15,6 +15,14 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - '.github/**'
+      - 'pom.xml'
+      - 'Makefile'
+      - 'Makefile.docker'
+      - 'Makefile.maven'
+      - 'Makefile.os'
+      - 'docker-images/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We run integration tests with our GitHub Actions only if a specific files are changed. However, this config was missing for pushes to main so this PR fixes it.

### Checklist

- [x] Make sure all tests pass

