### PR TITLE
Bump kubetest4j to 1.3.1 and add timeout to kubeCmdClient in LogCollector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <kindcontainer.version>2.1.0</kindcontainer.version>
         <testcontainer.version>2.0.2</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
-        <skodjob.kubetest4j.version>1.1.0</skodjob.kubetest4j.version>
+        <skodjob.kubetest4j.version>1.3.0</skodjob.kubetest4j.version>
         <skodjob-doc.version>0.6.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
         <access-operator.version>0.3.0</access-operator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <kindcontainer.version>2.1.0</kindcontainer.version>
         <testcontainer.version>2.0.2</testcontainer.version>
         <docker-java.version>3.4.0</docker-java.version>
-        <skodjob.kubetest4j.version>1.3.0</skodjob.kubetest4j.version>
+        <skodjob.kubetest4j.version>1.3.1</skodjob.kubetest4j.version>
         <skodjob-doc.version>0.6.0</skodjob-doc.version>
         <helm-client.version>0.0.15</helm-client.version>
         <access-operator.version>0.3.0</access-operator.version>

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestLogCollector.java
@@ -191,7 +191,8 @@ public class TestLogCollector {
     public static LogCollectorBuilder defaultLogCollectorBuilder() {
         return new LogCollectorBuilder()
             .withKubeClient(new KubeClient())
-            .withKubeCmdClient(new Kubectl())
+            // Kubectl will have 30s timeouts on the operations to now hang forever in case of node troubles
+            .withKubeCmdClient(new Kubectl().withTimeout(30))
             .withRootFolderPath(Environment.TEST_LOG_DIR)
             .withCollectPreviousLogs();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -795,6 +795,9 @@ public class AbstractKRaftUpgradeST extends AbstractST {
 
     protected void cleanUpKafkaTopics(String componentsNamespaceName) {
         if (CrdUtils.isCrdPresent(KafkaTopic.RESOURCE_PLURAL, KafkaTopic.RESOURCE_GROUP)) {
+            // Strip finalizers first so that topic deletion does not block waiting for the
+            // Topic Operator to respond — the operator may be slow or not yet fully ready.
+            KafkaTopicUtils.setFinalizersInAllTopicsToNull(componentsNamespaceName);
             // delete all topics created in test
             KafkaTopicUtils.deleteAllKafkaTopics(componentsNamespaceName);
         } else {
@@ -809,7 +812,6 @@ public class AbstractKRaftUpgradeST extends AbstractST {
         }
         if (kafkaTopicYaml != null) {
             LOGGER.info("Deleting KafkaTopic configuration files");
-            KafkaTopicUtils.setFinalizersInAllTopicsToNull(componentsNamespaceName);
             KubeResourceManager.get().kubeCmdClient().inNamespace(componentsNamespaceName).delete(kafkaTopicYaml);
         }
         if (kafkaYaml != null) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -781,12 +781,13 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      * Cleans resources installed to namespaces from example files and namespaces themselves.
      */
     protected void cleanUpStrimziUpgradeTestNamespaces() {
+        // Cleanup topics as first to not block namespace deletion due to finalizers
+        cleanUpKafkaTopics(TEST_SUITE_NAMESPACE);
         // flush resources tracked by the resource manager (Kafka, KafkaNodePool, ...) while their CRDs
         // still exist - otherwise the CRDs get removed below by deleteInstalledYamls() first, and the
         // framework's own automatic cleanup (running after this @AfterEach) fails trying to list/delete
         // CRs whose CRD is already gone
         KubeResourceManager.get().deleteResources();
-        cleanUpKafkaTopics(TEST_SUITE_NAMESPACE);
         deleteInstalledYamls(CO_NAMESPACE, TEST_SUITE_NAMESPACE, coDir);
         NamespaceUtils.deleteNamespace(CO_NAMESPACE);
         NamespaceUtils.deleteNamespace(Environment.TEST_SUITE_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractKRaftUpgradeST.java
@@ -781,6 +781,11 @@ public class AbstractKRaftUpgradeST extends AbstractST {
      * Cleans resources installed to namespaces from example files and namespaces themselves.
      */
     protected void cleanUpStrimziUpgradeTestNamespaces() {
+        // flush resources tracked by the resource manager (Kafka, KafkaNodePool, ...) while their CRDs
+        // still exist - otherwise the CRDs get removed below by deleteInstalledYamls() first, and the
+        // framework's own automatic cleanup (running after this @AfterEach) fails trying to list/delete
+        // CRs whose CRD is already gone
+        KubeResourceManager.get().deleteResources();
         cleanUpKafkaTopics(TEST_SUITE_NAMESPACE);
         deleteInstalledYamls(CO_NAMESPACE, TEST_SUITE_NAMESPACE, coDir);
         NamespaceUtils.deleteNamespace(CO_NAMESPACE);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Dependency update

### Description

This PR bumps kubetest4j to version 1.3 . Also during testing of Strimzi 1.2.0 I found that in case of node failures it can happen that log collector hangs forever and the tests eventually hit the timeout of execution pipeline. This should be mitigated by setting timeout to `kubeCmdClient` created inside `LogCollector`. I think 30s should be sufficient for most of the operations as the timeout is per command.

### Checklist

- [ ] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
