### PR TITLE
Fixed private key generation in PKCS#8 format directly (removed conversion from PKCS#1)

### DIFF
--- a/certificate-issuer/src/main/java/io/strimzi/certs/OpenSslCertIssuer.java
+++ b/certificate-issuer/src/main/java/io/strimzi/certs/OpenSslCertIssuer.java
@@ -286,7 +286,6 @@ public class OpenSslCertIssuer implements CertIssuer {
         }
 
         // Generate a CSR for the key
-        Path tmpKey = null;
         Path sna = null;
         Path defaultConfig = null;
         Path csrFile = null;
@@ -295,18 +294,13 @@ public class OpenSslCertIssuer implements CertIssuer {
         Path attr = null;
 
         try {
-            tmpKey = Files.createTempFile(null, null);
-            boolean keyInPkcs1;
             if (subjectKeyFile.length() == 0) {
-                // Generate a key pair
-                new OpensslArgs("openssl", "genrsa")
-                        .optArg("-out", tmpKey)
-                        .opt("4096")
+                // Generate a new key pair directly in PKCS#8 format (bracketed by BEGIN/END PRIVATE KEY)
+                new OpensslArgs("openssl", "genpkey")
+                        .optArg("-algorithm", "RSA")
+                        .optArg("-pkeyopt", "rsa_keygen_bits:4096")
+                        .optArg("-out", subjectKeyFile)
                         .exec();
-                keyInPkcs1 = true;
-            } else {
-                Files.copy(subjectKeyFile.toPath(), tmpKey, StandardCopyOption.REPLACE_EXISTING);
-                keyInPkcs1 = false;
             }
 
             csrFile = Files.createTempFile(null, null);
@@ -314,7 +308,7 @@ public class OpenSslCertIssuer implements CertIssuer {
             new OpensslArgs("openssl", "req")
                     .opt("-new")
                     .optArg("-config", sna, true)
-                    .optArg("-key", tmpKey)
+                    .optArg("-key", subjectKeyFile)
                     .optArg("-out", csrFile)
                     .optArg("-subj", subject)
                     .exec();
@@ -328,7 +322,7 @@ public class OpenSslCertIssuer implements CertIssuer {
                     .opt("-utf8").opt("-batch").opt("-notext");
             if (issuerCaCertFile == null) {
                 opt.opt("-selfsign");
-                opt.optArg("-keyfile", tmpKey);
+                opt.optArg("-keyfile", subjectKeyFile);
             } else {
                 opt.optArg("-cert", issuerCaCertFile);
                 opt.optArg("-keyfile", issuerCaKeyFile);
@@ -344,19 +338,8 @@ public class OpenSslCertIssuer implements CertIssuer {
                     .basicConstraints("critical,CA:true,pathlen:" + pathLength)
                     .keyUsage("critical,keyCertSign,cRLSign")
                     .exec(false);
-
-            if (keyInPkcs1) {
-                // If the key is in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
-                // convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)
-                new OpensslArgs("openssl", "pkcs8")
-                        .opt("-topk8").opt("-nocrypt")
-                        .optArg("-in", tmpKey)
-                        .optArg("-out", subjectKeyFile)
-                        .exec();
-            }
         } finally {
-            deleteAll(tmpKey,
-                    database,
+            deleteAll(database,
                     // The .old files are created by OpenSSL
                     database != null ? Paths.get(database + ".old") : null,
                     attr,


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `generateCaCert` method in `OpenSslCertIssuer` creates the CA private key with `openssl genrsa`, which produces a PKCS#1 key, and then converts it to PKCS#8 with a separate `openssl pkcs8 -topk8 -nocrypt` call, using a temporary working file in between. I am not sure about the reason for doing this in the past but I think it doesn't make any sense.

This PR uses `openssl genpkey` instead. It can emit an unencrypted PKCS#8 key (still 4096 bits) directly and straight into the subject key file and uses that same file for the `openssl req` and `openssl ca` calls, removing the temporary file, the conversion step, and the flag that tracked it. The code also has one fewer openssl subprocess per CA key generation.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
