### PR TITLE
Rename `strimzi-tls` and `strimzi-mtls` to `tls` and `mtls`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthentication.java
@@ -25,12 +25,11 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"type", "expirationSeconds"})
+@JsonPropertyOrder({"type"})
 @EqualsAndHashCode
 @ToString
 public class ClusterSecurityAuthentication implements UnknownPropertyPreserving {
     private ClusterSecurityAuthenticationType type;
-    private Integer expirationSeconds;
     private Map<String, Object> additionalProperties;
 
     @Description("""
@@ -47,19 +46,6 @@ public class ClusterSecurityAuthentication implements UnknownPropertyPreserving 
 
     public void setType(ClusterSecurityAuthenticationType type) {
         this.type = type;
-    }
-
-    @Description("The expiration time in seconds for the Service Account tokens used for authentication. " +
-            "This field is only applicable for `type: service-account` authentication. " +
-            "Defaults to 1 hour when not set.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @RequiredInVersions("v1+")
-    public Integer getExpirationSeconds() {
-        return expirationSeconds;
-    }
-
-    public void setExpirationSeconds(Integer expirationSeconds) {
-        this.expirationSeconds = expirationSeconds;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthentication.java
@@ -33,9 +33,9 @@ public class ClusterSecurityAuthentication implements UnknownPropertyPreserving 
     private Map<String, Object> additionalProperties;
 
     @Description("The type of authentication used for this cluster's internal communication. " +
-            "Supported types are:" +
-            "* `none` for no authentication" +
-            "* `strimzi-mtls` for Strimzi-based mTLS encryption")
+            "Supported types are:\n\n" +
+            "* `none` for no authentication\n" +
+            "* `mtls` for  mTLS encryption")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityAuthenticationType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthentication.java
@@ -25,17 +25,20 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"type"})
+@JsonPropertyOrder({"type", "expirationSeconds"})
 @EqualsAndHashCode
 @ToString
 public class ClusterSecurityAuthentication implements UnknownPropertyPreserving {
     private ClusterSecurityAuthenticationType type;
+    private Integer expirationSeconds;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of authentication used for this cluster's internal communication. " +
-            "Supported types are:\n\n" +
-            "* `none` for no authentication\n" +
-            "* `mtls` for  mTLS encryption")
+    @Description("""
+            The type of authentication used for this cluster's internal communication.
+            Supported types are:
+            
+            * `none` for no authentication
+            * `mtls` for mTLS authentication""")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityAuthenticationType getType() {
@@ -44,6 +47,19 @@ public class ClusterSecurityAuthentication implements UnknownPropertyPreserving 
 
     public void setType(ClusterSecurityAuthenticationType type) {
         this.type = type;
+    }
+
+    @Description("The expiration time in seconds for the Service Account tokens used for authentication. " +
+            "This field is only applicable for `type: service-account` authentication. " +
+            "Defaults to 1 hour when not set.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @RequiredInVersions("v1+")
+    public Integer getExpirationSeconds() {
+        return expirationSeconds;
+    }
+
+    public void setExpirationSeconds(Integer expirationSeconds) {
+        this.expirationSeconds = expirationSeconds;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
@@ -33,8 +33,9 @@ public class ClusterSecurityAuthenticationStatus implements UnknownPropertyPrese
     private Map<String, Object> additionalProperties;
 
     @Description("The type of authentication currently used for this cluster's internal communication. " +
-            "Supported types are:" +
-            "* `strimzi-mtls` for Strimzi-based mTLS encryption")
+            "Supported types are:\n\n" +
+            "* `none` for no authentication\n" +
+            "* `mtls` for  mTLS encryption")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityAuthenticationType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationStatus.java
@@ -32,10 +32,12 @@ public class ClusterSecurityAuthenticationStatus implements UnknownPropertyPrese
     private ClusterSecurityAuthenticationType type;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of authentication currently used for this cluster's internal communication. " +
-            "Supported types are:\n\n" +
-            "* `none` for no authentication\n" +
-            "* `mtls` for  mTLS encryption")
+    @Description("""
+            The type of authentication currently used for this cluster's internal communication.
+            Supported types are:
+            
+            * `none` for no authentication
+            * `mtls` for mTLS authentication""")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityAuthenticationType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationType.java
@@ -12,13 +12,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public enum ClusterSecurityAuthenticationType {
     NONE,
-    STRIMZI_MTLS;
+    MTLS;
 
     @JsonCreator
     public static ClusterSecurityAuthenticationType forValue(String value) {
         return switch (value) {
             case "none" -> NONE;
-            case "strimzi-mtls" -> STRIMZI_MTLS;
+            case "mtls" -> MTLS;
             default -> null;
         };
     }
@@ -27,7 +27,7 @@ public enum ClusterSecurityAuthenticationType {
     public String toValue() {
         return switch (this) {
             case NONE -> "none";
-            case STRIMZI_MTLS -> "strimzi-mtls";
+            case MTLS -> "mtls";
         };
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryption.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryption.java
@@ -33,9 +33,9 @@ public class ClusterSecurityEncryption implements UnknownPropertyPreserving {
     private Map<String, Object> additionalProperties;
 
     @Description("The type of encryption used for this cluster's internal communication. " +
-            "Supported types are:" +
-            "* `none` for no encryption" +
-            "* `strimzi-tls` for Strimzi-based TLS encryption")
+            "Supported types are:\n\n" +
+            "* `none` for no encryption\n" +
+            "* `tls` for TLS encryption")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityEncryptionType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryption.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryption.java
@@ -32,10 +32,12 @@ public class ClusterSecurityEncryption implements UnknownPropertyPreserving {
     private ClusterSecurityEncryptionType type;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of encryption used for this cluster's internal communication. " +
-            "Supported types are:\n\n" +
-            "* `none` for no encryption\n" +
-            "* `tls` for TLS encryption")
+    @Description("""
+            The type of encryption used for this cluster's internal communication. \
+            Supported types are:
+            
+            * `none` for no encryption
+            * `tls` for TLS encryption""")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityEncryptionType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
@@ -33,8 +33,9 @@ public class ClusterSecurityEncryptionStatus implements UnknownPropertyPreservin
     private Map<String, Object> additionalProperties;
 
     @Description("The type of encryption currently used for this cluster's internal communication. " +
-            "Supported types are:" +
-            "* `strimzi-tls` for Strimzi-based TLS encryption")
+            "Supported types are:\n\n" +
+            "* `none` for no encryption\n" +
+            "* `tls` for TLS encryption")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityEncryptionType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionStatus.java
@@ -32,10 +32,12 @@ public class ClusterSecurityEncryptionStatus implements UnknownPropertyPreservin
     private ClusterSecurityEncryptionType type;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of encryption currently used for this cluster's internal communication. " +
-            "Supported types are:\n\n" +
-            "* `none` for no encryption\n" +
-            "* `tls` for TLS encryption")
+    @Description("""
+            The type of encryption currently used for this cluster's internal communication. \
+            Supported types are:
+            
+            * `none` for no encryption
+            * `tls` for TLS encryption""")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @RequiredInVersions("v1+")
     public ClusterSecurityEncryptionType getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionType.java
@@ -12,13 +12,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public enum ClusterSecurityEncryptionType {
     NONE,
-    STRIMZI_TLS;
+    TLS;
 
     @JsonCreator
     public static ClusterSecurityEncryptionType forValue(String value) {
         return switch (value) {
             case "none" -> NONE;
-            case "strimzi-tls" -> STRIMZI_TLS;
+            case "tls" -> TLS;
             default -> null;
         };
     }
@@ -27,7 +27,7 @@ public enum ClusterSecurityEncryptionType {
     public String toValue() {
         return switch (this) {
             case NONE -> "none";
-            case STRIMZI_TLS -> "strimzi-tls";
+            case TLS -> "tls";
         };
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -335,7 +335,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         List<Volume> volumes = new ArrayList<>();
         volumes.add(VolumeUtils.createTempDirVolume(templatePod));
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             // The CA certificate is used for encryption of Kafka client.
             // The CC certificate is needed for encryption of the HTTP server.
             // So we need both volumes regardless whether mTLS is enabled or not.
@@ -355,7 +355,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         List<VolumeMount> volumeMounts = new ArrayList<>();
         volumeMounts.add(VolumeUtils.createTempDirVolumeMount());
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             // The CA certificate is used for encryption of Kafka client.
             // The CC certificate is needed for encryption of the HTTP server.
             // So we need both volume mounts regardless whether mTLS is enabled or not.
@@ -432,8 +432,8 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KAFKA_BOOTSTRAP_SERVERS, KafkaResources.bootstrapServiceName(cluster) + ":" + KafkaCluster.REPLICATION_PORT));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
-        varList.add(ContainerUtils.createEnvVar(ENV_VAR_TLS_ENABLED, String.valueOf(securityContext.isStrimziTlsEncryption())));
-        varList.add(ContainerUtils.createEnvVar(ENV_VAR_MTLS_ENABLED, String.valueOf(securityContext.isStrimziMtlsAuthentication())));
+        varList.add(ContainerUtils.createEnvVar(ENV_VAR_TLS_ENABLED, String.valueOf(securityContext.isTlsEncryption())));
+        varList.add(ContainerUtils.createEnvVar(ENV_VAR_MTLS_ENABLED, String.valueOf(securityContext.isMtlsAuthentication())));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_API_AUTH_ENABLED, String.valueOf(configuration.isApiAuthEnabled())));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_API_HEALTHCHECK_USERNAME, CruiseControlApiProperties.HEALTHCHECK_USERNAME));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_API_PORT, String.valueOf(REST_API_PORT)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -199,11 +199,11 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
         }
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_SECURITY_PROTOCOL, "SSL"));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_TLS_TRUSTED_CERTS_SECRET_NAME, AbstractModel.clusterCaCertSecretName(cluster)));
 
-            if (securityContext.isStrimziMtlsAuthentication()) {
+            if (securityContext.isMtlsAuthentication()) {
                 varList.add(ContainerUtils.createEnvVar(ENV_VAR_TLS_SECRET_NAME, KafkaResources.entityTopicOperatorSecretName(cluster)));
                 varList.add(ContainerUtils.createEnvVar(ENV_VAR_TLS_KEY_NAME, Ca.SecretEntry.KEY.asKey(EntityOperator.COMPONENT_TYPE)));
                 varList.add(ContainerUtils.createEnvVar(ENV_VAR_TLS_CERT_NAME, Ca.SecretEntry.CRT.asKey(EntityOperator.COMPONENT_TYPE)));
@@ -225,7 +225,7 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_RACK_ENABLED, Boolean.toString(rackAwarenessEnabled)));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_HOSTNAME, String.format("%s-cruise-control.%s.svc", cluster, namespace)));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_PORT, String.valueOf(CRUISE_CONTROL_API_PORT)));
-            varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_SSL_ENABLED, String.valueOf(securityContext.isStrimziTlsEncryption())));
+            varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_SSL_ENABLED, String.valueOf(securityContext.isTlsEncryption())));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_AUTH_ENABLED, "true"));
             // Truststore and API credentials are mounted in the container
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -210,10 +210,10 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_CLIENTS_CA_VALIDITY, Integer.toString(clientsCaValidityDays)));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME, KafkaCluster.clusterCaCertSecretName(cluster)));
 
-            if (securityContext.isStrimziMtlsAuthentication()) {
+            if (securityContext.isMtlsAuthentication()) {
                 varList.add(ContainerUtils.createEnvVar(ENV_VAR_EO_KEY_SECRET_NAME, KafkaResources.entityUserOperatorSecretName(cluster)));
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaAgentConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaAgentConfigurationBuilder.java
@@ -42,11 +42,11 @@ public class KafkaAgentConfigurationBuilder {
     public KafkaAgentConfigurationBuilder withSecurity(KafkaClusterSecurityContext securityContext)   {
         printSectionHeader("Security configuration");
 
-        if (securityContext.isStrimziTlsEncryption())   {
+        if (securityContext.isTlsEncryption())   {
             writer.println("namespace=" + reconciliation.namespace());
             writer.println("sslKeyStoreSecretName=" + node.podName());
 
-            if (securityContext.isStrimziMtlsAuthentication()) {
+            if (securityContext.isMtlsAuthentication()) {
                 writer.println("sslTrustStoreSecretName=" + reconciliation.name() + "-cluster-ca-cert");
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -110,13 +110,13 @@ public class KafkaBrokerConfigurationBuilder {
             // to the pods behind the bootstrap one when they are not ready during startup.
             writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_BOOTSTRAP_SERVERS + "=" + KafkaResources.brokersServiceName(clusterName) + ":9091");
 
-            if (securityContext.isStrimziTlsEncryption())   {
+            if (securityContext.isTlsEncryption())   {
                 writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_ENDPOINT_ID_ALGO + "=HTTPS");
                 writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SECURITY_PROTOCOL + "=SSL");
                 writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_TYPE + "=PEM");
                 writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_CERTIFICATES + "=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), KafkaResources.trustBundleSecretName(clusterName), "cluster-ca.crt"));
 
-                if (securityContext.isStrimziMtlsAuthentication())   {
+                if (securityContext.isMtlsAuthentication())   {
                     writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_KEYSTORE_TYPE + "=PEM");
                     writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_KEYSTORE_CERTIFICATE_CHAIN + "=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".crt"));
                     writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_KEYSTORE_KEY + "=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".key"));
@@ -251,7 +251,7 @@ public class KafkaBrokerConfigurationBuilder {
 
         // Control plane listener is configured for all nodes. Even brokers need to connect and talk to controllers, so
         // they need to know what is the security protocol and security configuration
-        securityProtocol.add(CONTROL_PLANE_LISTENER_NAME + ":" + getSecurityProtocol(securityContext.isStrimziTlsEncryption(), false));
+        securityProtocol.add(CONTROL_PLANE_LISTENER_NAME + ":" + getSecurityProtocol(securityContext.isTlsEncryption(), false));
         configureControlPlaneListener(clusterName);
 
         ////////////////////
@@ -274,7 +274,7 @@ public class KafkaBrokerConfigurationBuilder {
 
         if (node.broker()) {
             // Replication Listener to be configured only on brokers
-            securityProtocol.add(REPLICATION_LISTENER_NAME + ":" + getSecurityProtocol(securityContext.isStrimziTlsEncryption(), false));
+            securityProtocol.add(REPLICATION_LISTENER_NAME + ":" + getSecurityProtocol(securityContext.isTlsEncryption(), false));
             listeners.add(REPLICATION_LISTENER_NAME + "://0.0.0.0:9091");
             advertisedListeners.add(String.format("%s://%s:9091",
                     REPLICATION_LISTENER_NAME,
@@ -359,7 +359,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param listenerName  Name of the listener
      */
     private void configureReplicationOrControlPlaneListener(String listenerName, String clusterName) {
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             writer.println("listener.name." + listenerName + ".ssl.truststore.certificates=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), KafkaResources.trustBundleSecretName(clusterName), "cluster-ca.crt"));
             writer.println("listener.name." + listenerName + ".ssl.truststore.type=PEM");
 
@@ -368,7 +368,7 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println("listener.name." + listenerName + ".ssl.keystore.key=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".key"));
             writer.println("listener.name." + listenerName + ".ssl.keystore.type=PEM");
 
-            if (securityContext.isStrimziMtlsAuthentication())  {
+            if (securityContext.isMtlsAuthentication())  {
                 writer.println("listener.name." + listenerName + ".ssl.client.auth=required");
             }
 
@@ -489,7 +489,7 @@ public class KafkaBrokerConfigurationBuilder {
         if (authorization != null) {
             List<String> superUsers = new ArrayList<>();
 
-            if (securityContext.isStrimziMtlsAuthentication()) {
+            if (securityContext.isMtlsAuthentication()) {
                 // Superusers for mTLS authentication => they represent the internal components
                 superUsers.add(String.format("User:CN=%s,O=io.strimzi", KafkaResources.kafkaComponentName(clusterName)));
                 superUsers.add(String.format("User:CN=%s-%s,O=io.strimzi", clusterName, "entity-topic-operator"));
@@ -797,12 +797,12 @@ public class KafkaBrokerConfigurationBuilder {
         writer.println("remote.log.metadata.manager.listener.name=" + REPLICATION_LISTENER_NAME);
         writer.println("rlmm.config.remote.log.metadata.common.client.bootstrap.servers=" + clusterName + "-kafka-brokers:9091");
 
-        if (securityContext.isStrimziTlsEncryption())   {
+        if (securityContext.isTlsEncryption())   {
             writer.println("rlmm.config.remote.log.metadata.common.client.security.protocol=SSL");
             writer.println("rlmm.config.remote.log.metadata.common.client.ssl.truststore.certificates=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), KafkaResources.trustBundleSecretName(clusterName), "cluster-ca.crt"));
             writer.println("rlmm.config.remote.log.metadata.common.client.ssl.truststore.type=PEM");
 
-            if (securityContext.isStrimziMtlsAuthentication())  {
+            if (securityContext.isMtlsAuthentication())  {
                 writer.println("rlmm.config.remote.log.metadata.common.client.ssl.keystore.certificate.chain=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".crt"));
                 writer.println("rlmm.config.remote.log.metadata.common.client.ssl.keystore.key=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".key"));
                 writer.println("rlmm.config.remote.log.metadata.common.client.ssl.keystore.type=PEM");
@@ -863,12 +863,12 @@ public class KafkaBrokerConfigurationBuilder {
         // configuration of Admin client that will check the cluster
         writer.println("client.quota.callback.static.kafka.admin.bootstrap.servers=" + KafkaResources.brokersServiceName(clusterName) + ":9091");
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             writer.println("client.quota.callback.static.kafka.admin.security.protocol=SSL");
             writer.println("client.quota.callback.static.kafka.admin.ssl.truststore.certificates=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), KafkaResources.trustBundleSecretName(clusterName), "cluster-ca.crt"));
             writer.println("client.quota.callback.static.kafka.admin.ssl.truststore.type=PEM");
 
-            if (securityContext.isStrimziMtlsAuthentication())  {
+            if (securityContext.isMtlsAuthentication())  {
                 writer.println("client.quota.callback.static.kafka.admin.ssl.keystore.certificate.chain=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".crt"));
                 writer.println("client.quota.callback.static.kafka.admin.ssl.keystore.key=" + String.format(PLACEHOLDER_SECRET_TEMPLATE_KUBE_CONFIG_PROVIDER, reconciliation.namespace(), node.podName(), node.podName() + ".key"));
                 writer.println("client.quota.callback.static.kafka.admin.ssl.keystore.type=PEM");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContext.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContext.java
@@ -27,7 +27,7 @@ public class KafkaClusterSecurityContext {
     /**
      * The default Kafka Cluster Security Context configuration
      */
-    public static final KafkaClusterSecurityContext DEFAULT_KAFKA_CLUSTER_SECURITY_CONTEXT =  new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+    public static final KafkaClusterSecurityContext DEFAULT_KAFKA_CLUSTER_SECURITY_CONTEXT =  new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
 
     private final ClusterSecurityEncryptionType encryptionType;
     private final ClusterSecurityAuthenticationType authenticationType;
@@ -57,7 +57,7 @@ public class KafkaClusterSecurityContext {
         } else if (clusterSecurity == null) {
             // Cluster Security exists in status, but it is not configured in the annotation. We need to doublecheck
             // that the status uses the default configuration.
-            validateSpecAndStatusMatch(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS, clusterSecurityStatus);
+            validateSpecAndStatusMatch(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS, clusterSecurityStatus);
             return DEFAULT_KAFKA_CLUSTER_SECURITY_CONTEXT;
         } else if (clusterSecurityStatus == null) {
             // Cluster Security does not exist in status, but it is configured in the annotation. This is a new cluster
@@ -73,8 +73,8 @@ public class KafkaClusterSecurityContext {
 
     private static KafkaClusterSecurityContext createContextFromSpec(ClusterSecurity clusterSecurity) {
         return new KafkaClusterSecurityContext(
-                clusterSecurity.getEncryption() != null && clusterSecurity.getEncryption().getType() != null ? clusterSecurity.getEncryption().getType() : ClusterSecurityEncryptionType.STRIMZI_TLS,
-                clusterSecurity.getAuthentication() != null && clusterSecurity.getAuthentication().getType() != null ? clusterSecurity.getAuthentication().getType() : ClusterSecurityAuthenticationType.STRIMZI_MTLS
+                clusterSecurity.getEncryption() != null && clusterSecurity.getEncryption().getType() != null ? clusterSecurity.getEncryption().getType() : ClusterSecurityEncryptionType.TLS,
+                clusterSecurity.getAuthentication() != null && clusterSecurity.getAuthentication().getType() != null ? clusterSecurity.getAuthentication().getType() : ClusterSecurityAuthenticationType.MTLS
         );
     }
 
@@ -142,7 +142,7 @@ public class KafkaClusterSecurityContext {
      */
     private void validateDesiredConfiguration() {
         // Check that mTLS is not enabled when TLS is disabled
-        if (authenticationType == ClusterSecurityAuthenticationType.STRIMZI_MTLS && encryptionType != ClusterSecurityEncryptionType.STRIMZI_TLS) {
+        if (authenticationType == ClusterSecurityAuthenticationType.MTLS && encryptionType != ClusterSecurityEncryptionType.TLS) {
             LOGGER.errorOp("Desired Cluster Security configuration (encryption: {}, authentication: {}) is not valid: mTLS authentication can be used only with enabled TLS encryption",
                     encryptionType, authenticationType);
             throw new InvalidResourceException("Desired Cluster Security configuration is not valid: mTLS authentication can be used only with enabled TLS encryption.");
@@ -166,20 +166,20 @@ public class KafkaClusterSecurityContext {
     }
 
     /**
-     * Returns whether Strimzi-based TLS encryption should be used or not.
+     * Returns whether TLS encryption should be used or not.
      *
-     * @return  True if the encryption type is STRIMZI_TLS, false otherwise
+     * @return  True if the encryption type is TLS, false otherwise
      */
-    public boolean isStrimziTlsEncryption() {
-        return encryptionType == ClusterSecurityEncryptionType.STRIMZI_TLS;
+    public boolean isTlsEncryption() {
+        return encryptionType == ClusterSecurityEncryptionType.TLS;
     }
 
     /**
-     * Returns whether Strimzi-based mTLS authentication should be used or not.
+     * Returns whether mTLS authentication should be used or not.
      *
-     * @return  True if the authentication type is STRIMZI_MTLS, false otherwise
+     * @return  True if the authentication type is MTLS, false otherwise
      */
-    public boolean isStrimziMtlsAuthentication() {
-        return authenticationType == ClusterSecurityAuthenticationType.STRIMZI_MTLS;
+    public boolean isMtlsAuthentication() {
+        return authenticationType == ClusterSecurityAuthenticationType.MTLS;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -274,10 +274,10 @@ public class KafkaExporter extends AbstractModel {
 
         volumeList.add(VolumeUtils.createTempDirVolume(templatePod));
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             volumeList.add(VolumeUtils.createSecretVolume(CLUSTER_CA_CERTS_VOLUME_NAME, KafkaResources.trustBundleSecretName(cluster), isOpenShift));
 
-            if (securityContext.isStrimziMtlsAuthentication())  {
+            if (securityContext.isMtlsAuthentication())  {
                 volumeList.add(VolumeUtils.createSecretVolume(KAFKA_EXPORTER_CERTS_VOLUME_NAME, KafkaExporterResources.secretName(cluster), isOpenShift));
             }
         }
@@ -291,10 +291,10 @@ public class KafkaExporter extends AbstractModel {
         List<VolumeMount> volumeList = new ArrayList<>(3);
         volumeList.add(VolumeUtils.createTempDirVolumeMount());
 
-        if (securityContext.isStrimziTlsEncryption()) {
+        if (securityContext.isTlsEncryption()) {
             volumeList.add(VolumeUtils.createVolumeMount(CLUSTER_CA_CERTS_VOLUME_NAME, CLUSTER_CA_CERTS_VOLUME_MOUNT));
 
-            if (securityContext.isStrimziMtlsAuthentication()) {
+            if (securityContext.isMtlsAuthentication()) {
                 volumeList.add(VolumeUtils.createVolumeMount(KAFKA_EXPORTER_CERTS_VOLUME_NAME, KAFKA_EXPORTER_CERTS_VOLUME_MOUNT));
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -492,8 +492,8 @@ public class CaReconciler {
      */
     private Identity createCoIdentity() {
         return new Identity(
-                securityContext.isStrimziTlsEncryption() ? new PemTrustSet(clusterCaCertSecret) : null,
-                securityContext.isStrimziMtlsAuthentication() ? PemAuthIdentity.clusterOperator(coSecret) : null
+                securityContext.isTlsEncryption() ? new PemTrustSet(clusterCaCertSecret) : null,
+                securityContext.isMtlsAuthentication() ? PemAuthIdentity.clusterOperator(coSecret) : null
         );
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1220,7 +1220,7 @@ public class KafkaRebalanceAssemblyOperator
 
                                 CruiseControlConfiguration ccConfig = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet(), Map.of());
                                 KafkaClusterSecurityContext securityContext = KafkaClusterSecurityContext.fromCrd(kafka);
-                                CruiseControlApi apiClient = cruiseControlClientProvider(clusterCaCertSecret, ccApiSecret, ccConfig.isApiAuthEnabled(), securityContext.isStrimziTlsEncryption());
+                                CruiseControlApi apiClient = cruiseControlClientProvider(clusterCaCertSecret, ccApiSecret, ccConfig.isApiAuthEnabled(), securityContext.isTlsEncryption());
 
                                 // get latest KafkaRebalance state as it may have changed (see the patching above with "refresh" annotation)
                                 return VertxUtil.toFuture(kafkaRebalanceOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -131,9 +131,9 @@ public class ReconcilerUtils {
     public static Future<Identity> coIdentity(Reconciliation reconciliation, SecretOperator secretOperator, KafkaClusterSecurityContext securityContext) {
         return Future.join(
                     // The trustFuture gets the trust based on the security context
-                    securityContext.isStrimziTlsEncryption() ? clusterCaPemTrustSet(reconciliation, secretOperator) : Future.succeededFuture(null),
+                    securityContext.isTlsEncryption() ? clusterCaPemTrustSet(reconciliation, secretOperator) : Future.succeededFuture(null),
                     // The trustFuture gets the authentication details based on the security context
-                    securityContext.isStrimziMtlsAuthentication() ? coPemAuthIdentity(reconciliation, secretOperator) : Future.succeededFuture(null)
+                    securityContext.isMtlsAuthentication() ? coPemAuthIdentity(reconciliation, secretOperator) : Future.succeededFuture(null)
                 ).compose(res -> Future.succeededFuture(new Identity(res.resultAt(0), res.resultAt(1))));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -306,7 +306,7 @@ public class CruiseControlTest {
 
     @Test
     public void testTlsVolumesAndVolumeMounts() {
-        KafkaClusterSecurityContext tlsSecurityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        KafkaClusterSecurityContext tlsSecurityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
         CruiseControl cc = createCruiseControl(KAFKA, NODES, STORAGE, Map.of(), tlsSecurityContext);
         Deployment dep = cc.generateDeployment(Map.of(), true, null, null);
 
@@ -613,8 +613,8 @@ public class CruiseControlTest {
 
     @Test
     public void testApiSecurity() {
-        testApiSecurity(true, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
-        testApiSecurity(false, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        testApiSecurity(true, ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
+        testApiSecurity(false, ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
         testApiSecurity(false, ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE);
     }
 
@@ -624,11 +624,11 @@ public class CruiseControlTest {
         EnvVar e1 = new EnvVar(e1Key, e1Value, null);
 
         String e2Key = CruiseControl.ENV_VAR_TLS_ENABLED;
-        String e2Value = Boolean.toString(encryptionType == ClusterSecurityEncryptionType.STRIMZI_TLS);
+        String e2Value = Boolean.toString(encryptionType == ClusterSecurityEncryptionType.TLS);
         EnvVar e2 = new EnvVar(e2Key, e2Value, null);
 
         String e3Key = CruiseControl.ENV_VAR_MTLS_ENABLED;
-        String e3Value = Boolean.toString(authenticationType == ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        String e3Value = Boolean.toString(authenticationType == ClusterSecurityAuthenticationType.MTLS);
         EnvVar e3 = new EnvVar(e3Key, e3Value, null);
 
         Kafka kafka = new KafkaBuilder(KAFKA)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -110,7 +110,7 @@ public class EntityTopicOperatorTest {
 
     @Test
     public void testSecurityEnvVarsWithTlsAndMtls() {
-        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
 
         assertThat(getSecurityEnvVars(securityContext), is(List.of(
                 new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_SECURITY_PROTOCOL).withValue("SSL").build(),
@@ -122,7 +122,7 @@ public class EntityTopicOperatorTest {
 
     @Test
     public void testSecurityEnvVarsWithTlsWithoutAuthentication() {
-        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
 
         assertThat(getSecurityEnvVars(securityContext), is(List.of(
                 new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_SECURITY_PROTOCOL).withValue("SSL").build(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -111,7 +111,7 @@ public class EntityUserOperatorTest {
 
     @Test
     public void testSecurityEnvVarsWithTlsAndMtls() {
-        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
 
         assertThat(getSecurityEnvVars(securityContext), is(List.of(
                 new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME)).build(),
@@ -120,7 +120,7 @@ public class EntityUserOperatorTest {
 
     @Test
     public void testSecurityEnvVarsWithTlsWithoutAuthentication() {
-        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
 
         assertThat(getSecurityEnvVars(securityContext), is(List.of(
                 new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME)).build())));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaAgentConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaAgentConfigurationBuilderTest.java
@@ -31,8 +31,8 @@ public class KafkaAgentConfigurationBuilderTest {
     @Test
     public void testTlsWithoutAuthentication()  {
         KafkaClusterSecurityContext securityContext = mock(KafkaClusterSecurityContext.class);
-        when(securityContext.isStrimziTlsEncryption()).thenReturn(true);
-        when(securityContext.isStrimziMtlsAuthentication()).thenReturn(false);
+        when(securityContext.isTlsEncryption()).thenReturn(true);
+        when(securityContext.isMtlsAuthentication()).thenReturn(false);
 
         String configuration = new KafkaAgentConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
                 .withSecurity(securityContext)
@@ -47,8 +47,8 @@ public class KafkaAgentConfigurationBuilderTest {
     @Test
     public void testWithoutTlsOrAuthentication()  {
         KafkaClusterSecurityContext securityContext = mock(KafkaClusterSecurityContext.class);
-        when(securityContext.isStrimziTlsEncryption()).thenReturn(false);
-        when(securityContext.isStrimziMtlsAuthentication()).thenReturn(false);
+        when(securityContext.isTlsEncryption()).thenReturn(false);
+        when(securityContext.isMtlsAuthentication()).thenReturn(false);
 
         String configuration = new KafkaAgentConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
                 .withSecurity(securityContext)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -183,7 +183,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     public void testCruiseControlWithoutMtls()  {
         CruiseControlMetricsReporter ccMetricsReporter = new CruiseControlMetricsReporter("strimzi.cruisecontrol.metrics", 1, 1, 1);
 
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE))
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE))
                 .withCruiseControl("my-cluster", ccMetricsReporter, true)
                 .build();
 
@@ -367,7 +367,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .addToSuperUsers("jakub", "CN=kuba")
                 .build();
 
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE))
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE))
                 .withAuthorization("my-cluster", auth)
                 .build();
 
@@ -802,7 +802,7 @@ public class KafkaBrokerConfigurationBuilderTest {
 
     @Test
     public void testOnlyReplicationAndControlPlaneListenersWithoutMtls() {
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE))
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE))
                 .withListeners("my-cluster", "my-namespace", emptyList(), null, null)
                 .build();
 
@@ -1949,7 +1949,7 @@ public class KafkaBrokerConfigurationBuilderTest {
 
     @Test
     public void testWithTieredStorageWithoutMtls() {
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE))
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE))
                 .withTieredStorage("test-cluster-1", new TieredStorageCustomBuilder()
                         .withNewRemoteStorageManager()
                             .withClassName("com.example.kafka.tiered.storage.s3.S3RemoteStorageManager")
@@ -2054,7 +2054,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     public void testWithStrimziQuotasWithoutMtls() {
         QuotasPluginStrimzi quotasPluginStrimzi = new QuotasPluginStrimziBuilder().build();
 
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE))
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE))
             .withQuotas("my-personal-cluster", quotasPluginStrimzi)
             .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
@@ -28,13 +28,13 @@ public class KafkaClusterSecurityContextTest {
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-cluster";
     private static final String INTERNAL_CLUSTER_SECURITY_ANNOTATION = "strimzi.io/internal-cluster-security";
-    private static final String TLS_WITHOUT_AUTHENTICATION = "{\"encryption\":{\"type\":\"strimzi-tls\"},\"authentication\":{\"type\":\"none\"}}";
+    private static final String TLS_WITHOUT_AUTHENTICATION = "{\"encryption\":{\"type\":\"tls\"},\"authentication\":{\"type\":\"none\"}}";
     private static final String WITHOUT_ENCRYPTION_OR_AUTHENTICATION = "{\"encryption\":{\"type\":\"none\"},\"authentication\":{\"type\":\"none\"}}";
-    private static final String MTLS_WITHOUT_TLS = "{\"encryption\":{\"type\":\"none\"},\"authentication\":{\"type\":\"strimzi-mtls\"}}";
+    private static final String MTLS_WITHOUT_TLS = "{\"encryption\":{\"type\":\"none\"},\"authentication\":{\"type\":\"mtls\"}}";
 
     private static final Map<String, Object> VALID_STATUS = Map.of(
-            "encryption", Map.of("type", "strimzi-tls"),
-            "authentication", Map.of("type", "strimzi-mtls")
+            "encryption", Map.of("type", "tls"),
+            "authentication", Map.of("type", "mtls")
     );
 
     private static final Kafka KAFKA = new KafkaBuilder()
@@ -78,8 +78,8 @@ public class KafkaClusterSecurityContextTest {
     public void testFromCrdWithoutStatus()  {
         ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(KAFKA).toStatus();
 
-        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
-        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
     }
 
     @Test
@@ -92,8 +92,8 @@ public class KafkaClusterSecurityContextTest {
 
         ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(kafka).toStatus();
 
-        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
-        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
     }
 
     @Test
@@ -106,8 +106,8 @@ public class KafkaClusterSecurityContextTest {
 
         ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(kafka).toStatus();
 
-        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
-        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
     }
 
     @Test
@@ -116,10 +116,10 @@ public class KafkaClusterSecurityContextTest {
                 .withNewStatus()
                     .withClusterSecurity(new ClusterSecurityStatusBuilder()
                             .withNewEncryption()
-                                .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                                .withType(ClusterSecurityEncryptionType.TLS)
                             .endEncryption()
                             .withNewAuthentication()
-                                .withType(ClusterSecurityAuthenticationType.STRIMZI_MTLS)
+                                .withType(ClusterSecurityAuthenticationType.MTLS)
                             .endAuthentication()
                             .build())
                 .endStatus()
@@ -127,15 +127,15 @@ public class KafkaClusterSecurityContextTest {
 
         ClusterSecurityStatus status = KafkaClusterSecurityContext.fromCrd(kafka).toStatus();
 
-        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
-        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
     }
 
     @Test
     public void testFromCrdWithInvalidClusterSecurityInStatus()  {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .withNewStatus()
-                    .withClusterSecurity(Map.of("encryption", Map.of("type", "strimzi-tls")))
+                    .withClusterSecurity(Map.of("encryption", Map.of("type", "tls")))
                 .endStatus()
                 .build();
 
@@ -149,20 +149,20 @@ public class KafkaClusterSecurityContextTest {
 
         KafkaClusterSecurityContext context = KafkaClusterSecurityContext.fromCrd(kafka);
 
-        assertThat(context.isStrimziTlsEncryption(), is(false));
-        assertThat(context.isStrimziMtlsAuthentication(), is(false));
+        assertThat(context.isTlsEncryption(), is(false));
+        assertThat(context.isMtlsAuthentication(), is(false));
         assertThat(context.toStatus(), is(status(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)));
     }
 
     @Test
     public void testFromCrdWithMatchingClusterSecurityInAnnotationAndStatus()  {
-        ClusterSecurityStatus status = status(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        ClusterSecurityStatus status = status(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
         Kafka kafka = kafkaWithClusterSecurity(TLS_WITHOUT_AUTHENTICATION, status);
 
         KafkaClusterSecurityContext context = KafkaClusterSecurityContext.fromCrd(kafka);
 
-        assertThat(context.isStrimziTlsEncryption(), is(true));
-        assertThat(context.isStrimziMtlsAuthentication(), is(false));
+        assertThat(context.isTlsEncryption(), is(true));
+        assertThat(context.isMtlsAuthentication(), is(false));
         assertThat(context.toStatus(), is(status));
     }
 
@@ -180,7 +180,7 @@ public class KafkaClusterSecurityContextTest {
     public void testFromCrdWithNonDefaultStatusWithoutAnnotation()  {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .withNewStatus()
-                    .withClusterSecurity(status(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE))
+                    .withClusterSecurity(status(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE))
                 .endStatus()
                 .build();
 
@@ -203,35 +203,35 @@ public class KafkaClusterSecurityContextTest {
 
     @Test
     public void testTlsAndMtls()  {
-        KafkaClusterSecurityContext context = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        KafkaClusterSecurityContext context = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
 
-        assertThat(context.isStrimziTlsEncryption(), is(true));
-        assertThat(context.isStrimziMtlsAuthentication(), is(true));
-        assertThat(context.toStatus(), is(status(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS)));
+        assertThat(context.isTlsEncryption(), is(true));
+        assertThat(context.isMtlsAuthentication(), is(true));
+        assertThat(context.toStatus(), is(status(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS)));
     }
 
     @Test
     public void testTlsWithoutAuthentication()  {
-        KafkaClusterSecurityContext context = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        KafkaClusterSecurityContext context = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
 
-        assertThat(context.isStrimziTlsEncryption(), is(true));
-        assertThat(context.isStrimziMtlsAuthentication(), is(false));
-        assertThat(context.toStatus(), is(status(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE)));
+        assertThat(context.isTlsEncryption(), is(true));
+        assertThat(context.isMtlsAuthentication(), is(false));
+        assertThat(context.toStatus(), is(status(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE)));
     }
 
     @Test
     public void testWithoutEncryptionOrAuthentication()  {
         KafkaClusterSecurityContext context = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE);
 
-        assertThat(context.isStrimziTlsEncryption(), is(false));
-        assertThat(context.isStrimziMtlsAuthentication(), is(false));
+        assertThat(context.isTlsEncryption(), is(false));
+        assertThat(context.isMtlsAuthentication(), is(false));
         assertThat(context.toStatus(), is(status(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)));
     }
 
     @Test
     public void testMtlsWithoutTlsIsInvalid()  {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () ->
-                new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+                new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.MTLS));
 
         assertThat(e.getMessage(), is("Desired Cluster Security configuration is not valid: mTLS authentication can be used only with enabled TLS encryption."));
     }
@@ -252,13 +252,13 @@ public class KafkaClusterSecurityContextTest {
     public void testDeserializeSpecWithUnknownFields()  {
         ClusterSecurity clusterSecurity = KafkaClusterSecurityContext.deserializeSpec("""
                 {
-                    "encryption": {"type": "strimzi-tls", "someEncryptionField": "someEncryptionValue"},
+                    "encryption": {"type": "tls", "someEncryptionField": "someEncryptionValue"},
                     "authentication": {"type": "none"},
                     "someField": "someValue"
                 }
                 """);
 
-        assertThat(clusterSecurity.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+        assertThat(clusterSecurity.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
         assertThat(clusterSecurity.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.NONE));
         assertThat(clusterSecurity.getAdditionalProperties(), is(Map.of("someField", "someValue")));
         assertThat(clusterSecurity.getEncryption().getAdditionalProperties(), is(Map.of("someEncryptionField", "someEncryptionValue")));
@@ -285,8 +285,8 @@ public class KafkaClusterSecurityContextTest {
     public void testDeserializeStatus()  {
         ClusterSecurityStatus status = KafkaClusterSecurityContext.deserializeStatus(VALID_STATUS);
 
-        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
-        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
     }
 
     @Test
@@ -303,13 +303,13 @@ public class KafkaClusterSecurityContextTest {
     @Test
     public void testDeserializeStatusWithUnknownFields()  {
         ClusterSecurityStatus status = KafkaClusterSecurityContext.deserializeStatus(Map.of(
-                "encryption", Map.of("type", "strimzi-tls", "someEncryptionField", "someEncryptionValue"),
-                "authentication", Map.of("type", "strimzi-mtls"),
+                "encryption", Map.of("type", "tls", "someEncryptionField", "someEncryptionValue"),
+                "authentication", Map.of("type", "mtls"),
                 "someField", "someValue"
         ));
 
-        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
-        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
         assertThat(status.getAdditionalProperties(), is(Map.of("someField", "someValue")));
         assertThat(status.getEncryption().getAdditionalProperties(), is(Map.of("someEncryptionField", "someEncryptionValue")));
     }
@@ -327,13 +327,13 @@ public class KafkaClusterSecurityContextTest {
 
     @Test
     public void testDeserializeStatusWithMissingEncryption()  {
-        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of("authentication", Map.of("type", "strimzi-mtls"))));
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of("authentication", Map.of("type", "mtls"))));
         assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
     }
 
     @Test
     public void testDeserializeStatusWithMissingAuthentication()  {
-        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of("encryption", Map.of("type", "strimzi-tls"))));
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of("encryption", Map.of("type", "tls"))));
         assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
     }
 
@@ -341,7 +341,7 @@ public class KafkaClusterSecurityContextTest {
     public void testDeserializeStatusWithMissingEncryptionType()  {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
                 "encryption", Map.of(),
-                "authentication", Map.of("type", "strimzi-mtls")
+                "authentication", Map.of("type", "mtls")
         )));
         assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
     }
@@ -349,7 +349,7 @@ public class KafkaClusterSecurityContextTest {
     @Test
     public void testDeserializeStatusWithMissingAuthenticationType()  {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
-                "encryption", Map.of("type", "strimzi-tls"),
+                "encryption", Map.of("type", "tls"),
                 "authentication", Map.of()
         )));
         assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
@@ -359,7 +359,7 @@ public class KafkaClusterSecurityContextTest {
     public void testDeserializeStatusWithUnsupportedEncryptionType()  {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
                 "encryption", Map.of("type", "some-other-tls"),
-                "authentication", Map.of("type", "strimzi-mtls")
+                "authentication", Map.of("type", "mtls")
         )));
         assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
     }
@@ -367,7 +367,7 @@ public class KafkaClusterSecurityContextTest {
     @Test
     public void testDeserializeStatusWithUnsupportedAuthenticationType()  {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus(Map.of(
-                "encryption", Map.of("type", "strimzi-tls"),
+                "encryption", Map.of("type", "tls"),
                 "authentication", Map.of("type", "some-other-mtls")
         )));
         assertThat(e.getMessage(), is("Invalid ClusterSecurityStatus: encryption or authentication configuration is not set"));
@@ -375,7 +375,7 @@ public class KafkaClusterSecurityContextTest {
 
     @Test
     public void testDeserializeStatusFromUnsupportedType()  {
-        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus("strimzi-tls"));
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.deserializeStatus("tls"));
         assertThat(e.getMessage(), is("Failed to deserialize ClusterSecurityStatus"));
         assertThat(e.getCause(), is(notNullValue()));
         assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
@@ -398,10 +398,10 @@ public class KafkaClusterSecurityContextTest {
 
         assertThat(status, is(new ClusterSecurityStatusBuilder()
                 .withNewEncryption()
-                    .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                    .withType(ClusterSecurityEncryptionType.TLS)
                 .endEncryption()
                 .withNewAuthentication()
-                    .withType(ClusterSecurityAuthenticationType.STRIMZI_MTLS)
+                    .withType(ClusterSecurityAuthenticationType.MTLS)
                 .endAuthentication()
                 .build()));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -212,7 +212,7 @@ public class KafkaExporterTest {
 
     @Test
     public void testGenerateDeploymentWithTlsWithoutMtls() {
-        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE);
+        KafkaClusterSecurityContext securityContext = new KafkaClusterSecurityContext(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE);
         KafkaExporter ke = KafkaExporter.fromCrd(new Reconciliation("test", KAFKA.getKind(), NAMESPACE, CLUSTER_NAME), KAFKA, VERSIONS, SHARED_ENV_PROVIDER, securityContext);
         Deployment dep = ke.generateDeployment(Map.of(), true, null, null);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -108,10 +108,10 @@ public class KafkaStatusTest {
                     .withClusterId("my-cluster-id")
                     .withClusterSecurity(new ClusterSecurityStatusBuilder()
                             .withNewEncryption()
-                                .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                                .withType(ClusterSecurityEncryptionType.TLS)
                             .endEncryption()
                             .withNewAuthentication()
-                                .withType(ClusterSecurityAuthenticationType.STRIMZI_MTLS)
+                                .withType(ClusterSecurityAuthenticationType.MTLS)
                             .endAuthentication()
                             .build())
                 .endStatus()
@@ -167,9 +167,9 @@ public class KafkaStatusTest {
             assertThat(status.getClusterSecurity(), is(notNullValue()));
             ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
             assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
             assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
 
             async.flag();
         })));
@@ -215,9 +215,9 @@ public class KafkaStatusTest {
                 assertThat(status.getClusterSecurity(), is(notNullValue()));
                 ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
                 assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
-                assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+                assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
                 assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
-                assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+                assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
 
                 async.flag();
             })));
@@ -277,9 +277,9 @@ public class KafkaStatusTest {
             assertThat(status.getClusterSecurity(), is(notNullValue()));
             ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
             assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
             assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
 
             async.flag();
         })));
@@ -344,9 +344,9 @@ public class KafkaStatusTest {
             assertThat(status.getClusterSecurity(), is(notNullValue()));
             ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
             assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
             assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
 
             async.flag();
         })));
@@ -429,9 +429,9 @@ public class KafkaStatusTest {
             assertThat(status.getClusterSecurity(), is(notNullValue()));
             ClusterSecurityStatus clusterSecurityStatus = KafkaClusterSecurityContext.deserializeStatus(status.getClusterSecurity());
             assertThat(clusterSecurityStatus.getEncryption(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.STRIMZI_TLS));
+            assertThat(clusterSecurityStatus.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
             assertThat(clusterSecurityStatus.getAuthentication(), is(notNullValue()));
-            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.STRIMZI_MTLS));
+            assertThat(clusterSecurityStatus.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
 
             async.flag();
         })));
@@ -448,7 +448,7 @@ public class KafkaStatusTest {
                 .editStatus()
                     .withClusterSecurity(new ClusterSecurityStatusBuilder()
                             .withNewEncryption()
-                                .withType(ClusterSecurityEncryptionType.STRIMZI_TLS)
+                                .withType(ClusterSecurityEncryptionType.TLS)
                             .endEncryption()
                             .build())
                 .endStatus()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
@@ -153,8 +153,8 @@ public class ReconcilerUtilsTest {
         when(mockSecretOps.getAsync(NAMESPACE, KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))
                 .thenReturn(CompletableFuture.completedFuture(clusterCaSecret));
         KafkaClusterSecurityContext securityContext = mock(KafkaClusterSecurityContext.class);
-        when(securityContext.isStrimziTlsEncryption()).thenReturn(true);
-        when(securityContext.isStrimziMtlsAuthentication()).thenReturn(false);
+        when(securityContext.isTlsEncryption()).thenReturn(true);
+        when(securityContext.isMtlsAuthentication()).thenReturn(false);
 
         Checkpoint async = context.checkpoint();
         ReconcilerUtils.coIdentity(Reconciliation.DUMMY_RECONCILIATION, mockSecretOps, securityContext)
@@ -171,8 +171,8 @@ public class ReconcilerUtilsTest {
     public void testCoIdentityWithoutTlsOrAuthentication(VertxTestContext context) {
         SecretOperator mockSecretOps = mock(SecretOperator.class);
         KafkaClusterSecurityContext securityContext = mock(KafkaClusterSecurityContext.class);
-        when(securityContext.isStrimziTlsEncryption()).thenReturn(false);
-        when(securityContext.isStrimziMtlsAuthentication()).thenReturn(false);
+        when(securityContext.isTlsEncryption()).thenReturn(false);
+        when(securityContext.isMtlsAuthentication()).thenReturn(false);
 
         Checkpoint async = context.checkpoint();
         ReconcilerUtils.coIdentity(Reconciliation.DUMMY_RECONCILIATION, mockSecretOps, securityContext)

--- a/documentation/modules/security/con-internal-cluster-security.adoc
+++ b/documentation/modules/security/con-internal-cluster-security.adoc
@@ -39,23 +39,23 @@ The annotation is a temporary configuration interface and might also change.
 |Description
 
 |Encryption
-|`strimzi-tls`
-|Encrypts internal communication by using Strimzi-managed TLS certificates.
+|`tls`
+|Encrypts internal communication by using TLS certificates.
 
 |Encryption
 |`none`
 |Disables TLS encryption for internal communication.
 
 |Authentication
-|`strimzi-mtls`
-|Authenticates internal components by using Strimzi-managed mTLS certificates.
+|`mtls`
+|Authenticates internal components by using mTLS certificates.
 
 |Authentication
 |`none`
 |Disables mTLS authentication governed by the internal cluster security configuration.
 |===
 
-The `strimzi-mtls` authentication type requires `strimzi-tls` encryption.
+The `mtls` authentication type requires `tls` encryption.
 Consequently, disabling TLS encryption also requires authentication to be disabled.
 The supported combinations are:
 
@@ -69,7 +69,7 @@ Disable authentication only if other controls, such as network isolation or a se
 
 == Default internal cluster security
 
-If the `strimzi.io/internal-cluster-security` annotation is not present, Strimzi uses `strimzi-tls` encryption with `strimzi-mtls` authentication.
+If the `strimzi.io/internal-cluster-security` annotation is not present, Strimzi uses `tls` encryption with `mtls` authentication.
 This behavior is unchanged from previous releases.
 
 == (Early Access) Disabling mTLS authentication
@@ -89,7 +89,7 @@ metadata:
     strimzi.io/internal-cluster-security: |
       {
         "encryption": {
-          "type": "strimzi-tls"
+          "type": "tls"
         },
         "authentication": {
           "type": "none"

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/ClusterSecurityST.java
@@ -83,7 +83,7 @@ class ClusterSecurityST extends AbstractST {
      */
     private Stream<Arguments> securityConfigurationCombos() {
         return Stream.of(
-                Arguments.of(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.NONE),
+                Arguments.of(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.NONE),
                 Arguments.of(ClusterSecurityEncryptionType.NONE, ClusterSecurityAuthenticationType.NONE)
         );
     }
@@ -258,7 +258,7 @@ class ClusterSecurityST extends AbstractST {
                 KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getTopicName(), testStorage.getClusterName(), 3, 3, 2).build()
         );
 
-        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
 
         // Test sending and consuming messages works
         KafkaProducerConsumer clients = new KafkaProducerConsumerBuilder()
@@ -293,8 +293,8 @@ class ClusterSecurityST extends AbstractST {
         ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getConsumerName(), 2 * testStorage.getMessageCount());
 
         // Migrate back to the original to close the round trip
-        migrateClusterSecurity(testStorage, ClusterSecuritySTUtils.clusterSecurityAnnotation(ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS));
-        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.STRIMZI_TLS, ClusterSecurityAuthenticationType.STRIMZI_MTLS);
+        migrateClusterSecurity(testStorage, ClusterSecuritySTUtils.clusterSecurityAnnotation(ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS));
+        ClusterSecuritySTUtils.assertClusterSecurityStatus(testStorage, ClusterSecurityEncryptionType.TLS, ClusterSecurityAuthenticationType.MTLS);
 
         // Test sending and consuming messages still works
         clients.setMessageCount(testStorage.getMessageCount());


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

As discussed in https://cloud-native.slack.com/archives/C018247K8T0/p1787326321695999, this renames the `strimzi-tls` and `strimzi-mtls` types in Cluster Security configuration to `tls` and `mtls`. That better corresponds to their meaning as they just configure TLS/mTLS. Where the certificates are coming from is matter of the CA and its configuration. It also fixes some missing types and newlines in the description annotations.

### Checklist

- [x] Update documentation
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
