### PR TITLE
Remove vertx from `KraftVersionChangeCreator` class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
@@ -11,16 +11,16 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.KafkaUpgradeException;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
-import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.Labels;
-import io.vertx.core.Future;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import static io.strimzi.operator.cluster.model.KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION;
 import static io.strimzi.operator.cluster.model.KafkaVersion.compareMetadataVersions;
@@ -78,33 +78,33 @@ public class KRaftVersionChangeCreator {
      * Collects the information from the Kubernetes resources and creates the KafkaVersionChange instance describing the
      * version change in this reconciliation
      *
-     * @return  Future which completes with the KafkaVersionChange instance
+     * @return  CompletionStage which completes with the KafkaVersionChange instance
      */
-    public Future<KafkaVersionChange> reconcile()    {
+    public CompletionStage<KafkaVersionChange> reconcile()    {
         return getPods()
-                .compose(this::detectToAndFromVersions)
-                .compose(i -> prepareVersionChange());
+                .thenCompose(this::detectToAndFromVersions)
+                .thenCompose(i -> prepareVersionChange());
     }
 
     /**
      * Collects any existing Kafka pods so that we can later get the version information from them.
      *
-     * @return  Future which completes when the Kafka broker pods are retrieved
+     * @return  CompletionStage which completes when the Kafka broker pods are retrieved
      */
-    private Future<List<Pod>> getPods()   {
+    private CompletionStage<List<Pod>> getPods()   {
         Labels selectorLabels = Labels.forStrimziKind(Kafka.RESOURCE_KIND)
                 .withStrimziCluster(reconciliation.name())
                 .withStrimziName(KafkaResources.kafkaComponentName(reconciliation.name()));
 
-        return VertxUtil.toFuture(podOperator.listAsync(reconciliation.namespace(), selectorLabels));
+        return podOperator.listAsync(reconciliation.namespace(), selectorLabels);
     }
 
     /**
      * Detects the current and desired Kafka versions based on the information collected from Kubernetes
      *
-     * @return  Future which completes when the "to" and "from" versions are collected
+     * @return  CompletionStage which completes when the "to" and "from" versions are collected
      */
-    private Future<Void> detectToAndFromVersions(List<Pod> pods)    {
+    private CompletionStage<Void> detectToAndFromVersions(List<Pod> pods)    {
         String lowestKafkaVersion = null;
         String highestKafkaVersion = null;
 
@@ -166,16 +166,16 @@ public class KRaftVersionChangeCreator {
             versionTo = versionFromCr;
         }
 
-        return Future.succeededFuture();
+        return CompletableFuture.completedFuture(null);
     }
 
     /**
      * Plans the version change and creates a KafkaVersionChange object which contains the main versions as well as the
      * metadata version.
      *
-     * @return  Future with the KafkaVersionChange instance describing the Kafka version changes
+     * @return  CompletionStage with the KafkaVersionChange instance describing the Kafka version changes
      */
-    private Future<KafkaVersionChange>  prepareVersionChange()  {
+    private CompletionStage<KafkaVersionChange>  prepareVersionChange()  {
         String metadataVersion;
 
         if (versionFrom.compareTo(versionTo) == 0) { // => no version change
@@ -192,7 +192,7 @@ public class KRaftVersionChangeCreator {
             }
         }
 
-        return Future.succeededFuture(new KafkaVersionChange(versionFrom, versionTo, null, null, metadataVersion));
+        return CompletableFuture.completedFuture(new KafkaVersionChange(versionFrom, versionTo, null, null, metadataVersion));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -474,8 +474,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * @return  Future with Reconciliation State
          */
         Future<ReconciliationState> versionChange()    {
-            return versionChangeCreator()
-                    .reconcile()
+            return VertxUtil.toFuture(versionChangeCreator()
+                    .reconcile())
                     .compose(versionChange -> {
                         this.versionChange = versionChange;
                         return Future.succeededFuture(this);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -22,12 +22,14 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class KRaftVersionChangeCreatorTest {
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-cluster";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -16,20 +16,18 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaUpgradeException;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.KafkaVersionChange;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -39,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(VertxExtension.class)
 public class KRaftVersionChangeCreatorTest {
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-cluster";
@@ -111,54 +108,42 @@ public class KRaftVersionChangeCreatorTest {
     //////////
 
     @Test
-    public void testNewClusterWithAllVersions(VertxTestContext context) {
+    public void testNewClusterWithAllVersions() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), VERSIONS.defaultVersion().metadataVersion(), VERSIONS.defaultVersion().metadataVersion()),
                 mockRos(List.of())
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     @Test
-    public void testNewClusterWithoutVersion(VertxTestContext context) {
+    public void testNewClusterWithoutVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(null, null, null),
                 mockRos(List.of())
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     @Test
-    public void testNewClusterWithKafkaVersionOnly(VertxTestContext context) {
+    public void testNewClusterWithKafkaVersionOnly() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), null, null),
                 mockRos(List.of())
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     //////////
@@ -166,121 +151,94 @@ public class KRaftVersionChangeCreatorTest {
     //////////
 
     @Test
-    public void testExistingClusterWithAllVersion(VertxTestContext context) {
+    public void testExistingClusterWithAllVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), VERSIONS.defaultVersion().metadataVersion(), VERSIONS.defaultVersion().metadataVersion()),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     @Test
-    public void testExistingClusterWithoutVersions(VertxTestContext context) {
+    public void testExistingClusterWithoutVersions() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(null, VERSIONS.defaultVersion().metadataVersion(), null),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     @Test
-    public void testExistingClusterWithoutVersionsWithOldMetadataVersion(VertxTestContext context) {
+    public void testExistingClusterWithoutVersionsWithOldMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(null, "3.4-IV2", null),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     @Test
-    public void testExistingClusterWithNewMetadataVersion(VertxTestContext context) {
+    public void testExistingClusterWithNewMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), "3.4-IV2", "3.6"),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is("3.6"));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is("3.6"));
     }
 
     @Test
-    public void testExistingClusterWithRemovedMetadataVersion(VertxTestContext context) {
+    public void testExistingClusterWithRemovedMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), "3.4-IV2", null),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
     }
 
     @Test
-    public void testExistingClusterWithWrongMetadataVersion(VertxTestContext context) {
+    public void testExistingClusterWithWrongMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), "3.4-IV2", "5.11-IV2"),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is("3.4-IV2"));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is("3.4-IV2"));
     }
 
     @Test
-    public void testExistingClusterWithPodWithoutAnnotations(VertxTestContext context) {
+    public void testExistingClusterWithPodWithoutAnnotations() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), VERSIONS.defaultVersion().metadataVersion(), VERSIONS.defaultVersion().metadataVersion()),
                 mockRos(mockUniformPods(null))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.failing(c -> context.verify(() -> {
-            assertThat(c, is(instanceOf(KafkaUpgradeException.class)));
-            assertThat(c.getMessage(), is("Kafka Pods exist, but do not contain the strimzi.io/kafka-version annotation to detect their version. Kafka upgrade cannot be detected."));
-
-            async.flag();
-        })));
+        CompletionException ex = assertThrows(CompletionException.class,
+                () -> vcc.reconcile().toCompletableFuture().join());
+        assertThat(ex.getCause(), is(instanceOf(KafkaUpgradeException.class)));
+        assertThat(ex.getCause().getMessage(), is("Kafka Pods exist, but do not contain the strimzi.io/kafka-version annotation to detect their version. Kafka upgrade cannot be detected."));
     }
 
     //////////
@@ -288,87 +246,68 @@ public class KRaftVersionChangeCreatorTest {
     //////////
 
     @Test
-    public void testUpgradeWithAllVersion(VertxTestContext context) {
+    public void testUpgradeWithAllVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), VERSIONS.defaultVersion().metadataVersion()),
                 mockRos(mockUniformPods(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testUpgradeWithoutVersion(VertxTestContext context) {
+    public void testUpgradeWithoutVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(null, VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), null),
                 mockRos(mockUniformPods(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testUpgradeWithAllVersionAndMixedPods(VertxTestContext context) {
+    public void testUpgradeWithAllVersionAndMixedPods() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), VERSIONS.defaultVersion().metadataVersion()),
                 mockRos(mockMixedPods(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testUpgradeWithoutVersionAndMixedPods(VertxTestContext context) {
+    public void testUpgradeWithoutVersionAndMixedPods() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(null, VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), null),
                 mockRos(mockMixedPods(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.to(), is(VERSIONS.defaultVersion()));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.to(), is(VERSIONS.defaultVersion()));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testUpgradeWithWrongCurrentMetadataVersion(VertxTestContext context) {
+    public void testUpgradeWithWrongCurrentMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.defaultVersion().version(), "5.11-IV1", VERSIONS.defaultVersion().metadataVersion()),
                 mockRos(mockUniformPods(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.failing(c -> context.verify(() -> {
-            assertThat(c, is(instanceOf(KafkaUpgradeException.class)));
-            assertThat(c.getMessage(), is("The current metadata version (5.11-IV1) has to be lower or equal to the Kafka broker version we upgrade from (" + VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version() + ")"));
-
-            async.flag();
-        })));
+        CompletionException ex = assertThrows(CompletionException.class,
+                () -> vcc.reconcile().toCompletableFuture().join());
+        assertThat(ex.getCause(), is(instanceOf(KafkaUpgradeException.class)));
+        assertThat(ex.getCause().getMessage(), is("The current metadata version (5.11-IV1) has to be lower or equal to the Kafka broker version we upgrade from (" + VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version() + ")"));
     }
 
     //////////
@@ -376,106 +315,82 @@ public class KRaftVersionChangeCreatorTest {
     //////////
 
     @Test
-    public void testDowngradeWithAllVersion(VertxTestContext context) {
+    public void testDowngradeWithAllVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testDowngradeWithUnsetDesiredMetadataVersion(VertxTestContext context) {
+    public void testDowngradeWithUnsetDesiredMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), null),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testDowngradeWithOldMetadataVersion(VertxTestContext context) {
+    public void testDowngradeWithOldMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), "3.4-IV2", "3.4-IV2"),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.metadataVersion(), is("3.4-IV2"));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.metadataVersion(), is("3.4-IV2"));
     }
 
     @Test
-    public void testDowngradeWithAllVersionAndMixedPods(VertxTestContext context) {
+    public void testDowngradeWithAllVersionAndMixedPods() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockMixedPods(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from(), is(VERSIONS.defaultVersion()));
-            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from(), is(VERSIONS.defaultVersion()));
+        assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
     }
-    
+
     @Test
-    public void testDowngradeFromUnknownVersion(VertxTestContext context) {
+    public void testDowngradeFromUnknownVersion() {
         String unknownVersion = KafkaVersionTestUtils.HIGH_UNKNOWN_KAFKA_VERSION;
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(unknownVersion))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from().version(), is(unknownVersion));
-            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from().version(), is(unknownVersion));
+        assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
-    public void testUpgradeFromUnknownVersion(VertxTestContext context) {
+    public void testUpgradeFromUnknownVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), "3.9-IV99"),
                 mockRos(mockUniformPods(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.from().version(), is(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION));
-            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)));
-            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()));
-
-            async.flag();
-        })));
+        KafkaVersionChange c = vcc.reconcile().toCompletableFuture().join();
+        assertThat(c.from().version(), is(KafkaVersionTestUtils.LOW_UNKNOWN_KAFKA_VERSION));
+        assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)));
+        assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()));
     }
 
     @Test
@@ -485,35 +400,29 @@ public class KRaftVersionChangeCreatorTest {
     }
 
     @Test
-    public void testDowngradeWithWrongCurrentMetadataVersion(VertxTestContext context) {
+    public void testDowngradeWithWrongCurrentMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), "5.11-IV1", VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.failing(c -> context.verify(() -> {
-            assertThat(c, is(instanceOf(KafkaUpgradeException.class)));
-            assertThat(c.getMessage(), is("The current metadata version (5.11-IV1) has to be lower or equal to the Kafka broker version we are downgrading to (" + VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version() + ")"));
-
-            async.flag();
-        })));
+        CompletionException ex = assertThrows(CompletionException.class,
+                () -> vcc.reconcile().toCompletableFuture().join());
+        assertThat(ex.getCause(), is(instanceOf(KafkaUpgradeException.class)));
+        assertThat(ex.getCause().getMessage(), is("The current metadata version (5.11-IV1) has to be lower or equal to the Kafka broker version we are downgrading to (" + VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version() + ")"));
     }
 
     @Test
-    public void testDowngradeWithNonDowngradedCurrentMetadataVersion(VertxTestContext context) {
+    public void testDowngradeWithNonDowngradedCurrentMetadataVersion() {
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version(), VERSIONS.defaultVersion().metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(VERSIONS.defaultVersion().version()))
         );
 
-        Checkpoint async = context.checkpoint();
-        vcc.reconcile().onComplete(context.failing(c -> context.verify(() -> {
-            assertThat(c, is(instanceOf(KafkaUpgradeException.class)));
-            assertThat(c.getMessage(), is("The current metadata version (" + VERSIONS.defaultVersion().metadataVersion() + ") has to be lower or equal to the Kafka broker version we are downgrading to (" + VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version() + ")"));
-
-            async.flag();
-        })));
+        CompletionException ex = assertThrows(CompletionException.class,
+                () -> vcc.reconcile().toCompletableFuture().join());
+        assertThat(ex.getCause(), is(instanceOf(KafkaUpgradeException.class)));
+        assertThat(ex.getCause().getMessage(), is("The current metadata version (" + VERSIONS.defaultVersion().metadataVersion() + ") has to be lower or equal to the Kafka broker version we are downgrading to (" + VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).version() + ")"));
     }
 
     //////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -566,8 +567,9 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
                 })
                 .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
                 .onComplete(context.failing(v -> context.verify(() -> {
-                    assertThat(v, is(instanceOf(KafkaUpgradeException.class)));
-                    assertThat(v.getMessage(), is("The current metadata version (" + KafkaVersionTestUtils.LATEST_METADATA_VERSION + ") has to be lower or equal to the Kafka broker version we are downgrading to (" + KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION + ")"));
+                    assertThat(v, instanceOf(CompletionException.class));
+                    assertThat(v.getCause(), is(instanceOf(KafkaUpgradeException.class)));
+                    assertThat(v.getCause().getMessage(), is("The current metadata version (" + KafkaVersionTestUtils.LATEST_METADATA_VERSION + ") has to be lower or equal to the Kafka broker version we are downgrading to (" + KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION + ")"));
 
                     assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_METADATA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes vertx completely from `KraftVersionChangeCreator` its associated test class
and uses the java classes instead. This PR will help in finishing #13066

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
