### PR TITLE
Bumped micrometer to fix CVE-2026-59296 and CVE-2026-59295

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <jetty.version>12.0.36</jetty.version>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
         <netty.version>4.2.17.Final</netty.version>
-        <micrometer.version>1.16.6</micrometer.version>
+        <micrometer.version>1.17.1</micrometer.version>
         <commons-codec.version>1.13</commons-codec.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <javaluator.version>3.0.6</javaluator.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps micrometer to fix https://nvd.nist.gov/vuln/detail/cve-2026-59295 and https://nvd.nist.gov/vuln/detail/cve-2026-59296