### PR TITLE
Enable `rest.extension.classes` in Kafka Connect and MirrorMaker 2

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -36,7 +36,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     public static final String FORBIDDEN_PREFIXES = "group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter.";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes";
 
     private Map<String, Object> config = new HashMap<>(0);
     private String bootstrapServers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
 @ToString
 public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving {
     public static final String FORBIDDEN_PREFIXES = "group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes";
 
     private String alias;
     private String bootstrapServers;

--- a/documentation/assemblies/configuring/assembly-config.adoc
+++ b/documentation/assemblies/configuring/assembly-config.adoc
@@ -114,6 +114,8 @@ include::../../modules/configuring/con-config-kafka-connect-build.adoc[leveloffs
 include::../../modules/configuring/con-config-kafka-connect-worker-settings.adoc[leveloffset=+2]
 // Running multiple Kafka Connect instances against the same Kafka cluster
 include::../../modules/configuring/con-config-kafka-connect-multiple-instances.adoc[leveloffset=+2]
+// Using custom REST Extensions with Kafka Connect and MirrorMaker 2
+include::../../modules/configuring/con-config-kafka-connect-rest-extensions.adoc[leveloffset=+2]
 
 //`KafkaConnector` resource config
 include::../../modules/configuring/con-config-kafka-connector.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1991,7 +1991,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Authentication configuration for Kafka Connect.
 |config
 |map
-|The Kafka Connect configuration. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|The Kafka Connect configuration. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes).
 |resources
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core[ResourceRequirements]
 |The maximum limits for CPU and memory resources and the requested initial resources.
@@ -3610,7 +3610,7 @@ include::../api/io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2TargetC
 |Authentication configuration for connecting to the cluster.
 |config
 |map
-|The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes).
 |====
 
 [id='type-KafkaMirrorMaker2MirrorSpec-{context}']
@@ -3675,7 +3675,7 @@ include::../api/io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Cluster
 |Authentication configuration for connecting to the cluster.
 |config
 |map
-|The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes).
 |====
 
 [id='type-KafkaMirrorMaker2ConnectorSpec-{context}']

--- a/documentation/modules/configuring/con-config-kafka-connect-rest-extensions.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect-rest-extensions.adoc
@@ -1,0 +1,67 @@
+:_mod-docs-content-type: CONCEPT
+
+// Module included in the following assemblies:
+//
+// assembly-config.adoc
+
+[id='con-config-kafka-connect-rest-extensions-{context}']
+= Using custom REST extensions with Kafka Connect and MirrorMaker 2
+
+[role="_abstract"]
+Add custom REST extensions to the Kafka Connect REST API by setting the `rest.extension.classes` property in the `KafkaConnect` or `KafkaMirrorMaker2` custom resource.
+REST extensions can add custom filtering, validation, or security mechanisms to the REST API.
+
+Each class listed in `rest.extension.classes` must implement the `ConnectRestExtension` interface and must be available on the Kafka Connect or MirrorMaker 2 classpath.
+Kafka Connect loads and runs the extensions in the order in which they are listed.
+
+Strimzi manages Kafka Connect and MirrorMaker 2 through the REST API, so custom REST extensions must not restrict the following:
+
+* Access to the `/health` endpoint, so that the liveness and readiness probes continue to work.
+* Inter-node communication between Kafka Connect or MirrorMaker 2 nodes, so that the nodes can communicate with each other.
+* Operations performed by the Cluster Operator on the Kafka Connect REST API when the `strimzi.io/use-connector-resources` annotation is enabled, so that connectors can be managed using `KafkaConnector` resources.
+
+Configuring REST extensions is an advanced option.
+Make sure that your extensions meet these requirements and test them outside of production before you deploy them to a production environment.
+
+== Configuring REST extensions in Kafka Connect
+
+For Kafka Connect, add the `rest.extension.classes` property to `spec.config`.
+
+.Example REST extension configuration for Kafka Connect
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect
+spec:
+  # ...
+  config:
+    rest.extension.classes: my.domain.package.MyCustomRestExtension,my.domain.package.AnotherRestExtension
+    # ...
+----
+
+* `rest.extension.classes` specifies a comma-separated list of `ConnectRestExtension` implementation classes.
+
+== Configuring REST extensions in MirrorMaker 2
+
+For MirrorMaker 2, add the `rest.extension.classes` property to `spec.target.config`.
+
+.Example REST extension configuration for MirrorMaker 2
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaMirrorMaker2ApiVersion}
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker-2
+spec:
+  target:
+    # ...
+    config:
+      rest.extension.classes: my.domain.package.MyCustomRestExtension,my.domain.package.AnotherRestExtension
+      # ...
+  mirrors:
+    # ...
+----
+
+* `rest.extension.classes` specifies a comma-separated list of `ConnectRestExtension` implementation classes.

--- a/documentation/modules/configuring/con-config-kafka-connect-rest-extensions.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect-rest-extensions.adoc
@@ -41,7 +41,7 @@ spec:
     # ...
 ----
 
-* `rest.extension.classes` specifies a comma-separated list of `ConnectRestExtension` implementation classes.
+* `rest.extension.classes` specifies a comma-separated list of fully qualified names of classes that implement Kafka's `ConnectRestExtension` interface.
 
 == Configuring REST extensions in MirrorMaker 2
 
@@ -64,4 +64,4 @@ spec:
     # ...
 ----
 
-* `rest.extension.classes` specifies a comma-separated list of `ConnectRestExtension` implementation classes.
+* `rest.extension.classes` specifies a comma-separated list of fully qualified names of classes that implement Kafka's `ConnectRestExtension` interface.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -166,7 +166,7 @@ spec:
                 config:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
-                  description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                  description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes)."
                 resources:
                   type: object
                   properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -173,7 +173,7 @@ spec:
                     config:
                       x-kubernetes-preserve-unknown-fields: true
                       type: object
-                      description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                      description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes)."
                   required:
                     - alias
                     - bootstrapServers
@@ -285,7 +285,7 @@ spec:
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
-                            description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                            description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes)."
                         required:
                           - alias
                           - bootstrapServers

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -165,7 +165,7 @@ spec:
               config:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
-                description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes)."
               resources:
                 type: object
                 properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -172,7 +172,7 @@ spec:
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
-                    description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                    description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes)."
                 required:
                 - alias
                 - bootstrapServers
@@ -284,7 +284,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                          description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: group.id, config.storage.topic, offset.storage.topic, status.storage.topic, ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, rest.extension.classes)."
                       required:
                       - alias
                       - bootstrapServers


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

This PR implements [SEP-156 Allow Configuring REST Extensions in Kafka Connect and MirrorMaker 2](https://github.com/strimzi/proposals/blob/main/156-allow-configuring-connect-rest-extensions.md) and enabled the `rest.extension.classes` option.

### Checklist

- [x] Update documentation
- [x]  Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
