### PR TITLE
Add support for projected Service Account token volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0
 
 * (Early Access) Configurable internal cluster security allows users to configure encryption and authentication on the internal connections within the Apache Kafka cluster.
+* Support for mounting projected service account tokens into Strimzi-managed Pods
 
 ### Major changes, deprecations, and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 @Buildable(editableEnabled = false, builderPackage = Constants.FABRIC8_KUBERNETES_API)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "name", "secret", "configMap", "emptyDir", "persistentVolumeClaim", "csi", "image" })
+@JsonPropertyOrder({ "name", "secret", "configMap", "emptyDir", "persistentVolumeClaim", "csi", "image", "projected" })
 @OneOf({
     @OneOf.Alternative({
         @OneOf.Alternative.Property(value = "secret", required = false),
@@ -36,7 +36,8 @@ import java.util.Map;
         @OneOf.Alternative.Property(value = "emptyDir", required = false),
         @OneOf.Alternative.Property(value = "persistentVolumeClaim", required = false),
         @OneOf.Alternative.Property(value = "csi", required = false),
-        @OneOf.Alternative.Property(value = "image", required = false)
+        @OneOf.Alternative.Property(value = "image", required = false),
+        @OneOf.Alternative.Property(value = "projected", required = false)
         })
 })
 @EqualsAndHashCode
@@ -49,6 +50,7 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
     private PersistentVolumeClaimVolumeSource persistentVolumeClaim;
     private CSIVolumeSource csi;
     private ImageVolumeSource image;
+    private ProjectedVolume projected;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Name to use for the volume. Required.")
@@ -124,6 +126,16 @@ public class AdditionalVolume implements UnknownPropertyPreserving {
 
     public void setImage(ImageVolumeSource image) {
         this.image = image;
+    }
+
+    @Description("`ProjectedVolume` object to use volume projection.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ProjectedVolume getProjected() {
+        return projected;
+    }
+
+    public void setProjected(ProjectedVolume projected) {
+        this.projected = projected;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ProjectedVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ProjectedVolume.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation for Projected volumes in additional volumes. We use our own class instead of Fabric8's class to
+ * control which projected volumes are supported.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"sources"})
+@EqualsAndHashCode
+@ToString
+public class ProjectedVolume implements UnknownPropertyPreserving {
+    private List<ProjectedVolumeSource> sources;
+    private Map<String, Object> additionalProperties;
+
+    @Description("List of projections that are part of this projected volumes. " +
+            "Currently, only Service Account projection is supported.")
+    public List<ProjectedVolumeSource> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<ProjectedVolumeSource> sources) {
+        this.sources = sources;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ProjectedVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ProjectedVolumeSource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.ServiceAccountTokenProjection;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.OneOf;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation for the individual projected volume sources in additional volumes. We use our own class instead of
+ * Fabric8's class to control which projected volumes are supported. However, the ServiceAccountTokenProjection class
+ * is already the end of the API path and can be reused from Fabric8.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"serviceAccountToken"})
+@OneOf({
+    @OneOf.Alternative({
+        @OneOf.Alternative.Property(value = "serviceAccountToken", required = false)
+    })
+})
+@EqualsAndHashCode
+@ToString
+public class ProjectedVolumeSource implements UnknownPropertyPreserving {
+    private ServiceAccountTokenProjection serviceAccountToken;
+    private Map<String, Object> additionalProperties;
+
+    @Description("information about the serviceAccountToken data to project.")
+    @KubeLink(group = "core", version = "v1", kind = "serviceaccounttokenprojection")
+    public ServiceAccountTokenProjection getServiceAccountToken() {
+        return serviceAccountToken;
+    }
+
+    public void setServiceAccountToken(ServiceAccountTokenProjection serviceAccountToken) {
+        this.serviceAccountToken = serviceAccountToken;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -8,11 +8,14 @@ import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.ProjectedVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeProjection;
+import io.fabric8.kubernetes.api.model.VolumeProjectionBuilder;
 import io.strimzi.api.kafka.model.common.template.AdditionalTemplatedVolume;
 import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
@@ -189,6 +192,23 @@ public class TemplateUtils {
             volumeBuilder.withCsi(volumeConfig.getCsi());
         } else if (volumeConfig.getImage() != null) {
             volumeBuilder.withImage(volumeConfig.getImage());
+        } else if (volumeConfig.getProjected() != null
+                && volumeConfig.getProjected().getSources() != null
+                && !volumeConfig.getProjected().getSources().isEmpty())    {
+            // We collect all the different sources. Currently, only Service Account Token sources are supported.
+            // But more might be added in the future.
+            List<VolumeProjection> sources = volumeConfig.getProjected().getSources().stream()
+                    .map(source -> {
+                        if (source.getServiceAccountToken() != null)    {
+                            return new VolumeProjectionBuilder().withServiceAccountToken(source.getServiceAccountToken()).build();
+                        } else {
+                            throw new InvalidResourceException("Only ServiceAccountTokenProjection is supported in projected volumes");
+                        }
+                    })
+                    .toList();
+
+            // Add the sources to the volume
+            volumeBuilder.withProjected(new ProjectedVolumeSourceBuilder().withSources(sources).build());
         }
 
         return volumeBuilder.build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
@@ -140,12 +140,23 @@ public class TemplateUtilsTest {
                         new AdditionalVolumeBuilder()
                                 .withName("oci-volume")
                                 .withImage(new ImageVolumeSourceBuilder().withReference("my-custom-oci-plugin:latest").withPullPolicy("Never").build())
+                                .build(),
+                        new AdditionalVolumeBuilder()
+                                .withName("projected-volume")
+                                .withNewProjected()
+                                    .addNewSource()
+                                        .withNewServiceAccountToken("my-audience", 600L, "my-token")
+                                    .endSource()
+                                    .addNewSource()
+                                        .withNewServiceAccountToken("my-other-audience", null, "my-other-token")
+                                    .endSource()
+                                .endProjected()
                                 .build())
                 .build();
 
         TemplateUtils.addAdditionalVolumes(templatePod, existingVolumes);
 
-        assertThat(existingVolumes.size(), is(8));
+        assertThat(existingVolumes.size(), is(9));
 
         assertThat(existingVolumes.get(0).getName(), is("existingVolume1"));
 
@@ -156,6 +167,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(1).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(1).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(1).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(2).getName(), is("cm-volume"));
         assertThat(existingVolumes.get(2).getConfigMap().getName(), is("my-cm"));
@@ -164,6 +176,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(2).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(2).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(2).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(3).getName(), is("empty-dir-volume"));
         assertThat(existingVolumes.get(3).getEmptyDir().getMedium(), is("Memory"));
@@ -173,6 +186,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(3).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(3).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(3).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(4).getName(), is("empty-dir-volume-no-options"));
         assertThat(existingVolumes.get(4).getEmptyDir().getMedium(), is(nullValue()));
@@ -182,6 +196,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(4).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(4).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(4).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(5).getName(), is("pvc-volume"));
         assertThat(existingVolumes.get(5).getPersistentVolumeClaim().getClaimName(), is("my-pvc"));
@@ -190,6 +205,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(5).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(5).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(5).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(6).getName(), is("csi-volume"));
         assertThat(existingVolumes.get(6).getCsi().getDriver(), is("csi.cert-manager.io"));
@@ -201,6 +217,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(6).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(6).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(6).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(6).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(7).getName(), is("oci-volume"));
         assertThat(existingVolumes.get(7).getImage().getReference(), is("my-custom-oci-plugin:latest"));
@@ -210,6 +227,72 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(7).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(7).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(7).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(7).getProjected(), is(nullValue()));
+
+        assertThat(existingVolumes.get(8).getName(), is("projected-volume"));
+        assertThat(existingVolumes.get(8).getProjected().getSources().size(), is(2));
+        assertThat(existingVolumes.get(8).getProjected().getSources().get(0).getServiceAccountToken().getAudience(), is("my-audience"));
+        assertThat(existingVolumes.get(8).getProjected().getSources().get(0).getServiceAccountToken().getExpirationSeconds(), is(600L));
+        assertThat(existingVolumes.get(8).getProjected().getSources().get(0).getServiceAccountToken().getPath(), is("my-token"));
+        assertThat(existingVolumes.get(8).getProjected().getSources().get(1).getServiceAccountToken().getAudience(), is("my-other-audience"));
+        assertThat(existingVolumes.get(8).getProjected().getSources().get(1).getServiceAccountToken().getExpirationSeconds(), is(nullValue()));
+        assertThat(existingVolumes.get(8).getProjected().getSources().get(1).getServiceAccountToken().getPath(), is("my-other-token"));
+        assertThat(existingVolumes.get(8).getSecret(), is(nullValue()));
+        assertThat(existingVolumes.get(8).getConfigMap(), is(nullValue()));
+        assertThat(existingVolumes.get(8).getEmptyDir(), is(nullValue()));
+        assertThat(existingVolumes.get(8).getPersistentVolumeClaim(), is(nullValue()));
+        assertThat(existingVolumes.get(8).getCsi(), is(nullValue()));
+        assertThat(existingVolumes.get(8).getImage(), is(nullValue()));
+    }
+
+    @Test
+    public void testAddAdditionalVolumes_ProjectedVolumeWithoutSources() {
+        List<Volume> existingVolumes = new ArrayList<>();
+
+        PodTemplate templatePod = new PodTemplateBuilder()
+                .withVolumes(
+                        new AdditionalVolumeBuilder()
+                                .withName("projected-volume-null-sources")
+                                .withNewProjected()
+                                .endProjected()
+                                .build(),
+                        new AdditionalVolumeBuilder()
+                                .withName("projected-volume-empty-sources")
+                                .withNewProjected()
+                                    .withSources(List.of())
+                                .endProjected()
+                                .build())
+                .build();
+
+        TemplateUtils.addAdditionalVolumes(templatePod, existingVolumes);
+
+        assertThat(existingVolumes.size(), is(2));
+
+        assertThat(existingVolumes.get(0).getName(), is("projected-volume-null-sources"));
+        assertThat(existingVolumes.get(0).getProjected(), is(nullValue()));
+
+        assertThat(existingVolumes.get(1).getName(), is("projected-volume-empty-sources"));
+        assertThat(existingVolumes.get(1).getProjected(), is(nullValue()));
+    }
+
+    @Test
+    public void testAddAdditionalVolumes_ProjectedVolumeWithUnsupportedSource() {
+        List<Volume> existingVolumes = new ArrayList<>();
+
+        PodTemplate templatePod = new PodTemplateBuilder()
+                .withVolumes(
+                        new AdditionalVolumeBuilder()
+                                .withName("projected-volume")
+                                .withNewProjected()
+                                    .addNewSource()
+                                    .endSource()
+                                .endProjected()
+                                .build())
+                .build();
+
+        InvalidResourceException exception = assertThrows(InvalidResourceException.class, () -> TemplateUtils.addAdditionalVolumes(templatePod, existingVolumes));
+
+        assertThat(exception.getMessage(), is("Only ServiceAccountTokenProjection is supported in projected volumes"));
     }
 
     @Test
@@ -285,6 +368,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(1).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(1).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(1).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(1).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(2).getName(), is("secret-volume2"));
         assertThat(existingVolumes.get(2).getSecret().getSecretName(), is("my-secret"));
@@ -296,6 +380,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(2).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(2).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(2).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(2).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(3).getName(), is("cm-volume"));
         assertThat(existingVolumes.get(3).getConfigMap().getName(), is("my-cm-5"));
@@ -304,6 +389,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(3).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(3).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(3).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(3).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(4).getName(), is("cm-volume2"));
         assertThat(existingVolumes.get(4).getConfigMap().getName(), is("my-cm"));
@@ -315,6 +401,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(4).getPersistentVolumeClaim(), is(nullValue()));
         assertThat(existingVolumes.get(4).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(4).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(4).getProjected(), is(nullValue()));
 
         assertThat(existingVolumes.get(5).getName(), is("pvc-volume"));
         assertThat(existingVolumes.get(5).getPersistentVolumeClaim().getClaimName(), is("pvc-5-my-cluster-brokers-5"));
@@ -323,6 +410,7 @@ public class TemplateUtilsTest {
         assertThat(existingVolumes.get(5).getEmptyDir(), is(nullValue()));
         assertThat(existingVolumes.get(5).getCsi(), is(nullValue()));
         assertThat(existingVolumes.get(5).getImage(), is(nullValue()));
+        assertThat(existingVolumes.get(5).getProjected(), is(nullValue()));
     }
 
     @Test

--- a/development-docs/systemtests/io.strimzi.systemtest.security.custom.CustomAuthenticationST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.security.custom.CustomAuthenticationST.md
@@ -1,0 +1,37 @@
+# CustomAuthenticationST
+
+**Description:** Test suite for verifying the custom authentication based on the Kubernetes Service Account tokens.
+
+**Before test execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy the Cluster Operator. | Cluster Operator is deployed and ready. |
+
+**Labels:**
+
+* [security](labels/security.md)
+
+<hr style="border:1px solid">
+
+## testServiceAccountAuthentication
+
+**Description:** This test case verifies the authentication based on the Kubernetes Service Account tokens. The Kafka listener validates the tokens against the JWKS endpoint of the Kubernetes API server and requires a custom audience. Kafka Connect and the Kafka clients authenticate with tokens obtained through projected Service Account token volumes.
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Create the broker and controller KafkaNodePools. | KafkaNodePools are created. |
+| 2. | Deploy a Kafka cluster with a custom listener that authenticates clients with Kubernetes Service Account tokens and requires a custom audience. | Kafka cluster is deployed and ready. |
+| 3. | Create a KafkaTopic. | KafkaTopic is ready. |
+| 4. | Deploy Kafka Connect with custom authentication and a projected Service Account token volume mounted into the Connect container. | Kafka Connect connects to the Kafka cluster and becomes ready. |
+| 5. | Create a FileStreamSink KafkaConnector consuming from the KafkaTopic. | KafkaConnector is ready. |
+| 6. | Produce messages with a Kafka client using a projected Service Account token with the expected audience. | The producer finishes successfully. |
+| 7. | Check the file sink of the KafkaConnector. | All produced messages are present in the file sink, so the connector consumed them over the authenticated listener. |
+| 8. | Produce messages with a Kafka client using a projected Service Account token with a different audience. | The producer fails to authenticate and does not deliver any messages. |
+
+**Labels:**
+
+* [security](labels/security.md)
+

--- a/development-docs/systemtests/labels/security.md
+++ b/development-docs/systemtests/labels/security.md
@@ -47,6 +47,7 @@ They cover authentication and authorization mechanisms (OAuth, ACLs, OPA integra
 - [testReplacingCustomClientsKeyPairToInvokeRenewalProcess](../io.strimzi.systemtest.security.custom.CustomCaST.md)
 - [testReplacingCustomClusterKeyPairToInvokeRenewalProcess](../io.strimzi.systemtest.security.custom.CustomCaST.md)
 - [testSaslPlainProducerConsumer](../io.strimzi.systemtest.security.oauth.OauthPlainST.md)
+- [testServiceAccountAuthentication](../io.strimzi.systemtest.security.custom.CustomAuthenticationST.md)
 - [testTeamAReadFromTopic](../io.strimzi.systemtest.security.oauth.OauthAuthorizationST.md)
 - [testTeamAWriteToTopic](../io.strimzi.systemtest.security.oauth.OauthAuthorizationST.md)
 - [testTeamAWriteToTopicStartingWithXAndTeamBReadFromTopicStartingWithX](../io.strimzi.systemtest.security.oauth.OauthAuthorizationST.md)

--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationCustom.adoc
@@ -31,6 +31,61 @@ The `security.protocol `setting is generated automatically from the `sasl` prope
 If your custom authentication mechanism requires additional information from `Secret` or `ConfigMap` resources, use the link:{BookURLConfiguring}#con-common-configuration-volumes-reference[Additional Volumes^] feature to mount them into the operands.
 Kafka configuration providers can be used to load them from the disk.
 
+= Using Kubernetes Service Account tokens for authentication
+
+If the Kafka cluster has a listener that authenticates clients with Kubernetes Service Account tokens, you can connect the operand to it using `custom` authentication with the `OAUTHBEARER` SASL mechanism.
+The operand reads the token from a file mounted into its pod and presents it to the Kafka cluster.
+For information on how to configure such a listener, see the xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom` schema reference].
+
+Strimzi mounts the Service Account token of the operand into the `/var/run/secrets/kubernetes.io/serviceaccount` directory.
+This token is issued for the default audience of the Kubernetes API server.
+If the Kafka listener requires a specific audience, use a projected Service Account token volume to mount a token issued for that audience instead.
+
+.Example client authentication configuration using a projected Service Account token
+[source,yaml,subs="attributes+"]
+----
+spec:
+  authentication:
+    type: custom
+    sasl: true
+    config:
+      sasl.mechanism: OAUTHBEARER
+      sasl.login.callback.handler.class: io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
+      sasl.jaas.config: |
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+          oauth.access.token.location="/mnt/auth-token/token";
+  template:
+    pod:
+      volumes:
+        - name: auth-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: my-internal-listener
+                  expirationSeconds: 3600
+                  path: token
+    connectContainer:
+      volumeMounts:
+        - name: auth-token
+          mountPath: /mnt/auth-token
+----
+
+In this configuration:
+
+* The `projected` volume asks Kubernetes to issue a token for the Service Account of the operand pod with the `my-internal-listener` audience and to store it in a file named `token`.
+* The volume is mounted at `/mnt/auth-token`, so the token is available in the `/mnt/auth-token/token` file.
+Additional volumes can be mounted only into paths that start with `/mnt`.
+For more information about additional volumes, see link:{BookURLConfiguring}#con-common-configuration-volumes-reference[Additional Volumes^].
+* `oauth.access.token.location` tells the Kafka client where to find the token file.
+* `sasl.login.callback.handler.class` sets the Strimzi callback handler that passes the token to the Kafka cluster.
+
+The `connectContainer` name used in this example applies to `KafkaConnect` and `KafkaMirrorMaker2` resources.
+For `KafkaBridge` resources, use `bridgeContainer` instead.
+
+NOTE: A projected Service Account token is always issued for the Service Account used by the pod.
+It cannot be used to obtain a token for a different Service Account.
+Strimzi operands use a Service Account named after the component: `<connect_cluster_name>-connect` for Kafka Connect, `<mirror_maker_2_cluster_name>-mirrormaker2` for MirrorMaker 2, and `<bridge_name>-bridge` for the HTTP Bridge.
+
 = Using additional authentication plugins
 
 Custom authentication mechanisms might require additional plugins for the operand.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom.adoc
@@ -86,6 +86,85 @@ spec:
             mountPath: /mnt/my-truststore
 ----
 
+= Configuring Service Account-based authentication
+
+You can also use `custom` authentication to authenticate clients with Kubernetes Service Account tokens.
+Kubernetes issues the tokens and publishes the keys needed to validate them, so you don't have to run and manage your own OAuth server.
+This makes Service Account tokens a convenient option for internal listeners used by clients that run in the same Kubernetes cluster as the Kafka cluster.
+
+The listener uses the `OAUTHBEARER` SASL mechanism and validates the tokens as JSON Web Tokens (JWTs) against the JSON Web Key Set (JWKS) endpoint published by the Kubernetes API server.
+Strimzi mounts the Service Account token of the Kafka node together with the Kubernetes CA certificate into the `/var/run/secrets/kubernetes.io/serviceaccount` directory of the Kafka containers.
+The listener configuration uses them to authenticate against the JWKS endpoint and to trust the TLS certificate of the Kubernetes API server.
+
+.Example Service Account-based authentication configuration
+[source,yaml,subs="attributes+"]
+----
+spec:
+  kafka:
+    config:
+      # Required by the Strimzi OAuth library
+      principal.builder.class: io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
+    listeners:
+      - name: sa
+        port: 9092
+        type: internal
+        tls: true
+        authentication:
+          type: custom
+          sasl: true
+          listenerConfig:
+            sasl.enabled.mechanisms: OAUTHBEARER
+            oauthbearer.sasl.server.callback.handler.class: io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
+            oauthbearer.sasl.jaas.config: |
+              org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+                unsecuredLoginStringClaim_sub="unused"
+                oauth.check.access.token.type="false"
+                oauth.custom.claim.check="@.aud anyof ['my-internal-listener']"
+                oauth.valid.issuer.uri="https://kubernetes.default.svc.cluster.local"
+                oauth.jwks.endpoint.uri="https://kubernetes.default.svc.cluster.local/openid/v1/jwks"
+                oauth.jwks.refresh.seconds="300"
+                oauth.username.claim="sub"
+                oauth.ssl.truststore.location="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                oauth.ssl.truststore.type="PEM"
+                oauth.server.bearer.token.location="/var/run/secrets/kubernetes.io/serviceaccount/token"
+                oauth.include.accept.header="false";
+----
+
+In this configuration:
+
+* `oauth.jwks.endpoint.uri` points to the JWKS endpoint of the Kubernetes API server, which publishes the keys used to sign the Service Account tokens.
+Tokens are validated locally by the Kafka nodes using these keys.
+* `oauth.valid.issuer.uri` is the token issuer of your Kubernetes cluster and is checked against the `iss` claim of the token.
+* `oauth.server.bearer.token.location` and `oauth.ssl.truststore.location` point to the Service Account token and the Kubernetes CA certificate mounted by Strimzi into the Kafka containers.
+The token is used to authenticate against the JWKS endpoint, which is not available to unauthenticated users by default.
+* `oauth.username.claim` uses the `sub` claim of the token as the name of the Kafka principal.
+* `oauth.check.access.token.type` is disabled because Service Account tokens don't contain the `typ` claim expected by the OAuth standard.
+* `oauth.include.accept.header` is disabled because the Kubernetes API server rejects requests that set the `Accept` header.
+* `unsecuredLoginStringClaim_sub` satisfies the parameter validation of the `OAuthBearerLoginModule` and isn't used for authentication.
+* `oauth.custom.claim.check` restricts the listener to tokens issued for a specific audience.
+* `principal.builder.class` maps the validated tokens to Kafka principals.
+For more information on the requirements that apply to principal builders, see the description of setting a custom principal builder that follows.
+
+NOTE: The issuer URI and the address of the JWKS endpoint depend on your Kubernetes cluster.
+Many Kubernetes clusters use `https://kubernetes.default.svc.cluster.local`, but managed Kubernetes services often use a different, externally hosted issuer.
+To find the values used by your cluster, run `kubectl get --raw /.well-known/openid-configuration` and check the `issuer` and `jwks_uri` fields.
+
+== Kafka principals and ACLs
+
+Clients are identified by the `sub` claim of the token, which for Service Account tokens has the format `system:serviceaccount:<namespace>:<service_account_name>`.
+Use these names when configuring ACL rules.
+
+Strimzi operands use a Service Account named after the component, so a Kafka Connect cluster named `my-connect` deployed in the `myproject` namespace authenticates as `User:system:serviceaccount:myproject:my-connect-connect`.
+
+== Restricting the token audience
+
+Without an audience check, any Service Account token from the Kubernetes cluster can be used to authenticate to the Kafka cluster, including the tokens that Pods use to communicate with the Kubernetes API.
+The `oauth.custom.claim.check` option in the example accepts only tokens that have `my-internal-listener` in their `aud` claim.
+Tokens issued for a custom audience are in turn rejected by the Kubernetes API server, which limits how they can be used if they leak.
+
+Clients have to request a token with a matching audience.
+Strimzi operands can do this using a projected Service Account token volume, as described in the xref:type-KafkaClientAuthenticationCustom-{context}[`KafkaClientAuthenticationCustom` schema reference].
+
 = Setting a custom principal builder
 
 You can set a custom principal builder in the Kafka cluster configuration.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -956,6 +956,9 @@ Used in: xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-StatefulPodTe
 |image
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#imagevolumesource-v1-core[ImageVolumeSource]
 |`ImageVolumeSource` object to use to populate the volume.
+|projected
+|xref:type-ProjectedVolume-{context}[`ProjectedVolume`]
+|`ProjectedVolume` object to use volume projection.
 |====
 
 [id='type-EmptyDirVolume-{context}']
@@ -973,6 +976,34 @@ Used in: xref:type-AdditionalVolume-{context}[`AdditionalVolume`]
 |sizeLimit
 |string
 |The total amount of local storage required for this EmptyDir volume (for example 1Gi).
+|====
+
+[id='type-ProjectedVolume-{context}']
+= `ProjectedVolume` schema reference
+
+Used in: xref:type-AdditionalVolume-{context}[`AdditionalVolume`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|sources
+|xref:type-ProjectedVolumeSource-{context}[`ProjectedVolumeSource`] array
+|List of projections that are part of this projected volumes. Currently, only Service Account projection is supported.
+|====
+
+[id='type-ProjectedVolumeSource-{context}']
+= `ProjectedVolumeSource` schema reference
+
+Used in: xref:type-ProjectedVolume-{context}[`ProjectedVolume`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|serviceAccountToken
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#serviceaccounttokenprojection-v1-core[ServiceAccountTokenProjection]
+|information about the serviceAccountToken data to project.
 |====
 
 [id='type-AdditionalTemplatedVolume-{context}']

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -827,6 +827,7 @@ Supported Volume Types
 * PersistentVolumeClaims
 * CSI Volumes
 * Image Volumes
+* Projected Service Account Tokens
 
 .Example configuration for additional volumes
 [source,yaml,subs=attributes+]
@@ -859,6 +860,13 @@ spec:
           - name: example-oci-plugin
             image:
               reference: my-registry.io/oci-artifacts/example-plugin:latest
+          - name: auth-token
+            projected:
+              sources:
+                - serviceAccountToken:
+                    audience: my-internal-listener
+                    expirationSeconds: 3600
+                    path: token
       kafkaContainer:
         volumeMounts:
           - name: example-secret
@@ -873,6 +881,8 @@ spec:
             mountPath: /mnt/certificate
           - name: example-oci-plugin
             mountPath: /mnt/example-plugin
+          - name: auth-token
+            mountPath: /mnt/auth-token
 ----
 
 You can use volumes to store files containing configuration values for a Kafka component and then load those values using a configuration provider.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1266,6 +1266,29 @@ spec:
                                       reference:
                                         type: string
                                     description: '`ImageVolumeSource` object to use to populate the volume.'
+                                  projected:
+                                    type: object
+                                    properties:
+                                      sources:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            serviceAccountToken:
+                                              type: object
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              description: information about the serviceAccountToken data to project.
+                                          oneOf:
+                                            - properties:
+                                                serviceAccountToken: {}
+                                        description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                    description: '`ProjectedVolume` object to use volume projection.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -1274,6 +1297,7 @@ spec:
                                       persistentVolumeClaim: {}
                                       csi: {}
                                       image: {}
+                                      projected: {}
                               description: Additional volumes that can be mounted to the pod.
                             templatedVolumes:
                               type: array
@@ -3005,6 +3029,29 @@ spec:
                                       reference:
                                         type: string
                                     description: '`ImageVolumeSource` object to use to populate the volume.'
+                                  projected:
+                                    type: object
+                                    properties:
+                                      sources:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            serviceAccountToken:
+                                              type: object
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              description: information about the serviceAccountToken data to project.
+                                          oneOf:
+                                            - properties:
+                                                serviceAccountToken: {}
+                                        description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                    description: '`ProjectedVolume` object to use volume projection.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -3013,6 +3060,7 @@ spec:
                                       persistentVolumeClaim: {}
                                       csi: {}
                                       image: {}
+                                      projected: {}
                               description: Additional volumes that can be mounted to the pod.
                             hostUsers:
                               type: boolean
@@ -4256,6 +4304,29 @@ spec:
                                       reference:
                                         type: string
                                     description: '`ImageVolumeSource` object to use to populate the volume.'
+                                  projected:
+                                    type: object
+                                    properties:
+                                      sources:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            serviceAccountToken:
+                                              type: object
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              description: information about the serviceAccountToken data to project.
+                                          oneOf:
+                                            - properties:
+                                                serviceAccountToken: {}
+                                        description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                    description: '`ProjectedVolume` object to use volume projection.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -4264,6 +4335,7 @@ spec:
                                       persistentVolumeClaim: {}
                                       csi: {}
                                       image: {}
+                                      projected: {}
                               description: Additional volumes that can be mounted to the pod.
                             hostUsers:
                               type: boolean
@@ -5385,6 +5457,29 @@ spec:
                                       reference:
                                         type: string
                                     description: '`ImageVolumeSource` object to use to populate the volume.'
+                                  projected:
+                                    type: object
+                                    properties:
+                                      sources:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            serviceAccountToken:
+                                              type: object
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              description: information about the serviceAccountToken data to project.
+                                          oneOf:
+                                            - properties:
+                                                serviceAccountToken: {}
+                                        description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                    description: '`ProjectedVolume` object to use volume projection.'
                                 oneOf:
                                   - properties:
                                       secret: {}
@@ -5393,6 +5488,7 @@ spec:
                                       persistentVolumeClaim: {}
                                       csi: {}
                                       image: {}
+                                      projected: {}
                               description: Additional volumes that can be mounted to the pod.
                             hostUsers:
                               type: boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1052,6 +1052,29 @@ spec:
                                   reference:
                                     type: string
                                 description: '`ImageVolumeSource` object to use to populate the volume.'
+                              projected:
+                                type: object
+                                properties:
+                                  sources:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        serviceAccountToken:
+                                          type: object
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          description: information about the serviceAccountToken data to project.
+                                      oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                    description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                description: '`ProjectedVolume` object to use volume projection.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -1060,6 +1083,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                           description: Additional volumes that can be mounted to the pod.
                         templatedVolumes:
                           type: array
@@ -2174,6 +2198,29 @@ spec:
                                   reference:
                                     type: string
                                 description: '`ImageVolumeSource` object to use to populate the volume.'
+                              projected:
+                                type: object
+                                properties:
+                                  sources:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        serviceAccountToken:
+                                          type: object
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          description: information about the serviceAccountToken data to project.
+                                      oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                    description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                description: '`ProjectedVolume` object to use volume projection.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2182,6 +2229,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                           description: Additional volumes that can be mounted to the pod.
                         hostUsers:
                           type: boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -874,6 +874,29 @@ spec:
                                   reference:
                                     type: string
                                 description: '`ImageVolumeSource` object to use to populate the volume.'
+                              projected:
+                                type: object
+                                properties:
+                                  sources:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        serviceAccountToken:
+                                          type: object
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          description: information about the serviceAccountToken data to project.
+                                      oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                    description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                description: '`ProjectedVolume` object to use volume projection.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -882,6 +905,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                           description: Additional volumes that can be mounted to the pod.
                         templatedVolumes:
                           type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1104,6 +1104,29 @@ spec:
                                   reference:
                                     type: string
                                 description: '`ImageVolumeSource` object to use to populate the volume.'
+                              projected:
+                                type: object
+                                properties:
+                                  sources:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        serviceAccountToken:
+                                          type: object
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          description: information about the serviceAccountToken data to project.
+                                      oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                    description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                description: '`ProjectedVolume` object to use volume projection.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -1112,6 +1135,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                           description: Additional volumes that can be mounted to the pod.
                         hostUsers:
                           type: boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1302,6 +1302,29 @@ spec:
                                   reference:
                                     type: string
                                 description: '`ImageVolumeSource` object to use to populate the volume.'
+                              projected:
+                                type: object
+                                properties:
+                                  sources:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        serviceAccountToken:
+                                          type: object
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          description: information about the serviceAccountToken data to project.
+                                      oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                    description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                description: '`ProjectedVolume` object to use volume projection.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -1310,6 +1333,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                           description: Additional volumes that can be mounted to the pod.
                         templatedVolumes:
                           type: array
@@ -2424,6 +2448,29 @@ spec:
                                   reference:
                                     type: string
                                 description: '`ImageVolumeSource` object to use to populate the volume.'
+                              projected:
+                                type: object
+                                properties:
+                                  sources:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        serviceAccountToken:
+                                          type: object
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          description: information about the serviceAccountToken data to project.
+                                      oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                    description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                description: '`ProjectedVolume` object to use volume projection.'
                             oneOf:
                               - properties:
                                   secret: {}
@@ -2432,6 +2479,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                           description: Additional volumes that can be mounted to the pod.
                         hostUsers:
                           type: boolean

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1265,6 +1265,29 @@ spec:
                                     reference:
                                       type: string
                                   description: '`ImageVolumeSource` object to use to populate the volume.'
+                                projected:
+                                  type: object
+                                  properties:
+                                    sources:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          serviceAccountToken:
+                                            type: object
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                type: integer
+                                              path:
+                                                type: string
+                                            description: information about the serviceAccountToken data to project.
+                                        oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                      description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                  description: '`ProjectedVolume` object to use volume projection.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -1273,6 +1296,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                             description: Additional volumes that can be mounted to the pod.
                           templatedVolumes:
                             type: array
@@ -3004,6 +3028,29 @@ spec:
                                     reference:
                                       type: string
                                   description: '`ImageVolumeSource` object to use to populate the volume.'
+                                projected:
+                                  type: object
+                                  properties:
+                                    sources:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          serviceAccountToken:
+                                            type: object
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                type: integer
+                                              path:
+                                                type: string
+                                            description: information about the serviceAccountToken data to project.
+                                        oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                      description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                  description: '`ProjectedVolume` object to use volume projection.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -3012,6 +3059,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                             description: Additional volumes that can be mounted to the pod.
                           hostUsers:
                             type: boolean
@@ -4255,6 +4303,29 @@ spec:
                                     reference:
                                       type: string
                                   description: '`ImageVolumeSource` object to use to populate the volume.'
+                                projected:
+                                  type: object
+                                  properties:
+                                    sources:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          serviceAccountToken:
+                                            type: object
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                type: integer
+                                              path:
+                                                type: string
+                                            description: information about the serviceAccountToken data to project.
+                                        oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                      description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                  description: '`ProjectedVolume` object to use volume projection.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -4263,6 +4334,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                             description: Additional volumes that can be mounted to the pod.
                           hostUsers:
                             type: boolean
@@ -5384,6 +5456,29 @@ spec:
                                     reference:
                                       type: string
                                   description: '`ImageVolumeSource` object to use to populate the volume.'
+                                projected:
+                                  type: object
+                                  properties:
+                                    sources:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          serviceAccountToken:
+                                            type: object
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                type: integer
+                                              path:
+                                                type: string
+                                            description: information about the serviceAccountToken data to project.
+                                        oneOf:
+                                        - properties:
+                                            serviceAccountToken: {}
+                                      description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                                  description: '`ProjectedVolume` object to use volume projection.'
                               oneOf:
                               - properties:
                                   secret: {}
@@ -5392,6 +5487,7 @@ spec:
                                   persistentVolumeClaim: {}
                                   csi: {}
                                   image: {}
+                                  projected: {}
                             description: Additional volumes that can be mounted to the pod.
                           hostUsers:
                             type: boolean

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1051,6 +1051,29 @@ spec:
                                 reference:
                                   type: string
                               description: '`ImageVolumeSource` object to use to populate the volume.'
+                            projected:
+                              type: object
+                              properties:
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      serviceAccountToken:
+                                        type: object
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        description: information about the serviceAccountToken data to project.
+                                    oneOf:
+                                    - properties:
+                                        serviceAccountToken: {}
+                                  description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                              description: '`ProjectedVolume` object to use volume projection.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -1059,6 +1082,7 @@ spec:
                               persistentVolumeClaim: {}
                               csi: {}
                               image: {}
+                              projected: {}
                         description: Additional volumes that can be mounted to the pod.
                       templatedVolumes:
                         type: array
@@ -2173,6 +2197,29 @@ spec:
                                 reference:
                                   type: string
                               description: '`ImageVolumeSource` object to use to populate the volume.'
+                            projected:
+                              type: object
+                              properties:
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      serviceAccountToken:
+                                        type: object
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        description: information about the serviceAccountToken data to project.
+                                    oneOf:
+                                    - properties:
+                                        serviceAccountToken: {}
+                                  description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                              description: '`ProjectedVolume` object to use volume projection.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -2181,6 +2228,7 @@ spec:
                               persistentVolumeClaim: {}
                               csi: {}
                               image: {}
+                              projected: {}
                         description: Additional volumes that can be mounted to the pod.
                       hostUsers:
                         type: boolean

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -873,6 +873,29 @@ spec:
                                 reference:
                                   type: string
                               description: '`ImageVolumeSource` object to use to populate the volume.'
+                            projected:
+                              type: object
+                              properties:
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      serviceAccountToken:
+                                        type: object
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        description: information about the serviceAccountToken data to project.
+                                    oneOf:
+                                    - properties:
+                                        serviceAccountToken: {}
+                                  description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                              description: '`ProjectedVolume` object to use volume projection.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -881,6 +904,7 @@ spec:
                               persistentVolumeClaim: {}
                               csi: {}
                               image: {}
+                              projected: {}
                         description: Additional volumes that can be mounted to the pod.
                       templatedVolumes:
                         type: array

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1103,6 +1103,29 @@ spec:
                                 reference:
                                   type: string
                               description: '`ImageVolumeSource` object to use to populate the volume.'
+                            projected:
+                              type: object
+                              properties:
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      serviceAccountToken:
+                                        type: object
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        description: information about the serviceAccountToken data to project.
+                                    oneOf:
+                                    - properties:
+                                        serviceAccountToken: {}
+                                  description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                              description: '`ProjectedVolume` object to use volume projection.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -1111,6 +1134,7 @@ spec:
                               persistentVolumeClaim: {}
                               csi: {}
                               image: {}
+                              projected: {}
                         description: Additional volumes that can be mounted to the pod.
                       hostUsers:
                         type: boolean

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1301,6 +1301,29 @@ spec:
                                 reference:
                                   type: string
                               description: '`ImageVolumeSource` object to use to populate the volume.'
+                            projected:
+                              type: object
+                              properties:
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      serviceAccountToken:
+                                        type: object
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        description: information about the serviceAccountToken data to project.
+                                    oneOf:
+                                    - properties:
+                                        serviceAccountToken: {}
+                                  description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                              description: '`ProjectedVolume` object to use volume projection.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -1309,6 +1332,7 @@ spec:
                               persistentVolumeClaim: {}
                               csi: {}
                               image: {}
+                              projected: {}
                         description: Additional volumes that can be mounted to the pod.
                       templatedVolumes:
                         type: array
@@ -2423,6 +2447,29 @@ spec:
                                 reference:
                                   type: string
                               description: '`ImageVolumeSource` object to use to populate the volume.'
+                            projected:
+                              type: object
+                              properties:
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      serviceAccountToken:
+                                        type: object
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        description: information about the serviceAccountToken data to project.
+                                    oneOf:
+                                    - properties:
+                                        serviceAccountToken: {}
+                                  description: "List of projections that are part of this projected volumes. Currently, only Service Account projection is supported."
+                              description: '`ProjectedVolume` object to use volume projection.'
                           oneOf:
                           - properties:
                               secret: {}
@@ -2431,6 +2478,7 @@ spec:
                               persistentVolumeClaim: {}
                               csi: {}
                               image: {}
+                              projected: {}
                         description: Additional volumes that can be mounted to the pod.
                       hostUsers:
                         type: boolean

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthenticationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthenticationST.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.security.custom;
+
+import io.fabric8.kubernetes.api.model.ServiceAccountTokenProjectionBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Label;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
+import io.skodjob.kubetest4j.resources.KubeResourceManager;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
+import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
+import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.testclients.clients.kafka.KafkaProducerClient;
+import io.strimzi.testclients.clients.kafka.KafkaProducerClientBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+
+import static io.strimzi.systemtest.TestTags.CONNECT;
+import static io.strimzi.systemtest.TestTags.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.TestTags.REGRESSION;
+
+/**
+ * Test suite for the custom authentication mechanisms that are not covered by the dedicated authentication types.
+ * Currently, it covers the authentication based on the Kubernetes Service Account tokens, which uses the `custom`
+ * authentication together with the OAUTHBEARER SASL mechanism and the Kubernetes API server as the identity provider.
+ */
+@Tag(REGRESSION)
+@Tag(CONNECT)
+@Tag(CONNECT_COMPONENTS)
+@SuiteDoc(
+    description = @Desc("Test suite for verifying the custom authentication based on the Kubernetes Service Account tokens."),
+    beforeTestSteps = {
+        @Step(value = "Deploy the Cluster Operator.", expected = "Cluster Operator is deployed and ready.")
+    },
+    labels = {
+        @Label(value = TestDocsLabels.SECURITY)
+    }
+)
+public class CustomAuthenticationST extends AbstractST {
+    private static final Logger LOGGER = LogManager.getLogger(CustomAuthenticationST.class);
+
+    private static final String LISTENER_AUDIENCE = "my-internal-listener";
+    private static final String TOKEN_VOLUME_NAME = "auth-token";
+    private static final String TOKEN_MOUNT_PATH = "/mnt/auth-token";
+    private static final String TOKEN_FILE_PATH = TOKEN_MOUNT_PATH + "/token";
+    private static final String JWKS_ENDPOINT_URI = "https://kubernetes.default.svc.cluster.local/openid/v1/jwks";
+    private static final String ISSUER_URI = "https://kubernetes.default.svc.cluster.local";
+    private static final String SERVICE_ACCOUNT_DIR = "/var/run/secrets/kubernetes.io/serviceaccount";
+
+    private static final String OAUTH_PRINCIPAL_BUILDER_CLASS = "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder";
+    private static final String OAUTH_SERVER_CALLBACK_HANDLER_CLASS = "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler";
+    private static final String OAUTH_CLIENT_CALLBACK_HANDLER_CLASS = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
+    private static final String OAUTH_BEARER_LOGIN_MODULE = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule";
+    private static final String STRING_CONVERTER_CLASS = "org.apache.kafka.connect.storage.StringConverter";
+
+    @ParallelNamespaceTest
+    @TestDoc(
+        description = @Desc("This test case verifies the authentication based on the Kubernetes Service Account tokens. " +
+            "The Kafka listener validates the tokens against the JWKS endpoint of the Kubernetes API server and requires a custom audience. " +
+            "Kafka Connect and the Kafka clients authenticate with tokens obtained through projected Service Account token volumes."),
+        steps = {
+            @Step(value = "Create the broker and controller KafkaNodePools.", expected = "KafkaNodePools are created."),
+            @Step(value = "Deploy a Kafka cluster with a custom listener that authenticates clients with Kubernetes Service Account tokens and requires a custom audience.", expected = "Kafka cluster is deployed and ready."),
+            @Step(value = "Create a KafkaTopic.", expected = "KafkaTopic is ready."),
+            @Step(value = "Deploy Kafka Connect with custom authentication and a projected Service Account token volume mounted into the Connect container.", expected = "Kafka Connect connects to the Kafka cluster and becomes ready."),
+            @Step(value = "Create a FileStreamSink KafkaConnector consuming from the KafkaTopic.", expected = "KafkaConnector is ready."),
+            @Step(value = "Produce messages with a Kafka client using a projected Service Account token with the expected audience.", expected = "The producer finishes successfully."),
+            @Step(value = "Check the file sink of the KafkaConnector.", expected = "All produced messages are present in the file sink, so the connector consumed them over the authenticated listener."),
+            @Step(value = "Produce messages with a Kafka client using a projected Service Account token with a different audience.", expected = "The producer fails to authenticate and does not deliver any messages.")
+        },
+        labels = {
+            @Label(value = TestDocsLabels.SECURITY)
+        }
+    )
+    @SuppressWarnings("checkstyle:MethodLength")
+    void testServiceAccountAuthentication() {
+        final TestStorage testStorage = new TestStorage(KubeResourceManager.get().getTestContext());
+
+        KubeResourceManager.get().createResourceWithWait(
+            KafkaNodePoolTemplates.brokerPool(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3).build(),
+            KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
+        );
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTemplates.kafka(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)
+            .editSpec()
+                .editKafka()
+                    // The Strimzi OAuth library requires its own principal builder
+                    .addToConfig("principal.builder.class", OAUTH_PRINCIPAL_BUILDER_CLASS)
+                    .withListeners(new GenericKafkaListenerBuilder()
+                        .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                        .withPort(9092)
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withTls(false)
+                        .withNewKafkaListenerAuthenticationCustomAuth()
+                            .withSasl(true)
+                            .addToListenerConfig("sasl.enabled.mechanisms", "OAUTHBEARER")
+                            .addToListenerConfig("oauthbearer.sasl.server.callback.handler.class", OAUTH_SERVER_CALLBACK_HANDLER_CLASS)
+                            .addToListenerConfig("oauthbearer.connections.max.reauth.ms", 3600000)
+                            .addToListenerConfig("oauthbearer.sasl.jaas.config", OAUTH_BEARER_LOGIN_MODULE + " required "
+                                    + "unsecuredLoginStringClaim_sub=\"unused\" "
+                                    + "oauth.check.access.token.type=\"false\" "
+                                    + "oauth.custom.claim.check=\"@.aud anyof ['" + LISTENER_AUDIENCE + "']\" "
+                                    + "oauth.valid.issuer.uri=\"" + ISSUER_URI + "\" "
+                                    + "oauth.jwks.endpoint.uri=\"" + JWKS_ENDPOINT_URI + "\" "
+                                    + "oauth.jwks.refresh.seconds=\"300\" "
+                                    + "oauth.username.claim=\"sub\" "
+                                    + "oauth.ssl.truststore.location=\"" + SERVICE_ACCOUNT_DIR + "/ca.crt\" "
+                                    + "oauth.ssl.truststore.type=\"PEM\" "
+                                    + "oauth.server.bearer.token.location=\"" + SERVICE_ACCOUNT_DIR + "/token\" "
+                                    + "oauth.include.accept.header=\"false\";")
+                        .endKafkaListenerAuthenticationCustomAuth()
+                        .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        KubeResourceManager.get().createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
+
+        final KafkaConnect connect = KafkaConnectTemplates.kafkaConnectWithFilePlugin(testStorage.getNamespaceName(), testStorage.getClusterName(), 1)
+            .editMetadata()
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .editSpec()
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+                .withNewKafkaClientAuthenticationCustom()
+                    .withSasl(true)
+                    .addToConfig("sasl.mechanism", "OAUTHBEARER")
+                    .addToConfig("sasl.login.callback.handler.class", OAUTH_CLIENT_CALLBACK_HANDLER_CLASS)
+                    .addToConfig("sasl.jaas.config", OAUTH_BEARER_LOGIN_MODULE + " required oauth.access.token.location=\"" + TOKEN_FILE_PATH + "\";")
+                .endKafkaClientAuthenticationCustom()
+                .addToConfig("key.converter", STRING_CONVERTER_CLASS)
+                .addToConfig("value.converter", STRING_CONVERTER_CLASS)
+                .addToConfig("key.converter.schemas.enable", false)
+                .addToConfig("value.converter.schemas.enable", false)
+                .editOrNewTemplate()
+                    .editOrNewPod()
+                        .addNewVolume()
+                            .withName(TOKEN_VOLUME_NAME)
+                            .withNewProjected()
+                                .addNewSource()
+                                    .withServiceAccountToken(new ServiceAccountTokenProjectionBuilder()
+                                            .withAudience(LISTENER_AUDIENCE)
+                                            .withExpirationSeconds(3600L)
+                                            .withPath("token")
+                                            .build())
+                                .endSource()
+                            .endProjected()
+                        .endVolume()
+                    .endPod()
+                    .editOrNewConnectContainer()
+                        .addToVolumeMounts(new VolumeMountBuilder()
+                            .withName(TOKEN_VOLUME_NAME)
+                            .withMountPath(TOKEN_MOUNT_PATH)
+                            .build())
+                    .endConnectContainer()
+                .endTemplate()
+            .endSpec()
+            .build();
+
+        // The TLS configuration comes from the default template and cannot be removed through the builder
+        connect.getSpec().setTls(null);
+
+        KubeResourceManager.get().createResourceWithWait(connect);
+
+        final String connectPodName = KubeResourceManager.get().kubeClient()
+            .listPodsByPrefixInName(testStorage.getNamespaceName(), KafkaConnectResources.componentName(testStorage.getClusterName()))
+            .get(0).getMetadata().getName();
+
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(testStorage.getNamespaceName(), connectPodName);
+
+        LOGGER.info("Creating FileStreamSink KafkaConnector: {}/{} for Topic: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getTopicName());
+        KubeResourceManager.get().createResourceWithWait(KafkaConnectorTemplates.kafkaConnector(testStorage.getNamespaceName(), testStorage.getClusterName())
+            .editSpec()
+                .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
+                .addToConfig("topics", testStorage.getTopicName())
+                .addToConfig("file", TestConstants.DEFAULT_SINK_FILE_PATH)
+                .addToConfig("key.converter", STRING_CONVERTER_CLASS)
+                .addToConfig("value.converter", STRING_CONVERTER_CLASS)
+            .endSpec()
+            .build());
+
+        LOGGER.info("Producing messages with a Service Account token issued for the expected audience: {}", LISTENER_AUDIENCE);
+        final KafkaProducerClient producer = new KafkaProducerClientBuilder()
+                .withName(testStorage.getProducerName())
+                .withNamespaceName(testStorage.getNamespaceName())
+                .withTopicName(testStorage.getTopicName())
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+                .withMessageCount(testStorage.getMessageCount())
+                .withAdditionalConfig(
+                        "security.protocol=SASL_PLAINTEXT\n"
+                                + "sasl.mechanism=OAUTHBEARER\n"
+                                + "sasl.login.callback.handler.class=" + OAUTH_CLIENT_CALLBACK_HANDLER_CLASS + "\n"
+                                + "sasl.jaas.config=" + OAUTH_BEARER_LOGIN_MODULE + " required oauth.access.token.location=\"" + TOKEN_FILE_PATH + "\";"
+                )
+                .build();
+
+        // We update the producer job to have the projected token as well
+        final Job producerJob = new JobBuilder(producer.getJob())
+            .editSpec()
+                .editTemplate()
+                    .editSpec()
+                        .addNewVolume()
+                            .withName(TOKEN_VOLUME_NAME)
+                            .withNewProjected()
+                                .addNewSource()
+                                    .withServiceAccountToken(new ServiceAccountTokenProjectionBuilder()
+                                            .withAudience(LISTENER_AUDIENCE)
+                                            .withExpirationSeconds(3600L)
+                                            .withPath("token")
+                                            .build())
+                                .endSource()
+                            .endProjected()
+                        .endVolume()
+                        .editFirstContainer()
+                            .addNewVolumeMount()
+                                .withName(TOKEN_VOLUME_NAME)
+                                .withMountPath(TOKEN_MOUNT_PATH)
+                            .endVolumeMount()
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build();
+        KubeResourceManager.get().createResourceWithWait(producerJob);
+        ClientUtils.waitForClientSuccess(testStorage.getNamespaceName(), testStorage.getProducerName(), testStorage.getMessageCount());
+
+        LOGGER.info("Checking that KafkaConnector consumed the messages over the Service Account authenticated listener");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
+    }
+
+    @BeforeAll
+    void setUp() {
+        SetupClusterOperator
+            .getInstance()
+            .withDefaultConfiguration()
+            .install();
+    }
+}


### PR DESCRIPTION
### Type of Change

- Enhancement / new feature

### Description

This PR implements the [SEP-155: Projected Service Account Tokens in Additional Volumes](https://github.com/strimzi/proposals/blob/main/155-projected-service-account-tokens-in-additional-volumes.md) and adds support for projected service account tokens to additional volumes. It also adds documentation and system tests for using them for service account based authentication in Apache Kafka clients.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md (if present)
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
