### PR TITLE
Fixed Strimzi metrics reporter documentation about allowList

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -617,7 +617,7 @@ The `metricsConfig` property contains configurations for the {StrimziMetricsRepo
 The Strimzi Metrics Reporter offers a lightweight solution for exposing Kafka metrics in Prometheus format, and avoiding complex mapping rules that can introduce latency.
 
 To enable Strimzi Metrics Reporter, set the type to `strimziMetricsReporter`.
-The `allowList` configuration is a comma-separated list of regex patterns to filter the metrics that are collected. This defaults to `.*`,  which allows all metrics.
+The `allowList` configuration is a list of regex patterns to filter the metrics that are collected. This defaults to `.*`, which allows all metrics.
 Changes to this field will not trigger rolling update, the configuration is dynamically updated for Kafka brokers and controllers.
 
 NOTE: Using `strimziMetricsReporter` is only supported in the Kafka brokers and controllers at the moment.
@@ -636,7 +636,7 @@ spec:
       type: strimziMetricsReporter
       values:
         allowList:
-          key: ".*"
+          - ".*"
     # ...
 ----
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The current documentation shows how to set the `allowList` for the Strimzi metrics reporter this way:

```yaml
metricsConfig:
  type: strimziMetricsReporter
  values:
    allowList:
      key: ".*"
```

But the above is currently wrong, there is no such `key` field defined within the `StrimziMetricsReporterValues` but just a list/array of strings. Actually, by applying the above you get `strict decoding error: unknown field "spec.metricsConfig.values.allowList[0].key"`.
This PR fixes the documentation showing the correct way:

```yaml
metricsConfig:
  type: strimziMetricsReporter
  values:
    allowList:
       - ".*"
```

### Checklist

- [x] Update documentation