### PR TITLE
Cluster Security: Add Service Account authentication to the documentation

### DIFF
--- a/documentation/assemblies/security/assembly-internal-cluster-security.adoc
+++ b/documentation/assemblies/security/assembly-internal-cluster-security.adoc
@@ -10,10 +10,11 @@
 [role="_abstract"]
 Configure the encryption and authentication used for communication between components of a Kafka cluster.
 The default TLS encryption and mTLS authentication provide secure internal communication.
-But you can disable mTLS or both options when your environment provides equivalent protection or has other requirements.
+But you can authenticate the components with Kubernetes service account tokens instead of mTLS certificates.
+You can also disable mTLS or both options when your environment provides equivalent protection or has other requirements.
 
 IMPORTANT: Changing the internal cluster security configuration requires downtime of the Kafka cluster.
-Make sure to carefully follow the xref:proc-changing-internal-cluster-security[Changing the internal cluster security configuration] procedure to avoid leaving the cluster in an invalid state.
+Make sure to carefully follow the xref:proc-changing-internal-cluster-security-{context}[Changing the internal cluster security configuration] procedure to avoid leaving the cluster in an invalid state.
 
 include::../../modules/security/con-internal-cluster-security.adoc[leveloffset=+1]
 

--- a/documentation/modules/security/con-internal-cluster-security.adoc
+++ b/documentation/modules/security/con-internal-cluster-security.adoc
@@ -51,16 +51,22 @@ The annotation is a temporary configuration interface and might also change.
 |Authenticates internal components by using mTLS certificates.
 
 |Authentication
+|`service-account`
+|Authenticates internal components by using Kubernetes service account tokens.
+
+|Authentication
 |`none`
-|Disables mTLS authentication governed by the internal cluster security configuration.
+|Disables authentication governed by the internal cluster security configuration.
 |===
 
 The `mtls` authentication type requires `tls` encryption.
-Consequently, disabling TLS encryption also requires authentication to be disabled.
+The `service-account` authentication type works with or without TLS encryption.
 The supported combinations are:
 
 * TLS encryption with mTLS authentication
+* TLS encryption with service account authentication
 * TLS encryption without authentication
+* No encryption with service account authentication
 * And no encryption with no authentication
 
 WARNING: When the authentication type is `none` and Kafka authorization is configured, Strimzi automatically makes the `ANONYMOUS` user a super user so that internal components can operate.
@@ -71,6 +77,81 @@ Disable authentication only if other controls, such as network isolation or a se
 
 If the `strimzi.io/internal-cluster-security` annotation is not present, Strimzi uses `tls` encryption with `mtls` authentication.
 This behavior is unchanged from previous releases.
+
+== (Early Access) Using service account authentication
+
+Set the authentication type to `service-account` to authenticate internal components with Kubernetes service account tokens instead of mTLS certificates.
+Each component mounts a projected service account token that is bound to the Kafka cluster and uses it to authenticate through the SASL `OAUTHBEARER` mechanism.
+Kafka brokers and controllers validate the tokens against the JWKS endpoint of the Kubernetes API server.
+The Kafka Agent validates the same tokens on its HTTP endpoints.
+
+Service account authentication can be combined with `tls` encryption or used without encryption.
+Use it with `tls` encryption unless internal traffic is encrypted by other means, such as a service mesh.
+
+.TLS encryption with service account authentication
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+      {
+        "encryption": {
+          "type": "tls"
+        },
+        "authentication": {
+          "type": "service-account",
+          "expirationSeconds": 3600
+        }
+      }
+spec:
+  # ...
+----
+
+The optional `expirationSeconds` property sets the validity of the issued tokens.
+It applies only to the `service-account` authentication type and defaults to `3600` (1 hour) when not set.
+Kubernetes requires a minimum of `600` (10 minutes) for projected service account tokens.
+Tokens are refreshed by Kubernetes before they expire, and the components pick up the refreshed tokens automatically.
+
+Components are authenticated as the Kubernetes service accounts they run under, using the `system:serviceaccount:<namespace>:<service_account_name>` principal format.
+Strimzi creates an additional service account named `<cluster_name>-cluster-operator` in the namespace of the Kafka cluster.
+The Cluster Operator requests tokens for this service account and uses them for its own connections to the Kafka cluster and to the Kafka Agent.
+The service account exists only while service account authentication is enabled.
+
+.Service accounts used for internal cluster authentication
+[cols="1,1m",options="header"]
+|===
+|Component
+|Service account
+
+|Kafka brokers and controllers
+|<cluster_name>-kafka
+
+|Cluster Operator
+|<cluster_name>-cluster-operator
+
+|Topic Operator and User Operator
+|<cluster_name>-entity-operator
+
+|Cruise Control
+|<cluster_name>-cruise-control
+
+|Kafka Exporter
+|<cluster_name>-kafka-exporter
+|===
+
+When Kafka authorization is configured, Strimzi adds these principals to the list of Kafka super users so that internal components can operate.
+Unlike the `none` authentication type, the `ANONYMOUS` user is not made a super user.
+
+Service account authentication has the following requirements:
+
+* The Cluster Operator must be allowed to create tokens by requesting them from the Kubernetes API.
+The required permission to `create` the `serviceaccounts/token` subresource is included in the `strimzi-cluster-operator-namespaced` cluster role in the Strimzi installation files.
+If you use customized RBAC resources, add this permission before enabling service account authentication.
+* The Kubernetes API server must use the default in-cluster service account issuer (`https://kubernetes.default.svc.cluster.local`) and expose the link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery[service account issuer discovery^] endpoints, which is the case in most Kubernetes distributions.
+Strimzi components use their Kubernetes service account tokens to authenticate to these endpoints, so anonymous access to them is not required.
 
 == (Early Access) Disabling mTLS authentication
 
@@ -129,6 +210,3 @@ spec:
 During reconciliation, the Cluster Operator records the selected configuration in `.status.clusterSecurity` of the `Kafka` resource.
 If a subsequent annotation change does not match the recorded configuration, reconciliation fails to protect the running cluster from an incompatible change.
 To change the configuration of an existing cluster, use the required downtime procedure.
-
-Additional authentication types are planned for future releases so that internal components can authenticate without mTLS.
-These authentication types are not currently available.

--- a/documentation/modules/security/con-internal-cluster-security.adoc
+++ b/documentation/modules/security/con-internal-cluster-security.adoc
@@ -81,7 +81,9 @@ This behavior is unchanged from previous releases.
 == (Early Access) Using service account authentication
 
 Set the authentication type to `service-account` to authenticate internal components with Kubernetes service account tokens instead of mTLS certificates.
-Each component mounts a projected service account token that is bound to the Kafka cluster and uses it to authenticate through the SASL `OAUTHBEARER` mechanism.
+All components use the the SASL `OAUTHBEARER` mechanism with a Service Account token for authentication.
+The operands get the token by mounting a projected service account token that is bound to the Kafka cluster.
+The Cluster Operator uses the Kubernetes `TokenRequest` to get the token.
 Kafka brokers and controllers validate the tokens against the JWKS endpoint of the Kubernetes API server.
 The Kafka Agent validates the same tokens on its HTTP endpoints.
 

--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -90,7 +90,9 @@ spec:
 [id='con-mutual-tls-authentication-{context}']
 == mTLS authentication
 
-mTLS authentication is always used for the communication between Kafka nodes.
+By default, mTLS authentication is also used for the communication between Kafka nodes and other Strimzi components.
+You can change this in the internal cluster security configuration.
+For more information, see xref:con-internal-cluster-security-{context}[Internal cluster encryption and authentication].
 
 Strimzi can configure Kafka to use TLS (Transport Layer Security) to provide encrypted communication between Kafka brokers and clients either with or without mutual authentication.
 For mutual, or two-way, authentication, both the server and the client present certificates.

--- a/documentation/modules/security/proc-changing-internal-cluster-security.adoc
+++ b/documentation/modules/security/proc-changing-internal-cluster-security.adoc
@@ -83,6 +83,15 @@ kubectl annotate kafka <cluster_name> \
   --overwrite
 ----
 +
+Or set the authentication type to `service-account` to keep TLS encryption and authenticate the components with Kubernetes service account tokens:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafka <cluster_name> \
+  strimzi.io/internal-cluster-security='{"encryption":{"type":"tls"},"authentication":{"type":"service-account"}}' \
+  --overwrite
+----
++
 Use one of the combinations described in xref:con-internal-cluster-security-{context}[Internal cluster encryption and authentication].
 
 . Unpause reconciliation of the `Kafka` resource:


### PR DESCRIPTION
### Type of Change

- Documentation
- Task

### Description

This PR continues the work on [SEP-150: Cluster Security](https://github.com/strimzi/proposals/blob/main/150-configurable-security-of-internal-communication.md) and adds the Service Account authentication to the documentation.

### Checklist

- [x] Update documentation
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))