### PR TITLE
update the wrong `renewal` config doc

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
@@ -78,7 +78,6 @@ public class CertificateAuthority implements UnknownPropertyPreserving {
     @Description("The number of days in the certificate renewal period. " +
             "This is the number of days before the a certificate expires during which renewal actions may be performed. " +
             "When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. " +
-            "When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. " +
             "Default is 30.")
     @Minimum(1)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)


### PR DESCRIPTION
### Type of change

_Select the type of your PR and delete the other items_

- Documentation

### Description

In https://github.com/strimzi/strimzi-kafka-operator/pull/806#discussion_r216555810 in 2018, we didn't fix the wrong `renewal` config doc:
> When generateCertificateAuthority is true, this will cause extra logging at WARN level about the pending certificate expiry. 

The WARN level log will be outputted when when generateCertificateAuthority is false (check [here](https://github.com/strimzi/strimzi-kafka-operator/blob/release-0.9.x/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java#L363-L368)). However, after years of updates and refactors, this WARN log will not logged anymore, so we should update the doc to remove this sentence.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [V ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
