### PR TITLE
Add missing Kafka JBOD example to the README.md

### DIFF
--- a/packaging/examples/kafka/README.md
+++ b/packaging/examples/kafka/README.md
@@ -2,6 +2,7 @@
 
 The examples in this directory demonstrate how you can use Kraft (ZooKeeper-less Apache Kafka) with Strimzi.
 * The [`kafka-persistent.yaml`](kafka-persistent.yaml) deploys a Kafka cluster with one pool of _KRaft controller_ nodes and one pool of _KRaft broker_ nodes.
+* The [`kafka-jbod.yaml`](kafka-jbod.yaml) deploys a Kafka cluster with one pool of _KRaft controller_ nodes and one pool of _KRaft broker_ nodes using multiple data volumes.
 * The [`kafka-ephemeral.yaml`](kafka-ephemeral.yaml) deploys a Kafka cluster with one pool of _KRaft controller_ nodes, one pool of _KRaft broker_ nodes and ephemeral storage.
 * The [`kafka-with-dual-role-nodes.yaml`](kafka-with-dual-role-nodes.yaml) deploys a Kafka cluster with one pool of KRaft nodes that share the _broker_ and _controller_ roles.
 * The [`kafka-single-node.yaml`](kafka-single-node.yaml) deploys a Kafka cluster with a single Kafka node that has both _broker_ and _controller_ roles.


### PR DESCRIPTION
### Type of change

- Task

### Description

The README.md in Kafka examples is missing the JBOD example. This PR adds it there.

### Checklist

- [x] Update documentation