### PR TITLE
Fix Cluster Security backwards compatibility issues

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityAuthenticationType.java
@@ -18,7 +18,7 @@ public enum ClusterSecurityAuthenticationType {
     public static ClusterSecurityAuthenticationType forValue(String value) {
         return switch (value) {
             case "none" -> NONE;
-            case "mtls" -> MTLS;
+            case "mtls", "strimzi-mtls" -> MTLS; // We have to keep the legacy strimzi-mtls here for downgrades/upgrades to/from 1.2.0
             default -> null;
         };
     }
@@ -27,7 +27,7 @@ public enum ClusterSecurityAuthenticationType {
     public String toValue() {
         return switch (this) {
             case NONE -> "none";
-            case MTLS -> "mtls";
+            case MTLS -> "strimzi-mtls"; // We have to keep the legacy strimzi-mtls here for downgrades/upgrades to/from 1.2.0
         };
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/clustersecurity/ClusterSecurityEncryptionType.java
@@ -18,7 +18,7 @@ public enum ClusterSecurityEncryptionType {
     public static ClusterSecurityEncryptionType forValue(String value) {
         return switch (value) {
             case "none" -> NONE;
-            case "tls" -> TLS;
+            case "tls", "strimzi-tls" -> TLS; // We have to keep the legacy strimzi-tls here for downgrades/upgrades to/from 1.2.0
             default -> null;
         };
     }
@@ -27,7 +27,7 @@ public enum ClusterSecurityEncryptionType {
     public String toValue() {
         return switch (this) {
             case NONE -> "none";
-            case TLS -> "tls";
+            case TLS -> "strimzi-tls"; // We have to keep the legacy strimzi-tls here for downgrades/upgrades to/from 1.2.0
         };
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
@@ -29,12 +29,18 @@ public class KafkaClusterSecurityContextTest {
     private static final String CLUSTER_NAME = "my-cluster";
     private static final String INTERNAL_CLUSTER_SECURITY_ANNOTATION = "strimzi.io/internal-cluster-security";
     private static final String TLS_WITHOUT_AUTHENTICATION = "{\"encryption\":{\"type\":\"tls\"},\"authentication\":{\"type\":\"none\"}}";
+    private static final String LEGACY_TLS_WITH_MTLS = "{\"encryption\":{\"type\":\"strimzi-tls\"},\"authentication\":{\"type\":\"strimzi-mtls\"}}";
     private static final String WITHOUT_ENCRYPTION_OR_AUTHENTICATION = "{\"encryption\":{\"type\":\"none\"},\"authentication\":{\"type\":\"none\"}}";
     private static final String MTLS_WITHOUT_TLS = "{\"encryption\":{\"type\":\"none\"},\"authentication\":{\"type\":\"mtls\"}}";
 
     private static final Map<String, Object> VALID_STATUS = Map.of(
             "encryption", Map.of("type", "tls"),
             "authentication", Map.of("type", "mtls")
+    );
+
+    private static final Map<String, Object> VALID_LEGACY_STATUS = Map.of(
+            "encryption", Map.of("type", "strimzi-tls"),
+            "authentication", Map.of("type", "strimzi-mtls")
     );
 
     private static final Kafka KAFKA = new KafkaBuilder()
@@ -249,6 +255,14 @@ public class KafkaClusterSecurityContextTest {
     }
 
     @Test
+    public void testDeserializeLegacySpec()  {
+        ClusterSecurity clusterSecurity = KafkaClusterSecurityContext.deserializeSpec(LEGACY_TLS_WITH_MTLS);
+
+        assertThat(clusterSecurity.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(clusterSecurity.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
+    }
+
+    @Test
     public void testDeserializeSpecWithUnknownFields()  {
         ClusterSecurity clusterSecurity = KafkaClusterSecurityContext.deserializeSpec("""
                 {
@@ -284,6 +298,14 @@ public class KafkaClusterSecurityContextTest {
     @Test
     public void testDeserializeStatus()  {
         ClusterSecurityStatus status = KafkaClusterSecurityContext.deserializeStatus(VALID_STATUS);
+
+        assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
+        assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));
+    }
+
+    @Test
+    public void testDeserializeLegacyStatus()  {
+        ClusterSecurityStatus status = KafkaClusterSecurityContext.deserializeStatus(VALID_LEGACY_STATUS);
 
         assertThat(status.getEncryption().getType(), is(ClusterSecurityEncryptionType.TLS));
         assertThat(status.getAuthentication().getType(), is(ClusterSecurityAuthenticationType.MTLS));


### PR DESCRIPTION
### Type of Change

- Bugfix

### Description

In https://github.com/strimzi/strimzi-kafka-operator/pull/13088 I changed the type names for the TLS/mTLS security configurations. However, I was stupid and I did not realize that we already shipped the status part in 1.2.0 and thus the change broker the backwards compatibility. This PR tries to fix the backward compatibility by using the old types in status while keeping the new nicer types for users in the annotation.

With this change:
* We are able to deserialize the spec and status with the legacy `strimzi-tls` and `strimzi-mtls` types => we can upgrade from the older versions
* We are able to deserialize the spec and status with the legacy `tls` and `mtls` types => users can use the user-friendly names in the spec and we reference them in the docs
* We serialize it with the legacy names `strimzi-tls` and `strimzi-mtls` in Kafka CR status => we can downgrade to 1.2.0

After few releases, when we stop worrying about a smooth downgrade to 1.2.0, we can start using the short names in status as well.

The other alternative is to revert #13088 and live with `strimzi-tls` and `strimzi-mtls` forever. But this Pr seems like a better solution.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests