### PR TITLE
Announce deprecation of PKCS12 certificate format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 * **From Strimzi 1.3.0 on, we support only Kubernetes 1.32 and newer.**
   Kubernetes 1.30 and 1.31 are not supported anymore.
+* PKCS12 format certificates are deprecated.
+  The `STRIMZI_PKCS12_KEYSTORE_GENERATION` env var will be set to false by default in a future release and then eventually removed completely.
+  Once removed, the CA certificate Secrets and User Secrets will only contain certificates in the PEM format.
 
 ## 1.2.0
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR and delete the other items_

- Documentation

### Description

Announce deprecation of PKCS12 certificate format
Issues #13128 and #13129 have been raised to cover changing the env var to false by default and subsequently removing it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [x] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
