### PR TITLE
Add support for projected Service Account token volumes: Additional review comments II

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom.adoc
@@ -106,7 +106,7 @@ spec:
       principal.builder.class: io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
     listeners:
       - name: sa
-        port: 9092
+        port: 9093
         type: internal
         tls: true
         authentication:
@@ -152,9 +152,9 @@ To find the values used by your cluster, run `kubectl get --raw /.well-known/ope
 == Kafka principals and ACLs
 
 Clients are identified by the `sub` claim of the token, which for Service Account tokens has the format `system:serviceaccount:<namespace>:<service_account_name>`.
+Strimzi operands use a Service Account named after the component: `<connect_cluster_name>-connect` for Kafka Connect, `<mirror_maker_2_cluster_name>-mirrormaker2` for MirrorMaker 2, and `<bridge_name>-bridge` for the HTTP Bridge.
+For example, a Kafka Connect cluster named `my-connect` deployed in the `myproject` namespace authenticates as `User:system:serviceaccount:myproject:my-connect-connect`.
 Use these names when configuring ACL rules.
-
-Strimzi operands use a Service Account named after the component, so a Kafka Connect cluster named `my-connect` deployed in the `myproject` namespace authenticates as `User:system:serviceaccount:myproject:my-connect-connect`.
 
 == Restricting the token audience
 


### PR DESCRIPTION
### Type of Change

- Documentation

### Description

This PR adds the review comments changes from @ppatierno for https://github.com/strimzi/strimzi-kafka-operator/pull/13105 which were raised only after the PR was merged.

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging