### PR TITLE
Check for minimal token expiration in Service Account cluster authentication

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/clustersecurity/kafka/AuthenticationConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/clustersecurity/kafka/AuthenticationConfiguration.java
@@ -43,6 +43,12 @@ public interface AuthenticationConfiguration {
                 && authentication.getExpirationSeconds() != null) {
             throw new InvalidResourceException("The expirationSeconds option in Cluster Security configuration can be used only with service-account authentication type.");
         }
+
+        if (authentication != null
+                && authentication.getExpirationSeconds() != null
+                && authentication.getExpirationSeconds() < 600) {
+            throw new InvalidResourceException("The expirationSeconds option in Cluster Security configuration must be set to at least 600 seconds.");
+        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterSecurityContextTest.java
@@ -300,6 +300,14 @@ public class KafkaClusterSecurityContextTest {
         assertThat(e.getMessage(), is("The expirationSeconds option in Cluster Security configuration can be used only with service-account authentication type."));
     }
 
+    @Test
+    public void testExpirationSecondsTooSmall()  {
+        Kafka kafka = kafkaWithClusterSecurity("{\"encryption\":{\"type\":\"tls\"},\"authentication\":{\"type\":\"service-account\", \"expirationSeconds\": \"300\"}}", null);
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaClusterSecurityContext.fromCrd(kafka));
+
+        assertThat(e.getMessage(), is("The expirationSeconds option in Cluster Security configuration must be set to at least 600 seconds."));
+    }
+
     //////////////////////////////////////////////////
     // Tests for the deserializeSpec method
     //////////////////////////////////////////////////


### PR DESCRIPTION
### Type of Change

- Task

### Description

This PR adds check for the minimal `expirationSeconds` in `type: service-account` internal cluster authentication. Kubernetes allows the minimal token expiration to be 10 minutes (600 seconds). So when user configures it to less than 600, we reject it and throw `InvalidResourceException`.

This should resolve #13131.

### Checklist

- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests