### PR TITLE
Add examples of internal cluster security

### DIFF
--- a/documentation/modules/configuring/con-config-examples.adoc
+++ b/documentation/modules/configuring/con-config-examples.adoc
@@ -32,7 +32,8 @@ examples
 ├── security <3>
 │   ├── tls-auth
 │   ├── scram-sha-512-auth
-│   └── keycloak-authorization
+│   ├── keycloak-authorization
+│   └── internal-cluster-security
 ├── mirror-maker <4>
 ├── metrics <5>
 ├── kafka <6>
@@ -45,6 +46,8 @@ examples
 <3> Authentication and authorization configuration for Kafka components. 
 Includes example configuration for TLS and SCRAM-SHA-512 authentication. 
 The Keycloak examples include a Keycloak realm specification and two `Kafka` custom resources with `type: custom` definitions for using OAuth 2.0 authentication and Keycloak authorization with or without metrics enabled.
+The internal cluster security examples are `Kafka` custom resources that use the `strimzi.io/internal-cluster-security` annotation to configure the xref:assembly-internal-cluster-security-{context}[encryption and authentication used for the communication between the Kafka cluster components].
+The examples cover the use of service account tokens instead of mTLS authentication, and the disabling of TLS encryption or of both encryption and authentication.
 <4> `KafkaMirrorMaker2` custom resource configurations for a deployment of MirrorMaker 2. Includes example configuration for replication policy and synchronization frequency.
 <5> xref:assembly-metrics-config-files-{context}[Metrics configuration], including Prometheus installation and Grafana dashboard files.
 <6> `Kafka` and `KafkaNodePool` custom resource configurations for a deployment of Kafka clusters that use KRaft mode. Includes example configuration for an ephemeral or persistent single or multi-node deployment.

--- a/packaging/examples/README.md
+++ b/packaging/examples/README.md
@@ -19,5 +19,6 @@ This folder contains different examples of Strimzi custom resources and demonstr
     * JMX Trans deployment
 * [Security](./security)
     * Deployments of Kafka, Kafka Connect and HTTP Bridge using TLS encryption, authentication and authorization
+    * Kafka cluster examples with different security configurations used for the internal communication between Kafka components (replication between brokers, etc.)
 * [Kafka Access examples](./kafka-access)
     * Examples of the `KafkaAccess` resources for the Strimzi Access Operator

--- a/packaging/examples/security/internal-cluster-security/kafka-no-encryption.yaml
+++ b/packaging/examples/security/internal-cluster-security/kafka-no-encryption.yaml
@@ -1,0 +1,74 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+            {
+              "encryption": {
+                "type": "none"
+              },
+              "authentication": {
+                "type": "service-account"
+              }
+            }
+spec:
+  kafka:
+    version: 4.3.1
+    metadataVersion: 4.3-IV0
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/packaging/examples/security/internal-cluster-security/kafka-no-mtls.yaml
+++ b/packaging/examples/security/internal-cluster-security/kafka-no-mtls.yaml
@@ -1,0 +1,74 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+            {
+              "encryption": {
+                "type": "tls"
+              },
+              "authentication": {
+                "type": "service-account"
+              }
+            }
+spec:
+  kafka:
+    version: 4.3.1
+    metadataVersion: 4.3-IV0
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/packaging/examples/security/internal-cluster-security/kafka-no-security.yaml
+++ b/packaging/examples/security/internal-cluster-security/kafka-no-security.yaml
@@ -1,0 +1,74 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/internal-cluster-security: |
+            {
+              "encryption": {
+                "type": "none"
+              },
+              "authentication": {
+                "type": "none"
+              }
+            }
+spec:
+  kafka:
+    version: 4.3.1
+    metadataVersion: 4.3-IV0
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
### Type of Change

- Documentation
- Task

### Description

This PR adds new examples for the internal cluster security. It includes examples for:

* No security at all
* No encryption with SA authentication
* TLS encryption with SA authentication

They are placed based on https://cloud-native.slack.com/archives/C018247K8T0/p1788252915346869. The purpose of these examples is to show them to users. But also to use it in the future in upgrade tests (upgrade tests are based on the example files).

### Checklist

- [x] Update documentation
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
