### PR TITLE
Add Service Account token cache for internal cluster authentication

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/auth/KubernetesRequestedServiceAccountTokenLoginCallbackHandler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/auth/KubernetesRequestedServiceAccountTokenLoginCallbackHandler.java
@@ -4,11 +4,6 @@
  */
 package io.strimzi.operator.cluster.auth;
 
-import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
-import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
@@ -20,18 +15,19 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Kafka SASL/OAUTHBEARER login callback handler that mints a fresh token via the Kubernetes TokenRequest API on each
- * invocation. The token is bound to a configured Service Account in a configured namespace, with a configured audience.
+ * Kafka SASL/OAUTHBEARER login callback handler that obtains the token for a configured Service Account in a
+ * configured namespace and with a configured audience from the {@link ServiceAccountTokenService}.
  *
- * There is currently no caching done internally. Kafka's OAuthBearerLoginModule uses the token lifetime to schedule the
- * next refresh, so a new TokenRequest is only made when the prior token is close to expiring.
+ * The tokens are cached by the token service and shared with the other users of the Service Account tokens such as the
+ * Kafka Agent client. So a new token is minted through the Kubernetes TokenRequest API only when the cached token is
+ * not usable anymore. Kafka's OAuthBearerLoginModule uses the token lifetime to schedule the next login, so it asks
+ * for a token only when the one it has is close to expiring.
  *
  * Example configuration in the {@code OAuthBearerLoginModule} entry:
  * {@code
@@ -71,7 +67,6 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
     private String audience;
     private long expirationSeconds;
     private String principalName;
-    private KubernetesClient client;
 
     /**
      * Default constructor — required because Kafka clients (Admin API client in our case) load the handler via reflection.
@@ -92,17 +87,16 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
         expirationSeconds = Long.parseLong(requiredOption(options, EXPIRATION_SECONDS_CONFIG));
         principalName = "User:system:serviceaccount:" + namespace + ":" + serviceAccountName;
 
-        client = buildKubernetesClient();
         LOGGER.debug("Configured Kubernetes Service Account token login for {} (audience={})", principalName, audience);
     }
 
     /**
-     * Factory for the Kubernetes client. Overridable so tests can inject a mock.
+     * Provides the token service used to get the tokens. Overridable so tests can inject their own instance.
      *
-     * @return  Kubernetes client used to call the TokenRequest API
+     * @return  Service Account token service
      */
-    /* test */ KubernetesClient buildKubernetesClient() {
-        return new KubernetesClientBuilder().withConfig(new ConfigBuilder().withUserAgent("strimzi-auth-token-callback").build()).build();
+    /* test */ ServiceAccountTokenService tokenService() {
+        return ServiceAccountTokenService.getInstance();
     }
 
     @Override
@@ -110,9 +104,9 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
         for (Callback callback : callbacks) {
             if (callback instanceof OAuthBearerTokenCallback tokenCallback) {
                 try {
-                    tokenCallback.token(mintToken());
+                    tokenCallback.token(oauthBearerToken());
                 } catch (RuntimeException e) {
-                    LOGGER.error("Failed to mint Service Account token for {}", principalName, e);
+                    LOGGER.error("Failed to get Service Account token for {}", principalName, e);
                     tokenCallback.error("invalid_token", e.getMessage(), null);
                 }
             } else {
@@ -121,35 +115,14 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
         }
     }
 
-    private OAuthBearerToken mintToken() {
-        TokenRequest request = new TokenRequestBuilder()
-                .withNewSpec()
-                    .withAudiences(audience)
-                    .withExpirationSeconds(expirationSeconds)
-                .endSpec()
-                .build();
-        TokenRequest response = client.serviceAccounts()
-                .inNamespace(namespace)
-                .withName(serviceAccountName)
-                .tokenRequest(request);
-
-        if (response == null || response.getStatus() == null || response.getStatus().getToken() == null) {
-            throw new IllegalStateException("Kubernetes API did not return a token for ServiceAccount " + namespace + "/" + serviceAccountName);
-        }
-
-        return new ServiceAccountToken(
-                response.getStatus().getToken(),
-                principalName,
-                Instant.parse(response.getStatus().getExpirationTimestamp()).toEpochMilli(),
-                System.currentTimeMillis()
-        );
+    private OAuthBearerToken oauthBearerToken() {
+        ServiceAccountToken token = tokenService().token(namespace, serviceAccountName, audience, expirationSeconds);
+        return new ServiceAccountOAuthBearerToken(token, principalName);
     }
 
     @Override
     public void close() {
-        if (client != null) {
-            client.close();
-        }
+        // The token service is shared and lives for the whole lifetime of the operator. So there is nothing to close.
     }
 
     private static String requiredOption(Map<String, ?> options, String key) {
@@ -160,22 +133,18 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
         return value.toString();
     }
 
-    private static final class ServiceAccountToken implements OAuthBearerToken {
-        private final String token;
+    private static final class ServiceAccountOAuthBearerToken implements OAuthBearerToken {
+        private final ServiceAccountToken token;
         private final String principalName;
-        private final long lifetimeMs;
-        private final long startTimeMs;
 
-        ServiceAccountToken(String token, String principalName, long lifetimeMs, long startTimeMs) {
+        ServiceAccountOAuthBearerToken(ServiceAccountToken token, String principalName) {
             this.token = token;
             this.principalName = principalName;
-            this.lifetimeMs = lifetimeMs;
-            this.startTimeMs = startTimeMs;
         }
 
         @Override
         public String value() {
-            return token;
+            return token.value();
         }
 
         @Override
@@ -185,7 +154,7 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
 
         @Override
         public long lifetimeMs() {
-            return lifetimeMs;
+            return token.expiresAtMs();
         }
 
         @Override
@@ -195,7 +164,7 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandler implemen
 
         @Override
         public Long startTimeMs() {
-            return startTimeMs;
+            return token.issuedAtMs();
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/auth/ServiceAccountToken.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/auth/ServiceAccountToken.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.auth;
+
+/**
+ * Represents a Service Account token obtained from the Kubernetes TokenRequest API.
+ *
+ * @param value         The token itself (a JWT token)
+ * @param issuedAtMs    Time when the token was issued as milliseconds since the epoch
+ * @param expiresAtMs   Time when the token expires as milliseconds since the epoch
+ */
+public record ServiceAccountToken(String value, long issuedAtMs, long expiresAtMs) {
+    /**
+     * Checks whether the token can be still used at a given point in time. The token is considered usable only until
+     * the given fraction of its lifetime elapses. That leaves enough time for the client to use it before it expires.
+     *
+     * @param nowMs         Point in time for which the validity should be checked as milliseconds since the epoch
+     * @param threshold     Fraction of the token lifetime after which the token is not used anymore
+     *
+     * @return  True if the token can be still used. False otherwise.
+     */
+    public boolean isUsableAt(long nowMs, double threshold) {
+        return nowMs < issuedAtMs + (long) (threshold * (expiresAtMs - issuedAtMs));
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/auth/ServiceAccountTokenService.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/auth/ServiceAccountTokenService.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.auth;
+
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides Service Account tokens obtained from the Kubernetes TokenRequest API and caches them for reuse.
+ *
+ * The tokens are used to authenticate the operator against the operands (Kafka brokers or the Kafka Agent). They are
+ * typically valid for one hour, but they are needed in every reconciliation which happens by default every two
+ * minutes. Without caching, every reconciliation of every cluster would create several new tokens. So the tokens are
+ * cached and shared by all components which need them.
+ *
+ * The tokens are cached per Service Account (and per audience and requested expiration) and reused until 80% of their
+ * lifetime elapses. Once that happens, the token is thrown away and a new one is requested when it is needed again.
+ * The tokens are never renewed proactively. That keeps the number of the token requests at minimum and makes sure we
+ * do not keep requesting tokens for clusters which were deleted or reconfigured to not use the Service Account
+ * authentication anymore. The unused tokens are removed from the cache by a reaper thread, so that the cache does not
+ * grow forever.
+ *
+ * As this class is a singleton, it is used to share the tokens between the Kafka Agent client and the Kafka Admin API
+ * clients. The Admin API clients get the tokens through the SASL login callback handler which is instantiated by the
+ * Kafka clients using reflection and cannot get the token service injected. The singleton is initialized lazily,
+ * because in many cases the Service Account authentication is not used at all and no tokens are needed.
+ */
+public class ServiceAccountTokenService {
+    private static final Logger LOGGER = LogManager.getLogger(ServiceAccountTokenService.class);
+
+    /**
+     * Fraction of the token lifetime after which the token is not used anymore and is removed from the cache. Most
+     * services expect the token to be renewed at 80% of their lifetime, so we use a slightly lower threshold to be on
+     * the safe side and try to renew it before they ask for it.
+     */
+    /* test */ static final double RENEWAL_THRESHOLD = 0.75;
+
+    /**
+     * Interval in which the reaper thread checks the cache for tokens which are not usable anymore. The minimal token
+     * expiration allowed by our API is 600 seconds, so this interval is short enough to not keep the unused tokens in
+     * the cache for a significant part of their lifetime.
+     */
+    private static final long REAPER_INTERVAL_MS = 60_000L;
+
+    private static volatile ServiceAccountTokenService instance;
+
+    private final KubernetesClient kubernetesClient;
+    private final Map<TokenKey, ServiceAccountToken> tokens = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService reaper;
+
+    /**
+     * Constructor
+     *
+     * @param kubernetesClient  Kubernetes client used to call the TokenRequest API
+     */
+    /* test */ ServiceAccountTokenService(KubernetesClient kubernetesClient) {
+        this(kubernetesClient, REAPER_INTERVAL_MS);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param kubernetesClient      Kubernetes client used to call the TokenRequest API
+     * @param reaperIntervalMs      Interval in which the unusable tokens are removed from the cache
+     */
+    /* test */ ServiceAccountTokenService(KubernetesClient kubernetesClient, long reaperIntervalMs) {
+        this.kubernetesClient = kubernetesClient;
+        this.reaper = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "service-account-token-reaper");
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.reaper.scheduleAtFixedRate(this::reapSafely, reaperIntervalMs, reaperIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Returns the singleton instance of the token service and creates it if it does not exist yet. The instance is
+     * created lazily, so that we do not create the Kubernetes client and the reaper thread in the many cases when the
+     * Service Account authentication is not used at all.
+     *
+     * @return  The token service instance
+     */
+    public static ServiceAccountTokenService getInstance() {
+        ServiceAccountTokenService result = instance;
+
+        if (result == null) {
+            synchronized (ServiceAccountTokenService.class) {
+                result = instance;
+
+                if (result == null) {
+                    LOGGER.info("Initializing the Service Account token service");
+                    result = new ServiceAccountTokenService(new OperatorKubernetesClientBuilder("strimzi-cluster-operator", ServiceAccountTokenService.class.getPackage().getImplementationVersion()).build());
+                    instance = result;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns a token for the Service Account used by the given identity. A cached token is returned when it is still
+     * usable. Otherwise, a new token is requested from the Kubernetes API.
+     *
+     * @param identity  Identity for which the token should be returned
+     *
+     * @return  The Service Account token
+     */
+    public ServiceAccountToken token(RequestedServiceAccountAuthIdentity identity) {
+        return token(identity.namespace(), identity.serviceAccountName(), identity.audience(), identity.expirationSeconds());
+    }
+
+    /**
+     * Returns a token for the given Service Account. A cached token is returned when it is still usable. Otherwise, a
+     * new token is requested from the Kubernetes API.
+     *
+     * @param namespace             Namespace of the Service Account
+     * @param serviceAccountName    Name of the Service Account
+     * @param audience              Audience which should be set in the token
+     * @param expirationSeconds     Expiration time of the token in seconds
+     *
+     * @return  The Service Account token
+     */
+    public ServiceAccountToken token(String namespace, String serviceAccountName, String audience, long expirationSeconds) {
+        long now = System.currentTimeMillis();
+
+        // The token is requested inside the compute method, so that we do not send multiple parallel token requests
+        // for the same Service Account. Requesting the token blocks other operations with the same key. But as the
+        // tokens are requested only once per ~80% of their lifetime, the blocking is very rare and very short.
+        return tokens.compute(
+                new TokenKey(namespace, serviceAccountName, audience, expirationSeconds),
+                (key, cached) -> cached != null && cached.isUsableAt(now, RENEWAL_THRESHOLD) ? cached : requestToken(key));
+    }
+
+    /**
+     * Requests a new token from the Kubernetes TokenRequest API.
+     *
+     * @param key   Key describing the token which should be requested
+     *
+     * @return  The new Service Account token
+     */
+    private ServiceAccountToken requestToken(TokenKey key) {
+        LOGGER.debug("Requesting new token for Service Account {}/{} with audience {}", key.namespace(), key.serviceAccountName(), key.audience());
+
+        TokenRequest request = new TokenRequestBuilder()
+                .withNewSpec()
+                    .withAudiences(key.audience())
+                    .withExpirationSeconds(key.expirationSeconds())
+                .endSpec()
+                .build();
+        TokenRequest response = kubernetesClient.serviceAccounts()
+                .inNamespace(key.namespace())
+                .withName(key.serviceAccountName())
+                .tokenRequest(request);
+
+        if (response == null || response.getStatus() == null || response.getStatus().getToken() == null || response.getStatus().getExpirationTimestamp() == null) {
+            throw new RuntimeException("Kubernetes API did not return a token for ServiceAccount " + key.namespace() + "/" + key.serviceAccountName());
+        }
+
+        // The expiration time is taken from the response and not from the request, because the Kubernetes API might
+        // issue the token with a shorter validity than we requested.
+        return new ServiceAccountToken(response.getStatus().getToken(), System.currentTimeMillis(), Instant.parse(response.getStatus().getExpirationTimestamp()).toEpochMilli());
+    }
+
+    /**
+     * Removes the tokens which are not usable anymore from the cache. The tokens are not renewed, so the tokens of the
+     * clusters which are not reconciled anymore (for example because they were deleted) are simply removed and the
+     * cache does not grow forever.
+     */
+    /* test */ void reap() {
+        long now = System.currentTimeMillis();
+
+        tokens.entrySet().removeIf(entry -> {
+            if (!entry.getValue().isUsableAt(now, RENEWAL_THRESHOLD)) {
+                LOGGER.debug("Removing the expiring token of the Service Account {}/{} with audience {} from the cache", entry.getKey().namespace(), entry.getKey().serviceAccountName(), entry.getKey().audience());
+                return true;
+            } else {
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Wraps the reaping in a try-catch block. Without it, any error thrown from the reaper would silently cancel the
+     * scheduled task and the tokens would be never removed from the cache again.
+     */
+    private void reapSafely() {
+        try {
+            reap();
+        } catch (Throwable e) {
+            LOGGER.warn("Failed to clean up the Service Account token cache", e);
+        }
+    }
+
+    /**
+     * Returns the number of the tokens currently held in the cache. Used by tests to check the caching and reaping.
+     *
+     * @return  Number of cached tokens
+     */
+    /* test */ int cachedTokens() {
+        return tokens.size();
+    }
+
+    /**
+     * Closes the token service and its resources. In the operator, the token service lives for the whole lifetime of
+     * the JVM. So this is used only from the tests.
+     */
+    /* test */ void close() {
+        reaper.shutdownNow();
+        kubernetesClient.close();
+    }
+
+    /**
+     * Key under which the tokens are cached. Tokens differing in any of these fields cannot be shared.
+     *
+     * @param namespace             Namespace of the Service Account
+     * @param serviceAccountName    Name of the Service Account
+     * @param audience              Audience set in the token
+     * @param expirationSeconds     Requested expiration time of the token in seconds
+     */
+    private record TokenKey(String namespace, String serviceAccountName, String audience, long expirationSeconds) { }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultKafkaAgentClientProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultKafkaAgentClientProvider.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.auth.Identity;
 
@@ -12,19 +11,13 @@ import io.strimzi.operator.common.auth.Identity;
  * Class to provide the real KafkaAgentClient which connects to actual Kafka Agent
  */
 public class DefaultKafkaAgentClientProvider implements KafkaAgentClientProvider {
-    private final KubernetesClient kubernetesClient;
-
     /**
      * Constructor
-     *
-     * @param kubernetesClient  Kubernetes client to interact with the Kubernetes API
      */
-    public DefaultKafkaAgentClientProvider(KubernetesClient kubernetesClient) {
-        this.kubernetesClient = kubernetesClient;
-    }
+    public DefaultKafkaAgentClientProvider() { }
 
     @Override
     public KafkaAgentClient createKafkaAgentClient(Reconciliation reconciliation, Identity identity) {
-        return new KafkaAgentClient(reconciliation, reconciliation.name(), reconciliation.namespace(), identity, kubernetesClient);
+        return new KafkaAgentClient(reconciliation, reconciliation.name(), reconciliation.namespace(), identity);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -6,11 +6,9 @@ package io.strimzi.operator.cluster.operator.resource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
-import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.cluster.auth.RequestedServiceAccountAuthIdentity;
+import io.strimzi.operator.cluster.auth.ServiceAccountTokenService;
 import io.strimzi.operator.cluster.model.DnsNameGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
@@ -30,7 +28,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-import java.time.Instant;
 
 /**
  * Creates HTTP client and interacts with Kafka Agent's REST endpoint
@@ -46,18 +43,12 @@ public class KafkaAgentClient {
     // executor indefinitely. The Kafka Agent only serves a small broker-state JSON, so 10 seconds is well above
     // the expected response time on a healthy broker yet small enough to keep the roller responsive.
     private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    // Fraction of the token lifetime after which the token is renewed.
-    private static final double TOKEN_RENEWAL_THRESHOLD = 0.8;
 
     private final String namespace;
     private final Reconciliation reconciliation;
     private final String cluster;
     private final Identity identity;
-    private final KubernetesClient kubernetesClient;
     private final HttpClient httpClient;
-
-    private String cachedToken;
-    private long cachedTokenRefreshAt;
 
     /**
      * Constructor
@@ -66,14 +57,12 @@ public class KafkaAgentClient {
      * @param cluster           Cluster name
      * @param namespace         Cluster namespace
      * @param identity          Trust set and identity for authentication for connecting to the Kafka cluster
-     * @param kubernetesClient  Kubernetes client used to get the token for the service account
      */
-    public KafkaAgentClient(Reconciliation reconciliation, String cluster, String namespace, Identity identity, KubernetesClient kubernetesClient) {
+    public KafkaAgentClient(Reconciliation reconciliation, String cluster, String namespace, Identity identity) {
         this.reconciliation = reconciliation;
         this.cluster = cluster;
         this.namespace = namespace;
         this.identity = identity;
-        this.kubernetesClient = kubernetesClient;
         this.httpClient = createHttpClient();
     }
 
@@ -126,7 +115,7 @@ public class KafkaAgentClient {
                     .GET();
 
             if (identity.authIdentity() instanceof RequestedServiceAccountAuthIdentity authIdentity) {
-                reqBuilder.header("Authorization", "Bearer " + currentToken(authIdentity));
+                reqBuilder.header("Authorization", "Bearer " + tokenService().token(authIdentity).value());
             }
 
             var response = httpClient.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
@@ -164,39 +153,13 @@ public class KafkaAgentClient {
     }
 
     /**
-     * Returns a valid Service Account token for the per-cluster cluster-operator SA, minting a fresh one via the
-     * Kubernetes TokenRequest API when no cached token is available, or when the cached one should be refreshed.
+     * Provides the token service used to get the Service Account tokens. Overridable so tests can inject their own
+     * instance. It is called only when the Service Account authentication is used, so that the token service is not
+     * initialized when it is not needed.
      *
-     * @param authIdentity  The RequestedServiceAccountAuthIdentity containing the authentication details
-     *
-     * @return  JWT token string suitable for use in an HTTP Authorization Bearer header
+     * @return  Service Account token service
      */
-    synchronized String currentToken(RequestedServiceAccountAuthIdentity authIdentity) {
-        // If we do not have the token yet or it should be refreshed, we get the new token from Kube API
-        if (cachedToken == null || System.currentTimeMillis() >= cachedTokenRefreshAt) {
-            TokenRequest request = new TokenRequestBuilder()
-                    .withNewSpec()
-                        .withAudiences(authIdentity.audience())
-                        .withExpirationSeconds(authIdentity.expirationSeconds())
-                    .endSpec()
-                    .build();
-            TokenRequest response = kubernetesClient.serviceAccounts()
-                    .inNamespace(authIdentity.namespace())
-                    .withName(authIdentity.serviceAccountName())
-                    .tokenRequest(request);
-
-            if (response == null || response.getStatus() == null || response.getStatus().getToken() == null || response.getStatus().getExpirationTimestamp() == null) {
-                throw new RuntimeException("Kubernetes API did not return a token for ServiceAccount " + authIdentity.namespace() + "/" + authIdentity.serviceAccountName());
-            }
-
-            cachedToken = response.getStatus().getToken();
-
-            // The token refresh time is computed from its expiration time to refresh it before it is expired.
-            long now = System.currentTimeMillis();
-            long expiresAt = Instant.parse(response.getStatus().getExpirationTimestamp()).toEpochMilli();
-            cachedTokenRefreshAt = now + (long) (TOKEN_RENEWAL_THRESHOLD * (expiresAt - now));
-        }
-
-        return cachedToken;
+    /* test */ ServiceAccountTokenService tokenService() {
+        return ServiceAccountTokenService.getInstance();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -245,7 +245,7 @@ public class ResourceOperatorSupplier {
         this(asyncExecutor,
             client,
             new DefaultAdminClientProvider(),
-            new DefaultKafkaAgentClientProvider(client),
+            new DefaultKafkaAgentClientProvider(),
             metricsProvider,
             pfa,
             new KubernetesRestartEventPublisher(client, operatorName),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/auth/KubernetesRequestedServiceAccountTokenLoginCallbackHandlerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/auth/KubernetesRequestedServiceAccountTokenLoginCallbackHandlerTest.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -23,6 +24,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,19 +51,27 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandlerTest {
     private static final String PRINCIPAL = "User:system:serviceaccount:my-namespace:my-cluster-cluster-operator";
     private static final String EXPIRATION_TIMESTAMP = "2026-08-27T17:00:00Z";
 
+    private final List<ServiceAccountTokenService> tokenServices = new ArrayList<>();
+
+    @AfterEach
+    public void tearDown() {
+        tokenServices.forEach(ServiceAccountTokenService::close);
+        tokenServices.clear();
+    }
+
     /**
-     * Handler subclass which injects a mocked Kubernetes client instead of building a real one.
+     * Handler subclass which injects a token service using a mocked Kubernetes client instead of using the singleton.
      */
     private static class MockedHandler extends KubernetesRequestedServiceAccountTokenLoginCallbackHandler {
-        private final KubernetesClient client;
+        private final ServiceAccountTokenService tokenService;
 
-        MockedHandler(KubernetesClient client) {
-            this.client = client;
+        MockedHandler(ServiceAccountTokenService tokenService) {
+            this.tokenService = tokenService;
         }
 
         @Override
-        KubernetesClient buildKubernetesClient() {
-            return client;
+        ServiceAccountTokenService tokenService() {
+            return tokenService;
         }
     }
 
@@ -106,8 +118,11 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandlerTest {
                 .build();
     }
 
-    private static KubernetesRequestedServiceAccountTokenLoginCallbackHandler configuredHandler(KubernetesClient client) {
-        KubernetesRequestedServiceAccountTokenLoginCallbackHandler handler = new MockedHandler(client);
+    private KubernetesRequestedServiceAccountTokenLoginCallbackHandler configuredHandler(KubernetesClient client) {
+        ServiceAccountTokenService tokenService = new ServiceAccountTokenService(client);
+        tokenServices.add(tokenService);
+
+        KubernetesRequestedServiceAccountTokenLoginCallbackHandler handler = new MockedHandler(tokenService);
         handler.configure(Map.of(), "OAUTHBEARER", jaasConfigEntries(options()));
         return handler;
     }
@@ -229,22 +244,39 @@ public class KubernetesRequestedServiceAccountTokenLoginCallbackHandlerTest {
         assertThat(e.getCallback(), is(callback));
     }
 
+    @Test
+    public void testHandleReusesTheCachedToken() throws Exception {
+        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
+        when(serviceAccountResource.tokenRequest(any())).thenReturn(tokenRequestResponse("my-token", Instant.now().plusSeconds(3600).toString()));
+
+        KubernetesRequestedServiceAccountTokenLoginCallbackHandler handler = configuredHandler(mockKubernetesClient(serviceAccountResource));
+
+        for (int i = 0; i < 3; i++) {
+            OAuthBearerTokenCallback callback = new OAuthBearerTokenCallback();
+            handler.handle(new Callback[]{callback});
+            assertThat(callback.token().value(), is("my-token"));
+        }
+
+        verify(serviceAccountResource, times(1)).tokenRequest(any());
+    }
+
     //////////////////////////////////////////////////
     // Tests for the close method
     //////////////////////////////////////////////////
 
     @Test
-    public void testCloseClosesTheClient() {
+    public void testCloseDoesNotCloseTheSharedResources() {
         KubernetesClient client = mockKubernetesClient(tokenRequestResponse("my-token", EXPIRATION_TIMESTAMP));
 
         configuredHandler(client).close();
 
-        verify(client).close();
+        // The Kubernetes client belongs to the shared token service and should not be closed by the handler
+        verify(client, never()).close();
     }
 
     @Test
     public void testCloseWithoutConfigure() {
         // Kafka can close a handler which failed to configure => this should not throw
-        new MockedHandler(mock(KubernetesClient.class)).close();
+        new KubernetesRequestedServiceAccountTokenLoginCallbackHandler().close();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/auth/ServiceAccountTokenServiceTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/auth/ServiceAccountTokenServiceTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.auth;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountList;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ServiceAccountTokenServiceTest {
+    private static final String NAMESPACE = "my-namespace";
+    private static final String SERVICE_ACCOUNT = "my-cluster-cluster-operator";
+    private static final String AUDIENCE = "strimzi.io/kafka/my-namespace/my-cluster";
+    private static final long EXPIRATION_SECONDS = 3600L;
+
+    private final List<ServiceAccountTokenService> services = new ArrayList<>();
+
+    @AfterEach
+    public void tearDown() {
+        services.forEach(ServiceAccountTokenService::close);
+        services.clear();
+    }
+
+    /**
+     * Creates the token service and registers it for clean-up after the test.
+     *
+     * @param kubernetesClient  Kubernetes client which should be used by the service
+     *
+     * @return  The token service
+     */
+    private ServiceAccountTokenService tokenService(KubernetesClient kubernetesClient) {
+        ServiceAccountTokenService service = new ServiceAccountTokenService(kubernetesClient);
+        services.add(service);
+        return service;
+    }
+
+    private ServiceAccountTokenService tokenService(KubernetesClient kubernetesClient, long reaperIntervalMs) {
+        ServiceAccountTokenService service = new ServiceAccountTokenService(kubernetesClient, reaperIntervalMs);
+        services.add(service);
+        return service;
+    }
+
+    private static TokenRequest tokenRequestResponse(String token, Instant expiration) {
+        return new TokenRequestBuilder()
+                .withNewStatus()
+                    .withToken(token)
+                    .withExpirationTimestamp(expiration != null ? expiration.toString() : null)
+                .endStatus()
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static KubernetesClient mockKubernetesClient(ServiceAccountResource serviceAccountResource) {
+        NonNamespaceOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> namespacedOp = mock(NonNamespaceOperation.class);
+        when(namespacedOp.withName(any())).thenReturn(serviceAccountResource);
+
+        MixedOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> op = mock(MixedOperation.class);
+        when(op.inNamespace(any())).thenReturn(namespacedOp);
+
+        KubernetesClient client = mock(KubernetesClient.class);
+        when(client.serviceAccounts()).thenReturn(op);
+
+        return client;
+    }
+
+    private static ServiceAccountResource mockServiceAccountResource(TokenRequest... responses) {
+        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
+
+        when(serviceAccountResource.tokenRequest(any())).thenReturn(responses[0], Arrays.copyOfRange(responses, 1, responses.length));
+
+        return serviceAccountResource;
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for getting the tokens
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testTokenIsRequestedFromTheKubernetesApi() {
+        Instant expiration = Instant.now().plusSeconds(EXPIRATION_SECONDS);
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", expiration));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        long before = System.currentTimeMillis();
+        ServiceAccountToken token = service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS);
+        long after = System.currentTimeMillis();
+
+        assertThat(token.value(), is("my-token"));
+        assertThat(token.expiresAtMs(), is(expiration.toEpochMilli()));
+        assertThat(token.issuedAtMs(), greaterThanOrEqualTo(before));
+        assertThat(token.issuedAtMs(), lessThanOrEqualTo(after));
+
+        ArgumentCaptor<TokenRequest> requestCaptor = ArgumentCaptor.forClass(TokenRequest.class);
+        verify(serviceAccountResource).tokenRequest(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getSpec().getAudiences(), is(List.of(AUDIENCE)));
+        assertThat(requestCaptor.getValue().getSpec().getExpirationSeconds(), is(EXPIRATION_SECONDS));
+    }
+
+    @Test
+    public void testTokenIsRequestedForTheIdentity() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        assertThat(service.token(new RequestedServiceAccountAuthIdentity(new Reconciliation("test", "Kafka", NAMESPACE, "my-cluster"), AUDIENCE, EXPIRATION_SECONDS)).value(), is("my-token"));
+
+        ArgumentCaptor<TokenRequest> requestCaptor = ArgumentCaptor.forClass(TokenRequest.class);
+        verify(serviceAccountResource).tokenRequest(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getSpec().getAudiences(), is(List.of(AUDIENCE)));
+        assertThat(requestCaptor.getValue().getSpec().getExpirationSeconds(), is(EXPIRATION_SECONDS));
+    }
+
+    @Test
+    public void testTokenIsCachedAndReused() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-token"));
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-token"));
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-token"));
+
+        verify(serviceAccountResource, times(1)).tokenRequest(any());
+        assertThat(service.cachedTokens(), is(1));
+    }
+
+    @Test
+    public void testTokenIsCachedWhenKubernetesShortensTheRequestedExpiration() {
+        // The Kubernetes API can issue the token with a shorter validity than requested. The caching has to follow the
+        // returned expiration time and not the requested one, otherwise the token would be requested on every call.
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().plusSeconds(600)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-token"));
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-token"));
+
+        verify(serviceAccountResource, times(1)).tokenRequest(any());
+    }
+
+    @Test
+    public void testNewTokenIsRequestedWhenTheCachedOneIsCloseToExpiration() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(
+                // The first token is already past the renewal threshold and should not be reused
+                tokenRequestResponse("my-old-token", Instant.now().minusSeconds(EXPIRATION_SECONDS)),
+                tokenRequestResponse("my-new-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-old-token"));
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-new-token"));
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-new-token"));
+
+        verify(serviceAccountResource, times(2)).tokenRequest(any());
+        assertThat(service.cachedTokens(), is(1));
+    }
+
+    @Test
+    public void testTokensAreCachedSeparatelyForDifferentServiceAccounts() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS);
+        service.token("other-namespace", SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS);
+        service.token(NAMESPACE, "other-cluster-cluster-operator", AUDIENCE, EXPIRATION_SECONDS);
+        service.token(NAMESPACE, SERVICE_ACCOUNT, "other-audience", EXPIRATION_SECONDS);
+        service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, 600L);
+
+        verify(serviceAccountResource, times(5)).tokenRequest(any());
+        assertThat(service.cachedTokens(), is(5));
+    }
+
+    @Test
+    public void testFailsWhenKubernetesApiReturnsNoResponse() {
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(mockServiceAccountResource((TokenRequest) null)));
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS));
+        assertThat(e.getMessage(), is("Kubernetes API did not return a token for ServiceAccount my-namespace/my-cluster-cluster-operator"));
+        assertThat(service.cachedTokens(), is(0));
+    }
+
+    @Test
+    public void testFailsWhenKubernetesApiReturnsNoStatus() {
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(mockServiceAccountResource(new TokenRequestBuilder().build())));
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS));
+        assertThat(e.getMessage(), is("Kubernetes API did not return a token for ServiceAccount my-namespace/my-cluster-cluster-operator"));
+    }
+
+    @Test
+    public void testFailsWhenKubernetesApiReturnsNoToken() {
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(mockServiceAccountResource(tokenRequestResponse(null, Instant.now().plusSeconds(EXPIRATION_SECONDS)))));
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS));
+        assertThat(e.getMessage(), is("Kubernetes API did not return a token for ServiceAccount my-namespace/my-cluster-cluster-operator"));
+    }
+
+    @Test
+    public void testFailsWhenKubernetesApiReturnsNoExpiration() {
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(mockServiceAccountResource(tokenRequestResponse("my-token", null))));
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS));
+        assertThat(e.getMessage(), is("Kubernetes API did not return a token for ServiceAccount my-namespace/my-cluster-cluster-operator"));
+    }
+
+    @Test
+    public void testFailedTokenRequestDoesNotBreakTheService() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(
+                // The first token is already past the renewal threshold, so every call requests a new token
+                tokenRequestResponse("my-old-token", Instant.now().minusSeconds(EXPIRATION_SECONDS)),
+                null,
+                tokenRequestResponse("my-new-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-old-token"));
+        assertThrows(RuntimeException.class, () -> service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS));
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-new-token"));
+    }
+
+    //////////////////////////////////////////////////
+    // Tests for the reaping of the unused tokens
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testReaperKeepsTheUsableTokens() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS);
+        assertThat(service.cachedTokens(), is(1));
+
+        service.reap();
+        assertThat(service.cachedTokens(), is(1));
+
+        // The token is still cached => no new token request is sent
+        assertThat(service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS).value(), is("my-token"));
+        verify(serviceAccountResource, times(1)).tokenRequest(any());
+    }
+
+    @Test
+    public void testReaperRemovesTheTokensWhichAreCloseToExpiration() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().minusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource));
+
+        service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS);
+        assertThat(service.cachedTokens(), is(1));
+
+        service.reap();
+        assertThat(service.cachedTokens(), is(0));
+    }
+
+    @Test
+    public void testReaperRunsPeriodically() {
+        ServiceAccountResource serviceAccountResource = mockServiceAccountResource(tokenRequestResponse("my-token", Instant.now().minusSeconds(EXPIRATION_SECONDS)));
+        ServiceAccountTokenService service = tokenService(mockKubernetesClient(serviceAccountResource), 10L);
+
+        service.token(NAMESPACE, SERVICE_ACCOUNT, AUDIENCE, EXPIRATION_SECONDS);
+
+        TestUtils.waitFor("the token to be removed from the cache by the reaper", 10, 10_000, () -> service.cachedTokens() == 0);
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -190,7 +190,7 @@ public class ConnectorMockTest {
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
                 metricsProvider,
                 pfa);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -158,7 +158,7 @@ public class KafkaConnectorIT {
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
                 metrics,
                 pfa
         );
@@ -225,7 +225,7 @@ public class KafkaConnectorIT {
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
                 metrics,
                 pfa
         );
@@ -271,7 +271,7 @@ public class KafkaConnectorIT {
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
                 metrics,
                 pfa
         );
@@ -328,7 +328,7 @@ public class KafkaConnectorIT {
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
             metrics,
                 pfa
         );
@@ -374,7 +374,7 @@ public class KafkaConnectorIT {
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
             metrics,
                 pfa
         );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -158,7 +158,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         supplier = new ResourceOperatorSupplier(VertxUtil.asExecutor(vertx.createSharedWorkerExecutor("kubernetes-ops-pool")),
                 client,
                 new DefaultAdminClientProvider(),
-                new DefaultKafkaAgentClientProvider(null),
+                new DefaultKafkaAgentClientProvider(),
                 ResourceUtils.metricsProvider(),
                 PFA);
         podSetController = new StrimziPodSetController(namespace, Labels.EMPTY, supplier.kafkaOperator, supplier.connectOperator, supplier.mirrorMaker2Operator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, Integer.parseInt(ClusterOperatorConfig.POD_SET_CONTROLLER_WORK_QUEUE_SIZE.defaultValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClientTest.java
@@ -5,41 +5,30 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import com.sun.net.httpserver.HttpServer;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
-import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
 import io.strimzi.operator.cluster.auth.RequestedServiceAccountAuthIdentity;
+import io.strimzi.operator.cluster.auth.ServiceAccountToken;
+import io.strimzi.operator.cluster.auth.ServiceAccountTokenService;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.auth.Identity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KafkaAgentClientTest {
@@ -59,29 +48,6 @@ public class KafkaAgentClientTest {
 
     private static RequestedServiceAccountAuthIdentity authIdentity() {
         return new RequestedServiceAccountAuthIdentity(RECONCILIATION, AUDIENCE, EXPIRATION_SECONDS);
-    }
-
-    private static TokenRequest tokenRequestResponse(String token, Instant expiration) {
-        return new TokenRequestBuilder()
-                .withNewStatus()
-                    .withToken(token)
-                    .withExpirationTimestamp(expiration != null ? expiration.toString() : null)
-                .endStatus()
-                .build();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static KubernetesClient mockKubernetesClient(ServiceAccountResource serviceAccountResource) {
-        NonNamespaceOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> namespacedOp = mock(NonNamespaceOperation.class);
-        when(namespacedOp.withName("my-cluster-cluster-operator")).thenReturn(serviceAccountResource);
-
-        MixedOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> op = mock(MixedOperation.class);
-        when(op.inNamespace("namespace")).thenReturn(namespacedOp);
-
-        KubernetesClient client = mock(KubernetesClient.class);
-        when(client.serviceAccounts()).thenReturn(op);
-
-        return client;
     }
 
     /**
@@ -109,7 +75,7 @@ public class KafkaAgentClientTest {
 
     @Test
     public void testBrokerInRecoveryState() {
-        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null), null));
+        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null)));
         doAnswer(invocation -> "{\"brokerState\":2,\"recoveryState\":{\"remainingLogsToRecover\":10,\"remainingSegmentsToRecover\":100}}").when(kafkaAgentClient).doGet(any());
         BrokerState actual = kafkaAgentClient.getBrokerState("mypod");
         assertTrue(actual.isBrokerInRecovery(), "broker is not in log recovery as expected");
@@ -119,7 +85,7 @@ public class KafkaAgentClientTest {
 
     @Test
     public void testBrokerInRunningState() {
-        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null), null));
+        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null)));
         doAnswer(invocation -> "{\"brokerState\":3}").when(kafkaAgentClient).doGet(any());
 
         BrokerState actual = kafkaAgentClient.getBrokerState("mypod");
@@ -130,7 +96,7 @@ public class KafkaAgentClientTest {
 
     @Test
     public void testInvalidJsonResponse() {
-        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null), null));
+        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null)));
         doAnswer(invocation -> "&\"brokerState\":3&").when(kafkaAgentClient).doGet(any());
 
         BrokerState actual = kafkaAgentClient.getBrokerState("mypod");
@@ -141,7 +107,7 @@ public class KafkaAgentClientTest {
 
     @Test
     public void testErrorResponse() {
-        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null), null));
+        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null)));
         doAnswer(invocation -> {
             throw new RuntimeException("Test failure");
         }).when(kafkaAgentClient).doGet(any());
@@ -153,91 +119,13 @@ public class KafkaAgentClientTest {
     }
 
     @Test
-    public void testTokenIsRequestedForTheClusterOperatorServiceAccount() {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        when(serviceAccountResource.tokenRequest(any())).thenReturn(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
-
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
-
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-token"));
-
-        ArgumentCaptor<TokenRequest> requestCaptor = ArgumentCaptor.forClass(TokenRequest.class);
-        verify(serviceAccountResource).tokenRequest(requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getSpec().getAudiences(), is(List.of(AUDIENCE)));
-        assertThat(requestCaptor.getValue().getSpec().getExpirationSeconds(), is(EXPIRATION_SECONDS));
-    }
-
-    @Test
-    public void testTokenIsCachedAndReused() {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        when(serviceAccountResource.tokenRequest(any())).thenReturn(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
-
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
-
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-token"));
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-token"));
-
-        verify(serviceAccountResource, times(1)).tokenRequest(any());
-    }
-
-    @Test
-    public void testTokenIsCachedWhenKubernetesShortensTheRequestedExpiration() {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        // The Kubernetes API can issue the token with a shorter validity than requested. The renewal has to follow the
-        // returned expiration time and not the requested one, otherwise the token would be renewed on every call.
-        when(serviceAccountResource.tokenRequest(any())).thenReturn(tokenRequestResponse("my-token", Instant.now().plusSeconds(60)));
-
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
-
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-token"));
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-token"));
-
-        verify(serviceAccountResource, times(1)).tokenRequest(any());
-    }
-
-    @Test
-    public void testTokenIsRenewedWhenItIsDueForRefresh() {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        when(serviceAccountResource.tokenRequest(any()))
-                // The first token is already past its refresh time and should not be reused
-                .thenReturn(tokenRequestResponse("my-old-token", Instant.now().minusSeconds(EXPIRATION_SECONDS)))
-                .thenReturn(tokenRequestResponse("my-new-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
-
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
-
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-old-token"));
-        assertThat(kafkaAgentClient.currentToken(authIdentity()), is("my-new-token"));
-
-        verify(serviceAccountResource, times(2)).tokenRequest(any());
-    }
-
-    @Test
-    public void testFailsWhenKubernetesApiReturnsNoToken() {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        when(serviceAccountResource.tokenRequest(any())).thenReturn(tokenRequestResponse(null, Instant.now().plusSeconds(EXPIRATION_SECONDS)));
-
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
-
-        RuntimeException e = assertThrows(RuntimeException.class, () -> kafkaAgentClient.currentToken(authIdentity()));
-        assertThat(e.getMessage(), is("Kubernetes API did not return a token for ServiceAccount namespace/my-cluster-cluster-operator"));
-    }
-
-    @Test
-    public void testFailsWhenKubernetesApiReturnsNoResponse() {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        when(serviceAccountResource.tokenRequest(any())).thenReturn(null);
-
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
-
-        assertThrows(RuntimeException.class, () -> kafkaAgentClient.currentToken(authIdentity()));
-    }
-
-    @Test
     public void testRequestIsSentWithTheServiceAccountToken() throws IOException {
-        ServiceAccountResource serviceAccountResource = mock(ServiceAccountResource.class);
-        when(serviceAccountResource.tokenRequest(any())).thenReturn(tokenRequestResponse("my-token", Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        // The token service is mocked here. Its own caching and renewal is covered by the ServiceAccountTokenServiceTest.
+        ServiceAccountTokenService tokenService = mock(ServiceAccountTokenService.class);
+        when(tokenService.token(any(RequestedServiceAccountAuthIdentity.class))).thenReturn(new ServiceAccountToken("my-token", System.currentTimeMillis(), System.currentTimeMillis() + 1000 * EXPIRATION_SECONDS));
 
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity()), mockKubernetesClient(serviceAccountResource));
+        KafkaAgentClient kafkaAgentClient = spy(new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, authIdentity())));
+        doReturn(tokenService).when(kafkaAgentClient).tokenService();
 
         assertThat(kafkaAgentClient.doGet(startHttpServer()), is("{\"brokerState\":3}"));
         assertThat(receivedAuthorization, is("Bearer my-token"));
@@ -245,7 +133,7 @@ public class KafkaAgentClientTest {
 
     @Test
     public void testRequestIsSentWithoutTokenWhenServiceAccountAuthenticationIsNotUsed() throws IOException {
-        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null), null);
+        KafkaAgentClient kafkaAgentClient = new KafkaAgentClient(RECONCILIATION, "my-cluster", "namespace", new Identity(null, null));
 
         assertThat(kafkaAgentClient.doGet(startHttpServer()), is("{\"brokerState\":3}"));
         assertThat(receivedAuthorization, is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -252,7 +252,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(NodeRef::nodeId).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 30);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 30);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we never find the controller we get ascending order
         doSuccessfulRollingRestart(kafkaRoller,
@@ -268,7 +268,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(NodeRef::nodeId).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(kafkaRoller,
@@ -283,7 +283,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(NodeRef::nodeId).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(kafkaRoller,
@@ -298,7 +298,7 @@ public class KafkaRollerTest {
                 bootstrapBrokers -> bootstrapBrokers != null && bootstrapBrokers.stream().map(NodeRef::nodeId).toList().equals(singletonList(1)) ? new RuntimeException("Test Exception") : null,
                 null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 4);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 4);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we force restart the node if we can't create an admin client
         doSuccessfulRollingRestart(kafkaRoller,
@@ -315,7 +315,7 @@ public class KafkaRollerTest {
                 noException(), null,
                 podId -> podId == nonActiveController ? new RuntimeException("Test Exception") : null, noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, activeController);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 3, 4, 1, 2));
@@ -329,7 +329,7 @@ public class KafkaRollerTest {
                 noException(), null,
                 podId -> podId == activeController ? new RuntimeException("Test Exception") : null, noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, activeController);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 1, 3, 4, 2));
@@ -342,7 +342,7 @@ public class KafkaRollerTest {
                 noException(),
                 new RuntimeException("Test Exception"), noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods (errors are logged)
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -356,7 +356,7 @@ public class KafkaRollerTest {
                 noException(),
                 new RuntimeException("Test Exception"), noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 3);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 3);
         // The algorithm should carry on rolling the pods (errors are logged),
         // because we did the active controller last order
         doSuccessfulRollingRestart(kafkaRoller,
@@ -373,7 +373,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 1 ? CompletableFuture.completedFuture(count.getAndDecrement() == 0)
                                 : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 2, 3, 4, 1));
@@ -388,7 +388,7 @@ public class KafkaRollerTest {
                 noException(), null, noException(), noException(),
                 combinedId ->
                         combinedId == 1 ? CompletableFuture.completedFuture(count.getAndDecrement() < 0) : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 3, 4, 1, 2));
@@ -402,7 +402,7 @@ public class KafkaRollerTest {
                 noException(), null, noException(), noException(),
                 controllerId ->
                         (controllerId == 1) ? CompletableFuture.completedFuture(count.getAndDecrement() == 0) : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 asList(0, 3, 4, 1, 2));
@@ -416,7 +416,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 1 ? CompletableFuture.completedFuture(false)
                                 : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
@@ -425,7 +425,7 @@ public class KafkaRollerTest {
         kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(brokerId != 1),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         clearRestarted();
         doFailingRollingRestart(kafkaRoller,
                 singletonList(1),
@@ -442,7 +442,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 1 ? CompletableFuture.completedFuture(false)
                                 : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
@@ -452,7 +452,7 @@ public class KafkaRollerTest {
         kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(brokerId != 1),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         clearRestarted();
         doFailingRollingRestart(kafkaRoller,
                 singletonList(1),
@@ -470,7 +470,7 @@ public class KafkaRollerTest {
                 brokerId ->
                         brokerId == 2 ? CompletableFuture.completedFuture(false)
                                 : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
@@ -481,7 +481,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(brokerId != 2),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(kafkaRoller,
                 singletonList(2),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
@@ -494,7 +494,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(REPLICAS, 0, 0), podOps,
                 noException(), null,
                 noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -507,7 +507,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, REPLICAS, 0), podOps,
                 noException(), null,
                 noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -520,7 +520,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
                 noException(), null,
                 noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -534,7 +534,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, REPLICAS), podOps,
                 noException(), null,
                 noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, controller);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, controller);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
@@ -548,7 +548,7 @@ public class KafkaRollerTest {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3), podOps,
                 noException(), null,
                 noException(), noException(),
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         // The algorithm should not carry on rolling the pods
         doSuccessfulConfigUpdate(kafkaRoller,
                 emptyList());
@@ -664,7 +664,7 @@ public class KafkaRollerTest {
     public void testSuccessfulRollingControllers() {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 3, 3),
                 mockPodOps(podId -> CompletableFuture.completedFuture(null)), noException(), null, noException(), noException(),
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5),
                 asList(0, 1, 2, 3, 4, 5));
@@ -674,7 +674,7 @@ public class KafkaRollerTest {
     public void testControllerNoQuorum() {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(0, 0, 3),
                 mockPodOps(podId -> CompletableFuture.completedFuture(null)), noException(), null, noException(), noException(),
-                brokerId -> CompletableFuture.completedFuture(false), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(false), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doFailingRollingRestart(kafkaRoller,
                 asList(0, 1, 2),
                 KafkaRoller.UnforceableProblem.class, "Pod c-kafka-0 cannot be updated right now.",
@@ -688,7 +688,7 @@ public class KafkaRollerTest {
                 podOps,
                 noException(), null, noException(), noException(),
                 brokerId -> brokerId == 2 || brokerId == 3 ? CompletableFuture.completedFuture(false) : CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 2);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 2);
         doFailingRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4),
                 KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is the active controller and there are other pods to verify first",
@@ -828,7 +828,7 @@ public class KafkaRollerTest {
     public void testRollWithAllRoles() {
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3),
                 mockPodOps(podId -> CompletableFuture.completedFuture(null)), noException(), null, noException(), noException(),
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, 6);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, 6);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8),
                 asList(3, 4, 5, 7, 8, 6, 0, 1, 2));
@@ -856,7 +856,7 @@ public class KafkaRollerTest {
         });
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addPodNames(3, 3, 3),
                 podOps, noException(), null, noException(), noException(),
-                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, -1);
+                brokerId -> CompletableFuture.completedFuture(true), new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, -1);
         doSuccessfulRollingRestart(kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8), // brokers, combined, controllers
                 asList(7, 4, 3, 5, 6, 8, 1, 0, 2)); //Rolls in order: unready controllers, ready controllers, unready brokers, ready brokers
@@ -889,7 +889,7 @@ public class KafkaRollerTest {
         return new TestingKafkaRoller(nodes, podOps,
                 noException(), null, noException(), noException(),
                 brokerId -> CompletableFuture.completedFuture(true),
-                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(null), false, null, activeController);
+                new DefaultAdminClientProvider(), new DefaultKafkaAgentClientProvider(), false, null, activeController);
     }
 
     private void doSuccessfulConfigUpdate(TestingKafkaRoller kafkaRoller,


### PR DESCRIPTION
### Type of Change

- Enhancement / new feature

### Description

When using service-account-based authentication for the cluster communication, we have to use Kubernetes token requests to get the tokens to authenticate with the Kafka cluster. Unlike the operands, the CO cannot mount the projected volumes for all clusters. Right now, the token is requested when creating the Kafka Admin Client and the Kafka Agent Client. This happens in every reconciliation (so every ~2 minutes).

This alone should not be overwhelming for the Kubernetes API server. But the tokens are per-cluster. So with more clusters (using service-account-based authentication), the number of requests would grow. Also, by default, the tokens are valid for 1 hour and thus are able to cover many reconciliations. And even is users opt to configure the minimal possible lifetime of 10 minutes, it would still cover multiple reconciliations.

So this PR introduces a central cached token service. It is lazily initialized as it might not be used at all in most operator instances. And it is singleton as it is shared between the Kafka and Agent clients. The cache also abstracts the token minting from the Agent client and Kafka client. It does not automatically renew the tokens. It just reaps the tokens before they expire and gets a new token next time it is requested. This way it makes sure the tokens for clusters that do not exist anymore or are not used anymore do not stay in the cache forever (until the CO is restarted).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))